### PR TITLE
Add dark theme with settings integration

### DIFF
--- a/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
@@ -1,0 +1,43 @@
+using DesktopApplicationTemplate.UI.Services;
+using System.Threading;
+using System.Windows;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ThemeManagerTests
+    {
+        [Fact]
+        public void ApplyTheme_LoadsResourceDictionary()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var app = new Application();
+                    ThemeManager.ApplyTheme(true);
+                    Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("DarkTheme.xaml") == true);
+                    ThemeManager.ApplyTheme(false);
+                    Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("LightTheme.xaml") == true);
+                    app.Shutdown();
+                }
+                catch (Exception e)
+                {
+                    ex = e;
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml
+++ b/DesktopApplicationTemplate.UI/App.xaml
@@ -6,39 +6,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/ToggleSwitch.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <!-- Global style for log boxes -->
-            <Style TargetType="RichTextBox">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="RichTextBox">
-                            <Border BorderBrush="#98FF98" BorderThickness="2" CornerRadius="5" Background="{TemplateBinding Background}">
-                                <ScrollViewer x:Name="PART_ContentHost"/>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-            <!-- Global style for text boxes including validation visuals -->
-            <Style TargetType="TextBox">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="TextBox">
-                            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="5" Background="{TemplateBinding Background}">
-                                <ScrollViewer x:Name="PART_ContentHost"/>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-                <Setter Property="BorderBrush" Value="LightGray"/>
-                <Setter Property="Background" Value="White"/>
-                <Style.Triggers>
-                    <Trigger Property="Validation.HasError" Value="True">
-                        <Setter Property="Background" Value="#FFEBEB"/>
-                        <Setter Property="BorderBrush" Value="DarkRed"/>
-                        <Setter Property="BorderThickness" Value="2"/>
-                    </Trigger>
-                </Style.Triggers>
-            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -77,6 +77,7 @@ namespace DesktopApplicationTemplate.UI
 
             var settings = AppHost.Services.GetRequiredService<SettingsViewModel>();
             settings.Load();
+            Services.ThemeManager.ApplyTheme(settings.DarkTheme);
 
             SplashWindow? splash = null;
             if (settings.FirstRun)

--- a/DesktopApplicationTemplate.UI/Services/ThemeManager.cs
+++ b/DesktopApplicationTemplate.UI/Services/ThemeManager.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Windows;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Provides runtime application theme switching.
+    /// </summary>
+    public static class ThemeManager
+    {
+        private static ResourceDictionary? _current;
+
+        /// <summary>
+        /// Apply the dark or light theme.
+        /// </summary>
+        /// <param name="useDark">True to apply the dark theme.</param>
+        public static void ApplyTheme(bool useDark)
+        {
+            var logger = App.AppHost.Services.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
+            var log = logger?.CreateLogger("ThemeManager");
+            try
+            {
+                log?.LogInformation("Applying {Theme} theme", useDark ? "dark" : "light");
+                var themeFile = useDark ? "Themes/DarkTheme.xaml" : "Themes/LightTheme.xaml";
+                var dict = new ResourceDictionary { Source = new Uri(themeFile, UriKind.Relative) };
+                if (_current != null)
+                {
+                    Application.Current.Resources.MergedDictionaries.Remove(_current);
+                }
+                Application.Current.Resources.MergedDictionaries.Add(dict);
+                _current = dict;
+                log?.LogInformation("Theme applied successfully: {Theme}", themeFile);
+            }
+            catch (Exception ex)
+            {
+                log?.LogError(ex, "Failed to apply theme");
+            }
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Themes/DarkTheme.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/DarkTheme.xaml
@@ -1,0 +1,51 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Dark theme resources with softer tones -->
+    <Color x:Key="WindowBackgroundColor">#FF2D2D30</Color>
+    <Color x:Key="ForegroundColor">#FFF1F1F1</Color>
+    <SolidColorBrush x:Key="WindowBackground" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="WindowForeground" Color="{StaticResource ForegroundColor}"/>
+
+    <!-- Global style for log boxes -->
+    <Style TargetType="RichTextBox">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RichTextBox">
+                    <Border BorderBrush="#507050" BorderThickness="2" CornerRadius="5" Background="{TemplateBinding Background}">
+                        <ScrollViewer x:Name="PART_ContentHost"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Background" Value="#333333"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+
+    <!-- Global style for text boxes including validation visuals -->
+    <Style TargetType="TextBox">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="5" Background="{TemplateBinding Background}">
+                        <ScrollViewer x:Name="PART_ContentHost"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="BorderBrush" Value="Gray"/>
+        <Setter Property="Background" Value="#3C3C3C"/>
+        <Setter Property="Foreground" Value="White"/>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="True">
+                <Setter Property="Background" Value="#5C2B2B"/>
+                <Setter Property="BorderBrush" Value="DarkRed"/>
+                <Setter Property="BorderThickness" Value="2"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="#444444"/>
+        <Setter Property="Foreground" Value="White"/>
+    </Style>
+</ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Themes/LightTheme.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/LightTheme.xaml
@@ -1,0 +1,43 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Light theme resources -->
+    <Color x:Key="WindowBackgroundColor">#FFFFFFFF</Color>
+    <Color x:Key="ForegroundColor">#FF000000</Color>
+    <SolidColorBrush x:Key="WindowBackground" Color="{StaticResource WindowBackgroundColor}"/>
+    <SolidColorBrush x:Key="WindowForeground" Color="{StaticResource ForegroundColor}"/>
+
+    <!-- Global style for log boxes -->
+    <Style TargetType="RichTextBox">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RichTextBox">
+                    <Border BorderBrush="#98FF98" BorderThickness="2" CornerRadius="5" Background="{TemplateBinding Background}">
+                        <ScrollViewer x:Name="PART_ContentHost"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Global style for text boxes including validation visuals -->
+    <Style TargetType="TextBox">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="5" Background="{TemplateBinding Background}">
+                        <ScrollViewer x:Name="PART_ContentHost"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="BorderBrush" Value="LightGray"/>
+        <Setter Property="Background" Value="White"/>
+        <Style.Triggers>
+            <Trigger Property="Validation.HasError" Value="True">
+                <Setter Property="Background" Value="#FFEBEB"/>
+                <Setter Property="BorderBrush" Value="DarkRed"/>
+                <Setter Property="BorderThickness" Value="2"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
@@ -21,6 +21,7 @@ namespace DesktopApplicationTemplate.UI.Views
         private void Save_Click(object sender, RoutedEventArgs e)
         {
             _viewModel.Save();
+            Services.ThemeManager.ApplyTheme(_viewModel.DarkTheme);
         }
 
         private void Back_Click(object sender, RoutedEventArgs e)
@@ -41,7 +42,10 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (res == MessageBoxResult.Cancel)
                     return;
                 if (res == MessageBoxResult.Yes)
+                {
                     _viewModel.Save();
+                    Services.ThemeManager.ApplyTheme(_viewModel.DarkTheme);
+                }
             }
             if (Parent is Frame frame)
                 frame.Content = new HomePage { DataContext = App.AppHost.Services.GetService(typeof(MainViewModel)) };

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Launch the UI from the command line:
 dotnet run --project DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
 ```
 
+The UI supports both light and dark themes. Open **Settings** within the application to toggle the theme and click **Save** to apply it immediately.
+
 Run the background service (useful for development):
 
 ```bash


### PR DESCRIPTION
## Summary
- add `ThemeManager` service for switching between light and dark styles
- provide `DarkTheme.xaml` and `LightTheme.xaml` resource dictionaries
- hook theme switching in `SettingsPage` and at startup
- document theme support in README
- add unit tests for theme manager

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882795110508326982e590f6c953076