### PR TITLE
Improve setup.sh workload check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,18 @@
 set -e
 
 dotnet restore
-dotnet workload install windowsdesktop
+
+if [ -z "$SKIP_WORKLOAD" ]; then
+    echo "Checking for windowsdesktop workload..."
+    if ! dotnet workload list | grep -q windowsdesktop; then
+        echo "Installing windowsdesktop workload..."
+        dotnet workload install windowsdesktop
+    else
+        echo "windowsdesktop workload already installed."
+    fi
+else
+    echo "SKIP_WORKLOAD set - skipping windowsdesktop workload installation." 
+fi
 dotnet build DesktopApplicationTemplate.sln
 dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
 


### PR DESCRIPTION
## Summary
- handle optional installation of windowsdesktop workload in setup.sh
- skip workload install when `SKIP_WORKLOAD=1`

## Testing
- `SKIP_WORKLOAD=1 ./setup.sh` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882862c534083269f6ef9be4a5b0f1e