### PR TITLE
Fix logger null checks

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -19,6 +19,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (_logger == null)
+                return;
+
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -35,6 +35,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (_logger == null)
+                return;
+
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -19,6 +19,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (_logger == null)
+                return;
+
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -19,6 +19,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (_logger == null)
+                return;
+
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -41,6 +41,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (_logger == null)
+                return;
+
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())


### PR DESCRIPTION
## Summary
- avoid null reference exceptions in service views

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688187bb90e4832698fa71e9befc8230