### PR TITLE
Fix double-click wiring

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -46,7 +46,7 @@
                                 Background="{Binding BackgroundColor}"
                                 BorderThickness="2" Padding="5" Margin="2"
                                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                MouseDoubleClick="ServiceItem_DoubleClick">
+                                MouseLeftButtonDown="ServiceItem_DoubleClick">
                             <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
                                 <Border.ContextMenu>
                                     <ContextMenu>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -105,6 +105,10 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void ServiceItem_DoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            // Ensure the handler only executes on a true double click
+            if (e.ClickCount != 2)
+                return;
+
             if ((sender as Border)?.DataContext is ServiceViewModel svc && svc.ServicePage != null)
             {
                 svc.IsActive = false;


### PR DESCRIPTION
## Summary
- fix the double-click attribute in `MainWindow.xaml`
- gate the double-click handler on `ClickCount`

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -c Release --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_6880e1b536c48326ac1e969376cf8711