### PR TITLE
Fix dynamic casting in MainWindow

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -56,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.Views
 
             if (svc.ServicePage != null)
             {
-                if (svc.ServicePage.DataContext is dynamic vm && vm.Logger is LoggingService logger)
+                var vm = svc.ServicePage.DataContext as dynamic;
+                if (vm != null && vm.Logger is LoggingService logger)
                 {
                     logger.LogAdded += entry => svc.AddLog(entry.Message, entry.Color);
                 }


### PR DESCRIPTION
## Summary
- update `MainWindow` to avoid pattern matching with `dynamic`

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881824aaffc8326b0dd22b1d1301f17