### PR TITLE
Connect service management with background worker

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.Service
+{
+    public class ServiceInfo
+    {
+        public string DisplayName { get; set; } = string.Empty;
+        public string ServiceType { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+        public DateTime Created { get; set; }
+    }
+
+    public class ServiceManager : IDisposable
+    {
+        private readonly ILogger<ServiceManager> _logger;
+        private readonly IConfiguration _config;
+        private readonly string _filePath;
+        private readonly Dictionary<string, CancellationTokenSource> _running = new();
+
+        public IReadOnlyCollection<string> ActiveServices => _running.Keys.ToList();
+
+        public ServiceManager(ILogger<ServiceManager> logger, IConfiguration config, string? filePath = null)
+        {
+            _logger = logger;
+            _config = config;
+            _filePath = filePath ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
+        }
+
+        public void Sync()
+        {
+            var infos = Load();
+            var active = new HashSet<string>(infos.Where(i => i.IsActive).Select(i => i.DisplayName));
+
+            foreach (var info in infos.Where(i => i.IsActive))
+            {
+                if (!_running.ContainsKey(info.DisplayName))
+                    StartService(info);
+            }
+
+            foreach (var name in _running.Keys.ToList())
+            {
+                if (!active.Contains(name))
+                    StopService(name);
+            }
+        }
+
+        private List<ServiceInfo> Load()
+        {
+            if (!File.Exists(_filePath))
+                return new List<ServiceInfo>();
+            try
+            {
+                var json = File.ReadAllText(_filePath);
+                return JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+            }
+            catch
+            {
+                return new List<ServiceInfo>();
+            }
+        }
+
+        private void StartService(ServiceInfo info)
+        {
+            _logger.LogInformation("Starting {type} service: {name}", info.ServiceType, info.DisplayName);
+            var cts = new CancellationTokenSource();
+            _running[info.DisplayName] = cts;
+            _ = Task.Run(() => RunServiceLoop(info, cts.Token));
+        }
+
+        private void StopService(string name)
+        {
+            if (_running.TryGetValue(name, out var cts))
+            {
+                _logger.LogInformation("Stopping service: {name}", name);
+                cts.Cancel();
+                _running.Remove(name);
+            }
+        }
+
+        private async Task RunServiceLoop(ServiceInfo info, CancellationToken token)
+        {
+            if (info.ServiceType == "Heartbeat")
+            {
+                var hb = _config.GetSection("Heartbeat");
+                var message = hb.GetValue<string>("Message", "PING");
+                var interval = hb.GetValue<int>("IntervalSeconds", 30);
+                while (!token.IsCancellationRequested)
+                {
+                    _logger.LogInformation("[{name}] {msg}", info.DisplayName, message);
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(interval), token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                    }
+                }
+            }
+            else
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(10), token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var cts in _running.Values)
+                cts.Cancel();
+            _running.Clear();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
@@ -1,0 +1,50 @@
+using DesktopApplicationTemplate.Service;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ServiceManagerTests
+    {
+        [Fact]
+        public void Sync_StartsAndStopsServicesBasedOnFile()
+        {
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                var services = new[]
+                {
+                    new ServiceInfo { DisplayName = "Svc1", ServiceType = "Heartbeat", IsActive = true },
+                    new ServiceInfo { DisplayName = "Svc2", ServiceType = "TCP", IsActive = false }
+                };
+                File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
+
+                IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    {"Heartbeat:Message", "HB"},
+                    {"Heartbeat:IntervalSeconds", "1"}
+                }).Build();
+
+                using var manager = new ServiceManager(NullLogger<ServiceManager>.Instance, config, tempFile);
+                manager.Sync();
+                Assert.Contains("Svc1", manager.ActiveServices);
+                Assert.DoesNotContain("Svc2", manager.ActiveServices);
+
+                services[0].IsActive = false;
+                File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
+                manager.Sync();
+
+                Assert.Empty(manager.ActiveServices);
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/WorkerTests.cs
+++ b/DesktopApplicationTemplate.Tests/WorkerTests.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Service;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using Xunit;
 
@@ -22,7 +23,8 @@ namespace DesktopApplicationTemplate.Tests
                 .Build();
 
             var logger = NullLogger<Worker>.Instance;
-            var worker = new Worker(logger, configuration);
+            var factory = NullLoggerFactory.Instance;
+            var worker = new Worker(logger, factory, configuration);
 
             Assert.Equal("TEST", worker.HeartbeatMessage);
             Assert.Equal(10, worker.IntervalSeconds);

--- a/DesktopApplicationTemplate.UI/Themes/ToggleSwitch.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/ToggleSwitch.xaml
@@ -9,7 +9,7 @@
                 <ControlTemplate TargetType="ToggleButton">
                     <Grid>
                         <Border x:Name="SwitchBorder"
-                                Background="LightCoral"
+                                Background="LightSkyBlue"
                                 CornerRadius="10"
                                 BorderBrush="DarkGray"
                                 BorderThickness="1">
@@ -23,7 +23,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="SwitchBorder" Property="Background" Value="LightGreen"/>
+                            <Setter TargetName="SwitchBorder" Property="Background" Value="MediumSeaGreen"/>
                             <Setter TargetName="SwitchKnob" Property="HorizontalAlignment" Value="Right"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="False">


### PR DESCRIPTION
## Summary
- add `ServiceManager` to load and run active services from `services.json`
- poll for service changes in `Worker`
- update the toggle switch to use calmer colors
- add tests for `ServiceManager` and update existing `WorkerTests`

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824ffb6514832683c234d03588bd00