### PR TITLE
Fix namespace for SaveConfirmationHelper

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Helpers


### PR DESCRIPTION
## Summary
- fix `SaveConfirmationHelper` missing `ILoggingService` namespace

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Release --nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827d82e12483268a96286bc2f411fa