### PR TITLE
Improve FTP VM tests by mocking file dialog

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -8,16 +8,17 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class FtpServiceViewModelTests
     {
+        private class StubFileDialogService : IFileDialogService
+        {
+            public string? OpenFile() => "stub.txt";
+        }
+
         [Fact]
         public void BrowseCommand_InitialPathEmpty_DoesNotThrow()
         {
-            if (!OperatingSystem.IsWindows())
-            {
-                return;
-            }
-            var vm = new FtpServiceViewModel();
+            var vm = new FtpServiceViewModel(new StubFileDialogService());
             vm.BrowseCommand.Execute(null);
-            Assert.True(true); // command executed without exception
+            Assert.Equal("stub.txt", vm.LocalPath);
 
             ConsoleTestLogger.LogPass();
         }

--- a/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
@@ -1,0 +1,13 @@
+using Microsoft.Win32;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public class FileDialogService : IFileDialogService
+    {
+        public string? OpenFile()
+        {
+            var dialog = new OpenFileDialog();
+            return dialog.ShowDialog() == true ? dialog.FileName : null;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
@@ -1,0 +1,7 @@
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public interface IFileDialogService
+    {
+        string? OpenFile();
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -55,8 +55,11 @@ public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
         /// </summary>
         public IFtpService? Service { get; set; }
 
-        public FtpServiceViewModel()
+        private readonly IFileDialogService _fileDialog;
+
+        public FtpServiceViewModel(IFileDialogService? fileDialog = null)
         {
+            _fileDialog = fileDialog ?? new FileDialogService();
             BrowseCommand = new RelayCommand(Browse);
             TransferCommand = new RelayCommand(async () => await TransferAsync());
             SaveCommand = new RelayCommand(Save);
@@ -64,9 +67,9 @@ public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
 
         private void Browse()
         {
-            var dialog = new Microsoft.Win32.OpenFileDialog();
-            if (dialog.ShowDialog() == true)
-                LocalPath = dialog.FileName;
+            var path = _fileDialog.OpenFile();
+            if (path != null)
+                LocalPath = path;
         }
 
         internal async Task TransferAsync()


### PR DESCRIPTION
## Summary
- inject a file dialog service into `FtpServiceViewModel`
- create `IFileDialogService` and default `FileDialogService`
- update FTP view model tests to use stub dialog service

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882582c2a908326817d8a0c32906dde