### PR TITLE
Add placeholders for all service views

### DIFF
--- a/DesktopApplication.Installer/DesktopApplication.Installer.csproj
+++ b/DesktopApplication.Installer/DesktopApplication.Installer.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="9.0.7" />
     <PackageReference Include="SSH.NET" Version="2025.0.0" />
-    <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="FluentFTP" Version="53.0.1" />
   </ItemGroup>
 

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
@@ -15,7 +15,12 @@
 
         <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
             <TextBlock Text="File Name Pattern:" VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <TextBox Width="300" Text="{Binding Configuration.FileNamePattern}"/>
+            <Grid Width="300">
+                <TextBox Text="{Binding Configuration.FileNamePattern}" x:Name="PatternBox"/>
+                <TextBlock Text="e.g. *.csv" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=PatternBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
         </StackPanel>
 
         <DataGrid Grid.Row="1" ItemsSource="{Binding Configuration.Columns}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedColumn}">

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
@@ -14,19 +14,40 @@
             <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
         <StackPanel Grid.Column="0" Margin="10">
-            <TextBox Text="{Binding Host}" x:Name="HostBox" Margin="0,0,0,5"/>
-            <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                       Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            <TextBox Text="{Binding Port}" Margin="0,0,0,5"/>
-            <TextBox Text="{Binding Username}" x:Name="UserBox" Margin="0,0,0,5"/>
-            <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                       Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding Host}" x:Name="HostBox"/>
+                <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding Port}" x:Name="PortBox"/>
+                <TextBlock Text="Port" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding Username}" x:Name="UserBox"/>
+                <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <PasswordBox PasswordChar="*" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Margin="0,0,0,5"/>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                <TextBox Text="{Binding LocalPath}" Width="180"/>
+                <Grid Width="180">
+                    <TextBox Text="{Binding LocalPath}" x:Name="LocalPathBox"/>
+                    <TextBlock Text="Local Path" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                               VerticalAlignment="Center"
+                               Visibility="{Binding Text, ElementName=LocalPathBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
                 <Button Content="Browse" Command="{Binding BrowseCommand}" Margin="5,0,0,0"/>
             </StackPanel>
-            <TextBox Text="{Binding RemotePath}" Margin="0,0,0,5"/>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding RemotePath}" x:Name="RemotePathBox"/>
+                <TextBlock Text="Remote Path" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=RemotePathBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <Button Content="Send" Command="{Binding TransferCommand}" Width="100"/>
         </StackPanel>
         <StackPanel Grid.Column="1" Margin="10">

--- a/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
@@ -40,30 +40,55 @@
 
             <!-- File Path -->
             <StackPanel Orientation="Horizontal" Margin="0 20 0 0">
-                <TextBox Width="400" Text="{Binding FilePath}" />
+                <Grid Width="400">
+                    <TextBox Text="{Binding FilePath}" x:Name="FilePathBox"/>
+                    <TextBlock Text="File Path" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                               VerticalAlignment="Center"
+                               Visibility="{Binding Text, ElementName=FilePathBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
                 <Button Content="Browse" Width="75" Margin="5,0,0,0" Command="{Binding BrowseCommand}" />
             </StackPanel>
 
             <!-- Contents Preview -->
             <TextBlock Text="Contents:" Margin="0,10,0,5"/>
-            <TextBox Height="80" Text="{Binding Contents}" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            <Grid>
+                <TextBox Height="80" Text="{Binding Contents}" x:Name="ContentsBox" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                <TextBlock Text="File Contents" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=ContentsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <!-- Options -->
             <StackPanel Orientation="Vertical" Margin="0,10,0,0">
                 <CheckBox Content="Send All Images" IsChecked="{Binding SendAllImages}" />
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                     <CheckBox Content="Send first {x} Images" IsChecked="{Binding SendFirstXEnabled}" />
-                    <TextBox Width="50" Margin="10,0,0,0" Text="{Binding SendXCount}" />
+                    <Grid Width="50" Margin="10,0,0,0">
+                        <TextBox Text="{Binding SendXCount}" x:Name="SendXCountBox"/>
+                        <TextBlock Text="X" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Visibility="{Binding Text, ElementName=SendXCountBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                    </Grid>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                     <CheckBox Content="Send Images TCP command" IsChecked="{Binding SendTcpCommandEnabled}" />
-                    <TextBox Width="150" Margin="10,0,0,0" Text="{Binding TcpCommand}" />
+                    <Grid Width="150" Margin="10,0,0,0">
+                        <TextBox Text="{Binding TcpCommand}" x:Name="TcpCommandBox"/>
+                        <TextBlock Text="TCP Command" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Visibility="{Binding Text, ElementName=TcpCommandBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                    </Grid>
                 </StackPanel>
             </StackPanel>
 
             <!-- New Image Names -->
             <TextBlock Text="New Image Names {Indexed}" Margin="0,15,0,5"/>
-            <TextBox Height="80" Text="{Binding ImageNames}" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+            <Grid>
+                <TextBox Height="80" Text="{Binding ImageNames}" x:Name="ImageNamesBox" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+                <TextBlock Text="One per line" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=ImageNamesBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
         </StackPanel>
 
         <StackPanel Grid.ColumnSpan="2" Grid.Row="2" HorizontalAlignment="Right" Margin="0,10,0,0">

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
@@ -12,7 +12,12 @@
         <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
         <StackPanel Margin="0,50,0,0">
             <TextBlock Text="Heartbeat Message" FontWeight="Bold" Margin="0,0,0,5"/>
-            <TextBox Text="{Binding BaseMessage}" Width="300"/>
+            <Grid Width="300">
+                <TextBox Text="{Binding BaseMessage}" x:Name="BaseMessageBox"/>
+                <TextBlock Text="Base message" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=BaseMessageBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <CheckBox Content="Include PING" IsChecked="{Binding IncludePing}" Margin="0,5,0,0"/>
             <CheckBox Content="Include STATUS" IsChecked="{Binding IncludeStatus}" Margin="0,5,0,0"/>
             <Button Content="Build" Command="{Binding BuildCommand}" Width="100" Margin="0,10,0,0"/>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -57,9 +57,19 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <TextBox Grid.Column="0" Text="{Binding RequestBody}" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
+            <Grid Grid.Column="0">
+                <TextBox Text="{Binding RequestBody}" x:Name="RequestBodyBox" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
+                <TextBlock Text="Request Body" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=RequestBodyBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <StackPanel Grid.Column="1">
-                <TextBox Text="{Binding ResponseBody}" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" IsReadOnly="True" Height="120"/>
+                <Grid>
+                    <TextBox Text="{Binding ResponseBody}" x:Name="ResponseBodyBox" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" IsReadOnly="True" Height="120"/>
+                    <TextBlock Text="Response Body" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                               VerticalAlignment="Center"
+                               Visibility="{Binding Text, ElementName=ResponseBodyBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
                 <TextBlock Text="Status: {Binding StatusCode}" Margin="0,5,0,0"/>
             </StackPanel>
         </Grid>

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
@@ -15,12 +15,30 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBox Width="140" Text="{Binding Host}" x:Name="HostBox"/>
-            <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                       Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            <TextBox Width="60" Margin="5,0,0,0" Text="{Binding Port}"/>
-            <TextBox Width="100" Margin="5,0,0,0" Text="{Binding ClientId}"/>
-            <TextBox Width="100" Margin="5,0,0,0" Text="{Binding Username}"/>
+            <Grid Width="140">
+                <TextBox Text="{Binding Host}" x:Name="HostBox"/>
+                <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Width="60" Margin="5,0,0,0">
+                <TextBox Text="{Binding Port}" x:Name="PortBox"/>
+                <TextBlock Text="Port" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Width="100" Margin="5,0,0,0">
+                <TextBox Text="{Binding ClientId}" x:Name="ClientIdBox"/>
+                <TextBlock Text="Client ID" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=ClientIdBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Width="100" Margin="5,0,0,0">
+                <TextBox Text="{Binding Username}" x:Name="UserBox"/>
+                <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <PasswordBox Width="100" Margin="5,0,0,0" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}"/>
             <Button Content="Connect" Command="{Binding ConnectCommand}" Margin="5,0,0,0" Width="80"/>
         </StackPanel>
@@ -31,12 +49,27 @@
             </Grid.ColumnDefinitions>
             <StackPanel Grid.Column="0">
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBox Width="200" Text="{Binding PublishTopic}"/>
-                    <TextBox Width="200" Margin="5,0,0,0" Text="{Binding PublishMessage}"/>
+                    <Grid Width="200">
+                        <TextBox Text="{Binding PublishTopic}" x:Name="PublishTopicBox"/>
+                        <TextBlock Text="Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Visibility="{Binding Text, ElementName=PublishTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                    </Grid>
+                    <Grid Width="200" Margin="5,0,0,0">
+                        <TextBox Text="{Binding PublishMessage}" x:Name="PublishMessageBox"/>
+                        <TextBlock Text="Message" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Visibility="{Binding Text, ElementName=PublishMessageBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                    </Grid>
                     <Button Content="Send" Width="60" Margin="5,0,0,0" Command="{Binding PublishCommand}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                    <TextBox Width="200" Text="{Binding NewTopic}"/>
+                    <Grid Width="200">
+                        <TextBox Text="{Binding NewTopic}" x:Name="NewTopicBox"/>
+                        <TextBlock Text="New Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Visibility="{Binding Text, ElementName=NewTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                    </Grid>
                     <Button Content="Add" Width="50" Margin="5,0,0,0" Command="{Binding AddTopicCommand}"/>
                     <Button Content="Remove" Width="60" Margin="5,0,0,0" Command="{Binding RemoveTopicCommand}"/>
                 </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml
@@ -14,19 +14,40 @@
             <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
         <StackPanel Grid.Column="0" Margin="10">
-            <TextBox Text="{Binding Host}" x:Name="HostBox" Margin="0,0,0,5"/>
-            <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                       Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            <TextBox Text="{Binding Port}" Margin="0,0,0,5"/>
-            <TextBox Text="{Binding Username}" x:Name="UserBox" Margin="0,0,0,5"/>
-            <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                       Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding Host}" x:Name="HostBox"/>
+                <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding Port}" x:Name="PortBox"/>
+                <TextBlock Text="Port" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding Username}" x:Name="UserBox"/>
+                <TextBlock Text="Username" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=UserBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <PasswordBox PasswordChar="*" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Margin="0,0,0,5"/>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                <TextBox Text="{Binding LocalPath}" Width="180"/>
+                <Grid Width="180">
+                    <TextBox Text="{Binding LocalPath}" x:Name="LocalPathBox"/>
+                    <TextBlock Text="Local Path" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                               VerticalAlignment="Center"
+                               Visibility="{Binding Text, ElementName=LocalPathBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
                 <Button Content="Browse" Command="{Binding BrowseCommand}" Margin="5,0,0,0"/>
             </StackPanel>
-            <TextBox Text="{Binding RemotePath}" Margin="0,0,0,5"/>
+            <Grid Margin="0,0,0,5">
+                <TextBox Text="{Binding RemotePath}" x:Name="RemotePathBox"/>
+                <TextBlock Text="Remote Path" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                           VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=RemotePathBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
             <Button Content="Send" Command="{Binding TransferCommand}" Width="100"/>
         </StackPanel>
         <StackPanel Grid.Column="1" Margin="10">


### PR DESCRIPTION
## Summary
- add placeholder text to service views and windows so users know what data belongs in each field
- update installer project to align MQTTnet package version

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688149ef399083269714ea74d5e1eb7a