### PR TITLE
Add service logging and tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -1,0 +1,40 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using System;
+using System.IO;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class CsvServiceTests
+    {
+        [Fact]
+        public void AppendRow_CreatesIncrementingFiles()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var vm = new CsvViewerViewModel();
+                vm.Configuration.FileNamePattern = Path.Combine(tempDir, "output_{index}.csv");
+                var service = new CsvService(vm);
+
+                service.AppendRow(new[] { "a", "b" });
+                service.AppendRow(new[] { "c", "d" });
+
+                var file1 = Path.Combine(tempDir, "output_0.csv");
+                var file2 = Path.Combine(tempDir, "output_1.csv");
+                Assert.True(File.Exists(file1));
+                Assert.True(File.Exists(file2));
+                Assert.Contains("a,b", File.ReadAllText(file1));
+                Assert.Contains("c,d", File.ReadAllText(file2));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
@@ -1,0 +1,29 @@
+using DesktopApplicationTemplate.UI.Services;
+using FluentFTP;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class FtpServiceTests
+    {
+        [Fact]
+        public async Task UploadAsync_InvokesClientOperations()
+        {
+            var client = new Mock<FtpClient>("host", new NetworkCredential("u","p"));
+            client.Setup(c => c.Connect());
+            client.Setup(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite));
+            client.Setup(c => c.Disconnect());
+
+            var service = new FtpService(client.Object);
+            await service.UploadAsync("local","remote");
+
+            client.Verify(c => c.Connect(), Times.Once);
+            client.Verify(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite), Times.Once);
+            client.Verify(c => c.Disconnect(), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
@@ -1,0 +1,31 @@
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
+using MQTTnet.Client;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class MqttServiceTests
+    {
+        [Fact]
+        public async Task ConnectAndPublish_CallsClient()
+        {
+            var client = new Mock<IMqttClient>();
+            client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>())).Returns(Task.CompletedTask);
+            client.Setup(c => c.SubscribeAsync(It.IsAny<string>())).Returns(Task.CompletedTask);
+            client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>())).Returns(Task.CompletedTask);
+
+            var service = new MqttService(client.Object);
+            await service.ConnectAsync("host", 1234, "id", null, null);
+            await service.SubscribeAsync(new[] { "topic" });
+            await service.PublishAsync("topic", "msg");
+
+            client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>()), Times.Once);
+            client.Verify(c => c.SubscribeAsync("topic"), Times.Once);
+            client.Verify(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>()), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/ScpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScpServiceTests.cs
@@ -1,0 +1,29 @@
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
+using Renci.SshNet;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ScpServiceTests
+    {
+        [Fact]
+        public async Task UploadAsync_InvokesClientOperations()
+        {
+            var client = new Mock<ScpClient>("host", 22, "u", "p");
+            client.Setup(c => c.Connect());
+            client.Setup(c => c.Upload(It.IsAny<System.IO.Stream>(), "remote"));
+            client.Setup(c => c.Disconnect());
+
+            var service = new ScpService(client.Object);
+            await service.UploadAsync("local", "remote");
+
+            client.Verify(c => c.Connect(), Times.Once);
+            client.Verify(c => c.Upload(It.IsAny<System.IO.Stream>(), "remote"), Times.Once);
+            client.Verify(c => c.Disconnect(), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -1,0 +1,42 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ServicePersistenceTests
+    {
+        [Fact]
+        public void SaveAndLoad_RoundTripsServices()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var original = typeof(ServicePersistence).GetField("FilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            string? oldPath = (string?)original!.GetValue(null);
+            original.SetValue(null, Path.Combine(tempDir, "services.json"));
+            try
+            {
+                var services = new List<ServiceViewModel>
+                {
+                    new ServiceViewModel{DisplayName="A", ServiceType="Heartbeat", IsActive=true, Order=0},
+                    new ServiceViewModel{DisplayName="B", ServiceType="TCP", IsActive=false, Order=1}
+                };
+
+                ServicePersistence.Save(services);
+                var loaded = ServicePersistence.Load();
+                Assert.Equal(2, loaded.Count);
+                Assert.Equal("A", loaded[0].DisplayName);
+            }
+            finally
+            {
+                original.SetValue(null, oldPath);
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/CsvService.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvService.cs
@@ -1,16 +1,19 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using System.Text;
 
+
 namespace DesktopApplicationTemplate.UI.Services
 {
     public class CsvService
     {
         private readonly CsvViewerViewModel _viewModel;
+        private readonly ILoggingService? _logger;
         private int _index = 0;
 
-        public CsvService(CsvViewerViewModel vm)
+        public CsvService(CsvViewerViewModel vm, ILoggingService? logger = null)
         {
             _viewModel = vm;
+            _logger = logger;
         }
 
         public void AppendRow(IEnumerable<string> values)
@@ -18,6 +21,7 @@ namespace DesktopApplicationTemplate.UI.Services
             string fileName = BuildFileName();
             var line = string.Join(",", values);
             System.IO.File.AppendAllText(fileName, line + System.Environment.NewLine, Encoding.UTF8);
+            _logger?.Log($"Appended row to {fileName}", LogLevel.Debug);
         }
 
         private string BuildFileName()

--- a/DesktopApplicationTemplate.UI/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FtpService.cs
@@ -2,26 +2,38 @@ using FluentFTP;
 using FluentFTP.Client.BaseClient; // Required for async methods
 using System.Threading.Tasks;
 
+
 namespace DesktopApplicationTemplate.UI.Services
 {
     public class FtpService : IFtpService
     {
         private readonly FtpClient _client;
-        public FtpService(string host, int port, string user, string pass)
+        private readonly ILoggingService? _logger;
+
+        public FtpService(string host, int port, string user, string pass, ILoggingService? logger = null)
         {
             var credentials = new System.Net.NetworkCredential(user, pass);
             _client = new FtpClient(host, credentials)
             {
                 Port = port
             };
+            _logger = logger;
+        }
 
+        internal FtpService(FtpClient client, ILoggingService? logger = null)
+        {
+            _client = client;
+            _logger = logger;
         }
 
         public async Task UploadAsync(string localPath, string remotePath)
         {
+            _logger?.Log($"Connecting to FTP {_client.Host}:{_client.Port}", LogLevel.Debug);
             _client.Connect();
+            _logger?.Log($"Uploading {localPath} -> {remotePath}", LogLevel.Debug);
             _client.UploadFile(localPath, remotePath, FtpRemoteExists.Overwrite);
             _client.Disconnect();
+            _logger?.Log("Upload finished", LogLevel.Debug);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -8,12 +8,19 @@ namespace DesktopApplicationTemplate.UI.Services
     public class MqttService
     {
         private readonly IMqttClient _client;
+        private readonly ILoggingService? _logger;
 
-        public MqttService()
+        public MqttService(ILoggingService? logger = null)
         {
-            // MqttFactory is provided by MQTTnet and is used to create clients
             var factory = new MqttFactory();
             _client = factory.CreateMqttClient();
+            _logger = logger;
+        }
+
+        internal MqttService(IMqttClient client, ILoggingService? logger = null)
+        {
+            _client = client;
+            _logger = logger;
         }
 
         public async Task ConnectAsync(string host, int port, string clientId, string? user, string? pass)
@@ -25,24 +32,29 @@ namespace DesktopApplicationTemplate.UI.Services
             if (!string.IsNullOrEmpty(user))
                 options = options.WithCredentials(user, pass);
 
+            _logger?.Log($"Connecting to MQTT {host}:{port}", LogLevel.Debug);
             await _client.ConnectAsync(options.Build());
+            _logger?.Log("MQTT connected", LogLevel.Debug);
         }
 
         public async Task SubscribeAsync(IEnumerable<string> topics)
         {
             foreach (var t in topics)
             {
+                _logger?.Log($"Subscribing to {t}", LogLevel.Debug);
                 await _client.SubscribeAsync(t);
             }
         }
 
         public async Task PublishAsync(string topic, string message)
         {
+            _logger?.Log($"Publishing to {topic}", LogLevel.Debug);
             var msg = new MqttApplicationMessageBuilder()
                 .WithTopic(topic)
                 .WithPayload(message)
                 .Build();
             await _client.PublishAsync(msg);
+            _logger?.Log("Publish complete", LogLevel.Debug);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ScpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/ScpService.cs
@@ -6,9 +6,18 @@ namespace DesktopApplicationTemplate.UI.Services
     public class ScpService
     {
         private readonly ScpClient _client;
-        public ScpService(string host, int port, string user, string password)
+        private readonly ILoggingService? _logger;
+
+        public ScpService(string host, int port, string user, string password, ILoggingService? logger = null)
         {
             _client = new ScpClient(host, port, user, password);
+            _logger = logger;
+        }
+
+        internal ScpService(ScpClient client, ILoggingService? logger = null)
+        {
+            _client = client;
+            _logger = logger;
         }
 
         public async Task UploadAsync(string localPath, string remotePath)
@@ -16,9 +25,12 @@ namespace DesktopApplicationTemplate.UI.Services
             await Task.Run(() =>
             {
                 using var stream = System.IO.File.OpenRead(localPath);
+                _logger?.Log($"Connecting to SCP {_client.ConnectionInfo.Host}:{_client.ConnectionInfo.Port}", LogLevel.Debug);
                 _client.Connect();
+                _logger?.Log($"Uploading {localPath} -> {remotePath}", LogLevel.Debug);
                 _client.Upload(stream, remotePath);
                 _client.Disconnect();
+                _logger?.Log("Upload finished", LogLevel.Debug);
             });
         }
     }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -10,7 +10,7 @@ namespace DesktopApplicationTemplate.UI.Services
     {
         private static readonly string FilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
 
-        public static void Save(IEnumerable<ServiceViewModel> services)
+        public static void Save(IEnumerable<ServiceViewModel> services, ILoggingService? logger = null)
         {
             var data = new List<ServiceInfo>();
             var index = 0;
@@ -26,19 +26,26 @@ namespace DesktopApplicationTemplate.UI.Services
                 });
             }
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
+            logger?.Log($"Saved {data.Count} services to {FilePath}", LogLevel.Debug);
         }
 
-        public static List<ServiceInfo> Load()
+        public static List<ServiceInfo> Load(ILoggingService? logger = null)
         {
             if (!File.Exists(FilePath))
+            {
+                logger?.Log("Services file not found", LogLevel.Warning);
                 return new List<ServiceInfo>();
+            }
             var json = File.ReadAllText(FilePath);
             try
             {
-                return JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+                var result = JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+                logger?.Log($"Loaded {result.Count} services", LogLevel.Debug);
+                return result;
             }
             catch
             {
+                logger?.Log("Failed to parse services file", LogLevel.Error);
                 return new List<ServiceInfo>();
             }
         }


### PR DESCRIPTION
## Summary
- add detailed logging to `CsvService`, `FtpService`, `ScpService`, `MqttService` and `ServicePersistence`
- allow dependency injection of service clients for tests
- create unit tests for service classes and persistence helpers

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827091dcac8326af6f32b26f6dfe55