### PR TITLE
Improve service UI with filtering and auto-selection

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/FilterViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FilterViewModel.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class FilterViewModel : INotifyPropertyChanged
+    {
+        private string _nameFilter = string.Empty;
+        public string NameFilter
+        {
+            get => _nameFilter;
+            set { _nameFilter = value; OnPropertyChanged(); }
+        }
+
+        private string _typeFilter = "All";
+        public string TypeFilter
+        {
+            get => _typeFilter;
+            set { _typeFilter = value; OnPropertyChanged(); }
+        }
+
+        private string _statusFilter = "All";
+        public string StatusFilter
+        {
+            get => _statusFilter;
+            set { _statusFilter = value; OnPropertyChanged(); }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string name = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
@@ -1,0 +1,44 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.FilterWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Filter Services" Height="230" Width="300">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Margin="0,5">
+            <TextBlock Text="Name:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <TextBox Width="200" Text="{Binding NameFilter}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,5">
+            <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <ComboBox Width="200" SelectedItem="{Binding TypeFilter}">
+                <ComboBoxItem>All</ComboBoxItem>
+                <ComboBoxItem>TCP</ComboBoxItem>
+                <ComboBoxItem>HTTP</ComboBoxItem>
+                <ComboBoxItem>File Observer</ComboBoxItem>
+                <ComboBoxItem>HID</ComboBoxItem>
+                <ComboBoxItem>Heartbeat</ComboBoxItem>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,5">
+            <TextBlock Text="Status:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <ComboBox Width="200" SelectedItem="{Binding StatusFilter}">
+                <ComboBoxItem>All</ComboBoxItem>
+                <ComboBoxItem>Active</ComboBoxItem>
+                <ComboBoxItem>Inactive</ComboBoxItem>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Apply" Width="75" Margin="0,0,5,0" Click="Apply_Click"/>
+            <Button Content="Close" Width="75" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class FilterWindow : Window
+    {
+        public FilterWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Apply_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        private void Close_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
-        Title="MainView" Height="450" Width="800">
+        Title="MainView" Height="600" Width="1000">
 
     <Window.Resources>
         <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
@@ -34,8 +34,11 @@
                 <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click"/>
             </StackPanel>
 
-            <TextBlock Text="Services" FontWeight="Bold" Margin="0,10"/>
-            <ListBox ItemsSource="{Binding Services}"
+            <StackPanel Orientation="Horizontal" Margin="0,10">
+                <TextBlock Text="Services" FontWeight="Bold" />
+                <Button Content="🔍" Width="20" Margin="5,0,0,0" Click="OpenFilter_Click"/>
+            </StackPanel>
+            <ListBox ItemsSource="{Binding FilteredServices}"
                      SelectedItem="{Binding SelectedService}"
                      BorderThickness="0"
                      HorizontalContentAlignment="Stretch"
@@ -80,7 +83,6 @@
             <Frame x:Name="ContentFrame" Height="200" NavigationUIVisibility="Hidden" />
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14"/>
             <Button Content="Edit Connection" Click="EditService_Click" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,5" Width="120"/>
-            <Button Content="CSV Viewer" Click="OpenCsvViewer_Click" Margin="0,5" Width="100"/>
             <TextBlock Text="Services Created:" />
             <TextBlock Text="{Binding ServicesCreated}" />
             <TextBlock Text="Current Active Services:" />
@@ -92,6 +94,7 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
+            <Button Content="CSV Viewer" Click="OpenCsvViewer_Click" Margin="0,5" Width="100"/>
         </StackPanel>
 
         <Button Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Click="OpenSettings_Click"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -136,6 +136,15 @@ namespace DesktopApplicationTemplate.UI.Views
             window.ShowDialog();
         }
 
+        private void OpenFilter_Click(object sender, RoutedEventArgs e)
+        {
+            var window = new FilterWindow { DataContext = _viewModel.Filters };
+            if (window.ShowDialog() == true)
+            {
+                // filters already applied via PropertyChanged event
+            }
+        }
+
         private void EditServiceMenu_Click(object sender, RoutedEventArgs e)
         {
             if ((sender as MenuItem)?.DataContext is ServiceViewModel svc && svc.ServicePage != null)
@@ -151,8 +160,18 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if ((sender as MenuItem)?.DataContext is ServiceViewModel svc)
             {
+                var index = _viewModel.Services.IndexOf(svc);
                 svc.LogAdded -= _viewModel.OnServiceLogAdded;
                 _viewModel.Services.Remove(svc);
+                if (_viewModel.Services.Count > 0)
+                {
+                    if (index >= _viewModel.Services.Count) index = _viewModel.Services.Count - 1;
+                    _viewModel.SelectedService = _viewModel.Services[index];
+                }
+                else
+                {
+                    _viewModel.SelectedService = null;
+                }
                 _viewModel.SaveServices();
             }
         }


### PR DESCRIPTION
## Summary
- allow changing service colors dynamically by notifying property changes
- grow main window size for more content
- move CSV viewer button below log section
- auto-select next service when removing items
- add filter icon with dialog to filter services

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881124c132c8326908e782f5e2b2c7c