### PR TITLE
Skip MQTT test on non-Windows

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -8,6 +8,10 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void AddTopicCommand_AddsTopic()
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
             var vm = new MqttServiceViewModel();
             vm.NewTopic = "test/topic";
             vm.AddTopicCommand.Execute(null);


### PR DESCRIPTION
## Summary
- prevent MQTT test from running on non-Windows hosts

## Testing
- `dotnet test` *(fails: WindowsDesktop workload missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882532523bc8326b2fdd1f70a5d54c9