### PR TITLE
Fix ambiguous Brush types and update constructors

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -5,7 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Documents;
-using System.Windows.Media;
+using WpfBrush = System.Windows.Media.Brush;
+using WpfBrushes = System.Windows.Media.Brushes;
 using System.Windows.Threading;
 
 namespace DesktopApplicationTemplate.Services
@@ -26,12 +27,12 @@ namespace DesktopApplicationTemplate.Services
             string formatted = $"[{DateTime.Now:HH:mm:ss}] [{level}] {message}";
             _dispatcher.Invoke(() =>
             {
-                Brush color = level switch
+                WpfBrush color = level switch
                 {
-                    LogLevel.Debug => Brushes.Black,
-                    LogLevel.Warning => Brushes.Orange,
-                    LogLevel.Error => Brushes.Red,
-                    _ => Brushes.Black
+                    LogLevel.Debug => WpfBrushes.Black,
+                    LogLevel.Warning => WpfBrushes.Orange,
+                    LogLevel.Error => WpfBrushes.Red,
+                    _ => WpfBrushes.Black
                 };
 
                 var paragraph = new Paragraph(new Run(formatted) { Foreground = color });

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -10,14 +10,15 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Controls;
-using System.Windows.Media;
+using WpfBrush = System.Windows.Media.Brush;
+using WpfBrushes = System.Windows.Media.Brushes;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class LogEntry
     {
         public string Message { get; set; } = string.Empty;
-        public Brush Color { get; set; } = Brushes.Black;
+        public WpfBrush Color { get; set; } = WpfBrushes.Black;
     }
 
     public class ServiceViewModel : INotifyPropertyChanged
@@ -26,8 +27,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public string ServiceType { get; set; } = string.Empty;
         public Page? Page { get; set; }
 
-        public Brush BackgroundColor { get; set; } = Brushes.LightGray;
-        public Brush BorderColor { get; set; } = Brushes.Gray;
+        public WpfBrush BackgroundColor { get; set; } = WpfBrushes.LightGray;
+        public WpfBrush BorderColor { get; set; } = WpfBrushes.Gray;
         public Page? ServicePage { get; set; }
  
 
@@ -42,19 +43,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     _isActive = value;
                     OnPropertyChanged();
                     if (_isActive)
-                        AddLog("[Service Activated]", Brushes.Green);
+                        AddLog("[Service Activated]", WpfBrushes.Green);
                     else
-                        AddLog("[Service Deactivated]", Brushes.Red);                }
+                        AddLog("[Service Deactivated]", WpfBrushes.Red);                }
             }
         }
 
         public ObservableCollection<LogEntry> Logs { get; set; } = new();
 
         public event Action<ServiceViewModel, LogEntry>? LogAdded;
-        public void AddLog(string message, Brush? color = null)
+        public void AddLog(string message, WpfBrush? color = null)
         {
             string ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss:ff");
-            var entry = new LogEntry { Message = $"{ts} {message}", Color = color ?? Brushes.Black };
+            var entry = new LogEntry { Message = $"{ts} {message}", Color = color ?? WpfBrushes.Black };
             Logs.Insert(0, entry);
             LogAdded?.Invoke(this, entry);
         }
@@ -66,7 +67,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var entry = new LogEntry
             {
                 Message = $"{timestamp} {message}",
-                Color = Brushes.Black
+                Color = WpfBrushes.Black
             };
             Logs.Insert(0, entry);
             LogAdded?.Invoke(this, entry);
@@ -80,12 +81,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             (BackgroundColor, BorderColor) = ServiceType switch
             {
-                "TCP" => (Brushes.LightBlue, Brushes.DarkBlue),
-                "HTTP" => (Brushes.LightGreen, Brushes.DarkGreen),
-                "File Observer" => (Brushes.LightSalmon, Brushes.DarkSalmon),
-                "HID" => (Brushes.LightYellow, Brushes.Goldenrod),
-                "Heartbeat" => (Brushes.LightPink, Brushes.DeepPink),
-                _ => (Brushes.LightGray, Brushes.Gray)
+                "TCP" => (WpfBrushes.LightBlue, WpfBrushes.DarkBlue),
+                "HTTP" => (WpfBrushes.LightGreen, WpfBrushes.DarkGreen),
+                "File Observer" => (WpfBrushes.LightSalmon, WpfBrushes.DarkSalmon),
+                "HID" => (WpfBrushes.LightYellow, WpfBrushes.Goldenrod),
+                "Heartbeat" => (WpfBrushes.LightPink, WpfBrushes.DeepPink),
+                _ => (WpfBrushes.LightGray, WpfBrushes.Gray)
             };
             OnPropertyChanged(nameof(BackgroundColor));
             OnPropertyChanged(nameof(BorderColor));

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualBasic;
 using System.Windows.Forms;
 using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
+using WpfColor = System.Windows.Media.Color;
 using System.Windows.Media;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Views;
@@ -174,7 +175,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 var dlg = new System.Windows.Forms.ColorDialog();
                 if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
                 {
-                    var color = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+                    var color = WpfColor.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
                     var brush = new SolidColorBrush(color);
                     foreach (var s in _viewModel.Services.Where(s => s.ServiceType == svc.ServiceType))
                     {

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
@@ -7,6 +7,9 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class SettingsPage : Page
     {
         private readonly SettingsViewModel _viewModel;
+        public SettingsPage() : this(new SettingsViewModel())
+        {
+        }
         public SettingsPage(SettingsViewModel vm)
         {
             InitializeComponent();


### PR DESCRIPTION
## Summary
- resolve ambiguous `Brush` and `Color` references by aliasing WPF types
- add parameterless constructor for `SettingsPage`
- clarify color creation in `MainWindow`
- keep logging service compatible with WPF brushes

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688102962ca8832684088124e5623325