### PR TITLE
Add settings page and persistence

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -72,6 +72,8 @@ namespace DesktopApplicationTemplate
 
         protected override async void OnExit(ExitEventArgs e)
         {
+            var vm = AppHost.Services.GetRequiredService<MainViewModel>();
+            vm.SaveServices();
             await AppHost.StopAsync();
             AppHost.Dispose();
             base.OnExit(e);

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -17,9 +17,16 @@
       <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="9.0.7" />
     </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <Folder Include="Themes\" />
   <Resource Include="Resources/*" />
-    </ItemGroup>
+    <Page Include="Views/ScriptEditorWindow.xaml" />
+    <Compile Include="Views/ScriptEditorWindow.xaml.cs" />
+    <Compile Include="Services/ServicePersistence.cs" />
+    <Compile Include="Models/UserSettings.cs" />
+    <Compile Include="ViewModels/SettingsViewModel.cs" />
+    <Page Include="Views/SettingsPage.xaml" />
+    <Compile Include="Views/SettingsPage.xaml.cs" />
+  </ItemGroup>
 
 </Project>

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -1,0 +1,10 @@
+namespace DesktopApplicationTemplate.Models
+{
+    public class UserSettings
+    {
+        public bool DarkTheme { get; set; }
+        public bool AutoCheckUpdates { get; set; }
+        public bool RunUIOnStartup { get; set; }
+        public bool RunServicesOnStartup { get; set; }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public static class ServicePersistence
+    {
+        private static readonly string FilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
+
+        public static void Save(IEnumerable<ServiceViewModel> services)
+        {
+            var data = new List<ServiceInfo>();
+            foreach (var s in services)
+            {
+                data.Add(new ServiceInfo
+                {
+                    DisplayName = s.DisplayName,
+                    ServiceType = s.ServiceType,
+                    IsActive = s.IsActive,
+                    Created = DateTime.Now
+                });
+            }
+            File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
+        }
+
+        public static List<ServiceInfo> Load()
+        {
+            if (!File.Exists(FilePath))
+                return new List<ServiceInfo>();
+            var json = File.ReadAllText(FilePath);
+            try
+            {
+                return JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+            }
+            catch
+            {
+                return new List<ServiceInfo>();
+            }
+        }
+    }
+
+    public class ServiceInfo
+    {
+        public string DisplayName { get; set; } = string.Empty;
+        public string ServiceType { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+        public DateTime Created { get; set; }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.IO;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class SettingsViewModel : INotifyPropertyChanged
+    {
+        private static readonly string FilePath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
+        private bool _darkTheme;
+        private bool _autoCheckUpdates;
+        private bool _runUIOnStartup;
+        private bool _runServicesOnStartup;
+        private bool _dirty;
+
+        public bool DarkTheme { get => _darkTheme; set { _darkTheme = value; _dirty = true; OnPropertyChanged(); } }
+        public bool AutoCheckUpdates { get => _autoCheckUpdates; set { _autoCheckUpdates = value; _dirty = true; OnPropertyChanged(); } }
+        public bool RunUIOnStartup { get => _runUIOnStartup; set { _runUIOnStartup = value; _dirty = true; OnPropertyChanged(); } }
+        public bool RunServicesOnStartup { get => _runServicesOnStartup; set { _runServicesOnStartup = value; _dirty = true; OnPropertyChanged(); } }
+        public bool HasUnsavedChanges => _dirty;
+
+        public void Load()
+        {
+            if (!File.Exists(FilePath))
+            {
+                return;
+            }
+            var json = File.ReadAllText(FilePath);
+            var obj = JsonSerializer.Deserialize<UserSettings>(json);
+            if (obj != null)
+            {
+                _darkTheme = obj.DarkTheme;
+                _autoCheckUpdates = obj.AutoCheckUpdates;
+                _runUIOnStartup = obj.RunUIOnStartup;
+                _runServicesOnStartup = obj.RunServicesOnStartup;
+            }
+        }
+
+        public void Save()
+        {
+            var data = new UserSettings
+            {
+                DarkTheme = _darkTheme,
+                AutoCheckUpdates = _autoCheckUpdates,
+                RunUIOnStartup = _runUIOnStartup,
+                RunServicesOnStartup = _runServicesOnStartup
+            };
+            File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
+            _dirty = false;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -10,12 +10,16 @@
         <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <StackPanel Margin="10">
-        <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14"/>
-        <TextBlock Text="Associated Steps:" FontStyle="Italic" Margin="0,10"/>
-        <TextBlock Text="Services Created:" />
-        <TextBlock Text="{Binding ServicesCreated}" />
-        <TextBlock Text="Current Active Services:" />
-        <TextBlock Text="{Binding CurrentActiveServices}" />
+        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}">
+            <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14" Margin="0,0,10,0"/>
+            <TextBlock Text="Associated Steps:" FontStyle="Italic"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,5">
+            <TextBlock Text="Services Created:" Margin="0,0,5,0"/>
+            <TextBlock Text="{Binding ServicesCreated}" Margin="0,0,10,0"/>
+            <TextBlock Text="Active Services:" Margin="0,0,5,0"/>
+            <TextBlock Text="{Binding CurrentActiveServices}" />
+        </StackPanel>
         <Button Content="Edit Service" Width="100" Margin="0,10,0,0" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Click="EditService_Click"/>
         <TextBox Text="{Binding DisplayLogs, Mode=OneWay, Converter={StaticResource LogListToStringConverter}}"
                  IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -12,6 +12,7 @@
         <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Window.Resources>
 
+    <Border BorderBrush="LimeGreen" BorderThickness="3" CornerRadius="10">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -53,6 +54,7 @@
                                         <MenuItem Header="Edit Service" Click="EditServiceMenu_Click" />
                                         <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
                                         <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
+                                        <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
                                     </ContextMenu>
                                 </Border.ContextMenu>
                                 <Grid>
@@ -92,6 +94,9 @@
             </ListBox>
         </StackPanel>
 
+        <Button Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Click="OpenSettings_Click"/>
+
     </Grid>
+    </Border>
 </Grid>
 </Window>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
@@ -1,0 +1,16 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.ScriptEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Script Editor" Height="400" Width="600">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBox x:Name="ScriptBox" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="0,0,5,0" Click="Ok_Click"/>
+            <Button Content="Cancel" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
@@ -1,0 +1,28 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class ScriptEditorWindow : Window
+    {
+        public string ScriptText { get; private set; } = string.Empty;
+
+        public ScriptEditorWindow(string initial)
+        {
+            InitializeComponent();
+            ScriptBox.Text = initial;
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            ScriptText = ScriptBox.Text;
+            DialogResult = true;
+            Close();
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
@@ -1,0 +1,24 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.SettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Title="Settings">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Image Source="pack://application:,,,/Resources/Logo.png" Width="120" MouseDown="Logo_Click" Cursor="Hand"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Margin="0,20,0,0">
+            <CheckBox Content="Dark Theme" IsChecked="{Binding DarkTheme}"/>
+            <CheckBox Content="Check for updates automatically" IsChecked="{Binding AutoCheckUpdates}"/>
+            <CheckBox Content="Run Application UI on startup" IsChecked="{Binding RunUIOnStartup}"/>
+            <CheckBox Content="Run background services on startup" IsChecked="{Binding RunServicesOnStartup}"/>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                <Button Content="Back" Width="80" Margin="0,0,5,0" Click="Back_Click"/>
+                <Button Content="Save" Width="80" Click="Save_Click"/>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class SettingsPage : Page
+    {
+        private readonly SettingsViewModel _viewModel;
+        public SettingsPage(SettingsViewModel vm)
+        {
+            InitializeComponent();
+            _viewModel = vm;
+            DataContext = _viewModel;
+            _viewModel.Load();
+        }
+
+        private void Save_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.Save();
+        }
+
+        private void Back_Click(object sender, RoutedEventArgs e)
+        {
+            HandleBack();
+        }
+
+        private void Logo_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            HandleBack();
+        }
+
+        private void HandleBack()
+        {
+            if (_viewModel.HasUnsavedChanges)
+            {
+                var res = MessageBox.Show("Save changes?", "Settings", MessageBoxButton.YesNoCancel);
+                if (res == MessageBoxResult.Cancel)
+                    return;
+                if (res == MessageBoxResult.Yes)
+                    _viewModel.Save();
+            }
+            if (Parent is Frame frame)
+                frame.Content = new HomePage { DataContext = App.AppHost.Services.GetService(typeof(MainViewModel)) };
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -77,6 +77,7 @@
                 </StackPanel>
                 <TextBlock Text="Script" FontWeight="Bold" Margin="0,0,0,5"/>
                 <TextBox Height="160" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Text="{Binding ScriptContent}"/>
+                <Button Content="Open Editor" Margin="0,5,0,5" Click="OpenEditor_Click" Width="100"/>
                 <TextBlock Text="Test Message" FontWeight="Bold" Margin="0,5,0,0"/>
                 <TextBox Text="{Binding TestMessage}" Margin="0,0,0,5"/>
                 <Button Content="Test Script" Margin="0,0,0,5" Command="{Binding TestScriptCommand}"/>
@@ -86,7 +87,8 @@
             <StackPanel Grid.Column="1" Margin="10">
                 <TextBlock Text="Chappie Log" FontWeight="Bold" FontSize="14"/>
                 <DockPanel Margin="0,5,0,5">
-                    <ComboBox Width="150" Margin="0,0,10,0">
+                    <ComboBox Width="150" Margin="0,0,10,0" SelectedIndex="0">
+                        <ComboBoxItem Content="All"/>
                         <ComboBoxItem Content="Debug"/>
                         <ComboBoxItem Content="Warning"/>
                         <ComboBoxItem Content="Error"/>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.Services;
+using DesktopApplicationTemplate.UI.Views;
 using System.Windows.Controls;
 
 namespace DesktopApplicationTemplate.UI.Views
@@ -25,6 +26,15 @@ namespace DesktopApplicationTemplate.UI.Views
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
             _startupService.RunStartupChecksAsync();
+        }
+
+        private void OpenEditor_Click(object sender, RoutedEventArgs e)
+        {
+            var editor = new ScriptEditorWindow(_viewModel.ScriptContent);
+            if (editor.ShowDialog() == true)
+            {
+                _viewModel.ScriptContent = editor.ScriptText;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix logs display for all services
- add script editor window and default log filter
- store services to a JSON file and reload on startup
- add settings page with basic options
- add gear button and color customization
- style tweaks

## Testing
- `dotnet build DesktopApplicationTemplate.sln -v:m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880fa8bf15c8326b5a58522b0a1e8ef