### PR TITLE
Fix settings project refs

### DIFF
--- a/DesktopApplication.Installer/DesktopApplication.Installer.csproj
+++ b/DesktopApplication.Installer/DesktopApplication.Installer.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="FluentFTP" Version="53.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
+++ b/DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="FluentFTP" Version="53.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Configuration.Binder reference to UI, service, and installer projects

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b4abff64832696173bbabc2718c3