### PR TITLE
Add SettingsViewModel FirstRun persistence test

### DIFF
--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class SettingsViewModelPersistenceTests
+    {
+        [Fact]
+        public void SaveAndLoad_PersistsFirstRun()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var original = SettingsViewModel.FilePath;
+            SettingsViewModel.FilePath = Path.Combine(tempDir, "userSettings.json");
+            try
+            {
+                var vm = new SettingsViewModel();
+                vm.FirstRun = false;
+                vm.Save();
+
+                var vm2 = new SettingsViewModel { FirstRun = true };
+                vm2.Load();
+
+                Assert.False(vm2.FirstRun);
+            }
+            finally
+            {
+                SettingsViewModel.FilePath = original;
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/InternalVisibility.cs
+++ b/DesktopApplicationTemplate.UI/InternalVisibility.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DesktopApplicationTemplate.Tests")]

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -7,5 +7,6 @@ namespace DesktopApplicationTemplate.Models
         public bool RunUIOnStartup { get; set; }
         public bool RunServicesOnStartup { get; set; }
         public bool LogTcpMessages { get; set; } = true;
+        public bool FirstRun { get; set; } = true;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -8,12 +8,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class SettingsViewModel : ViewModelBase
     {
-        private static readonly string FilePath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
+        internal static string FilePath { get; set; } =
+            Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
         private bool _darkTheme;
         private bool _autoCheckUpdates;
         private bool _runUIOnStartup;
         private bool _runServicesOnStartup;
         private bool _logTcpMessages = true;
+        private bool _firstRun = true;
         private bool _dirty;
 
         public static bool TcpLoggingEnabled { get; private set; } = true;
@@ -23,6 +25,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public bool RunUIOnStartup { get => _runUIOnStartup; set { _runUIOnStartup = value; _dirty = true; OnPropertyChanged(); } }
         public bool RunServicesOnStartup { get => _runServicesOnStartup; set { _runServicesOnStartup = value; _dirty = true; OnPropertyChanged(); } }
         public bool LogTcpMessages { get => _logTcpMessages; set { _logTcpMessages = value; _dirty = true; OnPropertyChanged(); } }
+        public bool FirstRun { get => _firstRun; set { _firstRun = value; _dirty = true; OnPropertyChanged(); } }
         public bool HasUnsavedChanges => _dirty;
 
         public void Load()
@@ -40,6 +43,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _runUIOnStartup = obj.RunUIOnStartup;
                 _runServicesOnStartup = obj.RunServicesOnStartup;
                 _logTcpMessages = obj.LogTcpMessages;
+                _firstRun = obj.FirstRun;
                 TcpLoggingEnabled = obj.LogTcpMessages;
             }
         }
@@ -52,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 AutoCheckUpdates = _autoCheckUpdates,
                 RunUIOnStartup = _runUIOnStartup,
                 RunServicesOnStartup = _runServicesOnStartup,
-                LogTcpMessages = _logTcpMessages
+                LogTcpMessages = _logTcpMessages,
+                FirstRun = _firstRun
             };
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
             TcpLoggingEnabled = _logTcpMessages;


### PR DESCRIPTION
## Summary
- allow customizing `SettingsViewModel` config path
- add a new `FirstRun` option to `UserSettings`
- persist `FirstRun` in `SettingsViewModel`
- expose internals to the test project
- test saving/loading of `FirstRun`

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817c59a96883268effef731e1e5461