### PR TITLE
Fix logo display by using pack URI

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
 
         <TextBlock Grid.Row="1" Text="Create New Service" FontSize="16" FontWeight="Bold" HorizontalAlignment="Center"/>
         <StackPanel Grid.Row="2" Margin="0,20,0,10">

--- a/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
@@ -17,9 +17,9 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Grid.ColumnSpan="2" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="300" Height="60" Grid.ColumnSpan="2" Margin="0,0,0,10"/>
 
         <!-- Observer List Panel -->
         <StackPanel Grid.Column="0" Margin="0,0,10,0">

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
@@ -9,7 +9,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
         <StackPanel Margin="0,50,0,0">
             <TextBlock Text="Heartbeat Message" FontWeight="Bold" Margin="0,0,0,5"/>
             <TextBox Text="{Binding BaseMessage}" Width="300"/>

--- a/DesktopApplicationTemplate.UI/Views/HidViews.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidViews.xaml
@@ -13,7 +13,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
         <StackPanel Grid.Row="1" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Save Configuration" Command="{Binding SaveCommand}" Width="150"/>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -21,9 +21,9 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
 
         <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
             <ComboBox Width="100" ItemsSource="{Binding Methods}" SelectedItem="{Binding SelectedMethod}" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -18,7 +18,7 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Image Source="Resources/Logo.png" Width="300" Height="60" Margin="10" HorizontalAlignment="Left"/>
+        <Image Source="pack://application:,,,/Resources/Logo.png" Width="300" Height="60" Margin="10" HorizontalAlignment="Left"/>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -19,9 +19,9 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
-        <Image Source="Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
+        <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="300" Height="60" Margin="0,0,0,10"/>
 
         <!-- Title -->
         <TextBlock Text="CHAPPIE DESKTOP APPLICATION"


### PR DESCRIPTION
## Summary
- ensure resources are referenced via pack URIs so WPF can load them

## Testing
- `dotnet build DesktopApplicationTemplate.sln -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880f56e1d788326b6d6b23a7b7aac32