### PR TITLE
Add CI workflow for .NET projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.404'
+    - name: Restore
+      run: dotnet restore
+    - name: Build
+      run: dotnet build DesktopApplicationTemplate.sln --configuration Release
+    - name: Test Unit
+      run: dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build
+    - name: Test Codex
+      run: dotnet test DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj --no-build


### PR DESCRIPTION
## Summary
- add CI workflow using Windows runner

## Testing
- `dotnet restore` *(fails: EnableWindowsTargeting warnings)*
- `dotnet build DesktopApplicationTemplate.sln --no-restore`
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: missing Microsoft.WindowsDesktop.App runtime)*
- `dotnet test DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj --no-build` *(fails: project not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838ba2e2808326be14f66d9dfe4748