### PR TITLE
Implement HID screen and CSV improvements

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -19,20 +19,30 @@ namespace DesktopApplicationTemplate.UI.Helpers
             set => SettingsViewModel.SaveConfirmationSuppressed = value;
         }
 
+        public static event Action? SaveConfirmed;
+
         public static void Show()
         {
             if (SaveConfirmationSuppressed)
+            {
+                SaveConfirmed?.Invoke();
                 return;
+            }
 
             var window = new SaveConfirmationWindow
             {
                 Owner = System.Windows.Application.Current.MainWindow
             };
-            if (window.ShowDialog() == true && window.DontShowAgain)
+            if (window.ShowDialog() == true)
             {
-                SaveConfirmationSuppressed = true;
-                var settingsVm = App.AppHost.Services.GetRequiredService<SettingsViewModel>();
-                settingsVm.Save();
+                if (window.DontShowAgain)
+                {
+                    SaveConfirmationSuppressed = true;
+                    var settingsVm = App.AppHost.Services.GetRequiredService<SettingsViewModel>();
+                    settingsVm.Save();
+                }
+
+                SaveConfirmed?.Invoke();
             }
         }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -10,14 +10,32 @@ using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class HidViewModel
+    public class HidViewModel : ViewModelBase
     {
+        private string _messageTemplate = string.Empty;
+        public string MessageTemplate
+        {
+            get => _messageTemplate;
+            set { _messageTemplate = value; OnPropertyChanged(); }
+        }
+
+        private string _finalMessage = string.Empty;
+        public string FinalMessage
+        {
+            get => _finalMessage;
+            set { _finalMessage = value; OnPropertyChanged(); }
+        }
+
+        public ICommand BuildCommand { get; }
         public ICommand SaveCommand { get; }
 
         public HidViewModel()
         {
+            BuildCommand = new RelayCommand(BuildMessage);
             SaveCommand = new RelayCommand(Save);
         }
+
+        private void BuildMessage() => FinalMessage = MessageTemplate;
 
         private void Save() => SaveConfirmationHelper.Show();
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -140,6 +140,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 };
                 newService.SetColorsByType();
                 newService.LogAdded += OnServiceLogAdded;
+                newService.ActiveChanged += OnServiceActiveChanged;
                 newService.AddLog("Service created", WpfBrushes.Blue);
                 Services.Add(newService);
                 OnPropertyChanged(nameof(ServicesCreated));
@@ -153,6 +154,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 var index = Services.IndexOf(SelectedService);
                 SelectedService.LogAdded -= OnServiceLogAdded;
+                SelectedService.ActiveChanged -= OnServiceActiveChanged;
                 Services.Remove(SelectedService);
                 if (Services.Count > 0)
                 {
@@ -197,6 +199,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 };
                 svc.SetColorsByType();
                 svc.LogAdded += OnServiceLogAdded;
+                svc.ActiveChanged += OnServiceActiveChanged;
                 Services.Add(svc);
             }
             OnPropertyChanged(nameof(ServicesCreated));
@@ -242,6 +245,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 }
             }
             OnPropertyChanged(nameof(DisplayLogs));
+        }
+
+        internal void OnServiceActiveChanged(bool _)
+        {
+            OnPropertyChanged(nameof(CurrentActiveServices));
         }
 
         // OnPropertyChanged inherited from ViewModelBase

--- a/DesktopApplicationTemplate.UI/Views/HidViews.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidViews.xaml
@@ -8,16 +8,25 @@
       d:DesignHeight="450" d:DesignWidth="800"
       Title="HidViews">
 
-    <Grid>
+    <Grid Margin="20">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+
         <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
-        <StackPanel Grid.Row="1" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="Save Configuration" Command="{Binding SaveCommand}" Width="150"/>
+        <StackPanel Grid.Row="1" Margin="0,40,0,0">
+            <TextBlock Text="HID Message" FontWeight="Bold" Margin="0,0,0,5"/>
+            <TextBox Text="{Binding MessageTemplate}" Height="80" AcceptsReturn="True" x:Name="TemplateBox"/>
+            <TextBlock Text="Final Message" FontWeight="Bold" Margin="0,10,0,5"/>
+            <TextBox Text="{Binding FinalMessage}" IsReadOnly="True" Height="80"/>
+            <Button Content="Build" Command="{Binding BuildCommand}" Width="100" Margin="0,10,0,0" HorizontalAlignment="Left"/>
         </StackPanel>
 
+        <StackPanel Grid.Row="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Save Configuration" Command="{Binding SaveCommand}" Width="150"/>
+        </StackPanel>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -87,6 +87,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
                 newService.SetColorsByType();
                 newService.LogAdded += _viewModel.OnServiceLogAdded;
+                newService.ActiveChanged += _viewModel.OnServiceActiveChanged;
 
                 GetOrCreateServicePage(newService);
 
@@ -103,7 +104,14 @@ namespace DesktopApplicationTemplate.UI.Views
                     };
                 }
 
-                if (newService.ServicePage != null)
+                if (type == "CSV Creator")
+                {
+                    var csvVm = App.AppHost.Services.GetRequiredService<CsvViewerViewModel>();
+                    var csvWindow = new CsvViewerWindow(csvVm);
+                    csvVm.RequestClose += () => csvWindow.Close();
+                    csvWindow.ShowDialog();
+                }
+                else if (newService.ServicePage != null)
                 {
                     var editor = new ServiceEditorWindow(newService.ServicePage);
                     editor.ShowDialog();
@@ -137,13 +145,23 @@ namespace DesktopApplicationTemplate.UI.Views
             if (_viewModel.SelectedService == null)
                 return;
 
-            var page = GetOrCreateServicePage(_viewModel.SelectedService);
-            if (page != null)
+            if (_viewModel.SelectedService.ServiceType == "CSV Creator")
             {
-                _viewModel.SelectedService.IsActive = false;
-                var editor = new ServiceEditorWindow(page);
-                editor.ShowDialog();
-                ContentFrame.Content = new HomePage { DataContext = _viewModel };
+                var vm = App.AppHost.Services.GetRequiredService<CsvViewerViewModel>();
+                var window = new CsvViewerWindow(vm);
+                vm.RequestClose += () => window.Close();
+                window.ShowDialog();
+            }
+            else
+            {
+                var page = GetOrCreateServicePage(_viewModel.SelectedService);
+                if (page != null)
+                {
+                    _viewModel.SelectedService.IsActive = false;
+                    var editor = new ServiceEditorWindow(page);
+                    editor.ShowDialog();
+                    ContentFrame.Content = new HomePage { DataContext = _viewModel };
+                }
             }
         }
 
@@ -160,6 +178,15 @@ namespace DesktopApplicationTemplate.UI.Views
 
             if ((sender as Border)?.DataContext is ServiceViewModel svc)
             {
+                if (svc.ServiceType == "CSV Creator")
+                {
+                    var vm = App.AppHost.Services.GetRequiredService<CsvViewerViewModel>();
+                    var window = new CsvViewerWindow(vm);
+                    vm.RequestClose += () => window.Close();
+                    window.ShowDialog();
+                    return;
+                }
+
                 var page = GetOrCreateServicePage(svc);
                 if (page != null)
                 {
@@ -192,6 +219,15 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if ((sender as MenuItem)?.DataContext is ServiceViewModel svc)
             {
+                if (svc.ServiceType == "CSV Creator")
+                {
+                    var vm = App.AppHost.Services.GetRequiredService<CsvViewerViewModel>();
+                    var window = new CsvViewerWindow(vm);
+                    vm.RequestClose += () => window.Close();
+                    window.ShowDialog();
+                    return;
+                }
+
                 var page = GetOrCreateServicePage(svc);
                 if (page != null)
                 {

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -9,6 +10,13 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             InitializeComponent();
             EditorFrame.Content = servicePage;
+            SaveConfirmationHelper.SaveConfirmed += OnSaveConfirmed;
+            Closed += (s, e) => SaveConfirmationHelper.SaveConfirmed -= OnSaveConfirmed;
+        }
+
+        private void OnSaveConfirmed()
+        {
+            Close();
         }
     }
 }


### PR DESCRIPTION
## Summary
- show Save confirmation once and close editor window
- improve service management and update active service count when toggled
- add HID editor screen for custom message design
- open CSV viewer when CSV service is double-clicked or edited

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821a65fc9083269a58c0765b939b4d