### PR TITLE
Fix duplicate service stats on home page

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -14,12 +14,6 @@
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14" Margin="0,0,10,0"/>
             <TextBlock Text="Associated Steps:" FontStyle="Italic"/>
         </StackPanel>
-        <StackPanel Orientation="Horizontal" Margin="0,5">
-            <TextBlock Text="Services Created:" Margin="0,0,5,0"/>
-            <TextBlock Text="{Binding ServicesCreated}" Margin="0,0,10,0"/>
-            <TextBlock Text="Active Services:" Margin="0,0,5,0"/>
-            <TextBlock Text="{Binding CurrentActiveServices}" />
-        </StackPanel>
         <TextBox Text="{Binding DisplayLogs, Mode=OneWay, Converter={StaticResource LogListToStringConverter}}"
                  IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
     </StackPanel>


### PR DESCRIPTION
## Summary
- clean up HomePage layout by removing duplicated "Services Created" and "Active Services" text blocks

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882197d30d48326bc3bf1374397ac41