### PR TITLE
Expose SaveConfirmation suppression via helper

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -7,15 +7,27 @@ namespace DesktopApplicationTemplate.UI.Helpers
 {
     public static class SaveConfirmationHelper
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether the save confirmation dialog
+        /// should be suppressed. This simply forwards to
+        /// <see cref="SettingsViewModel.SaveConfirmationSuppressed"/> so callers
+        /// do not need to depend on <see cref="SettingsViewModel"/> directly.
+        /// </summary>
+        public static bool SaveConfirmationSuppressed
+        {
+            get => SettingsViewModel.SaveConfirmationSuppressed;
+            set => SettingsViewModel.SaveConfirmationSuppressed = value;
+        }
+
         public static void Show()
         {
-            if (SettingsViewModel.SaveConfirmationSuppressed)
+            if (SaveConfirmationSuppressed)
                 return;
 
             var window = new SaveConfirmationWindow { Owner = Application.Current.MainWindow };
             if (window.ShowDialog() == true && window.DontShowAgain)
             {
-                SettingsViewModel.SaveConfirmationSuppressed = true;
+                SaveConfirmationSuppressed = true;
                 var settingsVm = App.AppHost.Services.GetRequiredService<SettingsViewModel>();
                 settingsVm.Save();
             }


### PR DESCRIPTION
## Summary
- add `SaveConfirmationSuppressed` property in `SaveConfirmationHelper`

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688214dd0bdc8326b408d5af1199c950