### PR TITLE
Fix view model bindings and add visibility converter

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -15,14 +15,61 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             set { _selectedObserver = value; OnPropertyChanged(); LoadObserverData(); }
         }
 
-        public string FilePath { get; set; }
-        public string Contents { get; set; }
-        public string ImageNames { get; set; }
-        public bool SendAllImages { get; set; }
-        public bool SendFirstXEnabled { get; set; }
-        public string SendXCount { get; set; } = "10";
-        public bool SendTcpCommandEnabled { get; set; }
-        public string TcpCommand { get; set; }
+        private string _filePath = string.Empty;
+        public string FilePath
+        {
+            get => _filePath;
+            set { _filePath = value; OnPropertyChanged(); }
+        }
+
+        private string _contents = string.Empty;
+        public string Contents
+        {
+            get => _contents;
+            set { _contents = value; OnPropertyChanged(); }
+        }
+
+        private string _imageNames = string.Empty;
+        public string ImageNames
+        {
+            get => _imageNames;
+            set { _imageNames = value; OnPropertyChanged(); }
+        }
+
+        private bool _sendAllImages;
+        public bool SendAllImages
+        {
+            get => _sendAllImages;
+            set { _sendAllImages = value; OnPropertyChanged(); }
+        }
+
+        private bool _sendFirstXEnabled;
+        public bool SendFirstXEnabled
+        {
+            get => _sendFirstXEnabled;
+            set { _sendFirstXEnabled = value; OnPropertyChanged(); }
+        }
+
+        private string _sendXCount = "10";
+        public string SendXCount
+        {
+            get => _sendXCount;
+            set { _sendXCount = value; OnPropertyChanged(); }
+        }
+
+        private bool _sendTcpCommandEnabled;
+        public bool SendTcpCommandEnabled
+        {
+            get => _sendTcpCommandEnabled;
+            set { _sendTcpCommandEnabled = value; OnPropertyChanged(); }
+        }
+
+        private string _tcpCommand = string.Empty;
+        public string TcpCommand
+        {
+            get => _tcpCommand;
+            set { _tcpCommand = value; OnPropertyChanged(); }
+        }
 
         public ICommand AddObserverCommand { get; }
         public ICommand RemoveObserverCommand { get; }
@@ -55,13 +102,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void AddObserver()
         {
-            Observers.Add(new FileObserver { Name = $"Observer{Observers.Count + 1}" });
+            var observer = new FileObserver { Name = $"Observer{Observers.Count + 1}" };
+            Observers.Add(observer);
+            SelectedObserver = observer;
         }
 
         private void RemoveObserver()
         {
             if (SelectedObserver != null)
+            {
                 Observers.Remove(SelectedObserver);
+                SelectedObserver = null;
+            }
         }
 
         private void BrowseFilePath()
@@ -70,7 +122,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (dialog.ShowDialog() == true)
             {
                 FilePath = dialog.FileName;
-                OnPropertyChanged(nameof(FilePath));
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows.Input;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -48,6 +49,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task SendRequestAsync()
         {
+            if (string.IsNullOrWhiteSpace(Url))
+            {
+                ResponseBody = "URL is required";
+                return;
+            }
+
             using HttpClient client = new();
             try
             {
@@ -68,6 +75,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             catch (HttpRequestException ex)
             {
                 ResponseBody = $"Error: {ex.Message}";
+            }
+            catch (System.Exception ex)
+            {
+                ResponseBody = $"Unexpected error: {ex.Message}";
             }
         }
 

--- a/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
@@ -6,9 +6,6 @@
       xmlns:vm="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
       mc:Ignorable="d">
 
-    <Page.DataContext>
-        <vm:FileObserverViewModel />
-    </Page.DataContext>
 
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -1,10 +1,15 @@
-﻿<Page x:Class="DesktopApplicationTemplate.Views.HttpServiceView"
+﻿<Page x:Class="DesktopApplicationTemplate.UI.Views.HttpServiceView" xmlns:vm="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="clr-namespace:DesktopApplicationTemplate.Views"
+      xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       mc:Ignorable="d">
+
+    <Page.Resources>
+        <local:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
+
 
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -20,9 +20,13 @@ namespace DesktopApplicationTemplate.UI.Views
     /// </summary>
     public partial class HttpServiceView : Page
     {
-        public HttpServiceView()
+        private readonly ViewModels.HttpServiceViewModel _viewModel;
+
+        public HttpServiceView(ViewModels.HttpServiceViewModel viewModel)
         {
             InitializeComponent();
+            _viewModel = viewModel;
+            DataContext = _viewModel;
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/StringNullOrEmptyToVisibilityConverter.cs
+++ b/DesktopApplicationTemplate.UI/Views/StringNullOrEmptyToVisibilityConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public class StringNullOrEmptyToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            bool isNullOrEmpty = string.IsNullOrEmpty(value as string);
+            return isNullOrEmpty ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix FileObserverView to use DI for DataContext
- clean up HttpServiceView namespace and add converter resource
- inject HttpServiceViewModel into HttpServiceView
- improve FileObserverViewModel property change notifications
- validate URL in HttpServiceViewModel requests
- add StringNullOrEmptyToVisibilityConverter helper

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8a2324848326bb7d4ebec46de618