### PR TITLE
Improve logging coverage

### DIFF
--- a/DesktopApplicationTemplate.Service/Worker.cs
+++ b/DesktopApplicationTemplate.Service/Worker.cs
@@ -27,14 +27,28 @@ namespace DesktopApplicationTemplate.Service
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             _logger.LogInformation("Service starting at: {time}", DateTimeOffset.Now);
+            _logger.LogDebug("Heartbeat interval set to {interval}s with message '{message}'", IntervalSeconds, HeartbeatMessage);
 
-            while (!stoppingToken.IsCancellationRequested)
+            try
             {
-                _logger.LogInformation("Heartbeat: {message}", HeartbeatMessage);
-                await Task.Delay(TimeSpan.FromSeconds(IntervalSeconds), stoppingToken);
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogDebug("Sending heartbeat message: {message}", HeartbeatMessage);
+                    await Task.Delay(TimeSpan.FromSeconds(IntervalSeconds), stoppingToken);
+                }
             }
-
-            _logger.LogInformation("Service stopping at: {time}", DateTimeOffset.Now);
+            catch (TaskCanceledException)
+            {
+                _logger.LogWarning("Heartbeat task cancelled");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Unhandled exception in Worker");
+            }
+            finally
+            {
+                _logger.LogInformation("Service stopping at: {time}", DateTimeOffset.Now);
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ILoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/ILoggingService.cs
@@ -15,6 +15,7 @@ namespace DesktopApplicationTemplate.UI.Services
     {
         Debug,
         Warning,
-        Error
+        Error,
+        Critical
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -32,6 +32,7 @@ namespace DesktopApplicationTemplate.UI.Services
                     LogLevel.Debug => WpfBrushes.Black,
                     LogLevel.Warning => WpfBrushes.Orange,
                     LogLevel.Error => WpfBrushes.Red,
+                    LogLevel.Critical => WpfBrushes.Purple,
                     _ => WpfBrushes.Black
                 };
 

--- a/DesktopApplicationTemplate.UI/Services/StartupService.cs
+++ b/DesktopApplicationTemplate.UI/Services/StartupService.cs
@@ -13,26 +13,30 @@ namespace DesktopApplicationTemplate.UI.Services
     {
         private readonly IConfiguration _configuration;
         private readonly AppSettings _appSettings;
+        private readonly ILoggingService? _logger;
 
-        public StartupService(IConfiguration configuration)
+        public StartupService(IConfiguration configuration, ILoggingService? logger = null)
         {
             _configuration = configuration;
             _appSettings = _configuration.GetSection("AppSettings").Get<AppSettings>() ?? new AppSettings();
+            _logger = logger;
         }
 
 
         public async Task RunStartupChecksAsync()
         {
-            Console.WriteLine($"[Startup] Environment: {_appSettings.Environment}");
+            _logger?.Log($"Environment: {_appSettings.Environment}", LogLevel.Debug);
             await Task.Run(() => DependencyChecker.CheckAll());
 
             if (_appSettings.AutoStart)
             {
                 AutoStartHelper.EnableAutoStart();
+                _logger?.Log("Auto-start enabled", LogLevel.Debug);
             }
             else
             {
                 AutoStartHelper.DisableAutoStart();
+                _logger?.Log("Auto-start disabled", LogLevel.Debug);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Windows.Input;
 using System.Threading.Tasks;
 using System.Windows;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -69,6 +70,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand SendCommand { get; }
         public ICommand SaveCommand { get; }
 
+        public ILoggingService? Logger { get; set; }
+
         public HttpServiceViewModel()
         {
             SendCommand = new RelayCommand(async () => await SendRequestAsync());
@@ -91,6 +94,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (string.IsNullOrWhiteSpace(Url))
             {
                 ResponseBody = "URL is required";
+                Logger?.Log("SendRequestAsync called with empty URL", LogLevel.Warning);
                 return;
             }
 
@@ -98,6 +102,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             try
             {
                 using var request = new HttpRequestMessage(new HttpMethod(SelectedMethod), Url);
+                Logger?.Log($"Sending {SelectedMethod} request to {Url}", LogLevel.Debug);
 
                 foreach (var h in Headers)
                 {
@@ -113,14 +118,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 HttpResponseMessage response = await client.SendAsync(request);
                 StatusCode = (int)response.StatusCode;
                 ResponseBody = await response.Content.ReadAsStringAsync();
+                Logger?.Log($"Received response with status {StatusCode}", LogLevel.Debug);
             }
             catch (HttpRequestException ex)
             {
                 ResponseBody = $"Error: {ex.Message}";
+                Logger?.Log($"HTTP error: {ex.Message}", LogLevel.Error);
             }
             catch (System.Exception ex)
             {
                 ResponseBody = $"Unexpected error: {ex.Message}";
+                Logger?.Log($"Critical error: {ex.Message}", LogLevel.Critical);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -124,14 +124,28 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private void ToggleServer()
         {
             IsServerRunning = !IsServerRunning;
-            Logger?.Log(IsServerRunning ? "Server Started" : "Server Stopped", LogLevel.Debug);
+            if (IsServerRunning)
+                Logger?.Log($"Server started on {ComputerIp}:{ListeningPort}", LogLevel.Debug);
+            else
+                Logger?.Log("Server stopped", LogLevel.Debug);
         }
 
         private void TestScript()
         {
-            var result = ScriptContent.Replace("message", TestMessage);
-            Logger?.Log($"Script output: {result}", LogLevel.Debug);
-            System.Windows.MessageBox.Show(result, "Test Result");
+            if (string.IsNullOrWhiteSpace(TestMessage))
+            {
+                Logger?.Log("TestScript called with empty message", LogLevel.Warning);
+            }
+            try
+            {
+                var result = ScriptContent.Replace("message", TestMessage);
+                Logger?.Log($"Script output: {result}", LogLevel.Debug);
+                System.Windows.MessageBox.Show(result, "Test Result");
+            }
+            catch (System.Exception ex)
+            {
+                Logger?.Log($"Script execution error: {ex.Message}", LogLevel.Error);
+            }
         }
 
         private void Save()

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -18,6 +18,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -63,7 +64,9 @@
             </StackPanel>
         </Grid>
 
-        <StackPanel Grid.Row="3" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <RichTextBox x:Name="LogBox" Grid.Row="3" Height="120" IsReadOnly="True" VerticalScrollBarVisibility="Auto" Margin="0,10,0,0" />
+
+        <StackPanel Grid.Row="4" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Save Configuration" Command="{Binding SaveCommand}" Width="150"/>
         </StackPanel>
     </Grid>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -27,6 +28,7 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
             _viewModel = viewModel;
             DataContext = _viewModel;
+            _viewModel.Logger = new LoggingService(LogBox, Dispatcher);
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `ILoggingService` with a `Critical` log level
- output critical messages in the `LoggingService`
- wire the HTTP service view with a log panel and log connection activity
- improve server debug logs in TCP service view model
- add detailed startup and heartbeat logs in the service worker

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_688120e7a9e88326a5fe78dace71f2eb