### PR TITLE
Fix create service window

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -25,15 +25,21 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void AddService_Click(object sender, RoutedEventArgs e)
         {
-            var page = App.AppHost.Services.GetRequiredService<CreateServicePage>();
-            page.ServiceCreated += (name, type) =>
+            // Open the service creation workflow in its own window
+            var window = App.AppHost.Services.GetRequiredService<CreateServiceWindow>();
+
+            if (window.ShowDialog() == true)
             {
+                var name = window.CreatedServiceName;
+                var type = window.CreatedServiceType;
+
                 var newService = new ServiceViewModel
                 {
                     DisplayName = $"{type} - {name}",
                     ServiceType = type,
                     IsActive = false
                 };
+
                 newService.SetColorsByType();
 
                 newService.ServicePage = type switch
@@ -55,9 +61,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     ContentFrame.Content = newService.ServicePage;
                 }
-            };
-
-            ContentFrame.Content = page;
+            }
         }
 
         private void OnEditRequested(ServiceViewModel service)


### PR DESCRIPTION
## Summary
- open the Create Service flow in its own window
- keep service creation workflow the same but navigate to the new service's UI after creation

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d7a04cac8326a1cc6220b921cb14