### PR TITLE
Improve logging and service creation naming

### DIFF
--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -2,6 +2,7 @@ using DesktopApplicationTemplate.UI.Services;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Threading;
+using System.IO;
 using Xunit;
 using System.Text.RegularExpressions;
 
@@ -25,6 +26,25 @@ namespace DesktopApplicationTemplate.Tests
             Assert.Contains("test", text);
             Assert.Contains($"[{level}]", text);
             Assert.Matches(@"\[\d{2}:\d{2}:\d{2}\]", text);
+        }
+
+        [Fact]
+        public void Log_WritesMessageToFile()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                var box = new RichTextBox();
+                var service = new LoggingService(box, Dispatcher.CurrentDispatcher, path);
+                service.Log("file-test", LogLevel.Debug);
+                var content = File.ReadAllText(path);
+                Assert.Contains("file-test", content);
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -15,11 +15,13 @@ namespace DesktopApplicationTemplate.UI.Services
     {
         private readonly WpfRichTextBox _outputBox;
         private readonly Dispatcher _dispatcher;
+        private readonly string _logFilePath;
 
-        public LoggingService(WpfRichTextBox outputBox, Dispatcher dispatcher)
+        public LoggingService(WpfRichTextBox outputBox, Dispatcher dispatcher, string logFilePath = "app.log")
         {
             _outputBox = outputBox;
             _dispatcher = dispatcher;
+            _logFilePath = logFilePath;
         }
 
         public void Log(string message, LogLevel level)
@@ -40,6 +42,14 @@ namespace DesktopApplicationTemplate.UI.Services
                 _outputBox.Document.Blocks.Add(paragraph);
                 _outputBox.ScrollToEnd();
             });
+            try
+            {
+                System.IO.File.AppendAllText(_logFilePath, formatted + Environment.NewLine);
+            }
+            catch
+            {
+                // ignore logging errors
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -143,14 +143,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var popup = new CreateServiceWindow(vm); // Replace with DI if needed
             if (popup.ShowDialog() == true)
             {
+                string name = popup.CreatedServiceName;
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    int index = Services.Count(s => s.ServiceType == popup.CreatedServiceType) + 1;
+                    name = $"{popup.CreatedServiceType}{index}";
+                }
                 var newService = new ServiceViewModel
                 {
-                    DisplayName = $"{popup.CreatedServiceType} - {popup.CreatedServiceName}",
+                    DisplayName = $"{popup.CreatedServiceType} - {name}",
                     ServiceType = popup.CreatedServiceType,
                     IsActive = false
                 };
                 newService.SetColorsByType();
                 newService.LogAdded += OnServiceLogAdded;
+                newService.AddLog("Service created", WpfBrushes.Blue);
                 Services.Add(newService);
                 OnPropertyChanged(nameof(ServicesCreated));
                 OnPropertyChanged(nameof(CurrentActiveServices));

--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -20,7 +20,6 @@
             <TextBlock Text="Active Services:" Margin="0,0,5,0"/>
             <TextBlock Text="{Binding CurrentActiveServices}" />
         </StackPanel>
-        <Button Content="Edit Service" Width="100" Margin="0,10,0,0" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Click="EditService_Click"/>
         <TextBox Text="{Binding DisplayLogs, Mode=OneWay, Converter={StaticResource LogListToStringConverter}}"
                  IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
     </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -40,7 +40,7 @@
             <Button Content="Send" Width="100" Command="{Binding SendCommand}" />
         </StackPanel>
 
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Headers}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHeader}" Margin="0 0 0 10" Height="100">
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Headers}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHeader}" Margin="0 0 0 10" Height="100" MaxWidth="300">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Key" Binding="{Binding Key}" Width="*"/>
                 <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="*"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -28,61 +28,67 @@
             </Grid.ColumnDefinitions>
 
         <!-- Left Panel -->
-        <StackPanel Grid.Column="0" Margin="10">
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+        <Grid Grid.Column="0" Margin="10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Grid.Row="0">
                 <Button Content="+" Width="30" Click="AddService_Click"/>
                 <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click"/>
             </StackPanel>
 
-            <StackPanel Orientation="Horizontal" Margin="0,10">
+            <StackPanel Orientation="Horizontal" Margin="0,10" Grid.Row="1">
                 <TextBlock Text="Services" FontWeight="Bold" />
                 <Button Content="🔍" Width="20" Margin="5,0,0,0" Click="OpenFilter_Click"/>
             </StackPanel>
-            <ListBox ItemsSource="{Binding FilteredServices}"
-                     SelectedItem="{Binding SelectedService}"
-                     BorderThickness="0"
-                     HorizontalContentAlignment="Stretch"
-                     SelectionChanged="ServiceList_SelectionChanged">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <Border CornerRadius="8"
-                                BorderBrush="{Binding BorderColor}"
-                                Background="{Binding BackgroundColor}"
-                                BorderThickness="2" Padding="5" Margin="2"
-                                HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                MouseLeftButtonDown="ServiceItem_DoubleClick">
-                            <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
-                                <Border.ContextMenu>
-                                    <ContextMenu>
-                                        <MenuItem Header="Edit Service" Click="EditServiceMenu_Click" />
-                                        <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
-                                        <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
-                                        <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
-                                    </ContextMenu>
-                                </Border.ContextMenu>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
+            <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+                <ListBox ItemsSource="{Binding FilteredServices}"
+                         SelectedItem="{Binding SelectedService}"
+                         BorderThickness="0"
+                         HorizontalContentAlignment="Stretch"
+                         SelectionChanged="ServiceList_SelectionChanged">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Border CornerRadius="8"
+                                    BorderBrush="{Binding BorderColor}"
+                                    Background="{Binding BackgroundColor}"
+                                    BorderThickness="2" Padding="5" Margin="2"
+                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                    MouseLeftButtonDown="ServiceItem_DoubleClick">
+                                <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
+                                    <Border.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem Header="Edit Service" Click="EditServiceMenu_Click" />
+                                            <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
+                                            <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
+                                            <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
+                                        </ContextMenu>
+                                    </Border.ContextMenu>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
 
-                                    <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" FontWeight="Bold"/>
-                                    <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}"
-                                                  Style="{StaticResource ToggleSwitchStyle}"/>
-                                </Grid>
+                                        <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" FontWeight="Bold"/>
+                                        <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}"
+                                                      Style="{StaticResource ToggleSwitchStyle}"/>
+                                    </Grid>
+                                </Border>
                             </Border>
-                        </Border>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-        </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </ScrollViewer>
+        </Grid>
 
         <!-- Right Panel -->
 
         <StackPanel Grid.Column="1" Margin="10">
             <Frame x:Name="ContentFrame" Height="200" NavigationUIVisibility="Hidden" />
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14"/>
-            <Button Content="Edit Connection" Click="EditService_Click" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,5" Width="120"/>
             <TextBlock Text="Services Created:" />
             <TextBlock Text="{Binding ServicesCreated}" />
             <TextBlock Text="Current Active Services:" />
@@ -94,7 +100,6 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-            <Button Content="CSV Viewer" Click="OpenCsvViewer_Click" Margin="0,5" Width="100"/>
         </StackPanel>
 
         <Button Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Click="OpenSettings_Click"/>


### PR DESCRIPTION
## Summary
- improve `LoggingService` with file output
- add file logging test coverage
- auto-generate service names when blank
- update Main window layout so service list scrolls
- trim main page buttons
- narrow key/value grid in HTTP service view

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881575f06dc832699cfeef92b0c970f