### PR TITLE
Add HID service infrastructure

### DIFF
--- a/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
+++ b/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+      <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/DesktopApplicationTemplate.Tests/HidDeviceTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidDeviceTests.cs
@@ -1,0 +1,25 @@
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class HidDeviceTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task SendKeysAsync_Logs()
+        {
+            var logger = new Mock<ILoggingService>();
+            var device = new HidDevice(logger.Object);
+
+            await device.SendKeysAsync("abc", 0, CancellationToken.None);
+
+            logger.Verify(l => l.Log("HID device sending: abc", LogLevel.Debug), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/HidServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidServiceTests.cs
@@ -1,0 +1,34 @@
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class HidServiceTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task SendAsync_DelayAndDeviceInvoked()
+        {
+            var device = new Mock<IHidDevice>();
+            device.Setup(d => d.SendKeysAsync("msg", 50, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var delay = new Mock<IDelayService>();
+            delay.Setup(d => d.DelayAsync(100, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var logger = new Mock<ILoggingService>();
+
+            var service = new HidService(device.Object, delay.Object, logger.Object);
+            await service.SendAsync("msg", 100, 50);
+
+            delay.Verify(d => d.DelayAsync(100, It.IsAny<CancellationToken>()), Times.Once);
+            device.Verify(d => d.SendKeysAsync("msg", 50, It.IsAny<CancellationToken>()), Times.Once);
+            logger.Verify(l => l.Log("HidService send start", LogLevel.Debug), Times.Once);
+            logger.Verify(l => l.Log("HidService send complete", LogLevel.Debug), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
@@ -1,6 +1,8 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Moq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -31,6 +33,25 @@ namespace DesktopApplicationTemplate.Tests
             Assert.True(forwarded);
             logger.Verify(l => l.Log("Building HID message", LogLevel.Debug), Times.Once);
             MessageForwarder.ForwardAction = null;
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void BuildCommand_InvokesHidService()
+        {
+            var hidService = new Mock<IHidService>();
+            hidService.Setup(s => s.SendAsync(">msg<", 0, 0, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var vm = new HidViewModel(hidService.Object);
+            vm.MessageTemplate = "msg";
+            vm.FormatTemplate = ">\u007b0\u007d<";
+
+            vm.BuildCommand.Execute(null);
+
+            hidService.Verify(s => s.SendAsync(">msg<", 0, 0, It.IsAny<CancellationToken>()), Times.Once);
 
             ConsoleTestLogger.LogPass();
         }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -51,6 +51,9 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<ScpServiceViewModel>();
             services.AddSingleton<HidViewModel>();
             services.AddSingleton<HidViews>();
+            services.AddSingleton<IDelayService, DelayService>();
+            services.AddSingleton<IHidDevice, HidDevice>();
+            services.AddSingleton<IHidService, HidService>();
             services.AddSingleton<MqttService>();
             services.AddSingleton<MQTTServiceView>();
             services.AddSingleton<MqttServiceViewModel>();

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentFTP" Version="53.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
-    <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.0" />
+      <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />

--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    /// <summary>
+    /// An asynchronous ICommand implementation.
+    /// </summary>
+    public class AsyncRelayCommand : ICommand
+    {
+        private readonly Func<Task> _execute;
+        private readonly Func<bool>? _canExecute;
+
+        public AsyncRelayCommand(Func<Task> execute, Func<bool>? canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+        public async void Execute(object? parameter)
+        {
+            await _execute().ConfigureAwait(false);
+        }
+
+        public event EventHandler? CanExecuteChanged;
+
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/DelayService.cs
+++ b/DesktopApplicationTemplate.UI/Services/DelayService.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Standard implementation of <see cref="IDelayService"/>.
+    /// </summary>
+    public class DelayService : IDelayService
+    {
+        public Task DelayAsync(int milliseconds, CancellationToken token)
+        {
+            return Task.Delay(milliseconds, token);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/HidDevice.cs
+++ b/DesktopApplicationTemplate.UI/Services/HidDevice.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Basic HID device implementation that logs outgoing messages.
+    /// </summary>
+    public class HidDevice : IHidDevice
+    {
+        private readonly ILoggingService? _logger;
+
+        public HidDevice(ILoggingService? logger = null)
+        {
+            _logger = logger;
+        }
+
+        public Task SendKeysAsync(string text, int keyDownTimeMs, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+            _ = keyDownTimeMs;
+            _logger?.Log($"HID device sending: {text}", LogLevel.Debug);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/HidService.cs
+++ b/DesktopApplicationTemplate.UI/Services/HidService.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Coordinates sending messages to a HID device with optional debounce delays.
+    /// </summary>
+    public class HidService : IHidService
+    {
+        private readonly IHidDevice _device;
+        private readonly IDelayService _delayService;
+        private readonly ILoggingService? _logger;
+
+        public HidService(IHidDevice device, IDelayService delayService, ILoggingService? logger = null)
+        {
+            _device = device;
+            _delayService = delayService;
+            _logger = logger;
+        }
+
+        public async Task SendAsync(string message, int debounceTimeMs, int keyDownTimeMs, CancellationToken token = default)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
+            _logger?.Log("HidService send start", LogLevel.Debug);
+            await _delayService.DelayAsync(debounceTimeMs, token).ConfigureAwait(false);
+            await _device.SendKeysAsync(message, keyDownTimeMs, token).ConfigureAwait(false);
+            _logger?.Log("HidService send complete", LogLevel.Debug);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/IDelayService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IDelayService.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Provides a testable abstraction over Task.Delay.
+    /// </summary>
+    public interface IDelayService
+    {
+        Task DelayAsync(int milliseconds, CancellationToken token);
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/IHidDevice.cs
+++ b/DesktopApplicationTemplate.UI/Services/IHidDevice.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Abstraction over a hardware device capable of sending HID keyboard input.
+    /// </summary>
+    public interface IHidDevice
+    {
+        /// <summary>
+        /// Sends the specified text to the HID target.
+        /// </summary>
+        /// <param name="text">Text to send as keyboard input.</param>
+        /// <param name="keyDownTimeMs">Duration in milliseconds each key is held down.</param>
+        /// <param name="token">Cancellation token.</param>
+        Task SendKeysAsync(string text, int keyDownTimeMs, CancellationToken token);
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/IHidService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IHidService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Service responsible for sending formatted HID messages to an attached device.
+    /// </summary>
+    public interface IHidService
+    {
+        /// <summary>
+        /// Sends the specified message to the HID device.
+        /// </summary>
+        /// <param name="message">Message to transmit.</param>
+        /// <param name="debounceTimeMs">Delay before sending, allowing hardware debounce.</param>
+        /// <param name="keyDownTimeMs">Duration each key is held down.</param>
+        /// <param name="token">Cancellation token.</param>
+        Task SendAsync(string message, int debounceTimeMs, int keyDownTimeMs, CancellationToken token = default);
+    }
+}


### PR DESCRIPTION
## Summary
- add HID service and device abstractions with logging and debounce
- integrate async HID messaging into view model and register in DI container
- cover HID messaging with new unit tests

## Testing
- `EnableWindowsTargeting=true dotnet build`
- `EnableWindowsTargeting=true dotnet test` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_688da1ea599083269771a542ea526e71