### PR TITLE
Enable headless run and service ordering

### DIFF
--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Linq;
+using System;
 
 namespace DesktopApplicationTemplate.Service
 {
@@ -11,12 +13,19 @@ namespace DesktopApplicationTemplate.Service
             CreateHostBuilder(args).Build().Run();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .UseWindowsService() // Enables Windows Service behavior
-                .ConfigureServices((hostContext, services) =>
-                {
-                    services.AddHostedService<Worker>(); // register the background service
-                });
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            bool runAsService = !args.Contains("--console");
+            var builder = Host.CreateDefaultBuilder(args);
+            if (runAsService && OperatingSystem.IsWindows())
+            {
+                builder = builder.UseWindowsService(); // Enables Windows Service behavior
+            }
+
+            return builder.ConfigureServices((hostContext, services) =>
+            {
+                services.AddHostedService<Worker>(); // register the background service
+            });
+        }
     }
 }

--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -16,6 +16,7 @@ namespace DesktopApplicationTemplate.Service
         public string ServiceType { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
+        public int Order { get; set; }
     }
 
     public class ServiceManager : IDisposable

--- a/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
@@ -18,8 +18,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 var services = new[]
                 {
-                    new ServiceInfo { DisplayName = "Svc1", ServiceType = "Heartbeat", IsActive = true },
-                    new ServiceInfo { DisplayName = "Svc2", ServiceType = "TCP", IsActive = false }
+                    new ServiceInfo { DisplayName = "Svc1", ServiceType = "Heartbeat", IsActive = true, Order = 0 },
+                    new ServiceInfo { DisplayName = "Svc2", ServiceType = "TCP", IsActive = false, Order = 1 }
                 };
                 File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
 

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -13,6 +13,7 @@ namespace DesktopApplicationTemplate.UI.Services
         public static void Save(IEnumerable<ServiceViewModel> services)
         {
             var data = new List<ServiceInfo>();
+            var index = 0;
             foreach (var s in services)
             {
                 data.Add(new ServiceInfo
@@ -20,7 +21,8 @@ namespace DesktopApplicationTemplate.UI.Services
                     DisplayName = s.DisplayName,
                     ServiceType = s.ServiceType,
                     IsActive = s.IsActive,
-                    Created = DateTime.Now
+                    Created = DateTime.Now,
+                    Order = index++
                 });
             }
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
@@ -48,5 +50,6 @@ namespace DesktopApplicationTemplate.UI.Services
         public string ServiceType { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
+        public int Order { get; set; }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -18,6 +18,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public string DisplayName { get; set; }
         public string ServiceType { get; set; } = string.Empty;
         public Page? Page { get; set; }
+        public int Order { get; set; }
 
         private WpfBrush _backgroundColor = WpfBrushes.LightGray;
         public WpfBrush BackgroundColor
@@ -136,7 +137,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 {
                     DisplayName = $"{popup.CreatedServiceType} - {name}",
                     ServiceType = popup.CreatedServiceType,
-                    IsActive = false
+                    IsActive = false,
+                    Order = Services.Count
                 };
                 newService.SetColorsByType();
                 newService.LogAdded += OnServiceLogAdded;
@@ -183,19 +185,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void SaveServices()
         {
+            // Update order prior to saving
+            for (int i = 0; i < Services.Count; i++)
+            {
+                Services[i].Order = i;
+            }
             ServicePersistence.Save(Services);
         }
 
         private void LoadServices()
         {
             var existing = ServicePersistence.Load();
-            foreach (var info in existing)
+            foreach (var info in existing.OrderBy(i => i.Order))
             {
                 var svc = new ServiceViewModel
                 {
                     DisplayName = info.DisplayName,
                     ServiceType = info.ServiceType,
-                    IsActive = info.IsActive
+                    IsActive = info.IsActive,
+                    Order = info.Order
                 };
                 svc.SetColorsByType();
                 svc.LogAdded += OnServiceLogAdded;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -55,7 +55,10 @@
                                     Background="{Binding BackgroundColor}"
                                     BorderThickness="2" Padding="5" Margin="2"
                                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                    MouseLeftButtonDown="ServiceItem_DoubleClick">
+                                    MouseLeftButtonDown="ServiceItem_DoubleClick"
+                                    PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown"
+                                    PreviewMouseMove="ServiceItem_PreviewMouseMove"
+                                    AllowDrop="True" Drop="ServiceItem_Drop">
                                 <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
                                     <Border.ContextMenu>
                                         <ContextMenu>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -318,5 +318,46 @@ namespace DesktopApplicationTemplate.UI.Views
             ContentFrame.Content = page;
         }
 
+        private Point _dragStart;
+        private void ServiceItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            _dragStart = e.GetPosition(null);
+        }
+
+        private void ServiceItem_PreviewMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            if (e.LeftButton != System.Windows.Input.MouseButtonState.Pressed)
+                return;
+
+            var position = e.GetPosition(null);
+            if (Math.Abs(position.X - _dragStart.X) > SystemParameters.MinimumHorizontalDragDistance ||
+                Math.Abs(position.Y - _dragStart.Y) > SystemParameters.MinimumVerticalDragDistance)
+            {
+                if (sender is Border border && border.DataContext is ServiceViewModel svc)
+                {
+                    DragDrop.DoDragDrop(border, svc, DragDropEffects.Move);
+                }
+            }
+        }
+
+        private void ServiceItem_Drop(object sender, DragEventArgs e)
+        {
+            if (!e.Data.GetDataPresent(typeof(ServiceViewModel)))
+                return;
+
+            var source = (ServiceViewModel)e.Data.GetData(typeof(ServiceViewModel))!;
+            var target = (sender as Border)?.DataContext as ServiceViewModel;
+            if (source == null || target == null || source == target)
+                return;
+
+            int oldIndex = _viewModel.Services.IndexOf(source);
+            int newIndex = _viewModel.Services.IndexOf(target);
+            if (oldIndex != newIndex)
+            {
+                _viewModel.Services.Move(oldIndex, newIndex);
+                _viewModel.SaveServices();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- allow `DesktopApplicationTemplate.Service` to run headless with `--console`
- persist order of created services
- drag-and-drop services in the UI

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825b890f54832683a6646ffc95757f