### PR TITLE
Fix TCP service UI namespace

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.IO;
 using System.Windows;
+using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate
 {
@@ -32,8 +33,8 @@ namespace DesktopApplicationTemplate
         {
             services.AddSingleton<Views.MainView>();
             services.AddSingleton<Services.IStartupService, Services.StartupService>();
-            services.AddSingleton<ViewModels.MainViewModel>();
-            services.AddSingleton<ViewModels.TcpServiceViewModel>();
+            services.AddSingleton<MainViewModel>();
+            services.AddSingleton<TcpServiceViewModel>();
             services.AddSingleton<Helpers.DependencyChecker>();
 
             // Load strongly typed settings

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DesktopApplicationTemplate.ViewModels
+namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class TcpServiceViewModel : INotifyPropertyChanged
     {

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -1,8 +1,10 @@
-﻿<Window x:Class="DesktopApplicationTemplate.Views.TcpServiceView"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Chappie Desktop Application" Height="650" Width="960"
-        WindowStartupLocation="CenterScreen">
+﻿<Page x:Class="DesktopApplicationTemplate.UI.Views.TcpServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      Title="Chappie Desktop Application">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -57,4 +59,4 @@
             </StackPanel>
         </Grid>
     </Grid>
-</Window>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -1,9 +1,9 @@
 ﻿using System.Windows;
-using DesktopApplicationTemplate.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.Services;
 using System.Windows.Controls;
 
-namespace DesktopApplicationTemplate.Views
+namespace DesktopApplicationTemplate.UI.Views
 {
     public partial class TcpServiceView : Page
     {


### PR DESCRIPTION
## Summary
- update TcpServiceView XAML to use Page
- adjust namespaces for TcpServiceView and its view model
- update dependency injection registrations

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop/targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e5f587c2c8326a25182b90b60226d