### PR TITLE
Simplify UI windows and logging

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using WpfRichTextBox = System.Windows.Controls.RichTextBox;
 using System.Windows.Documents;
 using WpfBrush = System.Windows.Media.Brush;
@@ -14,10 +12,10 @@ namespace DesktopApplicationTemplate.UI.Services
 {
     public class LoggingService : ILoggingService
     {
-        private readonly WpfRichTextBox _outputBox;
+        private readonly WpfRichTextBox _outputRichTextBox;
         private readonly Dispatcher _dispatcher;
         private readonly string _logFilePath;
-        private readonly List<LogEntry> _entries = new();
+        private readonly List<LogEntry> _logEntries = new();
 
         private LogLevel _minimumLevel = LogLevel.Debug;
         public LogLevel MinimumLevel
@@ -26,15 +24,16 @@ namespace DesktopApplicationTemplate.UI.Services
             set
             {
                 _minimumLevel = value;
+                Log($"Minimum level changed to {value}", LogLevel.Debug);
                 UpdateLogDisplay();
             }
         }
 
         public event Action<LogEntry>? LogAdded;
 
-        public LoggingService(WpfRichTextBox outputBox, Dispatcher dispatcher, string logFilePath = "app.log")
+        public LoggingService(WpfRichTextBox outputRichTextBox, Dispatcher dispatcher, string logFilePath = "app.log")
         {
-            _outputBox = outputBox;
+            _outputRichTextBox = outputRichTextBox;
             _dispatcher = dispatcher;
             _logFilePath = logFilePath;
         }
@@ -45,15 +44,15 @@ namespace DesktopApplicationTemplate.UI.Services
                                         Color = LevelToColor(level),
                                         Level = level };
 
-            _entries.Add(entry);
+            _logEntries.Add(entry);
 
             if (level >= MinimumLevel)
             {
                 _dispatcher.Invoke(() =>
                 {
                     var paragraph = new Paragraph(new Run(entry.Message) { Foreground = entry.Color });
-                    _outputBox.Document.Blocks.Add(paragraph);
-                    _outputBox.ScrollToEnd();
+                    _outputRichTextBox.Document.Blocks.Add(paragraph);
+                    _outputRichTextBox.ScrollToEnd();
                 });
             }
 
@@ -83,13 +82,13 @@ namespace DesktopApplicationTemplate.UI.Services
         {
             _dispatcher.Invoke(() =>
             {
-                _outputBox.Document.Blocks.Clear();
-                foreach (var e in _entries.Where(e => e.Level >= MinimumLevel))
+                _outputRichTextBox.Document.Blocks.Clear();
+                foreach (var e in _logEntries.Where(e => e.Level >= MinimumLevel))
                 {
                     var paragraph = new Paragraph(new Run(e.Message) { Foreground = e.Color });
-                    _outputBox.Document.Blocks.Add(paragraph);
+                    _outputRichTextBox.Document.Blocks.Add(paragraph);
                 }
-                _outputBox.ScrollToEnd();
+                _outputRichTextBox.ScrollToEnd();
             });
         }
     }

--- a/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.AsciiHelpWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="ASCII Help" SizeToContent="WidthAndHeight"
+        Title="ASCII Help" Width="900" Height="700"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.CloseConfirmationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Unsaved Changes" Width="300" Height="180"
+        Title="Unsaved Changes" Width="900" Height="700"
         WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>

--- a/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:toolkit="http://schemas.xceed.com/wpf/xaml/toolkit"
         WindowStartupLocation="CenterOwner"
-        Title="Pick a Color" Height="300" Width="300"
+        Title="Pick a Color" Width="900" Height="700"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
         }
 
-        public System.Windows.Media.Color SelectedColor => (System.Windows.Media.Color)ColorCanvas.SelectedColor;
+        public System.Windows.Media.Color ChosenColor => (System.Windows.Media.Color)ColorCanvas.SelectedColor;
 
         private void Ok_Click(object sender, RoutedEventArgs e)
         {

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.CreateServiceWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Create Service" Width="500" Height="400"
+        Title="Create Service" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
-        Title="CSV Viewer" Width="650" Height="450"
+        Title="CSV Viewer" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>

--- a/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
-        Title="Filter Services" Width="300" Height="250"
+        Title="Filter Services" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -310,7 +310,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 var dlg = new ColorPickerWindow { Owner = this };
                 if (dlg.ShowDialog() == true)
                 {
-                    var color = dlg.SelectedColor;
+                    var color = dlg.ChosenColor;
                     var brush = new SolidColorBrush(color);
                     foreach (var s in _viewModel.Services.Where(s => s.ServiceType == svc.ServiceType))
                     {

--- a/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.SaveConfirmationWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Save" Width="250" Height="180" WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        Title="Save" Width="900" Height="700" WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Service Editor" Width="800" Height="600"
+        Title="Service Editor" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>


### PR DESCRIPTION
## Summary
- clean up logging service variable names
- log minimum level changes
- remove unused `using` statements
- rename `SelectedColor` property to `ChosenColor`
- standardize window sizes with bubbly style

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874a9fc1c48326afc2518406e89515