### PR TITLE
Fix WPF test cleanup

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -36,11 +36,14 @@ namespace DesktopApplicationTemplate.Tests
                     Assert.Equal(350, list?.MaxHeight);
                 }
                 catch (Exception e) { ex = e; }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
             });
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
             thread.Join();
-            System.Windows.Application.Current?.Shutdown();
             if (ex != null) throw ex;
             ConsoleTestLogger.LogPass();
         }
@@ -67,6 +70,10 @@ namespace DesktopApplicationTemplate.Tests
                     Assert.True(bound);
                 }
                 catch (Exception e) { ex = e; }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
             });
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();

--- a/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
@@ -22,16 +22,20 @@ namespace DesktopApplicationTemplate.Tests
                 try
                 {
                     var app = System.Windows.Application.Current ?? new System.Windows.Application();
-                    
+
                     ThemeManager.ApplyTheme(true);
                     Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("DarkTheme.xaml") == true);
                     ThemeManager.ApplyTheme(false);
                     Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("LightTheme.xaml") == true);
-                    if (app.MainWindow.IsActive) app.Shutdown();
                 }
                 catch (Exception e)
                 {
                     ex = e;
+                }
+                finally
+                {
+                    // ensure application instance is cleaned up on the same thread it was created
+                    System.Windows.Application.Current?.Shutdown();
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);


### PR DESCRIPTION
## Summary
- ensure WPF tests dispose `Application` objects on the UI thread
- clean up test resource shutdowns

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: invalid test argument)*

------
https://chatgpt.com/codex/tasks/task_e_68842ef9759883268d23ff9beb67e586