### PR TITLE
Fix FTP test and logging

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.UI.Services;
 using FluentFTP;
+using FluentFTP.Client.BaseClient;
 using Moq;
 using System.Net;
 using System.Threading;

--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Helpers

--- a/DesktopApplicationTemplate.UI/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FtpService.cs
@@ -20,7 +20,7 @@ namespace DesktopApplicationTemplate.UI.Services
             _logger = logger;
         }
 
-        internal FtpService(FtpClient client, ILoggingService? logger = null)
+        public FtpService(FtpClient client, ILoggingService? logger = null)
         {
             _client = client;
             _logger = logger;


### PR DESCRIPTION
## Summary
- update SaveConfirmationHelper to use logging service
- expose FtpClient-based constructor publicly
- use async extension methods in FTP tests

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -v:m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build DesktopApplicationTemplate.sln -v:m` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827d5773848326adaf594302f96ab4