### PR TITLE
Update installer with network libs

### DIFF
--- a/DesktopApplication.Installer/DesktopApplication.Installer.csproj
+++ b/DesktopApplication.Installer/DesktopApplication.Installer.csproj
@@ -11,6 +11,11 @@
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.UI\DesktopApplicationTemplate.UI.csproj" />
     <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="9.0.7" />
+    <PackageReference Include="SSH.NET" Version="2020.0.1" />
+    <PackageReference Include="MQTTnet" Version="4.1.0.247" />
+    <PackageReference Include="FluentFTP" Version="53.0.1" />
   </ItemGroup>
 
 </Project>

--- a/DesktopApplication.Installer/ViewModels/ProgressWindowViewModel.cs
+++ b/DesktopApplication.Installer/ViewModels/ProgressWindowViewModel.cs
@@ -86,6 +86,13 @@ namespace DesktopApplication.Installer.ViewModels
             LogText += message + Environment.NewLine;
         }
 
+        private static readonly string[] AdditionalAssemblies =
+        {
+            "Renci.SshNet.dll",
+            "MQTTnet.dll",
+            "FluentFTP.dll"
+        };
+
         private void CopyApplicationFiles()
         {
             var sourceDir = AppContext.BaseDirectory;
@@ -94,6 +101,17 @@ namespace DesktopApplication.Installer.ViewModels
                 var dest = Path.Combine(_installPath, Path.GetFileName(file));
                 File.Copy(file, dest, overwrite: true);
             }
+
+            foreach (var name in AdditionalAssemblies)
+            {
+                var file = Directory.EnumerateFiles(sourceDir, name, SearchOption.AllDirectories).FirstOrDefault();
+                if (file is not null)
+                {
+                    var dest = Path.Combine(_installPath, Path.GetFileName(file));
+                    File.Copy(file, dest, overwrite: true);
+                }
+            }
+
             foreach (var dir in Directory.GetDirectories(sourceDir))
             {
                 var destDir = Path.Combine(_installPath, Path.GetFileName(dir));


### PR DESCRIPTION
## Summary
- reference network packages from Installer csproj
- ensure installer copy routine explicitly copies new assemblies

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812a2a350c83269ef3cb60b6227058