### PR TITLE
Fix null warnings and async FTP

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -34,6 +34,10 @@ namespace DesktopApplicationTemplate.Tests
             var lines = File.ReadAllLines(path);
             Assert.Equal("Svc,Svc Sent", lines[0]);
             Assert.Equal("hello world,", lines[1]);
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
         public void AppendRow_CreatesIncrementingFiles()
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
@@ -2,6 +2,7 @@ using DesktopApplicationTemplate.UI.Services;
 using FluentFTP;
 using Moq;
 using System.Net;
+using System.Threading;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -12,16 +13,16 @@ namespace DesktopApplicationTemplate.Tests
         public async Task UploadAsync_InvokesClientOperations()
         {
             var client = new Mock<FtpClient>("host", new NetworkCredential("u","p"));
-            client.Setup(c => c.Connect());
-            client.Setup(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite));
-            client.Setup(c => c.Disconnect());
+            client.Setup(c => c.ConnectAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            client.Setup(c => c.UploadFileAsync("local","remote", FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(FtpStatus.Success));
+            client.Setup(c => c.DisconnectAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
             var service = new FtpService(client.Object);
             await service.UploadAsync("local","remote");
 
-            client.Verify(c => c.Connect(), Times.Once);
-            client.Verify(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite), Times.Once);
-            client.Verify(c => c.Disconnect(), Times.Once);
+            client.Verify(c => c.ConnectAsync(It.IsAny<CancellationToken>()), Times.Once);
+            client.Verify(c => c.UploadFileAsync("local","remote", FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+            client.Verify(c => c.DisconnectAsync(It.IsAny<CancellationToken>()), Times.Once);
 
             ConsoleTestLogger.LogPass();
         }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -14,7 +14,7 @@ namespace DesktopApplicationTemplate.UI
 {
     public partial class App : System.Windows.Application
     {
-        public static IHost AppHost { get; private set; }
+        public static IHost AppHost { get; private set; } = null!;
 
         public App()
         {

--- a/DesktopApplicationTemplate.UI/Helpers/AutoStart.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AutoStart.cs
@@ -16,7 +16,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
         public static void EnableAutoStart()
         {
             using RegistryKey key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath, true)
-                                     ?? Registry.CurrentUser.CreateSubKey(RegistryKeyPath);
+                                     ?? Registry.CurrentUser.CreateSubKey(RegistryKeyPath)!;
 
             string exePath = Process.GetCurrentProcess().MainModule?.FileName ?? string.Empty;
             if (!string.IsNullOrWhiteSpace(exePath))

--- a/DesktopApplicationTemplate.UI/Services/CsvService.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvService.cs
@@ -56,6 +56,7 @@ namespace DesktopApplicationTemplate.UI.Services
             string fileName = BuildFileName();
             var line = string.Join(',', values.Select(v => v ?? string.Empty));
             File.AppendAllText(fileName, line + System.Environment.NewLine, Encoding.UTF8);
+            _logger?.Log($"Appended row to {fileName}", LogLevel.Debug);
         }
 
         private void EnsureHeader()
@@ -67,11 +68,9 @@ namespace DesktopApplicationTemplate.UI.Services
             {
                 var header = string.Join(',', _viewModel.Configuration.Columns.Select(c => c.Name));
                 File.AppendAllText(fileName, header + System.Environment.NewLine, Encoding.UTF8);
+                _logger?.Log($"Wrote CSV header to {fileName}", LogLevel.Debug);
             }
             _headerWritten = true;
-            var line = string.Join(",", values);
-            System.IO.File.AppendAllText(fileName, line + System.Environment.NewLine, Encoding.UTF8);
-            _logger?.Log($"Appended row to {fileName}", LogLevel.Debug);
         }
 
         private string BuildFileName()

--- a/DesktopApplicationTemplate.UI/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FtpService.cs
@@ -29,10 +29,10 @@ namespace DesktopApplicationTemplate.UI.Services
         public async Task UploadAsync(string localPath, string remotePath)
         {
             _logger?.Log($"Connecting to FTP {_client.Host}:{_client.Port}", LogLevel.Debug);
-            _client.Connect();
+            await _client.ConnectAsync();
             _logger?.Log($"Uploading {localPath} -> {remotePath}", LogLevel.Debug);
-            _client.UploadFile(localPath, remotePath, FtpRemoteExists.Overwrite);
-            _client.Disconnect();
+            await _client.UploadFileAsync(localPath, remotePath, FtpRemoteExists.Overwrite);
+            await _client.DisconnectAsync();
             _logger?.Log("Upload finished", LogLevel.Debug);
         }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -11,9 +11,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         public ObservableCollection<FileObserver> Observers { get; } = new();
         private FileObserver? _selectedObserver;
-        public FileObserver SelectedObserver
+        public FileObserver? SelectedObserver
         {
-            get => _selectedObserver!;
+            get => _selectedObserver;
             set { _selectedObserver = value; OnPropertyChanged(); LoadObserverData(); }
         }
 
@@ -136,14 +136,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
     public class FileObserver
     {
-        public string Name { get; set; }
-        public string FilePath { get; set; }
-        public string Contents { get; set; }
-        public string ImageNames { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string FilePath { get; set; } = string.Empty;
+        public string Contents { get; set; } = string.Empty;
+        public string ImageNames { get; set; } = string.Empty;
         public bool SendAll { get; set; }
         public bool SendFirstX { get; set; }
         public int XCount { get; set; } = 10;
         public bool SendTcp { get; set; }
-        public string TcpString { get; set; }
+        public string TcpString { get; set; } = string.Empty;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -15,7 +15,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
     public class ServiceViewModel : ViewModelBase
     {
-        public string DisplayName { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
         public string ServiceType { get; set; } = string.Empty;
         public Page? Page { get; set; }
         public int Order { get; set; }
@@ -95,9 +95,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public FilterViewModel Filters { get; } = new();
         public ObservableCollection<LogEntry> AllLogs { get; } = new();
         private ServiceViewModel? _selectedService;
-        public ServiceViewModel SelectedService
+        public ServiceViewModel? SelectedService
         {
-            get => _selectedService!;
+            get => _selectedService;
             set { _selectedService = value; OnPropertyChanged(); OnPropertyChanged(nameof(DisplayLogs)); }
         }
         public ICommand AddServiceCommand { get; }
@@ -167,7 +167,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 }
                 else
                 {
-                    SelectedService = null!;
+                    SelectedService = null;
                 }
                 OnPropertyChanged(nameof(ServicesCreated));
                 OnPropertyChanged(nameof(CurrentActiveServices));

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -7,8 +7,8 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class CreateServicePage : Page
     {
         private readonly CreateServiceViewModel _viewModel;
-        public string CreatedServiceName { get; private set; }
-        public string CreatedServiceType { get; private set; }
+        public string CreatedServiceName { get; private set; } = string.Empty;
+        public string CreatedServiceType { get; private set; } = string.Empty;
         public event Action<string,string>? ServiceCreated;
         public event Action? Cancelled;
 


### PR DESCRIPTION
## Summary
- ensure nullable handling for view models
- clean up csv logging with header write and row logging
- switch FTP service to async methods
- initialize UI properties for non-nullable strings
- fix unit tests for async FTP and CSV service

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_688276cbc6908326aa79b2cd8a234914