### PR TITLE
Add validation with default service naming

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
@@ -1,0 +1,20 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class CreateServiceViewModelTests
+    {
+        [Fact]
+        public void SelectedServiceType_GeneratesDefaultName()
+        {
+            var existing = new[] { "Heartbeat1" };
+            var vm = new CreateServiceViewModel(existing);
+            vm.SelectedServiceType = "Heartbeat";
+
+            Assert.Equal("Heartbeat2", vm.ServiceName);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -37,5 +37,31 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        public void SettingInvalidHost_AddsError()
+        {
+            var logger = new Mock<ILoggingService>();
+            var vm = new FtpServiceViewModel { Logger = logger.Object };
+            vm.Host = "bad_host";
+
+            Assert.True(vm.HasErrors);
+            logger.Verify(l => l.Log("Invalid FTP host entered", LogLevel.Warning), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void SettingInvalidPort_AddsError()
+        {
+            var logger = new Mock<ILoggingService>();
+            var vm = new FtpServiceViewModel { Logger = logger.Object };
+            vm.Port = "abc";
+
+            Assert.True(vm.HasErrors);
+            logger.Verify(l => l.Log("Invalid FTP port entered", LogLevel.Warning), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -37,5 +37,18 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        public void HttpService_SetInvalidUrl_AddsError()
+        {
+            var logger = new TestLogger();
+            var vm = new HttpServiceViewModel { Logger = logger };
+            vm.Url = "htp://bad";
+
+            Assert.True(vm.HasErrors);
+            Assert.Contains(logger.Entries, e => e.Message.Contains("Invalid HTTP URL"));
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml
+++ b/DesktopApplicationTemplate.UI/App.xaml
@@ -18,6 +18,27 @@
                     </Setter.Value>
                 </Setter>
             </Style>
+            <!-- Global style for text boxes including validation visuals -->
+            <Style TargetType="TextBox">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="TextBox">
+                            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="5" Background="{TemplateBinding Background}">
+                                <ScrollViewer x:Name="PART_ContentHost"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="BorderBrush" Value="LightGray"/>
+                <Setter Property="Background" Value="White"/>
+                <Style.Triggers>
+                    <Trigger Property="Validation.HasError" Value="True">
+                        <Setter Property="Background" Value="#FFEBEB"/>
+                        <Setter Property="BorderBrush" Value="DarkRed"/>
+                        <Setter Property="BorderThickness" Value="2"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -10,18 +10,47 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             "SCP", "MQTT", "FTP"
         };
 
+        private readonly HashSet<string> _existingNames;
+        private bool _autoName = true;
+
         private string _serviceName = string.Empty;
         public string ServiceName
         {
             get => _serviceName;
-            set { _serviceName = value; OnPropertyChanged(); }
+            set { _serviceName = value; OnPropertyChanged(); _autoName = false; }
         }
 
         private string _selectedServiceType = string.Empty;
         public string SelectedServiceType
         {
             get => _selectedServiceType;
-            set { _selectedServiceType = value; OnPropertyChanged(); }
+            set
+            {
+                _selectedServiceType = value;
+                OnPropertyChanged();
+                if (_autoName || string.IsNullOrWhiteSpace(ServiceName))
+                    GenerateDefaultName();
+            }
+        }
+
+        public CreateServiceViewModel(IEnumerable<string>? existingNames = null)
+        {
+            _existingNames = existingNames != null ? new HashSet<string>(existingNames) : new HashSet<string>();
+            if (ServiceTypes.Count > 0)
+            {
+                _selectedServiceType = ServiceTypes[0];
+                GenerateDefaultName();
+            }
+        }
+
+        private void GenerateDefaultName()
+        {
+            int index = 1;
+            while (_existingNames.Contains($"{SelectedServiceType}{index}"))
+                index++;
+            _autoName = true;
+            _serviceName = $"{SelectedServiceType}{index}";
+            OnPropertyChanged(nameof(ServiceName));
         }
 
         // OnPropertyChanged provided by ViewModelBase

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
@@ -6,7 +5,7 @@ using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
+public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
     {
         private string _host = string.Empty;
         public string Host
@@ -14,8 +13,16 @@ public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _host;
             set
             {
-                if (System.Net.IPAddress.TryParse(value, out _) || string.IsNullOrWhiteSpace(value))
-                    _host = value;
+                _host = value;
+                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                {
+                    AddError(nameof(Host), "Invalid host or IP address");
+                    Logger?.Log("Invalid FTP host entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(Host));
+                }
                 OnPropertyChanged();
             }
         }
@@ -26,8 +33,16 @@ public class FtpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _port;
             set
             {
-                if (int.TryParse(value, out _))
-                    _port = value;
+                _port = value;
+                if (!int.TryParse(value, out _))
+                {
+                    AddError(nameof(Port), "Port must be numeric");
+                    Logger?.Log("Invalid FTP port entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(Port));
+                }
                 OnPropertyChanged();
             }
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using System.Windows;
@@ -6,13 +5,25 @@ using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class HeartbeatViewModel : ViewModelBase
+    public class HeartbeatViewModel : ValidatableViewModelBase
     {
         private string _baseMessage = "HEARTBEAT";
         public string BaseMessage
         {
             get => _baseMessage;
-            set { _baseMessage = value; OnPropertyChanged(); }
+            set
+            {
+                _baseMessage = value;
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    AddError(nameof(BaseMessage), "Message cannot be empty");
+                }
+                else
+                {
+                    ClearErrors(nameof(BaseMessage));
+                }
+                OnPropertyChanged();
+            }
         }
 
         private bool _includePing;

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -11,7 +10,7 @@ using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class HttpServiceViewModel : ViewModelBase, ILoggingViewModel
+public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
     {
         public ObservableCollection<string> Methods { get; } = new() { "GET", "POST", "PUT", "DELETE" };
 
@@ -44,7 +43,20 @@ public class HttpServiceViewModel : ViewModelBase, ILoggingViewModel
         public string Url
         {
             get => _url;
-            set { _url = value; OnPropertyChanged(); }
+            set
+            {
+                _url = value;
+                if (!string.IsNullOrWhiteSpace(value) && !Uri.TryCreate(value, UriKind.Absolute, out _))
+                {
+                    AddError(nameof(Url), "Invalid URL");
+                    Logger?.Log("Invalid HTTP URL entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(Url));
+                }
+                OnPropertyChanged();
+            }
         }
 
         private string _requestBody = string.Empty;

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -123,7 +123,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void AddService()
         {
-            var vm = new CreateServiceViewModel();
+            var existing = Services.Select(s => s.DisplayName.Split(" - ").Last());
+            var vm = new CreateServiceViewModel(existing);
             var popup = new CreateServiceWindow(vm); // Replace with DI if needed
             if (popup.ShowDialog() == true)
             {

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -14,7 +13,7 @@ using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
+public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
     {
         private string _statusMessage = string.Empty;
         private bool _isServerRunning;
@@ -38,8 +37,16 @@ public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _computerIp;
             set
             {
-                if (System.Net.IPAddress.TryParse(value, out _) || string.IsNullOrWhiteSpace(value))
-                    _computerIp = value;
+                _computerIp = value;
+                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                {
+                    AddError(nameof(ComputerIp), "Invalid IP address");
+                    Logger?.Log("Invalid computer IP entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(ComputerIp));
+                }
                 OnPropertyChanged();
             }
         }
@@ -49,8 +56,16 @@ public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _listeningPort;
             set
             {
-                if (int.TryParse(value, out _))
-                    _listeningPort = value;
+                _listeningPort = value;
+                if (!int.TryParse(value, out _))
+                {
+                    AddError(nameof(ListeningPort), "Port must be numeric");
+                    Logger?.Log("Invalid listening port entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(ListeningPort));
+                }
                 OnPropertyChanged();
             }
         }
@@ -60,8 +75,16 @@ public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _serverIp;
             set
             {
-                if (System.Net.IPAddress.TryParse(value, out _) || string.IsNullOrWhiteSpace(value))
-                    _serverIp = value;
+                _serverIp = value;
+                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                {
+                    AddError(nameof(ServerIp), "Invalid IP address");
+                    Logger?.Log("Invalid server IP entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(ServerIp));
+                }
                 OnPropertyChanged();
             }
         }
@@ -71,8 +94,16 @@ public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _serverGateway;
             set
             {
-                if (System.Net.IPAddress.TryParse(value, out _) || string.IsNullOrWhiteSpace(value))
-                    _serverGateway = value;
+                _serverGateway = value;
+                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                {
+                    AddError(nameof(ServerGateway), "Invalid IP address");
+                    Logger?.Log("Invalid server gateway entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(ServerGateway));
+                }
                 OnPropertyChanged();
             }
         }
@@ -82,8 +113,16 @@ public class TcpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _serverPort;
             set
             {
-                if (int.TryParse(value, out _))
-                    _serverPort = value;
+                _serverPort = value;
+                if (!int.TryParse(value, out _))
+                {
+                    AddError(nameof(ServerPort), "Port must be numeric");
+                    Logger?.Log("Invalid server port entered", LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(ServerPort));
+                }
                 OnPropertyChanged();
             }
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/ValidatableViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ValidatableViewModelBase.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    /// <summary>
+    /// Base view model that supports validation using <see cref="INotifyDataErrorInfo"/>.
+    /// </summary>
+    public abstract class ValidatableViewModelBase : ViewModelBase, INotifyDataErrorInfo
+    {
+        private readonly Dictionary<string, List<string>> _errors = new();
+
+        /// <inheritdoc />
+        public bool HasErrors => _errors.Any();
+
+        /// <inheritdoc />
+        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+        /// <summary>
+        /// Retrieves validation errors for the specified property.
+        /// </summary>
+        public IEnumerable GetErrors(string? propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+                return _errors.SelectMany(e => e.Value);
+            return _errors.TryGetValue(propertyName, out var list) ? list : Enumerable.Empty<string>();
+        }
+
+        /// <summary>
+        /// Adds an error to the specified property.
+        /// </summary>
+        protected void AddError(string property, string error)
+        {
+            if (!_errors.ContainsKey(property))
+                _errors[property] = new List<string>();
+            if (!_errors[property].Contains(error))
+            {
+                _errors[property].Add(error);
+                ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(property));
+            }
+        }
+
+        /// <summary>
+        /// Clears any errors for the specified property.
+        /// </summary>
+        protected void ClearErrors(string property)
+        {
+            if (_errors.Remove(property))
+                ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(property));
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
@@ -15,13 +15,13 @@
         </Grid.ColumnDefinitions>
         <StackPanel Grid.Column="0" Margin="10">
             <Grid Margin="0,0,0,5">
-                <TextBox Text="{Binding Host}" x:Name="HostBox"/>
+                <TextBox Text="{Binding Host, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="HostBox"/>
                 <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
             <Grid Margin="0,0,0,5">
-                <TextBox Text="{Binding Port}" x:Name="PortBox"/>
+                <TextBox Text="{Binding Port, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="PortBox"/>
                 <TextBlock Text="Port" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatView.xaml
@@ -16,7 +16,7 @@
         <StackPanel Margin="0,50,0,0">
             <TextBlock Text="Heartbeat Message" FontWeight="Bold" Margin="0,0,0,5"/>
             <Grid Width="300">
-                <TextBox Text="{Binding BaseMessage}" x:Name="BaseMessageBox"/>
+                <TextBox Text="{Binding BaseMessage, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="BaseMessageBox"/>
                 <TextBlock Text="Base message" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=BaseMessageBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -29,7 +29,7 @@
         <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
             <ComboBox Width="100" ItemsSource="{Binding Methods}" SelectedItem="{Binding SelectedMethod}" />
             <Grid Width="400" Margin="10 0">
-                <TextBox Text="{Binding Url, UpdateSourceTrigger=PropertyChanged}" Name="UrlTextBox"/>
+                <TextBox Text="{Binding Url, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" Name="UrlTextBox"/>
                 <TextBlock Text="Enter URL"
                IsHitTestVisible="False"
                Foreground="Gray"

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -40,31 +40,31 @@
             <!-- LEFT SIDE -->
             <StackPanel Grid.Column="0" Margin="10">
                 <Grid Margin="0,0,0,5">
-                    <TextBox Text="{Binding ComputerIp, UpdateSourceTrigger=PropertyChanged}" x:Name="ComputerIpBox"/>
+                    <TextBox Text="{Binding ComputerIp, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ComputerIpBox"/>
                     <TextBlock Text="Computer IP" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ComputerIpBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
                 <Grid Margin="0,0,0,5">
-                    <TextBox Text="{Binding ListeningPort, UpdateSourceTrigger=PropertyChanged}" x:Name="ListenPortBox"/>
+                    <TextBox Text="{Binding ListeningPort, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ListenPortBox"/>
                     <TextBlock Text="Listening Port" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ListenPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
                 <Grid Margin="0,0,0,5">
-                    <TextBox Text="{Binding ServerIp, UpdateSourceTrigger=PropertyChanged}" x:Name="ServerIpBox"/>
+                    <TextBox Text="{Binding ServerIp, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ServerIpBox"/>
                     <TextBlock Text="Server IP" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ServerIpBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
                 <Grid Margin="0,0,0,5">
-                    <TextBox Text="{Binding ServerGateway, UpdateSourceTrigger=PropertyChanged}" x:Name="ServerGatewayBox"/>
+                    <TextBox Text="{Binding ServerGateway, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ServerGatewayBox"/>
                     <TextBlock Text="Server Gateway" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ServerGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
                 <Grid Margin="0,0,0,10">
-                    <TextBox Text="{Binding ServerPort, UpdateSourceTrigger=PropertyChanged}" x:Name="ServerPortBox"/>
+                    <TextBox Text="{Binding ServerPort, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ServerPortBox"/>
                     <TextBlock Text="Server Port" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ServerPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>


### PR DESCRIPTION
## Summary
- add ValidatableViewModelBase implementing `INotifyDataErrorInfo`
- default service names are generated in `CreateServiceViewModel`
- highlight invalid entries with bubbly styles in `App.xaml`
- validate host/port and url fields with red highlighting and logging
- extend unit tests for new validation features

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68826d47b9908326affaf35f907007b0