### PR TITLE
Fix XAML files to resolve build errors

### DIFF
--- a/DesktopApplication.Installer/Views/InstallerWindow.xaml
+++ b/DesktopApplication.Installer/Views/InstallerWindow.xaml
@@ -7,7 +7,14 @@
         mc:Ignorable="d"
         Title="Application Installer" Height="300" Width="500"
         WindowStartupLocation="CenterScreen">
-    <Grid Margin="10" RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />

--- a/DesktopApplication.Installer/Views/ProgressWindow.xaml
+++ b/DesktopApplication.Installer/Views/ProgressWindow.xaml
@@ -7,7 +7,13 @@
         mc:Ignorable="d"
         Title="Installing" Height="400" Width="600"
         WindowStartupLocation="CenterScreen">
-    <Grid Margin="10" RowDefinitions="Auto,* ,Auto" RowSpacing="10">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
         <ProgressBar Grid.Row="0" Height="20" Minimum="0" Maximum="100" Value="{Binding Progress}"/>
         <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Name="LogScrollViewer">
             <TextBlock Text="{Binding LogText}" TextWrapping="Wrap" />

--- a/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
@@ -11,12 +11,12 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
-
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
+
+        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
         <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Grid.ColumnSpan="2" Margin="0,0,0,10"/>
 

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -14,13 +14,13 @@
 
 
     <Grid Margin="20">
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
-
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
+
+        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
         <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -44,18 +44,18 @@
                                 BorderBrush="{Binding BorderColor}"
                                 Background="{Binding BackgroundColor}"
                                 BorderThickness="2" Padding="5" Margin="2">
+                            <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
 
-                        <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" FontWeight="Bold"/>
-                                <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}"
-                                              Style="{StaticResource ToggleSwitchStyle}"/>
-                            </Grid>
+                                    <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" FontWeight="Bold"/>
+                                    <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}"
+                                                  Style="{StaticResource ToggleSwitchStyle}"/>
+                                </Grid>
+                            </Border>
                         </Border>
                     </DataTemplate>
                 </ListBox.ItemTemplate>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -6,14 +6,14 @@
       mc:Ignorable="d"
       Title="Chappie Desktop Application">
     <Grid Margin="10">
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
-
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <!-- Title -->
             <RowDefinition Height="*"/>
             <!-- Main Content -->
         </Grid.RowDefinitions>
+
+        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
         <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
 


### PR DESCRIPTION
## Summary
- fix closing tags and nested borders in `MainWindow.xaml`
- move `Grid.RowDefinitions`/`Grid.ColumnDefinitions` before content in Tcp/FileObserver/Http views
- define row definitions explicitly in installer views

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880cceffb048326837e58c8caed1033