### PR TITLE
Fix BubblyWindow style reference

### DIFF
--- a/DesktopApplicationTemplate.Tests/BubblyWindowStyleTests.cs
+++ b/DesktopApplicationTemplate.Tests/BubblyWindowStyleTests.cs
@@ -1,0 +1,47 @@
+using DesktopApplicationTemplate.UI;
+using System;
+using System.Threading;
+using System.Windows;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class BubblyWindowStyleTests
+    {
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void BubblyWindowStyle_LoadsWithRoundedCorners()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? capturedException = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    var resourceDictionary = new ResourceDictionary
+                    {
+                        Source = new Uri("pack://application:,,,/DesktopApplicationTemplate.UI;component/Themes/BubblyWindow.xaml")
+                    };
+
+                    Assert.True(resourceDictionary.Contains("BubblyWindowStyle"));
+                    _ = (Style)resourceDictionary["BubblyWindowStyle"];
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            if (capturedException != null)
+                throw capturedException;
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
@@ -12,7 +12,6 @@
         </Setter>
         <Setter Property="BorderBrush" Value="#ADD8E6" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="CornerRadius" Value="10" />
         <Setter Property="AllowsTransparency" Value="True" />
         <Setter Property="WindowStyle" Value="None" />
         <Setter Property="Template">
@@ -21,7 +20,7 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
+                            CornerRadius="10"
                             Padding="5">
                         <Border.Effect>
                             <DropShadowEffect BlurRadius="15" ShadowDepth="0" Opacity="0.3" />


### PR DESCRIPTION
## Summary
- correct BubblyWindow style by removing invalid CornerRadius setter and moving radius into template
- add unit test ensuring BubblyWindow style loads

## Testing
- `/usr/share/dotnet/dotnet test --configuration Release -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_689379413f3c83268820b7b68e726d79