### PR TITLE
Show splash screen on first run

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -57,6 +57,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CsvViewerViewModel>();
             services.AddSingleton<CsvService>();
             services.AddSingleton<SettingsViewModel>();
+            services.AddTransient<SplashWindow>();
             services.AddTransient<CsvViewerWindow>();
             services.AddTransient<CreateServiceWindow>();
             services.AddTransient<CreateServicePage>();
@@ -72,8 +73,25 @@ namespace DesktopApplicationTemplate.UI
         {
             await AppHost.StartAsync();
 
+            var settings = AppHost.Services.GetRequiredService<SettingsViewModel>();
+            settings.Load();
+
+            SplashWindow? splash = null;
+            if (settings.FirstRun)
+            {
+                splash = AppHost.Services.GetRequiredService<SplashWindow>();
+                splash.Show();
+            }
+
             var startupService = AppHost.Services.GetRequiredService<IStartupService>();
             await startupService.RunStartupChecksAsync();
+
+            splash?.Close();
+            if (splash != null)
+            {
+                settings.FirstRun = false;
+                settings.Save();
+            }
 
             var mainWindow = AppHost.Services.GetRequiredService<MainView>();
             mainWindow.Show();

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -7,5 +7,6 @@ namespace DesktopApplicationTemplate.Models
         public bool RunUIOnStartup { get; set; }
         public bool RunServicesOnStartup { get; set; }
         public bool LogTcpMessages { get; set; } = true;
+        public bool FirstRun { get; set; } = true;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -14,6 +14,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private bool _runUIOnStartup;
         private bool _runServicesOnStartup;
         private bool _logTcpMessages = true;
+        private bool _firstRun = true;
         private bool _dirty;
 
         public static bool TcpLoggingEnabled { get; private set; } = true;
@@ -23,6 +24,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public bool RunUIOnStartup { get => _runUIOnStartup; set { _runUIOnStartup = value; _dirty = true; OnPropertyChanged(); } }
         public bool RunServicesOnStartup { get => _runServicesOnStartup; set { _runServicesOnStartup = value; _dirty = true; OnPropertyChanged(); } }
         public bool LogTcpMessages { get => _logTcpMessages; set { _logTcpMessages = value; _dirty = true; OnPropertyChanged(); } }
+        public bool FirstRun { get => _firstRun; set { _firstRun = value; _dirty = true; OnPropertyChanged(); } }
         public bool HasUnsavedChanges => _dirty;
 
         public void Load()
@@ -40,6 +42,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _runUIOnStartup = obj.RunUIOnStartup;
                 _runServicesOnStartup = obj.RunServicesOnStartup;
                 _logTcpMessages = obj.LogTcpMessages;
+                _firstRun = obj.FirstRun;
                 TcpLoggingEnabled = obj.LogTcpMessages;
             }
         }
@@ -52,7 +55,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 AutoCheckUpdates = _autoCheckUpdates,
                 RunUIOnStartup = _runUIOnStartup,
                 RunServicesOnStartup = _runServicesOnStartup,
-                LogTcpMessages = _logTcpMessages
+                LogTcpMessages = _logTcpMessages,
+                FirstRun = _firstRun
             };
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
             TcpLoggingEnabled = _logTcpMessages;

--- a/DesktopApplicationTemplate.UI/Views/SplashWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SplashWindow.xaml
@@ -1,0 +1,15 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.SplashWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterScreen">
+    <Border Background="#FFFAFAFA" Padding="20" CornerRadius="10" BorderBrush="#DDDDDD" BorderThickness="1">
+        <StackPanel>
+            <TextBlock Text="Welcome!" FontSize="20" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,10"/>
+            <TextBlock Text="Initializing..." HorizontalAlignment="Center"/>
+        </StackPanel>
+    </Border>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/SplashWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SplashWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class SplashWindow : Window
+    {
+        public SplashWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add FirstRun flag to user settings
- load settings in `App.xaml.cs` and display a splash screen when FirstRun is true
- register and show `SplashWindow`
- close splash after startup and persist FirstRun value

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817c59603c8326b601916924d3576d