### PR TITLE
Improve service list UI and window closing

### DIFF
--- a/DesktopApplication.Installer/Themes/BubblyWindow.xaml
+++ b/DesktopApplication.Installer/Themes/BubblyWindow.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:shell="clr-namespace:System.Windows;assembly=PresentationFramework">
     <Style TargetType="Window" x:Key="BubblyWindowStyle">
         <Setter Property="Background">
             <Setter.Value>
@@ -32,7 +33,10 @@
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="{TemplateBinding Title}" VerticalAlignment="Center" Margin="10,0" FontWeight="Bold" />
-                                        <Button Grid.Column="1" Content="X" Width="30" Height="30" Command="Close" Background="Transparent" BorderThickness="0" />
+                                        <Button Grid.Column="1" Content="X" Width="30" Height="30"
+                                                Command="{x:Static shell:SystemCommands.CloseWindowCommand}"
+                                                CommandTarget="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Background="Transparent" BorderThickness="0" />
                                     </Grid>
                                 </Border>
                                 <ContentPresenter />

--- a/DesktopApplicationTemplate.Tests/ScrollBarStyleTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScrollBarStyleTests.cs
@@ -1,0 +1,42 @@
+using DesktopApplicationTemplate.UI;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ScrollBarStyleTests
+    {
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void LightTheme_ScrollBarStyle_HasReducedWidth()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var dict = new ResourceDictionary { Source = new Uri("Themes/LightTheme.xaml", UriKind.Relative) };
+                    Assert.True(dict.Contains(typeof(ScrollBar)));
+                    var style = (Style)dict[typeof(ScrollBar)];
+                    var width = style.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == ScrollBar.WidthProperty)?.Value;
+                    var height = style.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == ScrollBar.HeightProperty)?.Value;
+                    Assert.Equal(8.0, (double)(width ?? 0));
+                    Assert.Equal(8.0, (double)(height ?? 0));
+                }
+                catch (Exception e) { ex = e; }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:shell="clr-namespace:System.Windows;assembly=PresentationFramework">
     <Style TargetType="Window" x:Key="BubblyWindowStyle">
         <Setter Property="Background">
             <Setter.Value>
@@ -32,7 +33,10 @@
                                             <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="{TemplateBinding Title}" VerticalAlignment="Center" Margin="10,0" FontWeight="Bold" />
-                                        <Button Grid.Column="1" Content="X" Width="30" Height="30" Command="Close" Background="Transparent" BorderThickness="0" />
+                                        <Button Grid.Column="1" Content="X" Width="30" Height="30"
+                                                Command="{x:Static shell:SystemCommands.CloseWindowCommand}"
+                                                CommandTarget="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Background="Transparent" BorderThickness="0" />
                                     </Grid>
                                 </Border>
                                 <ContentPresenter />

--- a/DesktopApplicationTemplate.UI/Themes/DarkTheme.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/DarkTheme.xaml
@@ -19,6 +19,13 @@
         </Setter>
         <Setter Property="Background" Value="#333333"/>
         <Setter Property="Foreground" Value="White"/>
+</Style>
+
+    <!-- Global style for scroll bars -->
+    <Style TargetType="ScrollBar">
+        <Setter Property="Width" Value="8"/>
+        <Setter Property="Height" Value="8"/>
+        <Setter Property="Background" Value="#555"/>
     </Style>
 
     <!-- Global style for text boxes including validation visuals -->

--- a/DesktopApplicationTemplate.UI/Themes/LightTheme.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/LightTheme.xaml
@@ -17,6 +17,13 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+</Style>
+
+    <!-- Global style for scroll bars -->
+    <Style TargetType="ScrollBar">
+        <Setter Property="Width" Value="8"/>
+        <Setter Property="Height" Value="8"/>
+        <Setter Property="Background" Value="#EEE"/>
     </Style>
 
     <!-- Global style for text boxes including validation visuals -->

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -49,10 +49,11 @@
                 <TextBlock Text="Services" FontWeight="Bold" />
                 <Button Content="🔍" Width="20" Margin="5,0,0,0" Click="OpenFilter_Click"/>
             </StackPanel>
-            <ListBox Grid.Row="2" ItemsSource="{Binding FilteredServices}"
+            <ListBox x:Name="ServiceList" Grid.Row="2" ItemsSource="{Binding FilteredServices}"
                      SelectedItem="{Binding SelectedService}"
                      BorderThickness="0"
                      HorizontalContentAlignment="Stretch"
+                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                      SelectionChanged="ServiceList_SelectionChanged">
                     <ListBox.ItemTemplate>
                         <DataTemplate>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -93,7 +93,9 @@ namespace DesktopApplicationTemplate.UI.Views
                 GetOrCreateServicePage(newService);
 
                 _viewModel.Services.Add(newService);
+                _logger?.LogInformation("Service {Name} added", newService.DisplayName);
                 _viewModel.SelectedService = newService;
+                ServiceList.ScrollIntoView(newService);
 
                 if (type == "MQTT" && newService.ServicePage is MQTTServiceView mqttView)
                 {


### PR DESCRIPTION
## Summary
- enable close button in BubblyWindow template via `SystemCommands.CloseWindowCommand`
- make service list scroll area nicer and ensure new items are visible
- reduce scrollbar size in light/dark themes
- add unit test checking scrollbar style

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a5bd8fa88326b7efc63da7574faa