### PR TITLE
Fix MQTT and logging tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -1,6 +1,11 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using MQTTnet.Client;
+using Moq;
 using Xunit;
+using System.Threading;
+using System;
+using MQTTnet.Packets;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -27,9 +32,11 @@ namespace DesktopApplicationTemplate.Tests
         public async Task ConnectAsync_LogsLifecycle()
         {
             var logger = new TestLogger();
-            var client = new Moq.Mock<MQTTnet.Client.IMqttClient>();
-            client.Setup(c => c.ConnectAsync(Moq.It.IsAny<MQTTnet.Client.Options.MqttClientOptions>())).Returns(System.Threading.Tasks.Task.CompletedTask);
-            client.Setup(c => c.SubscribeAsync(Moq.It.IsAny<string>())).Returns(System.Threading.Tasks.Task.CompletedTask);
+            var client = new Mock<IMqttClient>();
+            client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientConnectResult());
+            client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), string.Empty, Array.Empty<MqttUserProperty>()));
             var service = new MqttService(client.Object, logger);
             var vm = new MqttServiceViewModel(service, logger) { Host = "localhost", Port = "1883", ClientId = "c" };
 

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -1,7 +1,11 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
 using System.Threading.Tasks;
+using System.Net.Http;
+using Moq;
+using Moq.Protected;
 using Xunit;
+using System.Threading;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -45,12 +49,12 @@ namespace DesktopApplicationTemplate.Tests
         public async Task HttpService_SendRequest_LogsLifecycle()
         {
             var logger = new TestLogger();
-            var handler = new Moq.Mock<System.Net.Http.HttpMessageHandler>();
+            var handler = new Mock<HttpMessageHandler>();
             handler.Protected()
-                .Setup<System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage>>("SendAsync", Moq.ItExpr.IsAny<System.Net.Http.HttpRequestMessage>(), Moq.ItExpr.IsAny<System.Threading.CancellationToken>())
-                .ReturnsAsync(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
                 {
-                    Content = new System.Net.Http.StringContent("ok")
+                    Content = new StringContent("ok")
                 });
 
             var vm = new HttpServiceViewModel { Logger = logger, MessageHandler = handler.Object, Url = "http://localhost/" };

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -229,7 +229,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void LoadServices()
         {
-            var existing = ServicePersistence.Load();
+            var existing = ServicePersistence.Load(_logger);
             foreach (var info in existing.OrderBy(i => i.Order))
             {
                 var svc = new ServiceViewModel
@@ -242,7 +242,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 svc.SetColorsByType();
                 svc.LogAdded += OnServiceLogAdded;
                 svc.ActiveChanged += OnServiceActiveChanged;
+                _csvService.EnsureColumnsForService(svc.DisplayName);
                 Services.Add(svc);
+                _logger?.Log($"Loaded service {svc.DisplayName}", LogLevel.Debug);
             }
             OnPropertyChanged(nameof(ServicesCreated));
             OnPropertyChanged(nameof(CurrentActiveServices));


### PR DESCRIPTION
## Summary
- ensure CSV column creation when loading services
- log loaded services and pass logger to persistence load
- update MQTT service view model test mocks
- fix HTTP view model test mocks

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App 8.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688394d75ad08326b0903cc414fca44a