### PR TITLE
Implement installer progress UI and logging

### DIFF
--- a/DesktopApplication.Installer/DesktopApplication.Installer.csproj
+++ b/DesktopApplication.Installer/DesktopApplication.Installer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/DesktopApplication.Installer/Helpers/RelayCommand.cs
+++ b/DesktopApplication.Installer/Helpers/RelayCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows.Input;
+
+namespace DesktopApplication.Installer.Helpers
+{
+    internal class RelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool>? _canExecute;
+
+        public RelayCommand(Action execute, Func<bool>? canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+        public void Execute(object? parameter) => _execute();
+
+        public event EventHandler? CanExecuteChanged;
+
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/DesktopApplication.Installer/ViewModels/InstallerWindowViewModel.cs
+++ b/DesktopApplication.Installer/ViewModels/InstallerWindowViewModel.cs
@@ -1,12 +1,66 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Windows.Input;
+using DesktopApplication.Installer.Helpers;
 
 namespace DesktopApplication.Installer.ViewModels
 {
-    internal class InstallerWindowViewModel
+    internal class InstallerWindowViewModel : INotifyPropertyChanged
     {
+        private string _installPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        private bool _addFirewallRule;
+        private bool _runOnStartup;
+
+        public string InstallPath
+        {
+            get => _installPath;
+            set { _installPath = value; OnPropertyChanged(); }
+        }
+
+        public bool AddFirewallRule
+        {
+            get => _addFirewallRule;
+            set { _addFirewallRule = value; OnPropertyChanged(); }
+        }
+
+        public bool RunOnStartup
+        {
+            get => _runOnStartup;
+            set { _runOnStartup = value; OnPropertyChanged(); }
+        }
+
+        public ICommand BrowseCommand { get; }
+        public ICommand InstallCommand { get; }
+
+        public event Action<string, bool, bool>? InstallRequested;
+
+        public InstallerWindowViewModel()
+        {
+            BrowseCommand = new RelayCommand(Browse);
+            InstallCommand = new RelayCommand(Install);
+        }
+
+        private void Browse()
+        {
+            using var dialog = new System.Windows.Forms.FolderBrowserDialog();
+            if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                InstallPath = dialog.SelectedPath;
+            }
+        }
+
+        private void Install()
+        {
+            InstallRequested?.Invoke(InstallPath, AddFirewallRule, RunOnStartup);
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
     }
 }

--- a/DesktopApplication.Installer/ViewModels/ProgressWindowViewModel.cs
+++ b/DesktopApplication.Installer/ViewModels/ProgressWindowViewModel.cs
@@ -1,12 +1,95 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Input;
+using DesktopApplication.Installer.Helpers;
 
 namespace DesktopApplication.Installer.ViewModels
 {
-    internal class ProgressWindowViewModel
+    internal class ProgressWindowViewModel : INotifyPropertyChanged
     {
+        private readonly CancellationTokenSource _cts = new();
+        private int _progress;
+        private string _logText = string.Empty;
+
+        public int Progress
+        {
+            get => _progress;
+            private set { _progress = value; OnPropertyChanged(); }
+        }
+
+        public string LogText
+        {
+            get => _logText;
+            private set { _logText = value; OnPropertyChanged(); }
+        }
+
+        public ICommand CancelCommand { get; }
+
+        public event Action? Completed;
+
+        private readonly string _installPath;
+        private readonly bool _firewall;
+        private readonly bool _startup;
+
+        public ProgressWindowViewModel(string installPath, bool firewall, bool startup)
+        {
+            _installPath = installPath;
+            _firewall = firewall;
+            _startup = startup;
+            CancelCommand = new RelayCommand(() => _cts.Cancel());
+        }
+
+        public async Task StartAsync()
+        {
+            var logFile = Path.Combine(_installPath, "install_log.txt");
+            Directory.CreateDirectory(_installPath);
+            using var writer = new StreamWriter(logFile, append: false);
+            try
+            {
+                await RunStep(writer, 10, "Creating directories...", async () => await Task.Delay(500));
+                await RunStep(writer, 30, "Copying files...", async () => await Task.Delay(500));
+                await RunStep(writer, 60, "Installing dependencies...", async () => await Task.Delay(500));
+                if (_firewall)
+                    await RunStep(writer, 80, "Configuring firewall...", async () => await Task.Delay(500));
+                if (_startup)
+                    await RunStep(writer, 90, "Configuring autostart...", async () => await Task.Delay(500));
+                await RunStep(writer, 100, "Finished.", async () => await Task.Delay(200));
+            }
+            catch (OperationCanceledException)
+            {
+                AppendLog(writer, "Installation cancelled.");
+            }
+            finally
+            {
+                writer.Flush();
+                Completed?.Invoke();
+            }
+        }
+
+        private async Task RunStep(StreamWriter writer, int progress, string message, Func<Task> action)
+        {
+            _cts.Token.ThrowIfCancellationRequested();
+            AppendLog(writer, message);
+            await action();
+            Progress = progress;
+        }
+
+        private void AppendLog(StreamWriter writer, string message)
+        {
+            writer.WriteLine(message);
+            writer.Flush();
+            LogText += message + Environment.NewLine;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
     }
 }

--- a/DesktopApplication.Installer/Views/InstallerWindow.xaml
+++ b/DesktopApplication.Installer/Views/InstallerWindow.xaml
@@ -1,12 +1,25 @@
-﻿<Window x:Class="DesktopApplication.Installer.Views.InstallerWindow"
+<Window x:Class="DesktopApplication.Installer.Views.InstallerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DesktopApplication.Installer.Views"
         mc:Ignorable="d"
-        Title="InstallerWindow" Height="450" Width="800">
-    <Grid>
-        
+        Title="Application Installer" Height="300" Width="500"
+        WindowStartupLocation="CenterScreen">
+    <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="Install Location:" Grid.Row="0" VerticalAlignment="Center" />
+        <TextBox Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding InstallPath, UpdateSourceTrigger=PropertyChanged}"/>
+        <Button Grid.Row="0" Grid.Column="1" Content="Browse..." Padding="10,2" Margin="5,0,0,0" Command="{Binding BrowseCommand}" />
+
+        <CheckBox Grid.Row="2" Content="Allow firewall access" IsChecked="{Binding AddFirewallRule}" />
+        <CheckBox Grid.Row="3" Content="Run on startup" IsChecked="{Binding RunOnStartup}" />
+
+        <Button Grid.Row="4" Grid.ColumnSpan="2" Content="Install" Padding="10" HorizontalAlignment="Right" Width="100" Command="{Binding InstallCommand}" />
     </Grid>
 </Window>

--- a/DesktopApplication.Installer/Views/InstallerWindow.xaml.cs
+++ b/DesktopApplication.Installer/Views/InstallerWindow.xaml.cs
@@ -1,27 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using DesktopApplication.Installer.ViewModels;
 
 namespace DesktopApplication.Installer.Views
 {
-    /// <summary>
-    /// Interaction logic for InstallerWindow.xaml
-    /// </summary>
     public partial class InstallerWindow : Window
     {
+        private readonly InstallerWindowViewModel _vm = new();
+
         public InstallerWindow()
         {
             InitializeComponent();
+            DataContext = _vm;
+            _vm.InstallRequested += OnInstallRequested;
+        }
+
+        private async void OnInstallRequested(string path, bool firewall, bool startup)
+        {
+            var progressVm = new ProgressWindowViewModel(path, firewall, startup);
+            var progressWindow = new ProgressWindow { DataContext = progressVm, Owner = this };
+            progressVm.Completed += () => progressWindow.Close();
+            progressWindow.Show();
+            await progressVm.StartAsync();
         }
     }
 }

--- a/DesktopApplication.Installer/Views/ProgressWindow.xaml
+++ b/DesktopApplication.Installer/Views/ProgressWindow.xaml
@@ -1,12 +1,17 @@
-﻿<Window x:Class="DesktopApplication.Installer.Views.ProgressWindow"
+<Window x:Class="DesktopApplication.Installer.Views.ProgressWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DesktopApplication.Installer.Views"
         mc:Ignorable="d"
-        Title="ProgressWindow" Height="450" Width="800">
-    <Grid>
-        
+        Title="Installing" Height="400" Width="600"
+        WindowStartupLocation="CenterScreen">
+    <Grid Margin="10" RowDefinitions="Auto,* ,Auto" RowSpacing="10">
+        <ProgressBar Grid.Row="0" Height="20" Minimum="0" Maximum="100" Value="{Binding Progress}"/>
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Name="LogScrollViewer">
+            <TextBlock Text="{Binding LogText}" TextWrapping="Wrap" />
+        </ScrollViewer>
+        <Button Grid.Row="2" Content="Cancel" Width="80" HorizontalAlignment="Right" Command="{Binding CancelCommand}" />
     </Grid>
 </Window>

--- a/DesktopApplication.Installer/Views/ProgressWindow.xaml.cs
+++ b/DesktopApplication.Installer/Views/ProgressWindow.xaml.cs
@@ -1,27 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using DesktopApplication.Installer.ViewModels;
 
 namespace DesktopApplication.Installer.Views
 {
-    /// <summary>
-    /// Interaction logic for ProgressWindow.xaml
-    /// </summary>
     public partial class ProgressWindow : Window
     {
         public ProgressWindow()
         {
             InitializeComponent();
+            DataContextChanged += OnDataContextChanged;
+        }
+
+        private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is ProgressWindowViewModel oldVm)
+                oldVm.PropertyChanged -= OnVmPropertyChanged;
+            if (e.NewValue is ProgressWindowViewModel newVm)
+                newVm.PropertyChanged += OnVmPropertyChanged;
+        }
+
+        private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ProgressWindowViewModel.LogText))
+            {
+                LogScrollViewer.ScrollToEnd();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add progress UI with log and cancel support
- open folder browser for installation path
- prompt for firewall rules and autostart
- write install log

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_688051241e9c8326a699218fbca7c696