### PR TITLE
Fix tests and add theme path improvements

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -13,7 +13,7 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("WindowsSafe")]
         public void GenerateServiceName_IncrementsBasedOnExisting()
         {
-            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
+            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(configPath));
             var vm = new MainViewModel(csv);
             vm.Services.Add(new ServiceViewModel
@@ -43,15 +43,20 @@ namespace DesktopApplicationTemplate.Tests
         public void RemoveServiceCommand_LogsLifecycle()
         {
             var logger = new Mock<ILoggingService>();
-            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
+            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(configPath));
 
-            var vm = new MainViewModel(csv, logger.Object);
+            var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+            var vm = new MainViewModel(csv, logger.Object, servicesPath);
             var service = new ServiceViewModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
             vm.Services.Add(service);
             vm.SelectedService = service;
 
             vm.RemoveServiceCommand.Execute(null);
+
+            if (File.Exists(servicesPath))
+                File.Delete(servicesPath);
 
             logger.Verify(l => l.Log(It.Is<string>(m => m.Contains("Removing service")), It.IsAny<LogLevel>()), Times.Once);
             logger.Verify(l => l.Log(It.Is<string>(m => m.Contains("Service removed")), It.IsAny<LogLevel>()), Times.Once);

--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -28,9 +28,11 @@ namespace DesktopApplicationTemplate.Tests
                 {
                     if (System.Windows.Application.Current == null)
                         new DesktopApplicationTemplate.UI.App();
-                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString()+".json");
+                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
 
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)));
+                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), null, servicesPath);
                     var view = new MainView(vm);
                     var list = view.FindName("ServiceList") as System.Windows.Controls.ListBox;
                     Assert.Equal(350, list?.MaxHeight);
@@ -38,7 +40,8 @@ namespace DesktopApplicationTemplate.Tests
                 catch (Exception e) { ex = e; }
                 finally
                 {
-                    System.Windows.Application.Current?.Shutdown();
+                    if (System.Windows.Application.Current != null)
+                        System.Windows.Application.Current.Dispatcher.Invoke(() => System.Windows.Application.Current.Shutdown());
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);
@@ -62,8 +65,10 @@ namespace DesktopApplicationTemplate.Tests
                 {
                     if (System.Windows.Application.Current == null)
                         new DesktopApplicationTemplate.UI.App();
-                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString()+".json");
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)));
+                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
+                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), null, servicesPath);
                     var view = new MainView(vm);
                     bool bound = view.CommandBindings.OfType<CommandBinding>()
                                         .Any(b => b.Command == SystemCommands.CloseWindowCommand);
@@ -72,7 +77,8 @@ namespace DesktopApplicationTemplate.Tests
                 catch (Exception e) { ex = e; }
                 finally
                 {
-                    System.Windows.Application.Current?.Shutdown();
+                    if (System.Windows.Application.Current != null)
+                        System.Windows.Application.Current.Dispatcher.Invoke(() => System.Windows.Application.Current.Shutdown());
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);

--- a/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
@@ -35,7 +35,8 @@ namespace DesktopApplicationTemplate.Tests
                 finally
                 {
                     // ensure application instance is cleaned up on the same thread it was created
-                    System.Windows.Application.Current?.Shutdown();
+                    if (System.Windows.Application.Current != null)
+                        System.Windows.Application.Current.Dispatcher.Invoke(() => System.Windows.Application.Current.Shutdown());
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -25,7 +25,12 @@ namespace DesktopApplicationTemplate.UI.Services
                     Order = index++
                 });
             }
-            File.WriteAllText(FilePath, JsonSerializer.Serialize(data));
+
+            var json = JsonSerializer.Serialize(data);
+            logger?.Log($"Persisting services to {FilePath}", LogLevel.Debug);
+            using var fs = new FileStream(FilePath, FileMode.Create, FileAccess.Write, FileShare.None);
+            using var sw = new StreamWriter(fs);
+            sw.Write(json);
             logger?.Log($"Saved {data.Count} services to {FilePath}", LogLevel.Debug);
         }
 

--- a/DesktopApplicationTemplate.UI/Services/ThemeManager.cs
+++ b/DesktopApplicationTemplate.UI/Services/ThemeManager.cs
@@ -23,10 +23,12 @@ namespace DesktopApplicationTemplate.UI.Services
             {
                 log?.LogInformation("Applying {Theme} theme", useDark ? "dark" : "light");
                 var themeFile = useDark ? "Themes/DarkTheme.xaml" : "Themes/LightTheme.xaml";
-                var dict = new ResourceDictionary { Source = new Uri(themeFile, UriKind.Relative) };
+                var uri = new Uri($"pack://application:,,,/DesktopApplicationTemplate.UI;component/{themeFile}", UriKind.Absolute);
+                var dict = new ResourceDictionary { Source = uri };
                 if (_current != null)
                 {
                     System.Windows.Application.Current.Resources.MergedDictionaries.Remove(_current);
+                    log?.LogDebug("Removed previous theme dictionary");
                 }
                 System.Windows.Application.Current.Resources.MergedDictionaries.Add(dict);
                 _current = dict;

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -1,5 +1,5 @@
 using DesktopApplicationTemplate.Models;
-﻿using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Views;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -35,7 +35,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             set { _borderColor = value; OnPropertyChanged(); }
         }
         public Page? ServicePage { get; set; }
- 
+
 
         private bool _isActive;
         public bool IsActive
@@ -119,10 +119,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly CsvService _csvService;
         private readonly ILoggingService? _logger;
 
-        public MainViewModel(CsvService csvService, ILoggingService? logger = null)
+        public MainViewModel(CsvService csvService, ILoggingService? logger = null, string? servicesFilePath = null)
         {
             _csvService = csvService;
             _logger = logger;
+            if (!string.IsNullOrWhiteSpace(servicesFilePath))
+            {
+                ServicePersistence.FilePath = servicesFilePath!;
+                _logger?.Log($"Using service persistence path {ServicePersistence.FilePath}", LogLevel.Debug);
+            }
             AddServiceCommand = new RelayCommand(AddService);
             RemoveServiceCommand = new RelayCommand(RemoveSelectedService, () => SelectedService != null);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);


### PR DESCRIPTION
## Summary
- allow overriding service persistence path in `MainViewModel`
- ensure persistence writes with exclusive lock
- load theme dictionaries via pack URI and log actions
- adjust UI tests to run on separate persistence files and cleanly shutdown
- fix `RemoveServiceCommand_LogsLifecycle` test to use temp file

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build` *(fails: The argument path is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6884319b9f1483268ea9f9485aacadeb