### PR TITLE
Add HID output forwarding options

### DIFF
--- a/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Moq;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class HidViewModelTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void BuildMessage_FormatsAndForwards()
+        {
+            bool forwarded = false;
+            MessageForwarder.ForwardAction = (svc, msg) =>
+            {
+                if (svc == "Target" && msg == ">test<")
+                    forwarded = true;
+            };
+
+            var logger = new Mock<ILoggingService>();
+            var vm = new HidViewModel { Logger = logger.Object };
+            vm.AvailableServices.Add("Target");
+            vm.AttachedService = "Target";
+            vm.MessageTemplate = "test";
+            vm.FormatTemplate = ">\u007b0\u007d<";
+
+            vm.BuildCommand.Execute(null);
+
+            Assert.Equal(">test<", vm.FinalMessage);
+            Assert.True(forwarded);
+            logger.Verify(l => l.Log("Building HID message", LogLevel.Debug), Times.Once);
+            MessageForwarder.ForwardAction = null;
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/MessageForwarder.cs
+++ b/DesktopApplicationTemplate.UI/Services/MessageForwarder.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Provides simple forwarding of HID messages to another service.
+    /// </summary>
+    public static class MessageForwarder
+    {
+        /// <summary>
+        /// Optional action used for testing to intercept forwarding logic.
+        /// </summary>
+        public static System.Action<string, string>? ForwardAction { get; set; }
+
+        public static void Forward(string serviceName, string message)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+                return;
+
+            if (ForwardAction != null)
+            {
+                ForwardAction(serviceName, message);
+                return;
+            }
+
+            var mainVm = App.AppHost.Services.GetService(typeof(MainViewModel)) as MainViewModel;
+            var target = mainVm?.Services.FirstOrDefault(s => s.DisplayName == serviceName);
+            target?.AddLog($"[HID Forward] {message}");
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using System.Windows;
+﻿using System.Collections.ObjectModel;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -18,6 +13,47 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _messageTemplate;
             set { _messageTemplate = value; OnPropertyChanged(); }
         }
+
+        public ObservableCollection<string> AvailableServices { get; } = new();
+
+        private string _attachedService = string.Empty;
+        public string AttachedService
+        {
+            get => _attachedService;
+            set { _attachedService = value; OnPropertyChanged(); Logger?.Log($"Attached service set to {value}", LogLevel.Debug); }
+        }
+
+        public ObservableCollection<string> UsbProtocols { get; } = new() { "2.0", "3.0" };
+
+        private string _selectedUsbProtocol = "2.0";
+        public string SelectedUsbProtocol
+        {
+            get => _selectedUsbProtocol;
+            set { _selectedUsbProtocol = value; OnPropertyChanged(); Logger?.Log($"USB protocol set to {value}", LogLevel.Debug); }
+        }
+
+        private string _debounceTimeMs = "0";
+        public string DebounceTimeMs
+        {
+            get => _debounceTimeMs;
+            set { _debounceTimeMs = value; OnPropertyChanged(); Logger?.Log($"Debounce time set to {value}ms", LogLevel.Debug); }
+        }
+
+        private string _keyDownTimeMs = "0";
+        public string KeyDownTimeMs
+        {
+            get => _keyDownTimeMs;
+            set { _keyDownTimeMs = value; OnPropertyChanged(); Logger?.Log($"Key down time set to {value}ms", LogLevel.Debug); }
+        }
+
+        private string _formatTemplate = "{0}";
+        public string FormatTemplate
+        {
+            get => _formatTemplate;
+            set { _formatTemplate = value; OnPropertyChanged(); }
+        }
+
+        public ILoggingService? Logger { get; set; }
 
         private string _finalMessage = string.Empty;
         public string FinalMessage
@@ -35,8 +71,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             SaveCommand = new RelayCommand(Save);
         }
 
-        private void BuildMessage() => FinalMessage = MessageTemplate;
+        private void BuildMessage()
+        {
+            Logger?.Log("Building HID message", LogLevel.Debug);
+            FinalMessage = string.Format(FormatTemplate ?? "{0}", MessageTemplate);
+            Logger?.Log($"Final HID message: {FinalMessage}", LogLevel.Debug);
+            if (!string.IsNullOrWhiteSpace(AttachedService))
+            {
+                Logger?.Log($"Forwarding message to {AttachedService}", LogLevel.Debug);
+                MessageForwarder.Forward(AttachedService, FinalMessage);
+            }
+        }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save()
+        {
+            Logger?.Log("Saving HID configuration", LogLevel.Debug);
+            SaveConfirmationHelper.Show();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/HidViews.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidViews.xaml
@@ -17,11 +17,25 @@
 
         <Image Source="pack://application:,,,/Resources/Desktop-Icon.png" Width="100" HorizontalAlignment="Left" Margin="0,0,0,10"/>
 
-        <StackPanel Grid.Row="1" Margin="0,40,0,0">
+        <StackPanel Grid.Row="1" Margin="0,40,0,0" Width="400">
             <TextBlock Text="HID Message" FontWeight="Bold" Margin="0,0,0,5"/>
             <TextBox Text="{Binding MessageTemplate}" Height="80" AcceptsReturn="True" x:Name="TemplateBox"/>
+            <TextBlock Text="Format Template" FontWeight="Bold" Margin="0,10,0,5"/>
+            <TextBox Text="{Binding FormatTemplate}" Height="25"/>
             <TextBlock Text="Final Message" FontWeight="Bold" Margin="0,10,0,5"/>
             <TextBox Text="{Binding FinalMessage}" IsReadOnly="True" Height="80"/>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <TextBlock Text="USB:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                <ComboBox Width="80" ItemsSource="{Binding UsbProtocols}" SelectedItem="{Binding SelectedUsbProtocol}"/>
+                <TextBlock Text="Debounce (ms):" VerticalAlignment="Center" Margin="10,0,5,0"/>
+                <TextBox Width="60" Text="{Binding DebounceTimeMs}"/>
+                <TextBlock Text="Key Down (ms):" VerticalAlignment="Center" Margin="10,0,5,0"/>
+                <TextBox Width="60" Text="{Binding KeyDownTimeMs}"/>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <TextBlock Text="Forward To:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                <ComboBox Width="200" ItemsSource="{Binding AvailableServices}" SelectedItem="{Binding AttachedService}"/>
+            </StackPanel>
             <Button Content="Build" Command="{Binding BuildCommand}" Width="100" Margin="0,10,0,0" HorizontalAlignment="Left"/>
         </StackPanel>
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ no manual configuration is required.
 
 The UI exposes several built in service types. A brief description of each is shown below.
 
-- **HID** – configure HID devices and save their settings.
+- **HID** – configure HID devices, forward output to another service, set debounce and key down times, select USB protocol (2.0/3.0) and apply custom formatting.
 - **TCP** – run a lightweight TCP server and test message processing scripts.
 - **HTTP** – send HTTP requests with editable headers and body fields.
 - **File Observer** – watch folders and optionally send TCP commands when new files are detected.


### PR DESCRIPTION
## Summary
- allow HID service to forward messages to other services
- include USB protocol, debounce, key down and formatting options
- log HID save/build actions and optionally forward messages
- document HID service capabilities in README
- add test covering HID formatting and forwarding logic

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --settings tests.runsettings -p:EnableWindowsTargeting=true -p:UseWPF=false` *(fails: SelectionChangedEventArgs not found)*

------
https://chatgpt.com/codex/tasks/task_e_688764b4a590832698daf1182865c0f8