### PR TITLE
Improve installer dependency parsing

### DIFF
--- a/DesktopApplicationTemplate.Tests/DepsJsonParsingTests.cs
+++ b/DesktopApplicationTemplate.Tests/DepsJsonParsingTests.cs
@@ -1,0 +1,37 @@
+using DesktopApplication.Installer.ViewModels;
+using Xunit;
+using System.IO;
+using System.Linq;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class DepsJsonParsingTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    public void ParseRuntimeDependencies_ParsesRuntimeAndTargets()
+    {
+        var json = """
+        {
+          "targets": {
+            "net8.0": {
+              "Test.Lib/1.0.0": {
+                "runtime": {
+                  "lib/net8.0/Test.Lib.dll": {}
+                },
+                "runtimeTargets": {
+                  "runtimes/win/native/libtest.dll": { "assetType": "native" }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+        var deps = ProgressWindowViewModel.ParseRuntimeDependencies(json).ToList();
+        Assert.Contains(Path.Combine("lib", "net8.0", "Test.Lib.dll"), deps);
+        Assert.Contains(Path.Combine("runtimes", "win", "native", "libtest.dll"), deps);
+        ConsoleTestLogger.LogPass();
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `ProgressWindowViewModel` with helpers to parse `.deps.json`
- copy runtime dependencies using the new parsing logic
- add unit tests for `.deps.json` parsing

## Testing
- `dotnet test DesktopApplicationTemplate.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838bad2aa083269fe7fd0297a75fda