### PR TITLE
Fix namespace issues in UI

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml
+++ b/DesktopApplicationTemplate.UI/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="DesktopApplicationTemplate.App"
+﻿<Application x:Class="DesktopApplicationTemplate.UI.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -8,9 +8,9 @@ using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.Helpers;
 
 
-namespace DesktopApplicationTemplate
+namespace DesktopApplicationTemplate.UI
 {
-    public partial class App : Application
+    public partial class App : System.Windows.Application
     {
         public static IHost AppHost { get; private set; }
 

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 	
 	<PropertyGroup>
-		<StartupObject>DesktopApplicationTemplate.App</StartupObject>
+                <StartupObject>DesktopApplicationTemplate.UI.App</StartupObject>
 	</PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- fix namespace for App.xaml.cs and set explicit base class to resolve ambiguous Application reference
- update xaml class namespace
- update startup object in csproj

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881094c04b08326a60a6ba02a49220a