### PR TITLE
refactor: restructure main view layout

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -26,16 +26,25 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Image Source="pack://application:,,,/Resources/Logo.png" Width="Auto" Height="60" Margin="10" HorizontalAlignment="Left"/>
+        <!-- Top Bar -->
+        <Grid Grid.Row="0" Margin="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Image Source="pack://application:,,,/Resources/Logo.png" Height="60" HorizontalAlignment="Left" VerticalAlignment="Center"/>
+            <Button Grid.Column="1" Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Top" Click="OpenSettings_Click"/>
+        </Grid>
 
+        <!-- Main Content -->
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="230"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-        <!-- Left Panel -->
-        <Grid Grid.Column="0" Margin="10">
+            <!-- Left Panel -->
+            <Grid Grid.Column="0" Margin="10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -95,9 +104,9 @@
             </ListBox>
         </Grid>
 
-        <!-- Right Panel -->
+            <!-- Right Panel -->
 
-        <StackPanel Grid.Column="1" Margin="10">
+            <StackPanel Grid.Column="1" Margin="10">
             <Frame x:Name="ContentFrame" NavigationUIVisibility="Hidden" />
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14"/>
             <TextBlock Text="Services Created:" />
@@ -120,12 +129,9 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-        </StackPanel>
+            </StackPanel>
 
-        <Button Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Click="OpenSettings_Click"/>
-
-        <ResizeGrip HorizontalAlignment="Right" VerticalAlignment="Bottom" />
-
-    </Grid>
+            <ResizeGrip Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
+        </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- restructure main view into top bar and main content
- move settings button to the upper right

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App 8.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a00020df48326861211e611f1368b