### PR TITLE
Fix view registration

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -30,9 +30,9 @@ namespace DesktopApplicationTemplate
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddSingleton<Views.MainWindow>();
+            services.AddSingleton<Views.MainView>();
             services.AddSingleton<Services.IStartupService, Services.StartupService>();
-            services.AddSingleton<ViewModels.MainWindowViewModel>();
+            services.AddSingleton<ViewModels.MainViewModel>();
             services.AddSingleton<ViewModels.TcpServiceViewModel>();
             services.AddSingleton<Helpers.DependencyChecker>();
 
@@ -47,7 +47,7 @@ namespace DesktopApplicationTemplate
             var startupService = AppHost.Services.GetRequiredService<Services.IStartupService>();
             await startupService.RunStartupChecksAsync();
 
-            var mainWindow = AppHost.Services.GetRequiredService<Views.MainWindow>();
+            var mainWindow = AppHost.Services.GetRequiredService<Views.MainView>();
             mainWindow.Show();
 
             base.OnStartup(e);


### PR DESCRIPTION
## Summary
- use `MainView` and `MainViewModel` for DI registrations
- resolve the `MainView` from the service provider at startup

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5b30b02c832694a945c85cfe7198