### PR TITLE
Add setup script for environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Simple setup script for Codex environment
+# Installs .NET 8 SDK and restores project packages.
+
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-8.0
+
+dotnet restore DesktopApplicationTemplate.sln
+
+# Optionally build the service (UI projects require Windows)
+dotnet build DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing .NET SDK and building service

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688165b8b51483268304678cf7ba346e