### PR TITLE
Fix ambiguous OpenFileDialog usage

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
@@ -6,7 +6,7 @@ namespace DesktopApplicationTemplate.UI.Services
     {
         public string? OpenFile()
         {
-            var dialog = new OpenFileDialog();
+            var dialog = new Microsoft.Win32.OpenFileDialog();
             return dialog.ShowDialog() == true ? dialog.FileName : null;
         }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -76,7 +76,7 @@ public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
         {
             if (string.IsNullOrWhiteSpace(LocalPath) || string.IsNullOrWhiteSpace(RemotePath))
                 return;
-            var svc = Service ?? new FtpService(Host, int.Parse(Port), Username, Password);
+            var svc = Service ?? (IFtpService)new FtpService(Host, int.Parse(Port), Username, Password);
             await svc.UploadAsync(LocalPath, RemotePath);
             Logger?.Log("FTP upload complete", LogLevel.Debug);
         }


### PR DESCRIPTION
## Summary
- resolve OpenFileDialog ambiguity by fully qualifying the type
- cast new FtpService instance for null-coalescing logic

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825aaea8ac8326a9f0388925d7e3b1