### PR TITLE
Fix WPF test deadlock issues

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -40,8 +40,7 @@ namespace DesktopApplicationTemplate.Tests
                 catch (Exception e) { ex = e; }
                 finally
                 {
-                    if (System.Windows.Application.Current != null)
-                        System.Windows.Application.Current.Dispatcher.Invoke(() => System.Windows.Application.Current.Shutdown());
+                    System.Windows.Application.Current?.Shutdown();
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);
@@ -77,8 +76,7 @@ namespace DesktopApplicationTemplate.Tests
                 catch (Exception e) { ex = e; }
                 finally
                 {
-                    if (System.Windows.Application.Current != null)
-                        System.Windows.Application.Current.Dispatcher.Invoke(() => System.Windows.Application.Current.Shutdown());
+                    System.Windows.Application.Current?.Shutdown();
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);

--- a/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
@@ -35,8 +35,7 @@ namespace DesktopApplicationTemplate.Tests
                 finally
                 {
                     // ensure application instance is cleaned up on the same thread it was created
-                    if (System.Windows.Application.Current != null)
-                        System.Windows.Application.Current.Dispatcher.Invoke(() => System.Windows.Application.Current.Shutdown());
+                    System.Windows.Application.Current?.Shutdown();
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);


### PR DESCRIPTION
## Summary
- simplify WPF test cleanup logic to avoid Dispatcher deadlocks

## Testing
- `./setup.sh` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885165789d483268389876cff183acf