### PR TITLE
Update TCP service logging and scripting

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -7,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using DesktopApplicationTemplate.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -14,6 +16,71 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         private string _statusMessage;
         private bool _isServerRunning;
+
+        private string _computerIp = string.Empty;
+        private string _listeningPort = string.Empty;
+        private string _serverIp = string.Empty;
+        private string _serverGateway = string.Empty;
+        private string _serverPort = string.Empty;
+
+        private string _scriptContent = string.Empty;
+        private string _selectedLanguage = "Python";
+        private string _testMessage = string.Empty;
+
+        public ObservableCollection<string> ScriptLanguages { get; } = new() { "Python", "C#" };
+
+        public ILoggingService? Logger { get; set; }
+
+        public string ComputerIp
+        {
+            get => _computerIp;
+            set { _computerIp = value; OnPropertyChanged(); }
+        }
+
+        public string ListeningPort
+        {
+            get => _listeningPort;
+            set { _listeningPort = value; OnPropertyChanged(); }
+        }
+
+        public string ServerIp
+        {
+            get => _serverIp;
+            set { _serverIp = value; OnPropertyChanged(); }
+        }
+
+        public string ServerGateway
+        {
+            get => _serverGateway;
+            set { _serverGateway = value; OnPropertyChanged(); }
+        }
+
+        public string ServerPort
+        {
+            get => _serverPort;
+            set { _serverPort = value; OnPropertyChanged(); }
+        }
+
+        public string ScriptContent
+        {
+            get => _scriptContent;
+            set { _scriptContent = value; OnPropertyChanged(); }
+        }
+
+        public string SelectedLanguage
+        {
+            get => _selectedLanguage;
+            set { _selectedLanguage = value; OnPropertyChanged(); SetDefaultTemplate(); }
+        }
+
+        public string TestMessage
+        {
+            get => _testMessage;
+            set { _testMessage = value; OnPropertyChanged(); }
+        }
+
+        public ICommand ToggleServerCommand { get; }
+        public ICommand TestScriptCommand { get; }
 
         public string StatusMessage
         {
@@ -42,6 +109,29 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             StatusMessage = "Chappie is initializing...";
             IsServerRunning = false;
             SaveCommand = new RelayCommand(Save);
+            ToggleServerCommand = new RelayCommand(ToggleServer);
+            TestScriptCommand = new RelayCommand(TestScript);
+            SetDefaultTemplate();
+        }
+
+        private void SetDefaultTemplate()
+        {
+            ScriptContent = SelectedLanguage == "Python"
+                ? "def process(message):\n    # message is the incoming string\n    return message"
+                : "string Process(string message)\n{\n    // message is the incoming string\n    return message;\n}";
+        }
+
+        private void ToggleServer()
+        {
+            IsServerRunning = !IsServerRunning;
+            Logger?.Log(IsServerRunning ? "Server Started" : "Server Stopped", LogLevel.Debug);
+        }
+
+        private void TestScript()
+        {
+            var result = ScriptContent.Replace("message", TestMessage);
+            Logger?.Log($"Script output: {result}", LogLevel.Debug);
+            MessageBox.Show(result, "Test Result");
         }
 
         private void Save()

--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -17,7 +17,7 @@
         <TextBlock Text="Current Active Services:" />
         <TextBlock Text="{Binding CurrentActiveServices}" />
         <Button Content="Edit Service" Width="100" Margin="0,10,0,0" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Click="EditService_Click"/>
-        <TextBox Text="{Binding SelectedService.Logs, Converter={StaticResource LogListToStringConverter}}"
+        <TextBox Text="{Binding DisplayLogs, Converter={StaticResource LogListToStringConverter}}"
                  IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
     </StackPanel>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -3,8 +3,13 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       mc:Ignorable="d"
       Title="Chappie Desktop Application">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:LogListToStringConverter x:Key="LogListToStringConverter" />
+    </Page.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -34,18 +39,47 @@
 
             <!-- LEFT SIDE -->
             <StackPanel Grid.Column="0" Margin="10">
-                <TextBox Text="Computer IP" Margin="0,0,0,5"/>
-                <TextBox Text="Listening Port" Margin="0,0,0,5"/>
-                <TextBox Text="Server IP" Margin="0,0,0,5"/>
-                <TextBox Text="Server Gateway" Margin="0,0,0,5"/>
-                <TextBox Text="Server Port" Margin="0,0,0,10"/>
-                <Button Content="Start/Stop Server" Height="30" Margin="0,0,0,10"/>
+                <Grid Margin="0,0,0,5">
+                    <TextBox Text="{Binding ComputerIp, UpdateSourceTrigger=PropertyChanged}" x:Name="ComputerIpBox"/>
+                    <TextBlock Text="Computer IP" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                               Margin="5,0,0,0"
+                               Visibility="{Binding Text, ElementName=ComputerIpBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
+                <Grid Margin="0,0,0,5">
+                    <TextBox Text="{Binding ListeningPort, UpdateSourceTrigger=PropertyChanged}" x:Name="ListenPortBox"/>
+                    <TextBlock Text="Listening Port" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                               Margin="5,0,0,0"
+                               Visibility="{Binding Text, ElementName=ListenPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
+                <Grid Margin="0,0,0,5">
+                    <TextBox Text="{Binding ServerIp, UpdateSourceTrigger=PropertyChanged}" x:Name="ServerIpBox"/>
+                    <TextBlock Text="Server IP" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                               Margin="5,0,0,0"
+                               Visibility="{Binding Text, ElementName=ServerIpBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
+                <Grid Margin="0,0,0,5">
+                    <TextBox Text="{Binding ServerGateway, UpdateSourceTrigger=PropertyChanged}" x:Name="ServerGatewayBox"/>
+                    <TextBlock Text="Server Gateway" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                               Margin="5,0,0,0"
+                               Visibility="{Binding Text, ElementName=ServerGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
+                <Grid Margin="0,0,0,10">
+                    <TextBox Text="{Binding ServerPort, UpdateSourceTrigger=PropertyChanged}" x:Name="ServerPortBox"/>
+                    <TextBlock Text="Server Port" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                               Margin="5,0,0,0"
+                               Visibility="{Binding Text, ElementName=ServerPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
+                <Button Content="Start/Stop Server" Height="30" Margin="0,0,0,10" Command="{Binding ToggleServerCommand}"/>
 
-                <TextBlock Text="Python Script" FontWeight="Bold" Margin="0,10,0,5"/>
-                <DockPanel>
-                    <TextBox Height="150" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Width="200"/>
-                    <Button Content="Test Script" Margin="10,0,0,0"/>
-                </DockPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,10,0,5" VerticalAlignment="Center">
+                    <TextBlock Text="Script Language:" Margin="0,0,5,0" VerticalAlignment="Center"/>
+                    <ComboBox Width="100" ItemsSource="{Binding ScriptLanguages}" SelectedItem="{Binding SelectedLanguage}"/>
+                </StackPanel>
+                <TextBlock Text="Script" FontWeight="Bold" Margin="0,0,0,5"/>
+                <TextBox Height="160" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Text="{Binding ScriptContent}"/>
+                <TextBlock Text="Test Message" FontWeight="Bold" Margin="0,5,0,0"/>
+                <TextBox Text="{Binding TestMessage}" Margin="0,0,0,5"/>
+                <Button Content="Test Script" Margin="0,0,0,5" Command="{Binding TestScriptCommand}"/>
             </StackPanel>
 
             <!-- RIGHT SIDE -->
@@ -57,10 +91,9 @@
                         <ComboBoxItem Content="Warning"/>
                         <ComboBoxItem Content="Error"/>
                     </ComboBox>
-                    <Button Content="Update Log"/>
                 </DockPanel>
 
-                <TextBox Height="400" VerticalScrollBarVisibility="Auto" AcceptsReturn="True" Text="LOGGER" />
+                <RichTextBox x:Name="LogBox" Height="350" IsReadOnly="True" VerticalScrollBarVisibility="Auto" />
             </StackPanel>
         </Grid>
 

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _startupService = startupService;
 
             DataContext = _viewModel;
+            _viewModel.Logger = new LoggingService(LogBox, Dispatcher);
 
             Loaded += MainWindow_Loaded;
         }


### PR DESCRIPTION
## Summary
- add placeholder logic and script options to TCP view
- wire up TCP view to logging service
- collect logs from active services and show them on the home page
- expose script template/test controls in the TCP view
- store aggregated logs in the main view model

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880eb7f07908326ae8c7ea3db96f4b6