### PR TITLE
Add logging service tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -1,0 +1,30 @@
+using DesktopApplicationTemplate.UI.Services;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Threading;
+using Xunit;
+using System.Text.RegularExpressions;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class LoggingServiceTests
+    {
+        [Theory]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        public void Log_AddsFormattedMessageToRichTextBox(LogLevel level)
+        {
+            var box = new RichTextBox();
+            var service = new LoggingService(box, Dispatcher.CurrentDispatcher);
+
+            service.Log("test", level);
+
+            string text = new TextRange(box.Document.ContentStart, box.Document.ContentEnd).Text.Trim();
+            Assert.Contains("test", text);
+            Assert.Contains($"[{level}]", text);
+            Assert.Matches(@"\[\d{2}:\d{2}:\d{2}\]", text);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -1,0 +1,36 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Services;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class TcpHttpViewModelLoggingTests
+    {
+        [Fact]
+        public void TcpService_ToggleServer_LogsMessage()
+        {
+            var logger = new TestLogger();
+            var vm = new TcpServiceViewModel { Logger = logger };
+            vm.ComputerIp = "127.0.0.1";
+            vm.ListeningPort = "5000";
+
+            vm.ToggleServerCommand.Execute(null);
+
+            Assert.Single(logger.Entries);
+        }
+
+        [Fact]
+        public async Task HttpService_InvalidUrl_LogsWarning()
+        {
+            var logger = new TestLogger();
+            var vm = new HttpServiceViewModel { Logger = logger };
+            vm.Url = string.Empty;
+
+            await vm.SendRequestAsync();
+
+            Assert.Single(logger.Entries);
+            Assert.Equal(LogLevel.Warning, logger.Entries[0].Level);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/TestLogger.cs
+++ b/DesktopApplicationTemplate.Tests/TestLogger.cs
@@ -1,0 +1,15 @@
+using DesktopApplicationTemplate.UI.Services;
+using System.Collections.Generic;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class TestLogger : ILoggingService
+    {
+        public List<(string Message, LogLevel Level)> Entries { get; } = new();
+
+        public void Log(string message, LogLevel level)
+        {
+            Entries.Add((message, level));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test LoggingService formatting for all log levels
- test that TcpServiceViewModel and HttpServiceViewModel call logger

## Testing
- `dotnet test --no-build -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68812a2c574c832693abf33698f2491a