### PR TITLE
fix: set window transparency directly

### DIFF
--- a/DesktopApplication.Installer/Themes/BubblyWindow.xaml
+++ b/DesktopApplication.Installer/Themes/BubblyWindow.xaml
@@ -12,7 +12,6 @@
         </Setter>
         <Setter Property="BorderBrush" Value="#ADD8E6" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="AllowsTransparency" Value="True" />
         <Setter Property="WindowStyle" Value="None" />
         <Setter Property="Template">
             <Setter.Value>

--- a/DesktopApplication.Installer/Views/InstallerWindow.xaml
+++ b/DesktopApplication.Installer/Views/InstallerWindow.xaml
@@ -7,6 +7,7 @@
         mc:Ignorable="d"
         Title="Application Installer" Height="300" Width="500"
         WindowStartupLocation="CenterScreen"
+        AllowsTransparency="True"
         Style="{StaticResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplication.Installer/Views/ProgressWindow.xaml
+++ b/DesktopApplication.Installer/Views/ProgressWindow.xaml
@@ -7,6 +7,7 @@
         mc:Ignorable="d"
         Title="Installing" Height="400" Width="600"
         WindowStartupLocation="CenterScreen"
+        AllowsTransparency="True"
         Style="{StaticResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/BubblyWindow.xaml
@@ -12,7 +12,6 @@
         </Setter>
         <Setter Property="BorderBrush" Value="#ADD8E6" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="AllowsTransparency" Value="True" />
         <Setter Property="WindowStyle" Value="None" />
         <Setter Property="Template">
             <Setter.Value>

--- a/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/AsciiHelpWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="ASCII Help" Width="900" Height="700"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CloseConfirmationWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Unsaved Changes" Width="900" Height="700"
         WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:toolkit="http://schemas.xceed.com/wpf/xaml/toolkit"
         WindowStartupLocation="CenterOwner"
         Title="Pick a Color" Width="900" Height="700"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Create Service" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvViewerWindow.xaml
@@ -8,6 +8,7 @@
         mc:Ignorable="d"
         Title="CSV Viewer" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FilterWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         Title="Filter Services" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
         Title="MainView" Width="900" Height="700" ResizeMode="CanResizeWithGrip"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}" BorderBrush="LimeGreen" BorderThickness="3"
         MouseLeftButtonDown="Window_MouseLeftButtonDown">
 

--- a/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SaveConfirmationWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Save" Width="900" Height="700" WindowStartupLocation="CenterOwner" ResizeMode="NoResize"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Script Editor" SizeToContent="WidthAndHeight"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ServiceEditorWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Service Editor" Width="900" Height="700"
         WindowStartupLocation="CenterOwner"
+        AllowsTransparency="True"
         Style="{DynamicResource BubblyWindowStyle}">
     <Window.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
## Summary
- remove invalid AllowsTransparency setter from BubblyWindow style that caused XAML parse failures
- explicitly set AllowsTransparency on windows using BubblyWindowStyle across UI and installer

## Testing
- `dotnet test --no-build` *(fails: The argument DesktopApplicationTemplate.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa4b14b883269ba5e3c3533abb7d