### PR TITLE
Fix FTP service async

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
@@ -1,6 +1,5 @@
 using DesktopApplicationTemplate.UI.Services;
 using FluentFTP;
-using FluentFTP.Client.BaseClient;
 using Moq;
 using System.Net;
 using System.Threading;
@@ -13,16 +12,16 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public async Task UploadAsync_InvokesClientOperations()
         {
-            var client = new Mock<FtpClient>("host", new NetworkCredential("u","p"));
+            var client = new Mock<AsyncFtpClient>("host", 21, new NetworkCredential("u","p"));
             client.Setup(c => c.Connect(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            client.Setup(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(FtpStatus.Success));
+            client.Setup(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite, true, FtpVerify.None, It.IsAny<CancellationToken>())).Returns(Task.FromResult(FtpStatus.Success));
             client.Setup(c => c.Disconnect(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
             var service = new FtpService(client.Object);
             await service.UploadAsync("local","remote");
 
             client.Verify(c => c.Connect(It.IsAny<CancellationToken>()), Times.Once);
-            client.Verify(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+            client.Verify(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite, true, FtpVerify.None, It.IsAny<CancellationToken>()), Times.Once);
             client.Verify(c => c.Disconnect(It.IsAny<CancellationToken>()), Times.Once);
 
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.UI/Services/IFtpService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IFtpService.cs
@@ -1,9 +1,10 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Services
 {
     public interface IFtpService
     {
-        Task UploadAsync(string localPath, string remotePath);
+        Task UploadAsync(string localPath, string remotePath, CancellationToken token = default);
     }
 }


### PR DESCRIPTION
## Summary
- refactor `FtpService` to use `AsyncFtpClient`
- update `IFtpService` interface
- adjust unit tests for async FTP client

## Testing
- `./setup.sh` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688287b0c6408326a932e2fd197e24c8