### PR TITLE
Improve log filtering and networking UI

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -63,5 +63,16 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        public void PartialHost_WithTrailingDot_DoesNotError()
+        {
+            var vm = new FtpServiceViewModel();
+            vm.Host = "192.168.";
+
+            Assert.False(vm.HasErrors);
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -91,5 +91,40 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        public void MinimumLevel_Change_FiltersExistingLogs()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var box = new System.Windows.Controls.RichTextBox();
+                    var service = new LoggingService(box, Dispatcher.CurrentDispatcher);
+                    service.Log("debug", LogLevel.Debug);
+                    service.Log("error", LogLevel.Error);
+                    service.MinimumLevel = LogLevel.Error;
+                    string text = new TextRange(box.Document.ContentStart, box.Document.ContentEnd).Text;
+                    Assert.DoesNotContain("debug", text);
+                    Assert.Contains("error", text);
+                }
+                catch (Exception e)
+                {
+                    ex = e;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/InputValidators.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/InputValidators.cs
@@ -1,0 +1,14 @@
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public static class InputValidators
+    {
+        public static bool IsValidPartialIp(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return true;
+            if (value.EndsWith("."))
+                return true;
+            return System.Net.IPAddress.TryParse(value, out _);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Models/LogEntry.cs
+++ b/DesktopApplicationTemplate.UI/Models/LogEntry.cs
@@ -1,7 +1,10 @@
+using DesktopApplicationTemplate.UI.Services;
+
 namespace DesktopApplicationTemplate.Models
 {
     public class LogEntry
     {
+        public LogLevel Level { get; set; } = LogLevel.Debug;
         public string Message { get; set; } = string.Empty;
         public System.Windows.Media.Brush Color { get; set; } = System.Windows.Media.Brushes.Black;
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -14,7 +14,7 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             set
             {
                 _host = value;
-                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                if (!InputValidators.IsValidPartialIp(value))
                 {
                     AddError(nameof(Host), "Invalid host or IP address");
                     Logger?.Log("Invalid FTP host entered", LogLevel.Warning);

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.Models;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Data;
@@ -60,10 +61,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public event Action<ServiceViewModel, LogEntry>? LogAdded;
 
-        public void AddLog(string message, WpfBrush? color = null)
+        public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug)
         {
             var ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
-            var entry = new LogEntry { Message = $"{ts} {message}", Color = color ?? WpfBrushes.Black };
+            var entry = new LogEntry { Message = $"{ts} {message}", Color = color ?? WpfBrushes.Black, Level = level };
             Logs.Insert(0, entry);
             LogAdded?.Invoke(this, entry);
         }
@@ -106,7 +107,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public int ServicesCreated => Services.Count;
         public int CurrentActiveServices => Services.Count(s => s.IsActive);
 
-        public IEnumerable<LogEntry> DisplayLogs => SelectedService?.Logs ?? AllLogs;
+        private LogLevel _logLevelFilter = LogLevel.Debug;
+        public LogLevel LogLevelFilter
+        {
+            get => _logLevelFilter;
+            set { _logLevelFilter = value; OnPropertyChanged(); OnPropertyChanged(nameof(DisplayLogs)); }
+        }
+
+        public IEnumerable<LogEntry> DisplayLogs => (SelectedService?.Logs ?? AllLogs).Where(l => l.Level >= LogLevelFilter);
 
         private readonly CsvService _csvService;
 

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -15,7 +15,7 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _host;
             set
             {
-                if (System.Net.IPAddress.TryParse(value, out _) || string.IsNullOrWhiteSpace(value))
+                if (InputValidators.IsValidPartialIp(value))
                     _host = value;
                 OnPropertyChanged();
             }

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -14,7 +14,7 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel
             get => _host;
             set
             {
-                if (System.Net.IPAddress.TryParse(value, out _) || string.IsNullOrWhiteSpace(value))
+                if (InputValidators.IsValidPartialIp(value))
                     _host = value;
                 OnPropertyChanged();
             }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -24,6 +24,43 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         private string _serverGateway = string.Empty;
         private string _serverPort = string.Empty;
 
+        private bool _isUdp;
+        private bool _serverIpEnabled = true;
+        private string _selectedMode = "Listening";
+
+        public bool IsUdp
+        {
+            get => _isUdp;
+            set
+            {
+                _isUdp = value;
+                if (_isUdp)
+                {
+                    ServerIp = "0.0.0.0";
+                    ServerIpEnabled = false;
+                }
+                else
+                {
+                    ServerIpEnabled = true;
+                }
+                OnPropertyChanged();
+            }
+        }
+
+        public bool ServerIpEnabled
+        {
+            get => _serverIpEnabled;
+            set { _serverIpEnabled = value; OnPropertyChanged(); }
+        }
+
+        public ObservableCollection<string> Modes { get; } = new() { "Listening", "Sending" };
+
+        public string SelectedMode
+        {
+            get => _selectedMode;
+            set { _selectedMode = value; OnPropertyChanged(); }
+        }
+
         private string _scriptContent = string.Empty;
         private string _selectedLanguage = "Python";
         private string _testMessage = string.Empty;
@@ -38,7 +75,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             set
             {
                 _computerIp = value;
-                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                if (!InputValidators.IsValidPartialIp(value))
                 {
                     AddError(nameof(ComputerIp), "Invalid IP address");
                     Logger?.Log("Invalid computer IP entered", LogLevel.Warning);
@@ -76,7 +113,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             set
             {
                 _serverIp = value;
-                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                if (!InputValidators.IsValidPartialIp(value))
                 {
                     AddError(nameof(ServerIp), "Invalid IP address");
                     Logger?.Log("Invalid server IP entered", LogLevel.Warning);
@@ -95,7 +132,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             set
             {
                 _serverGateway = value;
-                if (!string.IsNullOrWhiteSpace(value) && !System.Net.IPAddress.TryParse(value, out _))
+                if (!InputValidators.IsValidPartialIp(value))
                 {
                     AddError(nameof(ServerGateway), "Invalid IP address");
                     Logger?.Log("Invalid server gateway entered", LogLevel.Warning);

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
@@ -16,7 +16,7 @@
         <StackPanel Grid.Column="0" Margin="10">
             <Grid Margin="0,0,0,5">
                 <TextBox Text="{Binding Host, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="HostBox"/>
-                <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                <TextBlock Text="Host (e.g. 192.168.1.20)" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -30,7 +30,7 @@
             <ComboBox Width="100" ItemsSource="{Binding Methods}" SelectedItem="{Binding SelectedMethod}" />
             <Grid Width="400" Margin="10 0">
                 <TextBox Text="{Binding Url, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" Name="UrlTextBox"/>
-                <TextBlock Text="Enter URL"
+                <TextBlock Text="http://127.0.0.1/api"
                IsHitTestVisible="False"
                Foreground="Gray"
                VerticalAlignment="Center"

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml
@@ -17,7 +17,7 @@
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
             <Grid Width="140">
                 <TextBox Text="{Binding Host}" x:Name="HostBox"/>
-                <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                <TextBlock Text="Host (e.g. broker.example.com)" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -94,6 +94,15 @@
             <TextBlock Text="{Binding ServicesCreated}" />
             <TextBlock Text="Current Active Services:" />
             <TextBlock Text="{Binding CurrentActiveServices}" />
+            <StackPanel Orientation="Horizontal" Margin="0,5,0,5">
+                <TextBlock Text="Log Level:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                <ComboBox x:Name="GlobalLogLevelBox" Width="120" SelectionChanged="GlobalLogLevelBox_SelectionChanged" SelectedIndex="0">
+                    <ComboBoxItem Content="All"/>
+                    <ComboBoxItem Content="Debug"/>
+                    <ComboBoxItem Content="Warning"/>
+                    <ComboBoxItem Content="Error"/>
+                </ComboBox>
+            </StackPanel>
             <ListBox ItemsSource="{Binding DisplayLogs}" Height="150">
                 <ListBox.ItemTemplate>
                     <DataTemplate>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -60,7 +60,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     if (vm.Logger != null)
                     {
-                        logger.LogAdded += entry => svc.AddLog(entry.Message, entry.Color);
+                        logger.LogAdded += entry => svc.AddLog(entry.Message, entry.Color, entry.Level);
                     }
                 }
             }
@@ -356,6 +356,20 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 _viewModel.Services.Move(oldIndex, newIndex);
                 _viewModel.SaveServices();
+            }
+        }
+
+        private void GlobalLogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (GlobalLogLevelBox.SelectedItem is ComboBoxItem item)
+            {
+                _viewModel.LogLevelFilter = item.Content?.ToString() switch
+                {
+                    "Warning" => LogLevel.Warning,
+                    "Error" => LogLevel.Error,
+                    "Debug" => LogLevel.Debug,
+                    _ => LogLevel.Debug
+                };
             }
         }
 

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml
@@ -16,7 +16,7 @@
         <StackPanel Grid.Column="0" Margin="10">
             <Grid Margin="0,0,0,5">
                 <TextBox Text="{Binding Host}" x:Name="HostBox"/>
-                <TextBlock Text="Host" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                <TextBlock Text="Host (e.g. 192.168.1.30)" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -41,7 +41,7 @@
             <StackPanel Grid.Column="0" Margin="10">
                 <Grid Margin="0,0,0,5">
                     <TextBox Text="{Binding ComputerIp, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ComputerIpBox"/>
-                    <TextBlock Text="Computer IP" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                    <TextBlock Text="Computer IP (e.g. 192.168.1.50)" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ComputerIpBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
@@ -51,15 +51,17 @@
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ListenPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
+                <CheckBox Content="UDP" IsChecked="{Binding IsUdp}" Margin="0,0,0,5"/>
+                <ComboBox ItemsSource="{Binding Modes}" SelectedItem="{Binding SelectedMode}" Width="120" Margin="0,0,0,5"/>
                 <Grid Margin="0,0,0,5">
-                    <TextBox Text="{Binding ServerIp, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ServerIpBox"/>
-                    <TextBlock Text="Server IP" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                    <TextBox Text="{Binding ServerIp, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ServerIpBox" IsEnabled="{Binding ServerIpEnabled}"/>
+                    <TextBlock Text="Server IP (e.g. 192.168.1.200)" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ServerIpBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>
                 <Grid Margin="0,0,0,5">
                     <TextBox Text="{Binding ServerGateway, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" x:Name="ServerGatewayBox"/>
-                    <TextBlock Text="Server Gateway" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
+                    <TextBlock Text="Gateway (e.g. 192.168.1.1)" IsHitTestVisible="False" Foreground="Gray" VerticalAlignment="Center"
                                Margin="5,0,0,0"
                                Visibility="{Binding Text, ElementName=ServerGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
                 </Grid>


### PR DESCRIPTION
## Summary
- add InputValidators helper and use for partial IP address validation
- enhance `LoggingService` with in-memory log store and filtering
- extend `MainViewModel` with log level filtering
- add UDP and mode options to `TcpServiceViewModel`
- tweak network placeholders in various service views
- add global log filter UI
- update tests for new behaviors

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882757cf8888326958fbb5ac89c5527