### PR TITLE
Add ASCII help dialog and update docs

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.AsciiHelpWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="ASCII Help" SizeToContent="WidthAndHeight">
+    <Grid Margin="10">
+        <TextBlock TextWrapping="Wrap" Width="300">
+            <Run Text="Common ASCII commands:"/>
+            <LineBreak/>
+            <Run Text="ACK (0x06) - acknowledge"/>
+            <LineBreak/>
+            <Run Text="NAK (0x15) - negative acknowledge"/>
+            <LineBreak/>
+            <Run Text="ENQ (0x05) - enquiry"/>
+            <LineBreak/>
+            <Run Text="ETX (0x03) - end of text"/>
+            <LineBreak/>
+            <LineBreak/>
+            <Run Text="Use these byte values when building messages to confirm or reject operations."/>
+        </TextBlock>
+    </Grid>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class AsciiHelpWindow : Window
+    {
+        public AsciiHelpWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
@@ -35,6 +35,7 @@
             <Button Content="Add Column" Command="{Binding AddColumnCommand}" Width="90"/>
             <Button Content="Remove" Command="{Binding RemoveColumnCommand}" Width="70" Margin="5,0,0,0"/>
             <Button Content="Save" Command="{Binding SaveCommand}" Width="60" Margin="5,0,0,0"/>
+            <Button Content="Help" Width="60" Margin="5,0,0,0" Click="Help_Click"/>
             <Button Content="Close" Command="{Binding CloseCommand}" Width="60" Margin="5,0,0,0"/>
         </StackPanel>
     </Grid>

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml.cs
@@ -10,5 +10,11 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
             DataContext = vm;
         }
+
+        private void Help_Click(object sender, RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml
@@ -81,6 +81,7 @@
                                    VerticalAlignment="Center"
                                    Visibility="{Binding Text, ElementName=TcpCommandBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                     </Grid>
+                    <Button Content="Help" Width="60" Margin="5,0,0,0" Click="Help_Click"/>
                 </StackPanel>
             </StackPanel>
 

--- a/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverView.xaml.cs
@@ -20,7 +20,13 @@ namespace DesktopApplicationTemplate.UI.Views
         private void FileObserverView_Loaded(object sender, RoutedEventArgs e)
         {
             // Optional: logic on load (e.g., preload a directory, start watch service, etc.)
-            // _viewModel.Initialize(); 
+            // _viewModel.Initialize();
+        }
+
+        private void Help_Click(object sender, RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
@@ -23,7 +23,10 @@
             </Grid>
             <CheckBox Content="Include PING" IsChecked="{Binding IncludePing}" Margin="0,5,0,0"/>
             <CheckBox Content="Include STATUS" IsChecked="{Binding IncludeStatus}" Margin="0,5,0,0"/>
-            <Button Content="Build" Command="{Binding BuildCommand}" Width="100" Margin="0,10,0,0"/>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <Button Content="Build" Command="{Binding BuildCommand}" Width="100"/>
+                <Button Content="Help" Width="80" Margin="5,0,0,0" Click="Help_Click"/>
+            </StackPanel>
             <TextBlock Text="Final Message:" Margin="0,10,0,0"/>
             <TextBox Text="{Binding FinalMessage}" IsReadOnly="True" Width="300"/>
         </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml.cs
@@ -10,5 +10,11 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
             DataContext = vm;
         }
+
+        private void Help_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -38,6 +38,7 @@
                Visibility="{Binding Text, ElementName=UrlTextBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
             <Button Content="Send" Width="100" Command="{Binding SendCommand}" />
+            <Button Content="Help" Width="80" Margin="5,0,0,0" Click="Help_Click"/>
         </StackPanel>
 
         <DataGrid Grid.Row="1" ItemsSource="{Binding Headers}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHeader}" Margin="0 0 0 10" Height="100" MaxWidth="300">

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -33,6 +33,12 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.Logger = _logger;
         }
 
+        private void Help_Click(object sender, RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
+        }
+
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_logger == null)

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
@@ -62,6 +62,7 @@
                                    Visibility="{Binding Text, ElementName=PublishMessageBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                     </Grid>
                     <Button Content="Send" Width="60" Margin="5,0,0,0" Command="{Binding PublishCommand}"/>
+                    <Button Content="Help" Width="60" Margin="5,0,0,0" Click="Help_Click"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                     <Grid Width="200">

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -17,6 +17,12 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.Logger = _logger;
         }
 
+        private void Help_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
+        }
+
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_logger == null)

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
@@ -11,6 +11,7 @@
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="OK" Width="80" Margin="0,0,5,0" Click="Ok_Click"/>
             <Button Content="Cancel" Width="80" Click="Cancel_Click"/>
+            <Button Content="Help" Width="80" Margin="5,0,0,0" Click="Help_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
@@ -24,5 +24,11 @@ namespace DesktopApplicationTemplate.UI.Views
             DialogResult = false;
             Close();
         }
+
+        private void Help_Click(object sender, RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -80,7 +80,10 @@
                 <Button Content="Open Editor" Margin="0,5,0,5" Click="OpenEditor_Click" Width="100"/>
                 <TextBlock Text="Test Message" FontWeight="Bold" Margin="0,5,0,0"/>
                 <TextBox Text="{Binding TestMessage}" Margin="0,0,0,5"/>
-                <Button Content="Test Script" Margin="0,0,0,5" Command="{Binding TestScriptCommand}"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button Content="Test Script" Command="{Binding TestScriptCommand}"/>
+                    <Button Content="Help" Width="80" Margin="5,0,0,0" Click="Help_Click"/>
+                </StackPanel>
             </StackPanel>
 
             <!-- RIGHT SIDE -->

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -63,5 +63,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
             }
         }
+
+        private void Help_Click(object sender, RoutedEventArgs e)
+        {
+            var help = new AsciiHelpWindow();
+            help.ShowDialog();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -58,3 +58,40 @@ dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.cs
 The installer copies all runtime dependencies based on the generated `.deps.json`
 file of the build output. New library references are automatically detected and
 no manual configuration is required.
+
+## Services overview
+
+The UI exposes several built in service types. A brief description of each is shown below.
+
+- **HID** – configure HID devices and save their settings.
+- **TCP** – run a lightweight TCP server and test message processing scripts.
+- **HTTP** – send HTTP requests with editable headers and body fields.
+- **File Observer** – watch folders and optionally send TCP commands when new files are detected.
+- **Heartbeat** – build simple heartbeat messages with optional `PING` and `STATUS` tokens.
+- **CSV Creator** – generate CSV files from values produced by other services.
+- **SCP / FTP / MQTT** – provide basic clients for those protocols.
+
+Each service has an editor page where the parameters and test messages can be modified.  A **Help** button is available on these pages to display common ASCII commands (ACK, NAK, ENQ, ETX) which can be inserted when building protocol messages.
+
+## Testing services locally
+
+After building the solution, run the UI project and navigate to the desired service page. Most services expose a test action (for example, "Send" on the HTTP page or "Test Script" on the TCP page) that can be executed locally. Logs for each service are displayed next to the editor fields.
+
+The background service can also be run from the command line:
+
+```bash
+dotnet run --project DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
+```
+
+This launches the hosted service which periodically emits a heartbeat message using the settings from `appsettings.json`.
+
+## CSV editor example
+
+Use the menu option **CSV Viewer** to open the CSV configuration window. Columns can be added and associated with a service and an optional script. When another service produces a value, call `CsvService.AppendRow` with the values and a CSV file will be written using the filename pattern from the editor. For example:
+
+```csharp
+// gather data from services
+csvService.AppendRow(new [] { tcpValue, httpStatus });
+```
+
+This appends a new row to `output_{index}.csv` with the TCP and HTTP values.


### PR DESCRIPTION
## Summary
- add an ASCII Help window and buttons in message editors
- document services and local testing instructions
- show how to link messages to a CSV via CsvService

## Testing
- `./setup.sh` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b5d558bc8326ad9cebf57604404e