### PR TITLE
Add save confirmation opt-out

### DIFF
--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -7,26 +7,30 @@ namespace DesktopApplicationTemplate.Tests
     public class SettingsViewModelPersistenceTests
     {
         [Fact]
-        public void SaveAndLoad_PersistsFirstRun()
+        public void SaveAndLoad_PersistsFirstRunAndSuppression()
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir);
             var original = SettingsViewModel.FilePath;
+            var suppressOrig = SettingsViewModel.SaveConfirmationSuppressed;
             SettingsViewModel.FilePath = Path.Combine(tempDir, "userSettings.json");
             try
             {
                 var vm = new SettingsViewModel();
                 vm.FirstRun = false;
+                SettingsViewModel.SaveConfirmationSuppressed = true;
                 vm.Save();
 
                 var vm2 = new SettingsViewModel { FirstRun = true };
                 vm2.Load();
 
                 Assert.False(vm2.FirstRun);
+                Assert.True(SettingsViewModel.SaveConfirmationSuppressed);
             }
             finally
             {
                 SettingsViewModel.FilePath = original;
+                SettingsViewModel.SaveConfirmationSuppressed = suppressOrig;
                 Directory.Delete(tempDir, true);
             }
         }

--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public static class SaveConfirmationHelper
+    {
+        public static void Show()
+        {
+            if (SettingsViewModel.SaveConfirmationSuppressed)
+                return;
+
+            var window = new SaveConfirmationWindow { Owner = Application.Current.MainWindow };
+            if (window.ShowDialog() == true && window.DontShowAgain)
+            {
+                SettingsViewModel.SaveConfirmationSuppressed = true;
+                var settingsVm = App.AppHost.Services.GetRequiredService<SettingsViewModel>();
+                settingsVm.Save();
+            }
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -8,5 +8,6 @@ namespace DesktopApplicationTemplate.Models
         public bool RunServicesOnStartup { get; set; }
         public bool LogTcpMessages { get; set; } = true;
         public bool FirstRun { get; set; } = true;
+        public bool SuppressSaveConfirmation { get; set; }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using System.Windows;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -128,10 +129,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        private void Save()
-        {
-            System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
-        }
+        private void Save() => SaveConfirmationHelper.Show();
 
         // OnPropertyChanged inherited from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -72,7 +73,7 @@ public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
             Logger?.Log("FTP upload complete", LogLevel.Debug);
         }
 
-        private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
+        private void Save() => SaveConfirmationHelper.Show();
 
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using System.Windows;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -58,10 +59,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             FinalMessage = msg;
         }
 
-        private void Save()
-        {
-            System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
-        }
+        private void Save() => SaveConfirmationHelper.Show();
 
         // OnPropertyChanged from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using System.Windows;
 using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -18,9 +19,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             SaveCommand = new RelayCommand(Save);
         }
 
-        private void Save()
-        {
-            System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
-        }
+        private void Save() => SaveConfirmationHelper.Show();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using System.Threading.Tasks;
 using System.Windows;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -84,10 +85,7 @@ public class HttpServiceViewModel : ViewModelBase, ILoggingViewModel
             SaveCommand = new RelayCommand(Save);
         }
 
-        private void Save()
-        {
-            System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
-        }
+        private void Save() => SaveConfirmationHelper.Show();
 
         public async Task SendRequestAsync()
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -86,7 +87,7 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel
             Logger?.Log($"Published to {PublishTopic}", LogLevel.Debug);
         }
 
-        private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
+        private void Save() => SaveConfirmationHelper.Show();
 
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -72,7 +73,7 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel
             Logger?.Log("File transferred", LogLevel.Debug);
         }
 
-        private void Save() => System.Windows.MessageBox.Show("Configuration saved.");
+        private void Save() => SaveConfirmationHelper.Show();
 
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -16,9 +16,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private bool _runServicesOnStartup;
         private bool _logTcpMessages = true;
         private bool _firstRun = true;
+        private static bool _suppressSaveConfirmation;
         private bool _dirty;
 
         public static bool TcpLoggingEnabled { get; private set; } = true;
+        public static bool SaveConfirmationSuppressed
+        {
+            get => _suppressSaveConfirmation;
+            internal set => _suppressSaveConfirmation = value;
+        }
 
         public bool DarkTheme { get => _darkTheme; set { _darkTheme = value; _dirty = true; OnPropertyChanged(); } }
         public bool AutoCheckUpdates { get => _autoCheckUpdates; set { _autoCheckUpdates = value; _dirty = true; OnPropertyChanged(); } }
@@ -45,6 +51,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _logTcpMessages = obj.LogTcpMessages;
                 _firstRun = obj.FirstRun;
                 TcpLoggingEnabled = obj.LogTcpMessages;
+                SaveConfirmationSuppressed = obj.SuppressSaveConfirmation;
             }
         }
 
@@ -57,7 +64,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 RunUIOnStartup = _runUIOnStartup,
                 RunServicesOnStartup = _runServicesOnStartup,
                 LogTcpMessages = _logTcpMessages,
-                FirstRun = _firstRun
+                FirstRun = _firstRun,
+                SuppressSaveConfirmation = SaveConfirmationSuppressed
             };
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
             TcpLoggingEnabled = _logTcpMessages;

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -201,10 +202,7 @@ public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
             }
         }
 
-        private void Save()
-        {
-            System.Windows.MessageBox.Show("Configuration saved.", "Save", MessageBoxButton.OK, MessageBoxImage.Information);
-        }
+        private void Save() => SaveConfirmationHelper.Show();
 
         // OnPropertyChanged inherited from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
@@ -1,0 +1,10 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.SaveConfirmationWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Save" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <StackPanel Margin="20">
+        <TextBlock Text="Configuration saved." Margin="0,0,0,10"/>
+        <CheckBox x:Name="DontShowAgainCheckBox" Content="Don't show this pop-up again." Margin="0,0,0,10"/>
+        <Button Content="OK" Width="80" HorizontalAlignment="Right" Click="Ok_Click"/>
+    </StackPanel>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml.cs
@@ -1,0 +1,20 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class SaveConfirmationWindow : Window
+    {
+        public bool DontShowAgain { get; private set; }
+
+        public SaveConfirmationWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            DontShowAgain = DontShowAgainCheckBox.IsChecked == true;
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SuppressSaveConfirmation` to `UserSettings`
- persist suppression state in `SettingsViewModel`
- add `SaveConfirmationWindow` with "don't show again" option
- display confirmation through `SaveConfirmationHelper`
- update all save commands to use the helper
- expand persistence tests

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818aeed86c8326b95fe74f0a072ae5