### PR TITLE
Fix compile-time issues and namespace consistency

### DIFF
--- a/DesktopApplication.Installer/DesktopApplication.Installer.csproj
+++ b/DesktopApplication.Installer/DesktopApplication.Installer.csproj
@@ -8,4 +8,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DesktopApplicationTemplate.UI\DesktopApplicationTemplate.UI.csproj" />
+    <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
@@ -1,4 +1,4 @@
-using DesktopApplicationTemplate.Services;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.Configuration;
 using Xunit;

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -35,7 +35,7 @@ namespace DesktopApplicationTemplate
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
             services.AddSingleton<MainView>();
-            services.AddSingleton<Services.IStartupService, Services.StartupService>();
+            services.AddSingleton<UI.Services.IStartupService, UI.Services.StartupService>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<TcpServiceViewModel>();
             services.AddSingleton<DependencyChecker>();
@@ -46,11 +46,13 @@ namespace DesktopApplicationTemplate
             services.AddSingleton<HeartbeatView>();
             services.AddSingleton<HeartbeatViewModel>();
             services.AddSingleton<CsvViewerViewModel>();
-            services.AddSingleton<Services.CsvService>();
+            services.AddSingleton<UI.Services.CsvService>();
+            services.AddSingleton<SettingsViewModel>();
             services.AddTransient<CsvViewerWindow>();
             services.AddTransient<CreateServiceWindow>();
             services.AddTransient<CreateServicePage>();
             services.AddTransient<CreateServiceViewModel>();
+            services.AddTransient<SettingsPage>();
 
 
             // Load strongly typed settings
@@ -61,7 +63,7 @@ namespace DesktopApplicationTemplate
         {
             await AppHost.StartAsync();
 
-            var startupService = AppHost.Services.GetRequiredService<Services.IStartupService>();
+            var startupService = AppHost.Services.GetRequiredService<UI.Services.IStartupService>();
             await startupService.RunStartupChecksAsync();
 
             var mainWindow = AppHost.Services.GetRequiredService<MainView>();

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -6,6 +6,7 @@
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
       <UseWPF>true</UseWPF>
+      <UseWindowsForms>true</UseWindowsForms>
     </PropertyGroup>
 	
 	<PropertyGroup>

--- a/DesktopApplicationTemplate.UI/Services/CsvService.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvService.cs
@@ -1,7 +1,7 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using System.Text;
 
-namespace DesktopApplicationTemplate.Services
+namespace DesktopApplicationTemplate.UI.Services
 {
     public class CsvService
     {

--- a/DesktopApplicationTemplate.UI/Services/ILoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/ILoggingService.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DesktopApplicationTemplate.Services
+namespace DesktopApplicationTemplate.UI.Services
 {
     public interface ILoggingService
     {

--- a/DesktopApplicationTemplate.UI/Services/IStartupService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IStartupService.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DesktopApplicationTemplate.Services
+namespace DesktopApplicationTemplate.UI.Services
 {
     public interface IStartupService
     {

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -9,7 +9,7 @@ using WpfBrush = System.Windows.Media.Brush;
 using WpfBrushes = System.Windows.Media.Brushes;
 using System.Windows.Threading;
 
-namespace DesktopApplicationTemplate.Services
+namespace DesktopApplicationTemplate.UI.Services
 {
     public class LoggingService : ILoggingService
     {

--- a/DesktopApplicationTemplate.UI/Services/StartupService.cs
+++ b/DesktopApplicationTemplate.UI/Services/StartupService.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DesktopApplicationTemplate.Services
+namespace DesktopApplicationTemplate.UI.Services
 {
     public class StartupService : IStartupService
     {

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -11,21 +11,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             "HID", "TCP", "HTTP", "File Observer", "Heartbeat", "CSV Creator"
         };
 
-        private string _serviceName;
+        private string _serviceName = string.Empty;
         public string ServiceName
         {
             get => _serviceName;
             set { _serviceName = value; OnPropertyChanged(); }
         }
 
-        private string _selectedServiceType;
+        private string _selectedServiceType = string.Empty;
         public string SelectedServiceType
         {
             get => _selectedServiceType;
             set { _selectedServiceType = value; OnPropertyChanged(); }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string name = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -9,10 +9,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     public class FileObserverViewModel : INotifyPropertyChanged
     {
         public ObservableCollection<FileObserver> Observers { get; } = new();
-        private FileObserver _selectedObserver;
+        private FileObserver? _selectedObserver;
         public FileObserver SelectedObserver
         {
-            get => _selectedObserver;
+            get => _selectedObserver!;
             set { _selectedObserver = value; OnPropertyChanged(); LoadObserverData(); }
         }
 
@@ -133,7 +133,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string name = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -21,7 +21,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public ObservableCollection<HeaderItem> Headers { get; } = new();
 
-        private HeaderItem _selectedHeader;
+        private HeaderItem _selectedHeader = new HeaderItem();
         public HeaderItem SelectedHeader
         {
             get => _selectedHeader;
@@ -38,21 +38,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             set { _selectedMethod = value; OnPropertyChanged(); }
         }
 
-        private string _url;
+        private string _url = string.Empty;
         public string Url
         {
             get => _url;
             set { _url = value; OnPropertyChanged(); }
         }
 
-        private string _requestBody;
+        private string _requestBody = string.Empty;
         public string RequestBody
         {
             get => _requestBody;
             set { _requestBody = value; OnPropertyChanged(); }
         }
 
-        private string _responseBody;
+        private string _responseBody = string.Empty;
         public string ResponseBody
         {
             get => _responseBody;
@@ -124,7 +124,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string name = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -73,7 +73,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             LogAdded?.Invoke(this, entry);
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string name = null) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 
@@ -98,10 +98,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         public ObservableCollection<ServiceViewModel> Services { get; set; } = new();
         public ObservableCollection<LogEntry> AllLogs { get; } = new();
-        private ServiceViewModel _selectedService;
+        private ServiceViewModel? _selectedService;
         public ServiceViewModel SelectedService
         {
-            get => _selectedService;
+            get => _selectedService!;
             set { _selectedService = value; OnPropertyChanged(); OnPropertyChanged(nameof(DisplayLogs)); }
         }
         public ICommand AddServiceCommand { get; }
@@ -191,7 +191,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             OnPropertyChanged(nameof(DisplayLogs));
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         private void OnPropertyChanged([CallerMemberName] string name = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -8,13 +8,13 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using DesktopApplicationTemplate.Services;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class TcpServiceViewModel : INotifyPropertyChanged
     {
-        private string _statusMessage;
+        private string _statusMessage = string.Empty;
         private bool _isServerRunning;
 
         private string _computerIp = string.Empty;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
-using DesktopApplicationTemplate.Services;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.VisualBasic;
 using System.Windows.Forms;

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows;
 using DesktopApplicationTemplate.UI.ViewModels;
-using DesktopApplicationTemplate.Services;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;
 using System.Windows.Controls;
 


### PR DESCRIPTION
## Summary
- align service namespaces under UI project
- allow nullable property changed handlers and initialize string fields
- add Windows Forms support in UI project
- register Settings dependencies and project references
- link UI and service projects in installer

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68810616dd5483269ebf530c9f9ebbf5