### PR TITLE
Improve docs, pipeline and tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,24 @@
+name: .NET
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build DesktopApplicationTemplate.sln --configuration Release
+    - name: Test
+      run: dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build
+

--- a/DesktopApplicationTemplate.Tests/ConsoleTestLogger.cs
+++ b/DesktopApplicationTemplate.Tests/ConsoleTestLogger.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public static class ConsoleTestLogger
+{
+    public static void LogPass([CallerMemberName] string? testName = null)
+    {
+        var prevColor = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine("\u001b[1m[Tests] " + testName + " PASSED\u001b[0m");
+        Console.ForegroundColor = prevColor;
+    }
+}

--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -16,6 +16,8 @@ namespace DesktopApplicationTemplate.Tests
             var vm = new FtpServiceViewModel();
             vm.BrowseCommand.Execute(null);
             Assert.True(true); // command executed without exception
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
+++ b/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
@@ -1,0 +1,44 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Tests;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class HttpServiceNetworkTests
+{
+    [Fact]
+    public async Task SendRequest_ReceivesLocalResponse()
+    {
+        var portPicker = new TcpListener(IPAddress.Loopback, 0);
+        portPicker.Start();
+        int port = ((IPEndPoint)portPicker.LocalEndpoint).Port;
+        portPicker.Stop();
+
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://localhost:{port}/");
+        listener.Start();
+
+        var respondTask = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            var buffer = Encoding.UTF8.GetBytes("ok");
+            ctx.Response.ContentLength64 = buffer.Length;
+            await ctx.Response.OutputStream.WriteAsync(buffer);
+            ctx.Response.OutputStream.Close();
+            listener.Stop();
+        });
+
+        var vm = new HttpServiceViewModel { Url = $"http://localhost:{port}/" };
+        await vm.SendRequestAsync();
+
+        await respondTask;
+
+        Assert.Equal(200, vm.StatusCode);
+        Assert.Equal("ok", vm.ResponseBody);
+
+        ConsoleTestLogger.LogPass();
+    }
+}

--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -31,6 +31,8 @@ namespace DesktopApplicationTemplate.Tests
             Assert.Contains("test", text);
             Assert.Contains($"[{level}]", text);
             Assert.Matches(@"\[\d{2}:\d{2}:\d{2}\]", text);
+
+            ConsoleTestLogger.LogPass();
         }
 
         [Fact]
@@ -55,5 +57,7 @@ namespace DesktopApplicationTemplate.Tests
                     File.Delete(path);
             }
         }
+
+        ConsoleTestLogger.LogPass();
     }
 }

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -12,6 +12,8 @@ namespace DesktopApplicationTemplate.Tests
             vm.NewTopic = "test/topic";
             vm.AddTopicCommand.Execute(null);
             Assert.Contains("test/topic", vm.Topics);
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
@@ -10,6 +10,8 @@ namespace DesktopApplicationTemplate.Tests
         {
             var vm = new ScpServiceViewModel();
             Assert.Equal("22", vm.Port);
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -33,6 +33,8 @@ namespace DesktopApplicationTemplate.Tests
                 SettingsViewModel.SaveConfirmationSuppressed = suppressOrig;
                 Directory.Delete(tempDir, true);
             }
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
@@ -35,6 +35,8 @@ namespace DesktopApplicationTemplate.Tests
             Assert.Equal("Information", settings.LogLevel);
             Assert.False(settings.AutoStart);
             Assert.Equal("/path/script.cs", settings.DefaultCSharpScriptPath);
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -18,6 +18,8 @@ namespace DesktopApplicationTemplate.Tests
             vm.ToggleServerCommand.Execute(null);
 
             Assert.Single(logger.Entries);
+
+            ConsoleTestLogger.LogPass();
         }
 
         [Fact]
@@ -31,6 +33,8 @@ namespace DesktopApplicationTemplate.Tests
 
             Assert.Single(logger.Entries);
             Assert.Equal(LogLevel.Warning, logger.Entries[0].Level);
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/WorkerTests.cs
+++ b/DesktopApplicationTemplate.Tests/WorkerTests.cs
@@ -26,6 +26,8 @@ namespace DesktopApplicationTemplate.Tests
 
             Assert.Equal("TEST", worker.HeartbeatMessage);
             Assert.Equal(10, worker.IntervalSeconds);
+
+            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -107,8 +107,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public IEnumerable<LogEntry> DisplayLogs => SelectedService?.Logs ?? AllLogs;
 
-        public MainViewModel()
+        private readonly CsvService _csvService;
+
+        public MainViewModel(CsvService csvService)
         {
+            _csvService = csvService;
             AddServiceCommand = new RelayCommand(AddService);
             RemoveServiceCommand = new RelayCommand(RemoveSelectedService, () => SelectedService != null);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
@@ -227,6 +230,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void OnServiceLogAdded(ServiceViewModel svc, LogEntry entry)
         {
             AllLogs.Insert(0, entry);
+            if (svc.ServiceType != "CSV Creator" && Services.Any(s => s.ServiceType == "CSV Creator"))
+            {
+                try
+                {
+                    _csvService.AppendRow(new[] { entry.Message });
+                }
+                catch
+                {
+                    // ignore CSV errors during logging
+                }
+            }
             OnPropertyChanged(nameof(DisplayLogs));
         }
 

--- a/README.md
+++ b/README.md
@@ -95,3 +95,25 @@ csvService.AppendRow(new [] { tcpValue, httpStatus });
 ```
 
 This appends a new row to `output_{index}.csv` with the TCP and HTTP values.
+
+## C# message scripts
+
+The **TCP** service can execute small C# scripts for transforming incoming
+messages. Create a folder named `Scripts` in the UI project and place your
+script files there. A script should expose a `string Process(string message)`
+method which receives the incoming message and returns the response. Configure
+`AppSettings:DefaultCSharpScriptPath` in the appropriate `appsettings` file to
+point at your script. When the TCP editor is opened with language set to `C#`,
+the script template will be loaded automatically.
+
+## Running startup scripts
+
+To restore dependencies, build the solution and run the unit tests from a shell
+environment use:
+
+```bash
+chmod +x setup.sh
+./setup.sh
+```
+
+This is helpful on CI hosts or when preparing a fresh development machine.

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@
 set -e
 
 dotnet restore
+dotnet workload install windowsdesktop
 dotnet build DesktopApplicationTemplate.sln
 dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
 


### PR DESCRIPTION
## Summary
- log test results in mint colored `ConsoleTestLogger`
- save service logs to CSV creator if available
- document how to use C# message scripts
- explain running the startup script in a shell
- add GitHub Actions workflow for Windows
- update setup.sh to install required workload
- add HTTP network test

## Testing
- `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: UseWPF requires Windows)*

------
https://chatgpt.com/codex/tasks/task_e_6881bc5ba7d08326adb9f38f320f0eee