### PR TITLE
Fix RelayCommand reference and remove duplicate project

### DIFF
--- a/DesktopApplicationTemplate.UI/Commands/RelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Commands/RelayCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows.Input;
+
+namespace DesktopApplicationTemplate.UI.Commands
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool>? _canExecute;
+
+        public event EventHandler? CanExecuteChanged;
+
+        public RelayCommand(Action execute, Func<bool>? canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+        public void Execute(object? parameter) => _execute();
+
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Commands;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {

--- a/DesktopApplicationTemplate.sln
+++ b/DesktopApplicationTemplate.sln
@@ -11,9 +11,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplication.Installe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.Tests", "DesktopApplicationTemplate.Tests\DesktopApplicationTemplate.Tests.csproj", "{382DA104-8B6A-490C-96E8-5C12A7A58E85}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.Tests", "DesktopApplicationTemplate.Tests\DesktopApplicationTemplate.Tests.csproj", "{382DA104-8B6A-490C-96E8-5C12A7A58E85}"
-EndProject
-Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU


### PR DESCRIPTION
## Summary
- implement a simple `RelayCommand` used by MainViewModel
- include new command namespace in MainViewModel
- remove duplicate entry in the solution file so build tools accept the sln

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6165541083269118258c429e717e