### PR TITLE
UI size tweaks and CSV cleanup

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -22,6 +22,21 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
+        public void RemoveColumnsForService_RemovesColumns()
+        {
+            var vm = new CsvViewerViewModel();
+            var svc = new CsvService(vm);
+
+            svc.EnsureColumnsForService("Svc");
+            svc.RemoveColumnsForService("Svc");
+
+            Assert.DoesNotContain(vm.Configuration.Columns, c => c.Name == "Svc");
+            Assert.DoesNotContain(vm.Configuration.Columns, c => c.Name == "Svc Sent");
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
         public void RecordLog_WritesCsvRow()
         {
             var vm = new CsvViewerViewModel();

--- a/DesktopApplicationTemplate.UI/Services/CsvService.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvService.cs
@@ -36,6 +36,23 @@ namespace DesktopApplicationTemplate.UI.Services
             _viewModel.Save();
         }
 
+        public void RemoveColumnsForService(string serviceName)
+        {
+            var sent = $"{serviceName} Sent";
+            var toRemove = _viewModel.Configuration.Columns
+                .Where(c => c.Name == serviceName || c.Name == sent)
+                .ToList();
+            foreach (var col in toRemove)
+            {
+                _viewModel.Configuration.Columns.Remove(col);
+                _logger?.Log($"Removed CSV column {col.Name}", LogLevel.Debug);
+            }
+            if (toRemove.Count > 0)
+            {
+                _viewModel.Save();
+            }
+        }
+
         public void RecordLog(string serviceName, string message)
         {
             EnsureColumnsForService(serviceName);

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -180,6 +180,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (SelectedService != null)
             {
                 var index = Services.IndexOf(SelectedService);
+                SelectedService.AddLog("Service removed", WpfBrushes.Red);
+                _csvService.RemoveColumnsForService(SelectedService.DisplayName);
                 SelectedService.LogAdded -= OnServiceLogAdded;
                 SelectedService.ActiveChanged -= OnServiceActiveChanged;
                 Services.Remove(SelectedService);

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
@@ -1,6 +1,10 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.CreateServiceWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Create Service" SizeToContent="WidthAndHeight">
-    <Frame x:Name="ContentFrame" NavigationUIVisibility="Hidden" />
+        Title="Create Service" Width="500" Height="400"
+        WindowStartupLocation="CenterOwner"
+        Style="{DynamicResource BubblyWindowStyle}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <Frame x:Name="ContentFrame" NavigationUIVisibility="Hidden" />
+    </ScrollViewer>
 </Window>

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
@@ -6,7 +6,9 @@
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
-        Title="CSV Viewer" SizeToContent="WidthAndHeight">
+        Title="CSV Viewer" Width="650" Height="450"
+        WindowStartupLocation="CenterOwner"
+        Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
     </Window.Resources>

--- a/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
@@ -2,7 +2,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        Title="Filter Services" SizeToContent="WidthAndHeight">
+        Title="Filter Services" Width="300" Height="250"
+        WindowStartupLocation="CenterOwner"
+        Style="{DynamicResource BubblyWindowStyle}">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.SaveConfirmationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Save" SizeToContent="WidthAndHeight" WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+        Title="Save" Width="250" Height="180" WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        Style="{DynamicResource BubblyWindowStyle}">
     <StackPanel Margin="20">
         <TextBlock Text="Configuration saved." Margin="0,0,0,10"/>
         <CheckBox x:Name="DontShowAgainCheckBox" Content="Don't show this pop-up again." Margin="0,0,0,10"/>

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
@@ -1,6 +1,10 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Service Editor" SizeToContent="WidthAndHeight">
-    <Frame x:Name="EditorFrame" NavigationUIVisibility="Hidden" />
+        Title="Service Editor" Width="800" Height="600"
+        WindowStartupLocation="CenterOwner"
+        Style="{DynamicResource BubblyWindowStyle}">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <Frame x:Name="EditorFrame" NavigationUIVisibility="Hidden" />
+    </ScrollViewer>
 </Window>


### PR DESCRIPTION
## Summary
- trim CSV configuration when services are removed
- add `RemoveColumnsForService` to `CsvService`
- log service removal and updated CSV cleanup
- apply bubbly window style with fixed sizing to popup windows
- test CSV column removal

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837981a70083269e9447b3cad02383