### PR TITLE
Refactor view models to share base

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -1,10 +1,8 @@
 ﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class CreateServiceViewModel : INotifyPropertyChanged
+    public class CreateServiceViewModel : ViewModelBase
     {
         public ObservableCollection<string> ServiceTypes { get; } = new()
         {
@@ -26,8 +24,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             set { _selectedServiceType = value; OnPropertyChanged(); }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged provided by ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/CsvViewerViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CsvViewerViewModel.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows.Input;
 
@@ -20,7 +18,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ObservableCollection<CsvColumnConfig> Columns { get; set; } = new();
     }
 
-    public class CsvViewerViewModel : INotifyPropertyChanged
+    public class CsvViewerViewModel : ViewModelBase
     {
         private const string ConfigPath = "csv_config.json";
 
@@ -58,8 +56,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             System.IO.File.WriteAllText(ConfigPath, json);
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // Uses OnPropertyChanged from ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -6,7 +6,7 @@ using System.Windows;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class FileObserverViewModel : INotifyPropertyChanged
+    public class FileObserverViewModel : ViewModelBase
     {
         public ObservableCollection<FileObserver> Observers { get; } = new();
         private FileObserver? _selectedObserver;
@@ -133,9 +133,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged inherited from ViewModelBase
     }
 
     public class FileObserver

--- a/DesktopApplicationTemplate.UI/ViewModels/FilterViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FilterViewModel.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class FilterViewModel : INotifyPropertyChanged
+    public class FilterViewModel : ViewModelBase
     {
         private string _nameFilter = string.Empty;
         public string NameFilter
@@ -26,8 +26,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             set { _statusFilter = value; OnPropertyChanged(); }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged from ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -5,7 +5,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class FtpServiceViewModel : INotifyPropertyChanged
+    public class FtpServiceViewModel : ViewModelBase
     {
         private string _host = string.Empty;
         public string Host { get => _host; set { _host = value; OnPropertyChanged(); } }
@@ -56,7 +56,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged provided by ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
@@ -5,7 +5,7 @@ using System.Windows;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class HeartbeatViewModel : INotifyPropertyChanged
+    public class HeartbeatViewModel : ViewModelBase
     {
         private string _baseMessage = "HEARTBEAT";
         public string BaseMessage
@@ -63,8 +63,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged from ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -10,7 +10,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class HttpServiceViewModel : INotifyPropertyChanged
+    public class HttpServiceViewModel : ViewModelBase
     {
         public ObservableCollection<string> Methods { get; } = new() { "GET", "POST", "PUT", "DELETE" };
 
@@ -137,8 +137,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged is inherited from ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -17,7 +17,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public WpfBrush Color { get; set; } = WpfBrushes.Black;
     }
 
-    public class ServiceViewModel : INotifyPropertyChanged
+    public class ServiceViewModel : ViewModelBase
     {
         public string DisplayName { get; set; }
         public string ServiceType { get; set; } = string.Empty;
@@ -62,30 +62,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public event Action<bool>? ActiveChanged;
 
         public event Action<ServiceViewModel, LogEntry>? LogAdded;
+
         public void AddLog(string message, WpfBrush? color = null)
         {
-            string ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss:ff");
+            var ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
             var entry = new LogEntry { Message = $"{ts} {message}", Color = color ?? WpfBrushes.Black };
             Logs.Insert(0, entry);
             LogAdded?.Invoke(this, entry);
         }
-
-
-        public void AddLog(string message)
-        {
-            var timestamp = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
-            var entry = new LogEntry
-            {
-                Message = $"{timestamp} {message}",
-                Color = WpfBrushes.Black
-            };
-            Logs.Insert(0, entry);
-            LogAdded?.Invoke(this, entry);
-        }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null) =>
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 
         public void SetColorsByType()
         {
@@ -107,7 +91,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     }
 
 
-    public class MainViewModel : INotifyPropertyChanged
+    public class MainViewModel : ViewModelBase
     {
         public ObservableCollection<ServiceViewModel> Services { get; set; } = new();
         public ICollectionView FilteredServices { get; }
@@ -243,9 +227,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             OnPropertyChanged(nameof(DisplayLogs));
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged inherited from ViewModelBase
     }
 
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -6,7 +6,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class MqttServiceViewModel : INotifyPropertyChanged
+    public class MqttServiceViewModel : ViewModelBase
     {
         private string _host = string.Empty;
         public string Host { get => _host; set { _host = value; OnPropertyChanged(); } }
@@ -70,7 +70,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged provided by ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -5,7 +5,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class ScpServiceViewModel : INotifyPropertyChanged
+    public class ScpServiceViewModel : ViewModelBase
     {
         private string _host = string.Empty;
         public string Host { get => _host; set { _host = value; OnPropertyChanged(); } }
@@ -56,7 +56,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        // OnPropertyChanged provided by ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -6,7 +6,7 @@ using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class SettingsViewModel : INotifyPropertyChanged
+    public class SettingsViewModel : ViewModelBase
     {
         private static readonly string FilePath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
         private bool _darkTheme;
@@ -51,10 +51,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _dirty = false;
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-        private void OnPropertyChanged([CallerMemberName] string? name = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        }
+        // OnPropertyChanged provided by ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -12,7 +12,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class TcpServiceViewModel : INotifyPropertyChanged
+    public class TcpServiceViewModel : ViewModelBase
     {
         private string _statusMessage = string.Empty;
         private bool _isServerRunning;
@@ -163,11 +163,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
-        public event PropertyChangedEventHandler? PropertyChanged;
-
-        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
+        // OnPropertyChanged inherited from ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ViewModelBase.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// Base class that implements <see cref="INotifyPropertyChanged"/> to reduce
+/// repetitive code across view models.
+/// </summary>
+public abstract class ViewModelBase : INotifyPropertyChanged
+{
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Notifies listeners that a property value has changed.
+    /// </summary>
+    /// <param name="propertyName">The name of the property that changed.</param>
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+


### PR DESCRIPTION
## Summary
- centralize INotifyPropertyChanged logic in new `ViewModelBase`
- have each view model inherit from the base class
- simplify `AddLog` overload in `MainViewModel`

## Testing
- `dotnet build DesktopApplicationTemplate.sln -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_688150c75b1483268f6dbe21a6946832