### PR TITLE
Improve service editor closure UX

### DIFF
--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -15,12 +15,14 @@ namespace DesktopApplicationTemplate.Tests
             Directory.CreateDirectory(tempDir);
             var original = SettingsViewModel.FilePath;
             var suppressOrig = SettingsViewModel.SaveConfirmationSuppressed;
+            var closeSuppressOrig = SettingsViewModel.CloseEditorConfirmationSuppressed;
             SettingsViewModel.FilePath = Path.Combine(tempDir, "userSettings.json");
             try
             {
                 var vm = new SettingsViewModel();
                 vm.FirstRun = false;
                 SettingsViewModel.SaveConfirmationSuppressed = true;
+                SettingsViewModel.CloseEditorConfirmationSuppressed = true;
                 vm.Save();
 
                 var vm2 = new SettingsViewModel { FirstRun = true };
@@ -28,11 +30,13 @@ namespace DesktopApplicationTemplate.Tests
 
                 Assert.False(vm2.FirstRun);
                 Assert.True(SettingsViewModel.SaveConfirmationSuppressed);
+                Assert.True(SettingsViewModel.CloseEditorConfirmationSuppressed);
             }
             finally
             {
                 SettingsViewModel.FilePath = original;
                 SettingsViewModel.SaveConfirmationSuppressed = suppressOrig;
+                SettingsViewModel.CloseEditorConfirmationSuppressed = closeSuppressOrig;
                 Directory.Delete(tempDir, true);
             }
 

--- a/DesktopApplicationTemplate.UI/Helpers/CloseEditorConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/CloseEditorConfirmationHelper.cs
@@ -1,0 +1,47 @@
+using System.Windows;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public static class CloseEditorConfirmationHelper
+    {
+        public static ILoggingService? Logger { get; set; }
+
+        public static bool ConfirmationSuppressed
+        {
+            get => SettingsViewModel.CloseEditorConfirmationSuppressed;
+            set => SettingsViewModel.CloseEditorConfirmationSuppressed = value;
+        }
+
+        public static bool Show()
+        {
+            Logger?.Log("Displaying close editor confirmation", LogLevel.Debug);
+            if (ConfirmationSuppressed)
+            {
+                Logger?.Log("Close confirmation suppressed", LogLevel.Debug);
+                return true;
+            }
+
+            var window = new CloseEditorConfirmationWindow
+            {
+                Owner = Application.Current.MainWindow
+            };
+            if (window.ShowDialog() == true)
+            {
+                if (window.DontShowAgain)
+                {
+                    ConfirmationSuppressed = true;
+                    var settingsVm = App.AppHost.Services.GetRequiredService<SettingsViewModel>();
+                    settingsVm.Save();
+                }
+                Logger?.Log("Close editor confirmed via dialog", LogLevel.Debug);
+                return true;
+            }
+            Logger?.Log("Close editor cancelled", LogLevel.Debug);
+            return false;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -9,5 +9,6 @@ namespace DesktopApplicationTemplate.Models
         public bool LogTcpMessages { get; set; } = true;
         public bool FirstRun { get; set; } = true;
         public bool SuppressSaveConfirmation { get; set; }
+        public bool SuppressCloseEditorConfirmation { get; set; }
     }
 }

--- a/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:shell="clr-namespace:System.Windows;assembly=PresentationFramework">
+                    xmlns:shell="clr-namespace:System.Windows;assembly=PresentationFramework"
+                    xmlns:chrome="clr-namespace:System.Windows.Shell;assembly=PresentationFramework">
     <Style TargetType="Window" x:Key="BubblyWindowStyle">
         <Setter Property="Background">
             <Setter.Value>
@@ -14,6 +15,12 @@
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="AllowsTransparency" Value="True" />
         <Setter Property="WindowStyle" Value="None" />
+        <Setter Property="ResizeMode" Value="CanResize" />
+        <Setter Property="chrome:WindowChrome.WindowChrome">
+            <Setter.Value>
+                <chrome:WindowChrome ResizeBorderThickness="5" CaptionHeight="30" CornerRadius="10" GlassFrameThickness="0" UseAeroCaptionButtons="False" />
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Window">

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private bool _logTcpMessages = true;
         private bool _firstRun = true;
         private static bool _suppressSaveConfirmation;
+        private static bool _suppressCloseEditorConfirmation;
         private bool _dirty;
 
         public static bool TcpLoggingEnabled { get; private set; } = true;
@@ -24,6 +25,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             get => _suppressSaveConfirmation;
             internal set => _suppressSaveConfirmation = value;
+        }
+
+        public static bool CloseEditorConfirmationSuppressed
+        {
+            get => _suppressCloseEditorConfirmation;
+            internal set => _suppressCloseEditorConfirmation = value;
         }
 
         public bool DarkTheme { get => _darkTheme; set { _darkTheme = value; _dirty = true; OnPropertyChanged(); } }
@@ -52,6 +59,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _firstRun = obj.FirstRun;
                 TcpLoggingEnabled = obj.LogTcpMessages;
                 SaveConfirmationSuppressed = obj.SuppressSaveConfirmation;
+                CloseEditorConfirmationSuppressed = obj.SuppressCloseEditorConfirmation;
             }
         }
 
@@ -65,7 +73,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 RunServicesOnStartup = _runServicesOnStartup,
                 LogTcpMessages = _logTcpMessages,
                 FirstRun = _firstRun,
-                SuppressSaveConfirmation = SaveConfirmationSuppressed
+                SuppressSaveConfirmation = SaveConfirmationSuppressed,
+                SuppressCloseEditorConfirmation = CloseEditorConfirmationSuppressed
             };
             File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
             TcpLoggingEnabled = _logTcpMessages;

--- a/DesktopApplicationTemplate.UI/Views/CloseEditorConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CloseEditorConfirmationWindow.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.CloseEditorConfirmationWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Discard Changes?" Width="300" Height="180" WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize" Style="{DynamicResource BubblyWindowStyle}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <StackPanel Margin="20">
+        <TextBlock Text="Configuration will not be saved. Leave this page?" TextWrapping="Wrap" Margin="0,0,0,10"/>
+        <CheckBox x:Name="DontShowAgainCheckBox" Content="Don't show this prompt again." Margin="0,0,0,10"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Yes" Width="80" Margin="0,0,5,0" Click="Yes_Click"/>
+            <Button Content="No" Width="80" Click="No_Click"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/CloseEditorConfirmationWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CloseEditorConfirmationWindow.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class CloseEditorConfirmationWindow : Window
+    {
+        public bool DontShowAgain { get; private set; }
+
+        public CloseEditorConfirmationWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Yes_Click(object sender, RoutedEventArgs e)
+        {
+            DontShowAgain = DontShowAgainCheckBox.IsChecked == true;
+            DialogResult = true;
+        }
+
+        private void No_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseEditorConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -33,6 +33,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseEditorConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseEditorConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, System.Windows.RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -17,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseEditorConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -12,11 +13,24 @@ namespace DesktopApplicationTemplate.UI.Views
             EditorFrame.Content = servicePage;
             SaveConfirmationHelper.SaveConfirmed += OnSaveConfirmed;
             Closed += (s, e) => SaveConfirmationHelper.SaveConfirmed -= OnSaveConfirmed;
+            Closing += OnClosing;
+            if (servicePage.DataContext is ILoggingViewModel vm)
+            {
+                CloseEditorConfirmationHelper.Logger = vm.Logger;
+            }
         }
 
         private void OnSaveConfirmed()
         {
             Close();
+        }
+
+        private void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (!CloseEditorConfirmationHelper.Show())
+            {
+                e.Cancel = true;
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -23,6 +23,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _logger = new LoggingService(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
             SaveConfirmationHelper.Logger = _logger;
+            CloseEditorConfirmationHelper.Logger = _logger;
 
             Loaded += MainWindow_Loaded;
         }


### PR DESCRIPTION
## Summary
- ask before closing service editor
- allow window resizing and drag
- persist new close confirmation setting
- wire close confirmation logging
- test SettingsViewModel persistence

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b84a9dc083269adb9862aaf7aadf