### PR TITLE
Add new network services

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -1,0 +1,16 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class FtpServiceViewModelTests
+    {
+        [Fact]
+        public void BrowseCommand_InitialPathEmpty_DoesNotThrow()
+        {
+            var vm = new FtpServiceViewModel();
+            vm.BrowseCommand.Execute(null);
+            Assert.True(true); // command executed without exception
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -1,0 +1,17 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class MqttServiceViewModelTests
+    {
+        [Fact]
+        public void AddTopicCommand_AddsTopic()
+        {
+            var vm = new MqttServiceViewModel();
+            vm.NewTopic = "test/topic";
+            vm.AddTopicCommand.Execute(null);
+            Assert.Contains("test/topic", vm.Topics);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
@@ -1,0 +1,15 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ScpServiceViewModelTests
+    {
+        [Fact]
+        public void DefaultPort_Is22()
+        {
+            var vm = new ScpServiceViewModel();
+            Assert.Equal("22", vm.Port);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -46,6 +46,12 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<FileObserverViewModel>();
             services.AddSingleton<HeartbeatView>();
             services.AddSingleton<HeartbeatViewModel>();
+            services.AddSingleton<SCPServiceView>();
+            services.AddSingleton<ScpServiceViewModel>();
+            services.AddSingleton<MQTTServiceView>();
+            services.AddSingleton<MqttServiceViewModel>();
+            services.AddSingleton<FTPServiceView>();
+            services.AddSingleton<FtpServiceViewModel>();
             services.AddSingleton<CsvViewerViewModel>();
             services.AddSingleton<CsvService>();
             services.AddSingleton<SettingsViewModel>();

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -17,6 +17,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="9.0.7" />
     <Reference Include="System.Windows.Forms" />
+    <PackageReference Include="SSH.NET" Version="2020.0.1" />
+    <PackageReference Include="MQTTnet" Version="4.1.0.247" />
+    <PackageReference Include="FluentFTP" Version="53.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopApplicationTemplate.UI/Helpers/PasswordBoxAssistant.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/PasswordBoxAssistant.cs
@@ -1,0 +1,59 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public static class PasswordBoxAssistant
+    {
+        public static readonly DependencyProperty BoundPasswordProperty = DependencyProperty.RegisterAttached(
+            "BoundPassword", typeof(string), typeof(PasswordBoxAssistant), new PropertyMetadata(string.Empty, OnBoundPasswordChanged));
+
+        public static string GetBoundPassword(DependencyObject obj) => (string)obj.GetValue(BoundPasswordProperty);
+        public static void SetBoundPassword(DependencyObject obj, string value) => obj.SetValue(BoundPasswordProperty, value);
+
+        public static readonly DependencyProperty BindPasswordProperty = DependencyProperty.RegisterAttached(
+            "BindPassword", typeof(bool), typeof(PasswordBoxAssistant), new PropertyMetadata(false, OnBindPasswordChanged));
+
+        public static bool GetBindPassword(DependencyObject obj) => (bool)obj.GetValue(BindPasswordProperty);
+        public static void SetBindPassword(DependencyObject obj, bool value) => obj.SetValue(BindPasswordProperty, value);
+
+        private static void OnBoundPasswordChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is PasswordBox box && !GetIsUpdating(box))
+            {
+                box.Password = e.NewValue as string ?? string.Empty;
+            }
+        }
+
+        private static void OnBindPasswordChanged(DependencyObject dp, DependencyPropertyChangedEventArgs e)
+        {
+            if (dp is PasswordBox box)
+            {
+                if ((bool)e.NewValue)
+                {
+                    box.PasswordChanged += HandlePasswordChanged;
+                }
+                else
+                {
+                    box.PasswordChanged -= HandlePasswordChanged;
+                }
+            }
+        }
+
+        private static readonly DependencyProperty IsUpdatingProperty = DependencyProperty.RegisterAttached(
+            "IsUpdating", typeof(bool), typeof(PasswordBoxAssistant));
+
+        private static bool GetIsUpdating(DependencyObject obj) => (bool)obj.GetValue(IsUpdatingProperty);
+        private static void SetIsUpdating(DependencyObject obj, bool value) => obj.SetValue(IsUpdatingProperty, value);
+
+        private static void HandlePasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (sender is PasswordBox box)
+            {
+                SetIsUpdating(box, true);
+                SetBoundPassword(box, box.Password);
+                SetIsUpdating(box, false);
+            }
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FtpService.cs
@@ -1,0 +1,21 @@
+using FluentFTP;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public class FtpService
+    {
+        private readonly FtpClient _client;
+        public FtpService(string host, int port, string user, string pass)
+        {
+            _client = new FtpClient(host, port, user, pass);
+        }
+
+        public async Task UploadAsync(string localPath, string remotePath)
+        {
+            await _client.ConnectAsync();
+            await _client.UploadFileAsync(localPath, remotePath, FtpRemoteExists.Overwrite);
+            await _client.DisconnectAsync();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -1,0 +1,48 @@
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public class MqttService
+    {
+        private readonly IMqttClient _client;
+        private readonly IMqttFactory _factory = new MqttFactory();
+
+        public MqttService()
+        {
+            _client = _factory.CreateMqttClient();
+        }
+
+        public async Task ConnectAsync(string host, int port, string clientId, string? user, string? pass)
+        {
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer(host, port)
+                .WithClientId(clientId);
+
+            if (!string.IsNullOrEmpty(user))
+                options = options.WithCredentials(user, pass);
+
+            await _client.ConnectAsync(options.Build());
+        }
+
+        public async Task SubscribeAsync(IEnumerable<string> topics)
+        {
+            foreach (var t in topics)
+            {
+                await _client.SubscribeAsync(t);
+            }
+        }
+
+        public async Task PublishAsync(string topic, string message)
+        {
+            var msg = new MqttApplicationMessageBuilder()
+                .WithTopic(topic)
+                .WithPayload(message)
+                .Build();
+            await _client.PublishAsync(msg);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ScpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/ScpService.cs
@@ -1,0 +1,25 @@
+using Renci.SshNet;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public class ScpService
+    {
+        private readonly ScpClient _client;
+        public ScpService(string host, int port, string user, string password)
+        {
+            _client = new ScpClient(host, port, user, password);
+        }
+
+        public async Task UploadAsync(string localPath, string remotePath)
+        {
+            await Task.Run(() =>
+            {
+                using var stream = System.IO.File.OpenRead(localPath);
+                _client.Connect();
+                _client.Upload(stream, remotePath);
+                _client.Disconnect();
+            });
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -8,7 +8,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         public ObservableCollection<string> ServiceTypes { get; } = new()
         {
-            "HID", "TCP", "HTTP", "File Observer", "Heartbeat", "CSV Creator"
+            "HID", "TCP", "HTTP", "File Observer", "Heartbeat", "CSV Creator",
+            "SCP", "MQTT", "FTP"
         };
 
         private string _serviceName = string.Empty;

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class FtpServiceViewModel : INotifyPropertyChanged
+    {
+        private string _host = string.Empty;
+        public string Host { get => _host; set { _host = value; OnPropertyChanged(); } }
+
+        private string _port = "21";
+        public string Port { get => _port; set { _port = value; OnPropertyChanged(); } }
+
+        private string _username = string.Empty;
+        public string Username { get => _username; set { _username = value; OnPropertyChanged(); } }
+
+        private string _password = string.Empty;
+        public string Password { get => _password; set { _password = value; OnPropertyChanged(); } }
+
+        private string _localPath = string.Empty;
+        public string LocalPath { get => _localPath; set { _localPath = value; OnPropertyChanged(); } }
+
+        private string _remotePath = string.Empty;
+        public string RemotePath { get => _remotePath; set { _remotePath = value; OnPropertyChanged(); } }
+
+        public ICommand BrowseCommand { get; }
+        public ICommand TransferCommand { get; }
+        public ICommand SaveCommand { get; }
+
+        public ILoggingService? Logger { get; set; }
+
+        public FtpServiceViewModel()
+        {
+            BrowseCommand = new RelayCommand(Browse);
+            TransferCommand = new RelayCommand(async () => await TransferAsync());
+            SaveCommand = new RelayCommand(Save);
+        }
+
+        private void Browse()
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog();
+            if (dialog.ShowDialog() == true)
+                LocalPath = dialog.FileName;
+        }
+
+        private async Task TransferAsync()
+        {
+            if (string.IsNullOrWhiteSpace(LocalPath) || string.IsNullOrWhiteSpace(RemotePath))
+                return;
+            var svc = new FtpService(Host, int.Parse(Port), Username, Password);
+            await svc.UploadAsync(LocalPath, RemotePath);
+            Logger?.Log("FTP upload complete", LogLevel.Debug);
+        }
+
+        private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -40,11 +40,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     if (_isActive)
                         AddLog("[Service Activated]", WpfBrushes.Green);
                     else
-                        AddLog("[Service Deactivated]", WpfBrushes.Red);                }
+                        AddLog("[Service Deactivated]", WpfBrushes.Red);
+                    ActiveChanged?.Invoke(_isActive);
+                }
             }
         }
 
         public ObservableCollection<LogEntry> Logs { get; set; } = new();
+        public event Action<bool>? ActiveChanged;
 
         public event Action<ServiceViewModel, LogEntry>? LogAdded;
         public void AddLog(string message, WpfBrush? color = null)
@@ -81,6 +84,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 "File Observer" => (WpfBrushes.LightSalmon, WpfBrushes.DarkSalmon),
                 "HID" => (WpfBrushes.LightYellow, WpfBrushes.Goldenrod),
                 "Heartbeat" => (WpfBrushes.LightPink, WpfBrushes.DeepPink),
+                "SCP" => (WpfBrushes.LightCyan, WpfBrushes.CadetBlue),
+                "MQTT" => (WpfBrushes.LightGoldenrodYellow, WpfBrushes.Goldenrod),
+                "FTP" => (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
                 _ => (WpfBrushes.LightGray, WpfBrushes.Gray)
             };
             OnPropertyChanged(nameof(BackgroundColor));

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -1,0 +1,76 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class MqttServiceViewModel : INotifyPropertyChanged
+    {
+        private string _host = string.Empty;
+        public string Host { get => _host; set { _host = value; OnPropertyChanged(); } }
+
+        private string _port = "1883";
+        public string Port { get => _port; set { _port = value; OnPropertyChanged(); } }
+
+        private string _clientId = "client1";
+        public string ClientId { get => _clientId; set { _clientId = value; OnPropertyChanged(); } }
+
+        private string _username = string.Empty;
+        public string Username { get => _username; set { _username = value; OnPropertyChanged(); } }
+
+        private string _password = string.Empty;
+        public string Password { get => _password; set { _password = value; OnPropertyChanged(); } }
+
+        private string _publishTopic = string.Empty;
+        public string PublishTopic { get => _publishTopic; set { _publishTopic = value; OnPropertyChanged(); } }
+
+        private string _publishMessage = string.Empty;
+        public string PublishMessage { get => _publishMessage; set { _publishMessage = value; OnPropertyChanged(); } }
+
+        private string _newTopic = string.Empty;
+        public string NewTopic { get => _newTopic; set { _newTopic = value; OnPropertyChanged(); } }
+
+        public ObservableCollection<string> Topics { get; } = new();
+
+        public ICommand AddTopicCommand { get; }
+        public ICommand RemoveTopicCommand { get; }
+        public ICommand ConnectCommand { get; }
+        public ICommand PublishCommand { get; }
+        public ICommand SaveCommand { get; }
+
+        public ILoggingService? Logger { get; set; }
+
+        private readonly MqttService _service = new();
+
+        public MqttServiceViewModel()
+        {
+            AddTopicCommand = new RelayCommand(() => { if(!string.IsNullOrWhiteSpace(NewTopic)){Topics.Add(NewTopic); NewTopic = string.Empty;} });
+            RemoveTopicCommand = new RelayCommand(() => { if(Topics.Contains(NewTopic)) Topics.Remove(NewTopic); });
+            ConnectCommand = new RelayCommand(async () => await ConnectAsync());
+            PublishCommand = new RelayCommand(async () => await PublishAsync());
+            SaveCommand = new RelayCommand(Save);
+        }
+
+        public async Task ConnectAsync()
+        {
+            await _service.ConnectAsync(Host, int.Parse(Port), ClientId, Username, Password);
+            await _service.SubscribeAsync(Topics);
+            Logger?.Log("MQTT connected", LogLevel.Debug);
+        }
+
+        public async Task PublishAsync()
+        {
+            if(string.IsNullOrWhiteSpace(PublishTopic) || string.IsNullOrWhiteSpace(PublishMessage))
+                return;
+            await _service.PublishAsync(PublishTopic, PublishMessage);
+            Logger?.Log($"Published to {PublishTopic}", LogLevel.Debug);
+        }
+
+        private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class ScpServiceViewModel : INotifyPropertyChanged
+    {
+        private string _host = string.Empty;
+        public string Host { get => _host; set { _host = value; OnPropertyChanged(); } }
+
+        private string _port = "22";
+        public string Port { get => _port; set { _port = value; OnPropertyChanged(); } }
+
+        private string _username = string.Empty;
+        public string Username { get => _username; set { _username = value; OnPropertyChanged(); } }
+
+        private string _password = string.Empty;
+        public string Password { get => _password; set { _password = value; OnPropertyChanged(); } }
+
+        private string _localPath = string.Empty;
+        public string LocalPath { get => _localPath; set { _localPath = value; OnPropertyChanged(); } }
+
+        private string _remotePath = string.Empty;
+        public string RemotePath { get => _remotePath; set { _remotePath = value; OnPropertyChanged(); } }
+
+        public ICommand BrowseCommand { get; }
+        public ICommand TransferCommand { get; }
+        public ICommand SaveCommand { get; }
+
+        public ILoggingService? Logger { get; set; }
+
+        public ScpServiceViewModel()
+        {
+            BrowseCommand = new RelayCommand(Browse);
+            TransferCommand = new RelayCommand(async () => await TransferAsync());
+            SaveCommand = new RelayCommand(Save);
+        }
+
+        private void Browse()
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog();
+            if (dialog.ShowDialog() == true)
+                LocalPath = dialog.FileName;
+        }
+
+        private async Task TransferAsync()
+        {
+            if (string.IsNullOrWhiteSpace(LocalPath) || string.IsNullOrWhiteSpace(RemotePath))
+                return;
+            var svc = new ScpService(Host, int.Parse(Port), Username, Password);
+            await svc.UploadAsync(LocalPath, RemotePath);
+            Logger?.Log("File transferred", LogLevel.Debug);
+        }
+
+        private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
@@ -1,0 +1,37 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.FTPServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0" Margin="10">
+            <TextBox Text="{Binding Host}" x:Name="HostBox" Margin="0,0,0,5"/>
+            <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                       Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <TextBox Text="{Binding Port}" Margin="0,0,0,5"/>
+            <TextBox Text="{Binding Username}" x:Name="UserBox" Margin="0,0,0,5"/>
+            <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                       Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <PasswordBox PasswordChar="*" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Margin="0,0,0,5"/>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                <TextBox Text="{Binding LocalPath}" Width="180"/>
+                <Button Content="Browse" Command="{Binding BrowseCommand}" Margin="5,0,0,0"/>
+            </StackPanel>
+            <TextBox Text="{Binding RemotePath}" Margin="0,0,0,5"/>
+            <Button Content="Send" Command="{Binding TransferCommand}" Width="100"/>
+        </StackPanel>
+        <StackPanel Grid.Column="1" Margin="10">
+            <TextBlock Text="Logs" FontWeight="Bold"/>
+            <RichTextBox x:Name="LogBox" Height="200" IsReadOnly="True"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class FTPServiceView : Page
+    {
+        private readonly FtpServiceViewModel _viewModel;
+        public FTPServiceView(FtpServiceViewModel vm)
+        {
+            InitializeComponent();
+            _viewModel = vm;
+            DataContext = vm;
+            _viewModel.Logger = new LoggingService(LogBox, Dispatcher);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
@@ -1,0 +1,52 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.MQTTServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBox Width="140" Text="{Binding Host}" x:Name="HostBox"/>
+            <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                       Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <TextBox Width="60" Margin="5,0,0,0" Text="{Binding Port}"/>
+            <TextBox Width="100" Margin="5,0,0,0" Text="{Binding ClientId}"/>
+            <TextBox Width="100" Margin="5,0,0,0" Text="{Binding Username}"/>
+            <PasswordBox Width="100" Margin="5,0,0,0" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}"/>
+            <Button Content="Connect" Command="{Binding ConnectCommand}" Margin="5,0,0,0" Width="80"/>
+        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                    <TextBox Width="200" Text="{Binding PublishTopic}"/>
+                    <TextBox Width="200" Margin="5,0,0,0" Text="{Binding PublishMessage}"/>
+                    <Button Content="Send" Width="60" Margin="5,0,0,0" Command="{Binding PublishCommand}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                    <TextBox Width="200" Text="{Binding NewTopic}"/>
+                    <Button Content="Add" Width="50" Margin="5,0,0,0" Command="{Binding AddTopicCommand}"/>
+                    <Button Content="Remove" Width="60" Margin="5,0,0,0" Command="{Binding RemoveTopicCommand}"/>
+                </StackPanel>
+                <ListBox ItemsSource="{Binding Topics}" Height="120" Margin="0,10,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Margin="10,0,0,0">
+                <TextBlock Text="Logs" FontWeight="Bold"/>
+                <RichTextBox x:Name="LogBox" Height="200" IsReadOnly="True"/>
+            </StackPanel>
+        </Grid>
+        <Button Grid.Row="2" Content="Save Configuration" Command="{Binding SaveCommand}" Width="150" HorizontalAlignment="Right" Margin="0,10,0,0"/>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class MQTTServiceView : Page
+    {
+        private readonly MqttServiceViewModel _viewModel;
+        public MQTTServiceView(MqttServiceViewModel vm)
+        {
+            InitializeComponent();
+            _viewModel = vm;
+            DataContext = vm;
+            _viewModel.Logger = new LoggingService(LogBox, Dispatcher);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -63,11 +63,24 @@ namespace DesktopApplicationTemplate.UI.Views
                     "File Observer" => App.AppHost.Services.GetRequiredService<FileObserverView>(),
                     "HID" => new HidViews(),
                     "Heartbeat" => new HeartbeatView(App.AppHost.Services.GetRequiredService<HeartbeatViewModel>()),
+                    "SCP" => new SCPServiceView(App.AppHost.Services.GetRequiredService<ScpServiceViewModel>()),
+                    "MQTT" => new MQTTServiceView(App.AppHost.Services.GetRequiredService<MqttServiceViewModel>()),
+                    "FTP" => new FTPServiceView(App.AppHost.Services.GetRequiredService<FtpServiceViewModel>()),
                     _ => null
                 };
 
                 _viewModel.Services.Add(newService);
                 _viewModel.SelectedService = newService;
+
+                if (type == "MQTT" && newService.ServicePage is MQTTServiceView mqttView)
+                {
+                    var vm = (MqttServiceViewModel)mqttView.DataContext!;
+                    newService.ActiveChanged += async active =>
+                    {
+                        if (active)
+                            await vm.ConnectAsync();
+                    };
+                }
 
                 if (newService.ServicePage != null)
                 {

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml
@@ -1,0 +1,37 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.SCPServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
+    <Grid Margin="10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0" Margin="10">
+            <TextBox Text="{Binding Host}" x:Name="HostBox" Margin="0,0,0,5"/>
+            <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                       Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <TextBox Text="{Binding Port}" Margin="0,0,0,5"/>
+            <TextBox Text="{Binding Username}" x:Name="UserBox" Margin="0,0,0,5"/>
+            <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                       Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <PasswordBox PasswordChar="*" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Margin="0,0,0,5"/>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                <TextBox Text="{Binding LocalPath}" Width="180"/>
+                <Button Content="Browse" Command="{Binding BrowseCommand}" Margin="5,0,0,0"/>
+            </StackPanel>
+            <TextBox Text="{Binding RemotePath}" Margin="0,0,0,5"/>
+            <Button Content="Send" Command="{Binding TransferCommand}" Width="100"/>
+        </StackPanel>
+        <StackPanel Grid.Column="1" Margin="10">
+            <TextBlock Text="Logs" FontWeight="Bold"/>
+            <RichTextBox x:Name="LogBox" Height="200" IsReadOnly="True"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -1,0 +1,18 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class SCPServiceView : Page
+    {
+        private readonly ScpServiceViewModel _viewModel;
+        public SCPServiceView(ScpServiceViewModel vm)
+        {
+            InitializeComponent();
+            _viewModel = vm;
+            DataContext = vm;
+            _viewModel.Logger = new LoggingService(LogBox, Dispatcher);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement SCP, MQTT and FTP services with views and view models
- register new services in DI container
- add activation hook for MQTT
- extend service creation choices and color scheme
- implement helper for binding PasswordBox
- add unit tests for new view models
- add network packages to UI project

## Testing
- `dotnet restore DesktopApplicationTemplate.sln`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop/targets not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop/targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881206ef22083269bd776a5ac14e661