### PR TITLE
Fix save confirmation helper ambiguity

### DIFF
--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -56,8 +56,8 @@ namespace DesktopApplicationTemplate.Tests
                 if (File.Exists(path))
                     File.Delete(path);
             }
-        }
 
-        ConsoleTestLogger.LogPass();
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -12,7 +12,10 @@ namespace DesktopApplicationTemplate.UI.Helpers
             if (SettingsViewModel.SaveConfirmationSuppressed)
                 return;
 
-            var window = new SaveConfirmationWindow { Owner = Application.Current.MainWindow };
+            var window = new SaveConfirmationWindow
+            {
+                Owner = System.Windows.Application.Current.MainWindow
+            };
             if (window.ShowDialog() == true && window.DontShowAgain)
             {
                 SettingsViewModel.SaveConfirmationSuppressed = true;


### PR DESCRIPTION
## Summary
- adjust `SaveConfirmationHelper` to use the fully qualified `Application` class
- fix misplaced `ConsoleTestLogger.LogPass()` in `LoggingServiceTests`

## Testing
- `dotnet test DesktopApplicationTemplate.sln -c Release -p:EnableWindowsTargeting=true` *(fails: missing `Microsoft.WindowsDesktop.App` runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68821443b57c83269586968b5bda15b7