### PR TITLE
Fix URL validation

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -46,10 +46,19 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             set
             {
                 _url = value;
-                if (!string.IsNullOrWhiteSpace(value) && !Uri.TryCreate(value, UriKind.Absolute, out _))
+                if (!string.IsNullOrWhiteSpace(value))
                 {
-                    AddError(nameof(Url), "Invalid URL");
-                    Logger?.Log("Invalid HTTP URL entered", LogLevel.Warning);
+                    if (Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
+                        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+                    {
+                        ClearErrors(nameof(Url));
+                        Logger?.Log("Valid HTTP URL set", LogLevel.Debug);
+                    }
+                    else
+                    {
+                        AddError(nameof(Url), "Invalid URL");
+                        Logger?.Log("Invalid HTTP URL entered", LogLevel.Warning);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- make URL validation in HttpServiceViewModel stricter by ensuring schemes are http or https
- add debug log when a valid URL is set

## Testing
- `dotnet test DesktopApplicationTemplate.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_688270648344832680cce1183c5d7dc0