### PR TITLE
Improve service logging

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -74,6 +74,7 @@ namespace DesktopApplicationTemplate.Service
             var cts = new CancellationTokenSource();
             _running[info.DisplayName] = cts;
             _ = Task.Run(() => RunServiceLoop(info, cts.Token));
+            _logger.LogInformation("Started service: {name}", info.DisplayName);
         }
 
         private void StopService(string name)
@@ -83,6 +84,7 @@ namespace DesktopApplicationTemplate.Service
                 _logger.LogInformation("Stopping service: {name}", name);
                 cts.Cancel();
                 _running.Remove(name);
+                _logger.LogInformation("Stopped service: {name}", name);
             }
         }
 

--- a/DesktopApplicationTemplate.Service/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.Service/Services/FtpService.cs
@@ -26,6 +26,7 @@ namespace DesktopApplicationTemplate.UI.Services
 
         public async Task UploadAsync(string localPath, string remotePath, CancellationToken token = default)
         {
+            _logger?.Log($"Starting FTP upload {localPath} -> {remotePath}", LogLevel.Debug);
             _logger?.Log($"Connecting to FTP {_client.Host}:{_client.Port}", LogLevel.Debug);
             try
             {
@@ -34,6 +35,7 @@ namespace DesktopApplicationTemplate.UI.Services
                 await _client.UploadFile(localPath, remotePath, FtpRemoteExists.Overwrite, true, FtpVerify.None, null, token);
                 await _client.Disconnect(token);
                 _logger?.Log("Upload finished", LogLevel.Debug);
+                _logger?.Log("FTP upload completed", LogLevel.Debug);
             }
             catch (Exception ex)
             {

--- a/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
@@ -30,5 +30,26 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        public async Task UploadAsync_LogsStartAndFinish()
+        {
+            var client = new Mock<FluentFTP.IAsyncFtpClient>();
+            client.SetupGet(c => c.Host).Returns("host");
+            client.SetupGet(c => c.Port).Returns(21);
+            client.Setup(c => c.Connect(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            client.Setup(c => c.UploadFile(It.IsAny<string>(), It.IsAny<string>(), FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<FtpVerify>(), It.IsAny<IProgress<FtpProgress>?>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(FtpStatus.Success));
+            client.Setup(c => c.Disconnect(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var logger = new TestLogger();
+            var service = new FtpService(client.Object, logger);
+            await service.UploadAsync("local", "remote");
+
+            Assert.Contains(logger.Entries, e => e.Message.Contains("Starting FTP upload"));
+            Assert.Contains(logger.Entries, e => e.Message.Contains("FTP upload completed"));
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -30,13 +30,16 @@ namespace DesktopApplicationTemplate.Tests
         public async Task TransferAsync_UsesProvidedService()
         {
             var mock = new Mock<IFtpService>();
-            var vm = new FtpServiceViewModel { Service = mock.Object };
+            var logger = new TestLogger();
+            var vm = new FtpServiceViewModel { Service = mock.Object, Logger = logger };
             vm.LocalPath = "local";
             vm.RemotePath = "remote";
 
             await vm.TransferAsync();
 
             mock.Verify(s => s.UploadAsync("local", "remote", It.IsAny<CancellationToken>()), Times.Once);
+            Assert.Contains(logger.Entries, e => e.Message == "Starting FTP transfer");
+            Assert.Contains(logger.Entries, e => e.Message == "Finished FTP transfer");
 
             ConsoleTestLogger.LogPass();
         }

--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -32,5 +32,24 @@ namespace DesktopApplicationTemplate.Tests
             Assert.Equal("HTTP4", next);
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        public void RemoveServiceCommand_LogsLifecycle()
+        {
+            var logger = new TestLogger();
+            var csv = new CsvService(new CsvViewerViewModel());
+            var vm = new MainViewModel(csv, logger);
+            var service = new ServiceViewModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
+            vm.Services.Add(service);
+            vm.SelectedService = service;
+
+            vm.RemoveServiceCommand.Execute(null);
+
+            Assert.Contains(logger.Entries, e => e.Message.Contains("Removing service"));
+            Assert.Contains(logger.Entries, e => e.Message.Contains("Service removed"));
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -20,5 +20,24 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        public async Task ConnectAsync_LogsLifecycle()
+        {
+            var logger = new TestLogger();
+            var client = new Moq.Mock<MQTTnet.Client.IMqttClient>();
+            client.Setup(c => c.ConnectAsync(Moq.It.IsAny<MQTTnet.Client.Options.MqttClientOptions>())).Returns(System.Threading.Tasks.Task.CompletedTask);
+            client.Setup(c => c.SubscribeAsync(Moq.It.IsAny<string>())).Returns(System.Threading.Tasks.Task.CompletedTask);
+            var service = new MqttService(client.Object, logger);
+            var vm = new MqttServiceViewModel(service, logger) { Host = "localhost", Port = "1883", ClientId = "c" };
+
+            await vm.ConnectAsync();
+
+            Assert.Contains(logger.Entries, e => e.Message == "MQTT connect start");
+            Assert.Contains(logger.Entries, e => e.Message == "MQTT connect finished");
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -42,6 +42,30 @@ namespace DesktopApplicationTemplate.Tests
 
         [Fact]
         [TestCategory("CodexSafe")]
+        public async Task HttpService_SendRequest_LogsLifecycle()
+        {
+            var logger = new TestLogger();
+            var handler = new Moq.Mock<System.Net.Http.HttpMessageHandler>();
+            handler.Protected()
+                .Setup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>>("SendAsync", Moq.ItExpr.IsAny<System.Net.Http.HttpRequestMessage>(), Moq.ItExpr.IsAny<System.Threading.CancellationToken>())
+                .ReturnsAsync(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new System.Net.Http.StringContent("ok")
+                });
+
+            var vm = new HttpServiceViewModel { Logger = logger, MessageHandler = handler.Object, Url = "http://localhost/" };
+
+            await vm.SendRequestAsync();
+
+            Assert.Contains(logger.Entries, e => e.Message == "Starting HTTP request");
+            Assert.Contains(logger.Entries, e => e.Message == "HTTP request completed");
+            Assert.Contains(logger.Entries, e => e.Message == "SendRequestAsync finished");
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
         public void HttpService_SetInvalidUrl_AddsError()
         {
             var logger = new TestLogger();

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -25,6 +25,7 @@ namespace DesktopApplicationTemplate.UI.Services
 
         public async Task ConnectAsync(string host, int port, string clientId, string? user, string? pass)
         {
+            _logger?.Log("MqttService connect start", LogLevel.Debug);
             var options = new MqttClientOptionsBuilder()
                 .WithTcpServer(host, port)
                 .WithClientId(clientId);
@@ -35,6 +36,7 @@ namespace DesktopApplicationTemplate.UI.Services
             _logger?.Log($"Connecting to MQTT {host}:{port}", LogLevel.Debug);
             await _client.ConnectAsync(options.Build());
             _logger?.Log("MQTT connected", LogLevel.Debug);
+            _logger?.Log("MqttService connect finished", LogLevel.Debug);
         }
 
         public async Task SubscribeAsync(IEnumerable<string> topics)
@@ -48,6 +50,7 @@ namespace DesktopApplicationTemplate.UI.Services
 
         public async Task PublishAsync(string topic, string message)
         {
+            _logger?.Log("MqttService publish start", LogLevel.Debug);
             _logger?.Log($"Publishing to {topic}", LogLevel.Debug);
             var msg = new MqttApplicationMessageBuilder()
                 .WithTopic(topic)
@@ -55,6 +58,7 @@ namespace DesktopApplicationTemplate.UI.Services
                 .Build();
             await _client.PublishAsync(msg);
             _logger?.Log("Publish complete", LogLevel.Debug);
+            _logger?.Log("MqttService publish finished", LogLevel.Debug);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -91,9 +91,11 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         {
             if (string.IsNullOrWhiteSpace(LocalPath) || string.IsNullOrWhiteSpace(RemotePath))
                 return;
-            var svc = Service ?? (IFtpService)new FtpService(Host, int.Parse(Port), Username, Password);
+            Logger?.Log("Starting FTP transfer", LogLevel.Debug);
+            var svc = Service ?? (IFtpService)new FtpService(Host, int.Parse(Port), Username, Password, Logger);
             await svc.UploadAsync(LocalPath, RemotePath);
             Logger?.Log("FTP upload complete", LogLevel.Debug);
+            Logger?.Log("Finished FTP transfer", LogLevel.Debug);
         }
 
         private void Save() => SaveConfirmationHelper.Show();

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -122,6 +122,8 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
                 return;
             }
 
+            Logger?.Log("Starting HTTP request", LogLevel.Debug);
+
             using HttpClient client = MessageHandler != null ? new HttpClient(MessageHandler) : new HttpClient();
             try
             {
@@ -148,6 +150,7 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
                 ResponseBody = await response.Content.ReadAsStringAsync();
                 Logger?.Log($"Received response with status {StatusCode}", LogLevel.Debug);
                 Logger?.Log($"Response Body: {ResponseBody}", LogLevel.Debug);
+                Logger?.Log("HTTP request completed", LogLevel.Debug);
             }
             catch (HttpRequestException ex)
             {
@@ -158,6 +161,10 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             {
                 ResponseBody = $"Unexpected error: {ex.Message}";
                 Logger?.Log($"Critical error: {ex.Message}", LogLevel.Critical);
+            }
+            finally
+            {
+                Logger?.Log("SendRequestAsync finished", LogLevel.Debug);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -117,10 +117,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public IEnumerable<LogEntry> DisplayLogs => (SelectedService?.Logs ?? AllLogs).Where(l => l.Level >= LogLevelFilter);
 
         private readonly CsvService _csvService;
+        private readonly ILoggingService? _logger;
 
-        public MainViewModel(CsvService csvService)
+        public MainViewModel(CsvService csvService, ILoggingService? logger = null)
         {
             _csvService = csvService;
+            _logger = logger;
             AddServiceCommand = new RelayCommand(AddService);
             RemoveServiceCommand = new RelayCommand(RemoveSelectedService, () => SelectedService != null);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
@@ -131,6 +133,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void AddService()
         {
+            _logger?.Log("AddService invoked", LogLevel.Debug);
             var existing = Services.Select(s => s.DisplayName.Split(" - ").Last());
             var vm = new CreateServiceViewModel(existing);
             var popup = new CreateServiceWindow(vm); // Replace with DI if needed
@@ -157,7 +160,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 Services.Add(newService);
                 OnPropertyChanged(nameof(ServicesCreated));
                 OnPropertyChanged(nameof(CurrentActiveServices));
+                _logger?.Log($"Service {newService.DisplayName} created", LogLevel.Debug);
             }
+            _logger?.Log("AddService completed", LogLevel.Debug);
         }
 
         internal string GenerateServiceName(string serviceType)
@@ -179,6 +184,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             if (SelectedService != null)
             {
+                _logger?.Log($"Removing service {SelectedService.DisplayName}", LogLevel.Debug);
                 var index = Services.IndexOf(SelectedService);
                 SelectedService.AddLog("Service removed", WpfBrushes.Red);
                 _csvService.RemoveColumnsForService(SelectedService.DisplayName);
@@ -198,6 +204,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 OnPropertyChanged(nameof(CurrentActiveServices));
                 OnPropertyChanged(nameof(DisplayLogs));
                 SaveServices();
+                _logger?.Log("Service removed", LogLevel.Debug);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -61,10 +61,12 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel
 
         public ILoggingService? Logger { get; set; }
 
-        private readonly MqttService _service = new();
+        private readonly MqttService _service;
 
-        public MqttServiceViewModel()
+        public MqttServiceViewModel(MqttService? service = null, ILoggingService? logger = null)
         {
+            Logger = logger;
+            _service = service ?? new MqttService(logger);
             AddTopicCommand = new RelayCommand(() => { if(!string.IsNullOrWhiteSpace(NewTopic)){Topics.Add(NewTopic); NewTopic = string.Empty;} });
             RemoveTopicCommand = new RelayCommand(() => { if(Topics.Contains(NewTopic)) Topics.Remove(NewTopic); });
             ConnectCommand = new RelayCommand(async () => await ConnectAsync());
@@ -74,17 +76,21 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel
 
         public async Task ConnectAsync()
         {
+            Logger?.Log("MQTT connect start", LogLevel.Debug);
             await _service.ConnectAsync(Host, int.Parse(Port), ClientId, Username, Password);
             await _service.SubscribeAsync(Topics);
             Logger?.Log("MQTT connected", LogLevel.Debug);
+            Logger?.Log("MQTT connect finished", LogLevel.Debug);
         }
 
         public async Task PublishAsync()
         {
             if(string.IsNullOrWhiteSpace(PublishTopic) || string.IsNullOrWhiteSpace(PublishMessage))
                 return;
+            Logger?.Log("MQTT publish start", LogLevel.Debug);
             await _service.PublishAsync(PublishTopic, PublishMessage);
             Logger?.Log($"Published to {PublishTopic}", LogLevel.Debug);
+            Logger?.Log("MQTT publish finished", LogLevel.Debug);
         }
 
         private void Save() => SaveConfirmationHelper.Show();

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -68,9 +68,11 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel
         {
             if (string.IsNullOrWhiteSpace(LocalPath) || string.IsNullOrWhiteSpace(RemotePath))
                 return;
-            var svc = new ScpService(Host, int.Parse(Port), Username, Password);
+            Logger?.Log("SCP transfer start", LogLevel.Debug);
+            var svc = new ScpService(Host, int.Parse(Port), Username, Password, Logger);
             await svc.UploadAsync(LocalPath, RemotePath);
             Logger?.Log("File transferred", LogLevel.Debug);
+            Logger?.Log("SCP transfer finished", LogLevel.Debug);
         }
 
         private void Save() => SaveConfirmationHelper.Show();


### PR DESCRIPTION
## Summary
- improve logging for services and view models
- expose optional logger in `MainViewModel`
- extend MQTT service injection pattern
- add unit tests for new log entries

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838bac054c8326a135464d16ea85a2