### PR TITLE
Add cross-service message references

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -25,11 +25,14 @@ namespace DesktopApplicationTemplate.Tests
                     new ServiceViewModel{DisplayName="A", ServiceType="Heartbeat", IsActive=true, Order=0},
                     new ServiceViewModel{DisplayName="B", ServiceType="TCP", IsActive=false, Order=1}
                 };
+                services[0].AssociatedServices.Add("B");
+                services[1].AssociatedServices.Add("A");
 
                 ServicePersistence.Save(services);
                 var loaded = ServicePersistence.Load();
                 Assert.Equal(2, loaded.Count);
                 Assert.Equal("A", loaded[0].DisplayName);
+                Assert.Contains("B", loaded[0].AssociatedServices);
             }
             finally
             {

--- a/DesktopApplicationTemplate.Tests/ServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceViewModelTests.cs
@@ -1,0 +1,29 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class ServiceViewModelTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void AddLog_ReferenceUpdatesAssociatedServices()
+        {
+            var a = new ServiceViewModel { DisplayName = "Heartbeat - A", ServiceType = "Heartbeat" };
+            var b = new ServiceViewModel { DisplayName = "TCP - B", ServiceType = "TCP" };
+            var services = new List<ServiceViewModel> { a, b };
+            ServiceViewModel.ResolveService = (type, name) =>
+                services.Find(s => s.ServiceType == type && s.DisplayName.Split(" - ").Last() == name);
+
+            a.AddLog("TCP.B.Test message");
+
+            Assert.Contains(b.Logs, l => l.Message.Contains("Test message"));
+            Assert.Contains(b.DisplayName, a.AssociatedServices);
+            Assert.Contains(a.DisplayName, b.AssociatedServices);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -22,7 +22,8 @@ namespace DesktopApplicationTemplate.UI.Services
                     ServiceType = s.ServiceType,
                     IsActive = s.IsActive,
                     Created = DateTime.Now,
-                    Order = index++
+                    Order = index++,
+                    AssociatedServices = new List<string>(s.AssociatedServices)
                 });
             }
 
@@ -63,5 +64,6 @@ namespace DesktopApplicationTemplate.UI.Services
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
         public int Order { get; set; }
+        public List<string> AssociatedServices { get; set; } = new();
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -10,10 +10,24 @@
         <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <StackPanel Margin="10">
-        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}">
+        <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,0,0,5">
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14" Margin="0,0,10,0"/>
-            <TextBlock Text="Associated Steps:" FontStyle="Italic"/>
+            <TextBlock Text="Associated Services:" FontStyle="Italic"/>
         </StackPanel>
+        <ItemsControl ItemsSource="{Binding SelectedService.AssociatedServices}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Border Background="LightGray" CornerRadius="10" Padding="4" Margin="0,0,5,0">
+                        <TextBlock Text="{Binding}"/>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
         <TextBox Text="{Binding DisplayLogs, Mode=OneWay, Converter={StaticResource LogListToStringConverter}}"
                  IsReadOnly="True" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
     </StackPanel>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ csvService.AppendRow(new [] { tcpValue, httpStatus });
 
 This appends a new row to `output_{index}.csv` with the TCP and HTTP values.
 
+## Referencing other service messages
+
+Any log entry can reference another service's message using the format
+`SERVICETYPE.ServiceName.Message`. When such a log is added, both services will
+link to each other under **Associated Services** and the referenced message will
+appear in the target service's log.
+
 ## C# message scripts
 
 The **TCP** service can execute small C# scripts for transforming incoming


### PR DESCRIPTION
## Summary
- implement associated service tracking and cross-service log references
- persist associated services in `ServicePersistence`
- display associated services on the Home page
- document message reference format in README
- add unit tests for persistence and log referencing

## Testing
- `dotnet build DesktopApplicationTemplate.sln -c Release` *(fails: command not found)*
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876bdd21f08326a07bbdedf2b7efbb