### PR TITLE
Fix request disposal in HttpService

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -104,8 +104,8 @@ public class HttpServiceViewModel : ViewModelBase, ILoggingViewModel
             using HttpClient client = MessageHandler != null ? new HttpClient(MessageHandler) : new HttpClient();
             try
             {
-                using var request = new HttpRequestMessage(new HttpMethod(SelectedMethod), Url);
-                Logger?.Log($"Sending {SelectedMethod} request to {Url}", LogLevel.Debug);
+                Logger?.Log($"Preparing {SelectedMethod} request to {Url}", LogLevel.Debug);
+                var request = new HttpRequestMessage(new HttpMethod(SelectedMethod), Url);
 
                 foreach (var h in Headers)
                 {


### PR DESCRIPTION
## Summary
- update `HttpServiceViewModel` so captured HttpRequestMessage isn't disposed prematurely
- improve logging message to describe request preparation

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826b2114b88326b5d6205fb55a9e81