### PR TITLE
Add debug logging for network operations

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -109,16 +109,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     if (!string.IsNullOrWhiteSpace(h.Key))
                         request.Headers.TryAddWithoutValidation(h.Key, h.Value);
                 }
+                var headerSummary = string.Join(", ", Headers.Where(h => !string.IsNullOrWhiteSpace(h.Key)).Select(h => $"{h.Key}:{h.Value}"));
+                if (!string.IsNullOrWhiteSpace(headerSummary))
+                    Logger?.Log($"Headers: {headerSummary}", LogLevel.Debug);
 
                 if (SelectedMethod != "GET" && SelectedMethod != "DELETE")
                 {
                     request.Content = new StringContent(RequestBody ?? string.Empty, Encoding.UTF8, "application/json");
+                    Logger?.Log($"Request Body: {RequestBody}", LogLevel.Debug);
                 }
 
                 HttpResponseMessage response = await client.SendAsync(request);
                 StatusCode = (int)response.StatusCode;
                 ResponseBody = await response.Content.ReadAsStringAsync();
                 Logger?.Log($"Received response with status {StatusCode}", LogLevel.Debug);
+                Logger?.Log($"Response Body: {ResponseBody}", LogLevel.Debug);
             }
             catch (HttpRequestException ex)
             {

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -76,7 +76,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public string TestMessage
         {
             get => _testMessage;
-            set { _testMessage = value; OnPropertyChanged(); }
+            set
+            {
+                _testMessage = value;
+                OnPropertyChanged();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    Logger?.Log($"Received test message: {value}", LogLevel.Debug);
+                }
+            }
         }
 
         public ICommand ToggleServerCommand { get; }
@@ -123,6 +131,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void ToggleServer()
         {
+            Logger?.Log("Toggling server state", LogLevel.Debug);
             IsServerRunning = !IsServerRunning;
             if (IsServerRunning)
                 Logger?.Log($"Server started on {ComputerIp}:{ListeningPort}", LogLevel.Debug);
@@ -136,6 +145,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 Logger?.Log("TestScript called with empty message", LogLevel.Warning);
             }
+            Logger?.Log($"Executing script using {SelectedLanguage}", LogLevel.Debug);
             try
             {
                 var result = ScriptContent.Replace("message", TestMessage);


### PR DESCRIPTION
## Summary
- enhance `TcpServiceViewModel` with more debug logs
- record headers, body, and responses in `HttpServiceViewModel`

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build --verbosity normal` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68812a24a0b88326b7c4eb0dd6123980