### PR TITLE
Add StartupService unit test project

### DIFF
--- a/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
+++ b/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DesktopApplicationTemplate.UI\DesktopApplicationTemplate.UI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DesktopApplicationTemplate.Tests/GlobalUsings.cs
+++ b/DesktopApplicationTemplate.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
@@ -1,0 +1,40 @@
+using DesktopApplicationTemplate.Services;
+using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+using System.Collections.Generic;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class StartupServiceTests
+    {
+        [Fact]
+        public void GetSettings_ReturnsExpectedValues()
+        {
+            var inMemorySettings = new Dictionary<string, string?>
+            {
+                {"AppSettings:Environment", "Test"},
+                {"AppSettings:ServerIP", "192.168.1.1"},
+                {"AppSettings:ServerPort", "1234"},
+                {"AppSettings:LogLevel", "Information"},
+                {"AppSettings:AutoStart", "false"},
+                {"AppSettings:DefaultPythonScriptPath", "/path/script.py"}
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(inMemorySettings)
+                .Build();
+
+            var startupService = new StartupService(configuration);
+
+            AppSettings settings = startupService.GetSettings();
+
+            Assert.Equal("Test", settings.Environment);
+            Assert.Equal("192.168.1.1", settings.ServerIP);
+            Assert.Equal(1234, settings.ServerPort);
+            Assert.Equal("Information", settings.LogLevel);
+            Assert.False(settings.AutoStart);
+            Assert.Equal("/path/script.py", settings.DefaultPythonScriptPath);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.sln
+++ b/DesktopApplicationTemplate.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DektopApplication.Installer", "DektopApplication.Installer\DektopApplication.Installer.csproj", "{E793727E-CE81-4F1E-9577-58C05AEAAEF6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.Tests", "DesktopApplicationTemplate.Tests\DesktopApplicationTemplate.Tests.csproj", "{382DA104-8B6A-490C-96E8-5C12A7A58E85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{E793727E-CE81-4F1E-9577-58C05AEAAEF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E793727E-CE81-4F1E-9577-58C05AEAAEF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E793727E-CE81-4F1E-9577-58C05AEAAEF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{382DA104-8B6A-490C-96E8-5C12A7A58E85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{382DA104-8B6A-490C-96E8-5C12A7A58E85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{382DA104-8B6A-490C-96E8-5C12A7A58E85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{382DA104-8B6A-490C-96E8-5C12A7A58E85}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a new `DesktopApplicationTemplate.Tests` xUnit project
- write `StartupServiceTests` that uses in‑memory configuration
- reference the UI project from the test project and include in solution

## Testing
- `dotnet restore DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj`
- `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e5b33005c8326aabde93e6bb3fc77