### PR TITLE
Add service editing window and context menu

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/VisualTreeHelperExtensions.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/VisualTreeHelperExtensions.cs
@@ -1,0 +1,20 @@
+using System.Windows;
+using System.Windows.Media;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public static class VisualTreeHelperExtensions
+    {
+        public static T? FindParent<T>(DependencyObject? child) where T : DependencyObject
+        {
+            DependencyObject? parent = child;
+            while (parent != null)
+            {
+                if (parent is T correctlyTyped)
+                    return correctlyTyped;
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+            return null;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -37,14 +37,23 @@
             <ListBox ItemsSource="{Binding Services}"
                      SelectedItem="{Binding SelectedService}"
                      BorderThickness="0"
+                     HorizontalContentAlignment="Stretch"
                      SelectionChanged="ServiceList_SelectionChanged">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <Border CornerRadius="8"
                                 BorderBrush="{Binding BorderColor}"
                                 Background="{Binding BackgroundColor}"
-                                BorderThickness="2" Padding="5" Margin="2">
+                                BorderThickness="2" Padding="5" Margin="2"
+                                HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                             <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
+                                <Border.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Edit Service" Click="EditServiceMenu_Click" />
+                                        <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
+                                        <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
+                                    </ContextMenu>
+                                </Border.ContextMenu>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
@@ -1,0 +1,6 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Service Editor" Height="450" Width="800">
+    <Frame x:Name="EditorFrame" NavigationUIVisibility="Hidden" />
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class ServiceEditorWindow : Window
+    {
+        public ServiceEditorWindow(Page servicePage)
+        {
+            InitializeComponent();
+            EditorFrame.Content = servicePage;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- stretch service items across list box row
- open new `ServiceEditorWindow` when editing a service
- add context menu with edit/rename/delete for each service
- allow escape key or clicking blank space to deselect service
- utility helper for searching the visual tree

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880da53e3088326a25e5dc2b1e0796d