### PR TITLE
Add close confirmation and draggable main window

### DIFF
--- a/DesktopApplicationTemplate.Tests/CloseConfirmationHelperTests.cs
+++ b/DesktopApplicationTemplate.Tests/CloseConfirmationHelperTests.cs
@@ -1,0 +1,20 @@
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class CloseConfirmationHelperTests
+    {
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void Show_ReturnsTrue_WhenSuppressed()
+        {
+            SettingsViewModel.CloseConfirmationSuppressed = true;
+            var result = CloseConfirmationHelper.Show();
+            Assert.True(result);
+            SettingsViewModel.CloseConfirmationSuppressed = false;
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -15,12 +15,14 @@ namespace DesktopApplicationTemplate.Tests
             Directory.CreateDirectory(tempDir);
             var original = SettingsViewModel.FilePath;
             var suppressOrig = SettingsViewModel.SaveConfirmationSuppressed;
+            var closeOrig = SettingsViewModel.CloseConfirmationSuppressed;
             SettingsViewModel.FilePath = Path.Combine(tempDir, "userSettings.json");
             try
             {
                 var vm = new SettingsViewModel();
                 vm.FirstRun = false;
                 SettingsViewModel.SaveConfirmationSuppressed = true;
+                SettingsViewModel.CloseConfirmationSuppressed = true;
                 vm.Save();
 
                 var vm2 = new SettingsViewModel { FirstRun = true };
@@ -28,11 +30,13 @@ namespace DesktopApplicationTemplate.Tests
 
                 Assert.False(vm2.FirstRun);
                 Assert.True(SettingsViewModel.SaveConfirmationSuppressed);
+                Assert.True(SettingsViewModel.CloseConfirmationSuppressed);
             }
             finally
             {
                 SettingsViewModel.FilePath = original;
                 SettingsViewModel.SaveConfirmationSuppressed = suppressOrig;
+                SettingsViewModel.CloseConfirmationSuppressed = closeOrig;
                 Directory.Delete(tempDir, true);
             }
 

--- a/DesktopApplicationTemplate.UI/Helpers/CloseConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/CloseConfirmationHelper.cs
@@ -1,0 +1,44 @@
+using System.Windows;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public static class CloseConfirmationHelper
+    {
+        public static ILoggingService? Logger { get; set; }
+
+        public static bool CloseConfirmationSuppressed
+        {
+            get => SettingsViewModel.CloseConfirmationSuppressed;
+            set => SettingsViewModel.CloseConfirmationSuppressed = value;
+        }
+
+        public static bool Show()
+        {
+            Logger?.Log("Displaying close confirmation", LogLevel.Debug);
+            if (CloseConfirmationSuppressed)
+            {
+                Logger?.Log("Close confirmation suppressed", LogLevel.Debug);
+                return true;
+            }
+
+            var window = new CloseConfirmationWindow
+            {
+                Owner = Application.Current.MainWindow
+            };
+            var result = window.ShowDialog() == true;
+            if (result && window.DontShowAgain)
+            {
+                CloseConfirmationSuppressed = true;
+                var settingsVm = App.AppHost.Services.GetRequiredService<SettingsViewModel>();
+                settingsVm.Save();
+            }
+
+            Logger?.Log(result ? "Close confirmed" : "Close canceled", LogLevel.Debug);
+            return result;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -9,5 +9,6 @@ namespace DesktopApplicationTemplate.Models
         public bool LogTcpMessages { get; set; } = true;
         public bool FirstRun { get; set; } = true;
         public bool SuppressSaveConfirmation { get; set; }
+        public bool SuppressCloseConfirmation { get; set; }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private bool _logTcpMessages = true;
         private bool _firstRun = true;
         private static bool _suppressSaveConfirmation;
+        private static bool _suppressCloseConfirmation;
         private bool _dirty;
 
         public static bool TcpLoggingEnabled { get; private set; } = true;
@@ -24,6 +25,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             get => _suppressSaveConfirmation;
             internal set => _suppressSaveConfirmation = value;
+        }
+
+        public static bool CloseConfirmationSuppressed
+        {
+            get => _suppressCloseConfirmation;
+            internal set => _suppressCloseConfirmation = value;
         }
 
         public bool DarkTheme { get => _darkTheme; set { _darkTheme = value; _dirty = true; OnPropertyChanged(); } }
@@ -52,6 +59,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _firstRun = obj.FirstRun;
                 TcpLoggingEnabled = obj.LogTcpMessages;
                 SaveConfirmationSuppressed = obj.SuppressSaveConfirmation;
+                CloseConfirmationSuppressed = obj.SuppressCloseConfirmation;
             }
         }
 
@@ -65,7 +73,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 RunServicesOnStartup = _runServicesOnStartup,
                 LogTcpMessages = _logTcpMessages,
                 FirstRun = _firstRun,
-                SuppressSaveConfirmation = SaveConfirmationSuppressed
+                SuppressSaveConfirmation = SaveConfirmationSuppressed,
+                SuppressCloseConfirmation = CloseConfirmationSuppressed
             };
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
             TcpLoggingEnabled = _logTcpMessages;

--- a/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml
@@ -1,0 +1,22 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.CloseConfirmationWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Unsaved Changes" Width="300" Height="180"
+        WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        Style="{DynamicResource BubblyWindowStyle}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <StackPanel Margin="20">
+        <TextBlock Text="Configuration won't be saved. Are you sure you want to leave?" TextWrapping="Wrap" Margin="0,0,0,10"/>
+        <CheckBox x:Name="DontShowAgainCheckBox" Content="Don't show this pop-up again." Margin="0,0,0,10"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Leave" Width="80" Margin="0,0,5,0" Click="Yes_Click"/>
+            <Button Content="Cancel" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class CloseConfirmationWindow : Window
+    {
+        public bool DontShowAgain { get; private set; }
+
+        public CloseConfirmationWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Yes_Click(object sender, RoutedEventArgs e)
+        {
+            DontShowAgain = DontShowAgainCheckBox.IsChecked == true;
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -33,6 +33,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -6,8 +6,9 @@
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
-        Title="MainView" SizeToContent="WidthAndHeight"
-        Style="{DynamicResource BubblyWindowStyle}">
+        Title="MainView" Width="900" Height="700" ResizeMode="CanResizeWithGrip"
+        Style="{DynamicResource BubblyWindowStyle}"
+        MouseLeftButtonDown="Window_MouseLeftButtonDown">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -122,6 +123,8 @@
         </StackPanel>
 
         <Button Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Click="OpenSettings_Click"/>
+
+        <ResizeGrip HorizontalAlignment="Right" VerticalAlignment="Bottom" />
 
     </Grid>
     </Grid>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -38,6 +38,15 @@ namespace DesktopApplicationTemplate.UI.Views
             Closing += (_, _) => _logger?.LogInformation("MainView closing");
         }
 
+        private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ButtonState == MouseButtonState.Pressed)
+            {
+                _logger?.LogDebug("Window drag initiated");
+                DragMove();
+            }
+        }
+
         private void CloseCommand_Executed(object sender, ExecutedRoutedEventArgs e)
         {
             _logger?.LogInformation("Close command invoked");

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
@@ -12,11 +12,23 @@ namespace DesktopApplicationTemplate.UI.Views
             EditorFrame.Content = servicePage;
             SaveConfirmationHelper.SaveConfirmed += OnSaveConfirmed;
             Closed += (s, e) => SaveConfirmationHelper.SaveConfirmed -= OnSaveConfirmed;
+            CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, (_, __) => Close()));
+            Closing += ServiceEditorWindow_Closing;
         }
 
         private void OnSaveConfirmed()
         {
             Close();
+        }
+
+        private void ServiceEditorWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
+        {
+            CloseConfirmationHelper.Logger?.Log("Service editor closing", Services.LogLevel.Debug);
+            if (!CloseConfirmationHelper.Show())
+            {
+                e.Cancel = true;
+                CloseConfirmationHelper.Logger?.Log("Close canceled", Services.LogLevel.Debug);
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -23,6 +23,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseConfirmationHelper.Logger = _logger;
 
             Loaded += MainWindow_Loaded;
         }


### PR DESCRIPTION
## Summary
- add a window/dialog to confirm closing without saving
- add helper to manage the new prompt
- persist close confirmation setting
- update service views and editor window to use new helper
- make MainView draggable and resizable
- add unit tests for new functionality

## Testing
- `dotnet test DesktopApplicationTemplate.sln --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b84a9dc083269adb9862aaf7aadf