### PR TITLE
Fix broken project references for Codex tests

### DIFF
--- a/DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj
+++ b/DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj
@@ -15,10 +15,6 @@
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
-    <ItemGroup>
-	    <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
-	    <ProjectReference Include="..\DesktopApplicationTemplate.Services\DesktopApplicationTemplate.Services.csproj" />
-    </ItemGroup>
 
 	<ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
## Summary
- remove invalid references in DesktopApplicationTemplate.Tests.Codex

## Testing
- `dotnet test DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj -v minimal`
- `dotnet test DesktopApplicationTemplate.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882862bf21883268381298cea05218d