### PR TITLE
Update logging for critical level

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -32,7 +32,7 @@ namespace DesktopApplicationTemplate.UI.Services
                     LogLevel.Debug => WpfBrushes.Black,
                     LogLevel.Warning => WpfBrushes.Orange,
                     LogLevel.Error => WpfBrushes.Red,
-                    LogLevel.Critical => WpfBrushes.Purple,
+                    LogLevel.Critical => WpfBrushes.DarkRed,
                     _ => WpfBrushes.Black
                 };
 


### PR DESCRIPTION
## Summary
- add color for `LogLevel.Critical` in `LoggingService`

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812a23df6483269cff9c1aafea4909