### PR TITLE
Fix missing CreateServiceWindow and log type

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -59,7 +59,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void AddLog(string message)
         {
             var timestamp = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
-            Logs.Insert(0, $"{timestamp} {message}");
+            Logs.Insert(0, new LogEntry
+            {
+                Message = $"{timestamp} {message}",
+                Color = Brushes.Black
+            });
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -10,6 +10,7 @@ namespace DesktopApplicationTemplate.UI.Views
         public string CreatedServiceName { get; private set; }
         public string CreatedServiceType { get; private set; }
         public event Action<string,string>? ServiceCreated;
+        public event Action? Cancelled;
 
         public CreateServicePage(CreateServiceViewModel viewModel)
         {
@@ -35,7 +36,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {
-            // cancellation can be handled by parent frame
+            Cancelled?.Invoke();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
@@ -1,0 +1,6 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.CreateServiceWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Create Service" Height="300" Width="450">
+    <Frame x:Name="ContentFrame" NavigationUIVisibility="Hidden" />
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class CreateServiceWindow : Window
+    {
+        public string CreatedServiceName { get; private set; } = string.Empty;
+        public string CreatedServiceType { get; private set; } = string.Empty;
+
+        public CreateServiceWindow(CreateServiceViewModel viewModel)
+        {
+            InitializeComponent();
+            var page = new CreateServicePage(viewModel);
+            page.ServiceCreated += (name, type) =>
+            {
+                CreatedServiceName = name;
+                CreatedServiceType = type;
+                DialogResult = true;
+            };
+            page.Cancelled += () =>
+            {
+                DialogResult = false;
+            };
+            ContentFrame.Content = page;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing CreateServiceWindow to host CreateServicePage
- fire a Cancelled event from CreateServicePage
- fix AddLog overload to insert a LogEntry

## Testing
- `dotnet build DesktopApplicationTemplate.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test DesktopApplicationTemplate.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880d44d76648326a9c93d8141a0d182