### PR TITLE
Add mint-green border style for log boxes

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml
+++ b/DesktopApplicationTemplate.UI/App.xaml
@@ -6,6 +6,18 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/ToggleSwitch.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <!-- Global style for log boxes -->
+            <Style TargetType="RichTextBox">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="RichTextBox">
+                            <Border BorderBrush="#98FF98" BorderThickness="2" CornerRadius="5" Background="{TemplateBinding Background}">
+                                <ScrollViewer x:Name="PART_ContentHost"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>


### PR DESCRIPTION
## Summary
- update `App.xaml` with global RichTextBox style using mint-green border

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -v minimal -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App missing)*

------
https://chatgpt.com/codex/tasks/task_e_68821a9d95308326b9c552e6b5a74cd5