### PR TITLE
Fix DisplayLogs binding

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -17,7 +17,7 @@
         <TextBlock Text="Current Active Services:" />
         <TextBlock Text="{Binding CurrentActiveServices}" />
         <Button Content="Edit Service" Width="100" Margin="0,10,0,0" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Click="EditService_Click"/>
-        <TextBox Text="{Binding DisplayLogs, Converter={StaticResource LogListToStringConverter}}"
+        <TextBox Text="{Binding DisplayLogs, Mode=OneWay, Converter={StaticResource LogListToStringConverter}}"
                  IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
     </StackPanel>
 </Page>


### PR DESCRIPTION
## Summary
- fix binding on DisplayLogs text box to use a read-only mode

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f45b43e88326b44b56313734daf1