### PR TITLE
Add network configuration UI and service

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -15,7 +15,8 @@ namespace DesktopApplicationTemplate.Tests
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(configPath));
-            var vm = new MainViewModel(csv);
+            var network = new Mock<INetworkConfigurationService>();
+            var vm = new MainViewModel(csv, network.Object);
             vm.Services.Add(new ServiceViewModel
             {
                 DisplayName = "HTTP - HTTP1",
@@ -45,10 +46,11 @@ namespace DesktopApplicationTemplate.Tests
             var logger = new Mock<ILoggingService>();
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(configPath));
+            var network = new Mock<INetworkConfigurationService>();
 
             var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
             Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-            var vm = new MainViewModel(csv, logger.Object, servicesPath);
+            var vm = new MainViewModel(csv, network.Object, logger.Object, servicesPath);
             var service = new ServiceViewModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
             vm.Services.Add(service);
             vm.SelectedService = service;

--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using Xunit;
 using System.IO;
+using Moq;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -32,7 +33,8 @@ namespace DesktopApplicationTemplate.Tests
 
                     var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
                     Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), null, servicesPath);
+                    var network = new Mock<INetworkConfigurationService>();
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), network.Object, null, servicesPath);
                     var view = new MainView(vm);
                     var list = view.FindName("ServiceList") as System.Windows.Controls.ListBox;
                     Assert.Equal(350, list?.MaxHeight);
@@ -67,7 +69,8 @@ namespace DesktopApplicationTemplate.Tests
                     var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
                     var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
                     Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), null, servicesPath);
+                    var network = new Mock<INetworkConfigurationService>();
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), network.Object, null, servicesPath);
                     var view = new MainView(vm);
                     bool bound = view.CommandBindings.OfType<CommandBinding>()
                                         .Any(b => b.Command == SystemCommands.CloseWindowCommand);
@@ -103,7 +106,8 @@ namespace DesktopApplicationTemplate.Tests
                     var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
                     var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
                     Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), null, servicesPath);
+                    var network = new Mock<INetworkConfigurationService>();
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), network.Object, null, servicesPath);
                     var view = new MainView(vm);
                     bool bound = view.CommandBindings.OfType<CommandBinding>()
                                         .Any(b => b.Command == SystemCommands.MinimizeWindowCommand);

--- a/DesktopApplicationTemplate.Tests/NetworkConfigurationServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/NetworkConfigurationServiceTests.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class NetworkConfigurationServiceTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task ApplyConfigurationAsync_InvokesProcessRunner()
+        {
+            var runner = new Mock<IProcessRunner>();
+            var logger = new Microsoft.Extensions.Logging.Abstractions.NullLogger<NetworkConfigurationService>();
+            var service = new NetworkConfigurationService(runner.Object, logger);
+            var config = new NetworkConfiguration
+            {
+                IpAddress = "1.1.1.1",
+                SubnetMask = "255.255.255.0",
+                Gateway = "1.1.1.254",
+                DnsPrimary = "8.8.8.8"
+            };
+
+            await service.ApplyConfigurationAsync(config, CancellationToken.None);
+
+            if (OperatingSystem.IsWindows())
+            {
+                runner.Verify(r => r.RunAsync("netsh", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            }
+            else
+            {
+                runner.Verify(r => r.RunAsync("ip", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/NetworkConfigurationViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/NetworkConfigurationViewModelTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Moq;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class NetworkConfigurationViewModelTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task LoadAndApplyConfiguration_UsesService()
+        {
+            var service = new Mock<INetworkConfigurationService>();
+            service.Setup(s => s.GetConfigurationAsync(default)).ReturnsAsync(new NetworkConfiguration
+            {
+                IpAddress = "2.2.2.2",
+                SubnetMask = "255.255.255.0",
+                Gateway = "2.2.2.254",
+                DnsPrimary = "8.8.4.4"
+            });
+
+            var vm = new NetworkConfigurationViewModel(service.Object, null);
+            await vm.LoadAsync();
+
+            Assert.Equal("2.2.2.2", vm.IpAddress);
+
+            vm.IpAddress = "3.3.3.3";
+            await vm.ApplyAsync();
+
+            service.Verify(s => s.ApplyConfigurationAsync(It.Is<NetworkConfiguration>(c => c.IpAddress == "3.3.3.3"), default), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -2,6 +2,7 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -39,6 +40,8 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<MainView>();
             services.AddSingleton<IStartupService, StartupService>();
             services.AddSingleton<MainViewModel>();
+            services.AddSingleton<IProcessRunner, ProcessRunner>();
+            services.AddSingleton<INetworkConfigurationService, NetworkConfigurationService>();
             services.AddSingleton<TcpServiceViewModel>();
             services.AddSingleton<DependencyChecker>();
             services.AddSingleton<HttpServiceView>();
@@ -68,7 +71,7 @@ namespace DesktopApplicationTemplate.UI
 
 
             // Load strongly typed settings
-            services.Configure<Models.AppSettings>(configuration.GetSection("AppSettings"));
+            services.Configure<AppSettings>(configuration.GetSection("AppSettings"));
         }
 
         protected override async void OnStartup(StartupEventArgs e)

--- a/DesktopApplicationTemplate.UI/Models/NetworkConfiguration.cs
+++ b/DesktopApplicationTemplate.UI/Models/NetworkConfiguration.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.Models
+{
+    public class NetworkConfiguration
+    {
+        public string IpAddress { get; init; } = string.Empty;
+        public string SubnetMask { get; init; } = string.Empty;
+        public string Gateway { get; init; } = string.Empty;
+        public string DnsPrimary { get; init; } = string.Empty;
+        public string DnsSecondary { get; init; } = string.Empty;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/INetworkConfigurationService.cs
+++ b/DesktopApplicationTemplate.UI/Services/INetworkConfigurationService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.UI.Models;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public interface INetworkConfigurationService
+    {
+        Task<NetworkConfiguration> GetConfigurationAsync(CancellationToken cancellationToken = default);
+        Task ApplyConfigurationAsync(NetworkConfiguration configuration, CancellationToken cancellationToken = default);
+        event EventHandler<NetworkConfiguration>? ConfigurationChanged;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/IProcessRunner.cs
+++ b/DesktopApplicationTemplate.UI/Services/IProcessRunner.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public interface IProcessRunner
+    {
+        Task RunAsync(string fileName, string arguments, CancellationToken cancellationToken = default);
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/NetworkConfigurationService.cs
+++ b/DesktopApplicationTemplate.UI/Services/NetworkConfigurationService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.UI.Models;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public class NetworkConfigurationService : INetworkConfigurationService
+    {
+        private readonly IProcessRunner _processRunner;
+        private readonly ILogger<NetworkConfigurationService>? _logger;
+
+        public event EventHandler<NetworkConfiguration>? ConfigurationChanged;
+
+        public NetworkConfigurationService(IProcessRunner processRunner, ILogger<NetworkConfigurationService>? logger = null)
+        {
+            _processRunner = processRunner;
+            _logger = logger;
+        }
+
+        public Task<NetworkConfiguration> GetConfigurationAsync(CancellationToken cancellationToken = default)
+        {
+            var iface = NetworkInterface.GetAllNetworkInterfaces()
+                .FirstOrDefault(n => n.Name.Equals("eth0", StringComparison.OrdinalIgnoreCase))
+                ?? NetworkInterface.GetAllNetworkInterfaces()
+                    .FirstOrDefault(n => n.OperationalStatus == OperationalStatus.Up);
+
+            if (iface == null)
+            {
+                _logger?.LogWarning("No active network interface found");
+                return Task.FromResult(new NetworkConfiguration());
+            }
+
+            var props = iface.GetIPProperties();
+            var unicast = props.UnicastAddresses.FirstOrDefault(a => a.Address.AddressFamily == AddressFamily.InterNetwork);
+            var gateway = props.GatewayAddresses.FirstOrDefault()?.Address.ToString() ?? string.Empty;
+            var dns = props.DnsAddresses.Where(a => a.AddressFamily == AddressFamily.InterNetwork)
+                                        .Select(a => a.ToString()).ToList();
+            var config = new NetworkConfiguration
+            {
+                IpAddress = unicast?.Address.ToString() ?? string.Empty,
+                SubnetMask = unicast?.IPv4Mask?.ToString() ?? string.Empty,
+                Gateway = gateway,
+                DnsPrimary = dns.ElementAtOrDefault(0) ?? string.Empty,
+                DnsSecondary = dns.ElementAtOrDefault(1) ?? string.Empty
+            };
+            _logger?.LogInformation("Retrieved network configuration for eth0: {IP}", config.IpAddress);
+            return Task.FromResult(config);
+        }
+
+        public async Task ApplyConfigurationAsync(NetworkConfiguration configuration, CancellationToken cancellationToken = default)
+        {
+            _logger?.LogInformation("Applying network configuration: {IP}/{Subnet} GW {Gateway}", configuration.IpAddress, configuration.SubnetMask, configuration.Gateway);
+            if (OperatingSystem.IsWindows())
+            {
+                await _processRunner.RunAsync("netsh", $"interface ip set address \"eth0\" static {configuration.IpAddress} {configuration.SubnetMask} {configuration.Gateway}", cancellationToken).ConfigureAwait(false);
+                await _processRunner.RunAsync("netsh", $"interface ip set dns \"eth0\" static {configuration.DnsPrimary}", cancellationToken).ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(configuration.DnsSecondary))
+                {
+                    await _processRunner.RunAsync("netsh", $"interface ip add dns \"eth0\" {configuration.DnsSecondary} index=2", cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                var prefix = SubnetToCidr(configuration.SubnetMask);
+                await _processRunner.RunAsync("ip", $"addr add {configuration.IpAddress}/{prefix} dev eth0", cancellationToken).ConfigureAwait(false);
+                await _processRunner.RunAsync("ip", $"route add default via {configuration.Gateway} dev eth0", cancellationToken).ConfigureAwait(false);
+                await _processRunner.RunAsync("sh", $"-c \"echo nameserver {configuration.DnsPrimary} > /etc/resolv.conf\"", cancellationToken).ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(configuration.DnsSecondary))
+                {
+                    await _processRunner.RunAsync("sh", $"-c \"echo nameserver {configuration.DnsSecondary} >> /etc/resolv.conf\"", cancellationToken).ConfigureAwait(false);
+                }
+            }
+            ConfigurationChanged?.Invoke(this, configuration);
+        }
+
+        private static int SubnetToCidr(string subnetMask)
+        {
+            if (string.IsNullOrWhiteSpace(subnetMask))
+                return 0;
+            var bytes = IPAddress.Parse(subnetMask).GetAddressBytes();
+            int count = 0;
+            foreach (var b in bytes)
+            {
+                count += Convert.ToString(b, 2).Count(c => c == '1');
+            }
+            return count;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ProcessRunner.cs
+++ b/DesktopApplicationTemplate.UI/Services/ProcessRunner.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public class ProcessRunner : IProcessRunner
+    {
+        public async Task RunAsync(string fileName, string arguments, CancellationToken cancellationToken = default)
+        {
+            var startInfo = new ProcessStartInfo(fileName, arguments)
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+            if (process.ExitCode != 0)
+            {
+                var error = await process.StandardError.ReadToEndAsync().ConfigureAwait(false);
+                throw new InvalidOperationException($"Command '{fileName} {arguments}' failed: {error}");
+            }
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -2,10 +2,11 @@ using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, INetworkAwareViewModel
     {
         private string _host = string.Empty;
         public string Host
@@ -99,6 +100,11 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         }
 
         private void Save() => SaveConfirmationHelper.Show();
+
+        public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
+        {
+            Host = configuration.IpAddress;
+        }
 
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/INetworkAwareViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/INetworkAwareViewModel.cs
@@ -1,0 +1,9 @@
+using DesktopApplicationTemplate.UI.Models;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public interface INetworkAwareViewModel
+    {
+        void UpdateNetworkConfiguration(NetworkConfiguration configuration);
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -4,10 +4,11 @@ using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel
+public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwareViewModel
     {
         private string _host = string.Empty;
         public string Host
@@ -94,6 +95,11 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel
         }
 
         private void Save() => SaveConfirmationHelper.Show();
+
+        public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
+        {
+            Host = configuration.IpAddress;
+        }
 
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/NetworkConfigurationViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/NetworkConfigurationViewModel.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class NetworkConfigurationViewModel : ViewModelBase
+    {
+        private readonly INetworkConfigurationService _service;
+        private readonly ILoggingService? _logger;
+
+        public NetworkConfigurationViewModel(INetworkConfigurationService service, ILoggingService? logger = null)
+        {
+            _service = service;
+            _logger = logger;
+            ApplyCommand = new RelayCommand(async () => await ApplyAsync());
+            RefreshCommand = new RelayCommand(async () => await LoadAsync());
+        }
+
+        private string _ipAddress = string.Empty;
+        public string IpAddress { get => _ipAddress; set { _ipAddress = value; OnPropertyChanged(); } }
+
+        private string _subnetMask = string.Empty;
+        public string SubnetMask { get => _subnetMask; set { _subnetMask = value; OnPropertyChanged(); } }
+
+        private string _gateway = string.Empty;
+        public string Gateway { get => _gateway; set { _gateway = value; OnPropertyChanged(); } }
+
+        private string _dnsPrimary = string.Empty;
+        public string DnsPrimary { get => _dnsPrimary; set { _dnsPrimary = value; OnPropertyChanged(); } }
+
+        private string _dnsSecondary = string.Empty;
+        public string DnsSecondary { get => _dnsSecondary; set { _dnsSecondary = value; OnPropertyChanged(); } }
+
+        public NetworkConfiguration CurrentConfiguration { get; private set; } = new();
+
+        public ICommand ApplyCommand { get; }
+        public ICommand RefreshCommand { get; }
+
+        public async Task LoadAsync()
+        {
+            CurrentConfiguration = await _service.GetConfigurationAsync().ConfigureAwait(false);
+            IpAddress = CurrentConfiguration.IpAddress;
+            SubnetMask = CurrentConfiguration.SubnetMask;
+            Gateway = CurrentConfiguration.Gateway;
+            DnsPrimary = CurrentConfiguration.DnsPrimary;
+            DnsSecondary = CurrentConfiguration.DnsSecondary;
+            _logger?.Log("Loaded network configuration", LogLevel.Debug);
+        }
+
+        public async Task ApplyAsync()
+        {
+            var config = new NetworkConfiguration
+            {
+                IpAddress = IpAddress,
+                SubnetMask = SubnetMask,
+                Gateway = Gateway,
+                DnsPrimary = DnsPrimary,
+                DnsSecondary = DnsSecondary
+            };
+            await _service.ApplyConfigurationAsync(config).ConfigureAwait(false);
+            CurrentConfiguration = config;
+            _logger?.Log("Applied network configuration", LogLevel.Debug);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -3,10 +3,11 @@ using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel
+public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwareViewModel
     {
         private string _host = string.Empty;
         public string Host
@@ -76,6 +77,11 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel
         }
 
         private void Save() => SaveConfirmationHelper.Show();
+
+        public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
+        {
+            Host = configuration.IpAddress;
+        }
 
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -10,10 +10,11 @@ using System.Windows;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, INetworkAwareViewModel
     {
         private string _statusMessage = string.Empty;
         private bool _isServerRunning;
@@ -279,6 +280,12 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         }
 
         private void Save() => SaveConfirmationHelper.Show();
+
+        public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
+        {
+            ComputerIp = configuration.IpAddress;
+            ServerGateway = configuration.Gateway;
+        }
 
         // OnPropertyChanged inherited from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -9,7 +9,37 @@
         <helpers:LogListToStringConverter x:Key="LogListToStringConverter" />
         <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
-    <StackPanel Margin="10">
+    <StackPanel Margin="10" >
+        <Border Background="WhiteSmoke" CornerRadius="8" Padding="10" Margin="0,0,0,10">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="IP Address:" Grid.Row="0" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding NetworkConfig.IpAddress}" Grid.Row="0" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                <TextBlock Text="Subnet:" Grid.Row="1" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding NetworkConfig.SubnetMask}" Grid.Row="1" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                <TextBlock Text="Gateway:" Grid.Row="2" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding NetworkConfig.Gateway}" Grid.Row="2" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                <TextBlock Text="DNS 1:" Grid.Row="3" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding NetworkConfig.DnsPrimary}" Grid.Row="3" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                <TextBlock Text="DNS 2:" Grid.Row="4" Margin="0,0,5,5"/>
+                <TextBox Text="{Binding NetworkConfig.DnsSecondary}" Grid.Row="4" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" HorizontalAlignment="Right">
+                    <Button Content="Refresh" Command="{Binding NetworkConfig.RefreshCommand}" Margin="0,5,5,0"/>
+                    <Button Content="Apply" Command="{Binding NetworkConfig.ApplyCommand}" Margin="0,5,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
         <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,0,0,5">
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14" Margin="0,0,10,0"/>
             <TextBlock Text="Associated Services:" FontStyle="Italic"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -89,6 +89,11 @@ namespace DesktopApplicationTemplate.UI.Views
                         logger.LogAdded += entry => svc.AddLog(entry.Message, entry.Color, entry.Level);
                     }
                 }
+
+                if (svc.ServicePage.DataContext is INetworkAwareViewModel navm)
+                {
+                    navm.UpdateNetworkConfiguration(_viewModel.NetworkConfig.CurrentConfiguration);
+                }
             }
 
             return svc.ServicePage;


### PR DESCRIPTION
## Summary
- add network configuration model, service and process runner
- expose network settings editor on home page with refresh/apply
- propagate IP changes to network-aware services

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fba5b59c8326a977e99844c3d378