### PR TITLE
Fix FtpClient initialization

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FtpService.cs
@@ -8,7 +8,7 @@ namespace DesktopApplicationTemplate.UI.Services
         private readonly FtpClient _client;
         public FtpService(string host, int port, string user, string pass)
         {
-            _client = new FtpClient(host, port, user, pass);
+            _client = new FtpClient(host, port, new System.Net.NetworkCredential(user, pass));
         }
 
         public async Task UploadAsync(string localPath, string remotePath)


### PR DESCRIPTION
## Summary
- fix how the FTP client is instantiated using NetworkCredential

## Testing
- `dotnet restore DesktopApplicationTemplate.sln`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68813cef82d083268e6a19d73aaa64c2