### PR TITLE
Improve service editing and logging

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
@@ -1,6 +1,6 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.CreateServiceWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Create Service" Height="300" Width="450">
+        Title="Create Service" SizeToContent="WidthAndHeight">
     <Frame x:Name="ContentFrame" NavigationUIVisibility="Hidden" />
 </Window>

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         mc:Ignorable="d"
-        Title="CSV Viewer" Height="350" Width="600">
+        Title="CSV Viewer" SizeToContent="WidthAndHeight">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.FilterWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Filter Services" Height="230" Width="300">
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        Title="Filter Services" SizeToContent="WidthAndHeight">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -18,21 +19,25 @@
         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,5">
             <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <ComboBox Width="200" SelectedItem="{Binding TypeFilter}">
-                <ComboBoxItem>All</ComboBoxItem>
-                <ComboBoxItem>TCP</ComboBoxItem>
-                <ComboBoxItem>HTTP</ComboBoxItem>
-                <ComboBoxItem>File Observer</ComboBoxItem>
-                <ComboBoxItem>HID</ComboBoxItem>
-                <ComboBoxItem>Heartbeat</ComboBoxItem>
+                <ComboBox.Items>
+                    <sys:String>All</sys:String>
+                    <sys:String>TCP</sys:String>
+                    <sys:String>HTTP</sys:String>
+                    <sys:String>File Observer</sys:String>
+                    <sys:String>HID</sys:String>
+                    <sys:String>Heartbeat</sys:String>
+                </ComboBox.Items>
             </ComboBox>
         </StackPanel>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,5">
             <TextBlock Text="Status:" VerticalAlignment="Center" Margin="0,0,5,0"/>
             <ComboBox Width="200" SelectedItem="{Binding StatusFilter}">
-                <ComboBoxItem>All</ComboBoxItem>
-                <ComboBoxItem>Active</ComboBoxItem>
-                <ComboBoxItem>Inactive</ComboBoxItem>
+                <ComboBox.Items>
+                    <sys:String>All</sys:String>
+                    <sys:String>Active</sys:String>
+                    <sys:String>Inactive</sys:String>
+                </ComboBox.Items>
             </ComboBox>
         </StackPanel>
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -87,7 +87,7 @@
             <TextBlock Text="{Binding ServicesCreated}" />
             <TextBlock Text="Current Active Services:" />
             <TextBlock Text="{Binding CurrentActiveServices}" />
-            <ListBox ItemsSource="{Binding SelectedService.Logs}" Height="150">
+            <ListBox ItemsSource="{Binding DisplayLogs}" Height="150">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.ScriptEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Script Editor" Height="400" Width="600">
+        Title="Script Editor" SizeToContent="WidthAndHeight">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
@@ -1,6 +1,6 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Service Editor" Height="450" Width="800">
+        Title="Service Editor" SizeToContent="WidthAndHeight">
     <Frame x:Name="EditorFrame" NavigationUIVisibility="Hidden" />
 </Window>


### PR DESCRIPTION
## Summary
- ensure log window always displays latest logs
- allow editing services created previously
- fix filtering dropdown to use string values
- resize popup windows automatically

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881499608f48326b5ea3d961e4f494d