### PR TITLE
Fix MainWindow XML errors

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -18,15 +18,8 @@
     </ItemGroup>
 
   <ItemGroup>
-      <Folder Include="Themes\" />
-  <Resource Include="Resources/*" />
-    <Page Include="Views/ScriptEditorWindow.xaml" />
-    <Compile Include="Views/ScriptEditorWindow.xaml.cs" />
-    <Compile Include="Services/ServicePersistence.cs" />
-    <Compile Include="Models/UserSettings.cs" />
-    <Compile Include="ViewModels/SettingsViewModel.cs" />
-    <Page Include="Views/SettingsPage.xaml" />
-    <Compile Include="Views/SettingsPage.xaml.cs" />
+    <Folder Include="Themes\" />
+    <Resource Include="Resources/*" />
   </ItemGroup>
 
 </Project>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -98,5 +98,4 @@
 
     </Grid>
     </Border>
-</Grid>
 </Window>


### PR DESCRIPTION
## Summary
- correct closing tags in `MainWindow.xaml`
- rely on default compile items in UI project

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: invalid dll argument due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_6880ff03c4c48326b64e05f4e9c16c2c