### PR TITLE
Fix startup registration for MainView

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -30,9 +30,9 @@ namespace DesktopApplicationTemplate
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddSingleton<Views.MainWindow>();
+            services.AddSingleton<Views.MainView>();
             services.AddSingleton<Services.IStartupService, Services.StartupService>();
-            services.AddSingleton<ViewModels.MainWindowViewModel>();
+            services.AddSingleton<ViewModels.MainViewModel>();
             services.AddSingleton<ViewModels.TcpServiceViewModel>();
             services.AddSingleton<Helpers.DependencyChecker>();
 
@@ -47,7 +47,7 @@ namespace DesktopApplicationTemplate
             var startupService = AppHost.Services.GetRequiredService<Services.IStartupService>();
             await startupService.RunStartupChecksAsync();
 
-            var mainWindow = AppHost.Services.GetRequiredService<Views.MainWindow>();
+            var mainWindow = AppHost.Services.GetRequiredService<Views.MainView>();
             mainWindow.Show();
 
             base.OnStartup(e);


### PR DESCRIPTION
## Summary
- fix wrong service registrations referencing non-existent MainWindow
- retrieve MainView and MainViewModel in startup

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e55896c788326bf70ff1221d8a90e