### PR TITLE
Fix build errors and extend installer

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -6,6 +6,7 @@
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
       <UseWPF>true</UseWPF>
+      <UseWindowsForms>true</UseWindowsForms>
     </PropertyGroup>
 	
 	<PropertyGroup>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.VisualBasic;
+using System.Windows.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 using System.Windows.Media;


### PR DESCRIPTION
## Summary
- enable Windows Forms in the UI project
- allow color picker through System.Windows.Forms
- copy application libraries during install

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Debug` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688100f6c54c8326bd896fbf00c7a4a5