### PR TITLE
Add minimize button and unify window border

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -85,5 +85,41 @@ namespace DesktopApplicationTemplate.Tests
             if (ex != null) throw ex;
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void MainView_HasMinimizeCommandBinding()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new DesktopApplicationTemplate.UI.App();
+                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
+                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), null, servicesPath);
+                    var view = new MainView(vm);
+                    bool bound = view.CommandBindings.OfType<CommandBinding>()
+                                        .Any(b => b.Command == SystemCommands.MinimizeWindowCommand);
+                    Assert.True(bound);
+                }
+                catch (Exception e) { ex = e; }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
@@ -12,6 +12,7 @@
         </Setter>
         <Setter Property="BorderBrush" Value="#ADD8E6" />
         <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="CornerRadius" Value="10" />
         <Setter Property="AllowsTransparency" Value="True" />
         <Setter Property="WindowStyle" Value="None" />
         <Setter Property="Template">
@@ -20,7 +21,8 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="10" Padding="5">
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Padding="5">
                         <Border.Effect>
                             <DropShadowEffect BlurRadius="15" ShadowDepth="0" Opacity="0.3" />
                         </Border.Effect>
@@ -31,9 +33,14 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition />
                                             <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="{TemplateBinding Title}" VerticalAlignment="Center" Margin="10,0" FontWeight="Bold" />
-                                        <Button Grid.Column="1" Content="X" Width="30" Height="30"
+                                        <Button Grid.Column="1" Content="_" Width="30" Height="30"
+                                                Command="{x:Static shell:SystemCommands.MinimizeWindowCommand}"
+                                                CommandTarget="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
+                                                Background="Transparent" BorderThickness="0" />
+                                        <Button Grid.Column="2" Content="X" Width="30" Height="30"
                                                 Command="{x:Static shell:SystemCommands.CloseWindowCommand}"
                                                 CommandTarget="{Binding RelativeSource={RelativeSource AncestorType=Window}}"
                                                 Background="Transparent" BorderThickness="0" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
         Title="MainView" Width="900" Height="700" ResizeMode="CanResizeWithGrip"
-        Style="{DynamicResource BubblyWindowStyle}"
+        Style="{DynamicResource BubblyWindowStyle}" BorderBrush="LimeGreen" BorderThickness="3" CornerRadius="15"
         MouseLeftButtonDown="Window_MouseLeftButtonDown">
 
     <Window.Resources>
@@ -19,7 +19,6 @@
         </ResourceDictionary>
     </Window.Resources>
 
-    <Border BorderBrush="LimeGreen" BorderThickness="3" CornerRadius="15">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -128,5 +127,4 @@
 
     </Grid>
     </Grid>
-    </Border>
 </Window>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -35,6 +35,7 @@ namespace DesktopApplicationTemplate.UI.Views
             KeyDown += MainView_KeyDown;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
+            CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
             Closing += (_, _) => _logger?.LogInformation("MainView closing");
         }
 
@@ -51,6 +52,12 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             _logger?.LogInformation("Close command invoked");
             Close();
+        }
+
+        private void MinimizeCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            _logger?.LogInformation("Minimize command invoked");
+            SystemCommands.MinimizeWindow(this);
         }
 
         private Page? GetOrCreateServicePage(ServiceViewModel svc)


### PR DESCRIPTION
## Summary
- restyle BubblyWindow template so the border can be customized
- include a minimize button in the title bar
- move the green rounded border to the window itself
- handle minimize command and log actions
- test for the minimize command binding

## Testing
- `dotnet test --no-build` *(fails: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874af1a8448326835f3486baf54d0e