### PR TITLE
Fix settings navigation and relocate network configuration

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -16,7 +16,8 @@ namespace DesktopApplicationTemplate.Tests
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(configPath));
             var network = new Mock<INetworkConfigurationService>();
-            var vm = new MainViewModel(csv, network.Object);
+            var networkVm = new NetworkConfigurationViewModel(network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object);
             vm.Services.Add(new ServiceViewModel
             {
                 DisplayName = "HTTP - HTTP1",
@@ -47,10 +48,11 @@ namespace DesktopApplicationTemplate.Tests
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(configPath));
             var network = new Mock<INetworkConfigurationService>();
+            var networkVm = new NetworkConfigurationViewModel(network.Object);
 
             var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
             Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-            var vm = new MainViewModel(csv, network.Object, logger.Object, servicesPath);
+            var vm = new MainViewModel(csv, networkVm, network.Object, logger.Object, servicesPath);
             var service = new ServiceViewModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
             vm.Services.Add(service);
             vm.SelectedService = service;

--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -34,7 +34,8 @@ namespace DesktopApplicationTemplate.Tests
                     var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
                     Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
                     var network = new Mock<INetworkConfigurationService>();
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), network.Object, null, servicesPath);
+                    var networkVm = new NetworkConfigurationViewModel(network.Object);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), networkVm, network.Object, null, servicesPath);
                     var view = new MainView(vm);
                     var list = view.FindName("ServiceList") as System.Windows.Controls.ListBox;
                     Assert.Equal(350, list?.MaxHeight);
@@ -70,7 +71,8 @@ namespace DesktopApplicationTemplate.Tests
                     var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
                     Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
                     var network = new Mock<INetworkConfigurationService>();
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), network.Object, null, servicesPath);
+                    var networkVm = new NetworkConfigurationViewModel(network.Object);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), networkVm, network.Object, null, servicesPath);
                     var view = new MainView(vm);
                     bool bound = view.CommandBindings.OfType<CommandBinding>()
                                         .Any(b => b.Command == SystemCommands.CloseWindowCommand);
@@ -107,7 +109,8 @@ namespace DesktopApplicationTemplate.Tests
                     var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
                     Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
                     var network = new Mock<INetworkConfigurationService>();
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), network.Object, null, servicesPath);
+                    var networkVm = new NetworkConfigurationViewModel(network.Object);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), networkVm, network.Object, null, servicesPath);
                     var view = new MainView(vm);
                     bool bound = view.CommandBindings.OfType<CommandBinding>()
                                         .Any(b => b.Command == SystemCommands.MinimizeWindowCommand);

--- a/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
@@ -1,0 +1,63 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Models;
+using Moq;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class SettingsPageNavigationTests
+    {
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void NavigateBack_ReturnsToHomePage()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new DesktopApplicationTemplate.UI.App();
+
+                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+
+                    var networkSvc = new Mock<INetworkConfigurationService>();
+                    networkSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>()))
+                              .ReturnsAsync(new NetworkConfiguration());
+                    var networkVm = new NetworkConfigurationViewModel(networkSvc.Object);
+
+                    var mainVm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), networkVm, networkSvc.Object, null, servicesPath);
+                    var mainView = new MainView(mainVm);
+                    var settingsPage = new SettingsPage(new SettingsViewModel(), networkVm);
+                    mainView.ContentFrame.Content = settingsPage;
+
+                    settingsPage.NavigateBack();
+
+                    Assert.IsType<HomePage>(mainView.ContentFrame.Content);
+                }
+                catch (Exception e) { ex = e; }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -39,9 +39,10 @@ namespace DesktopApplicationTemplate.UI
         {
             services.AddSingleton<MainView>();
             services.AddSingleton<IStartupService, StartupService>();
-            services.AddSingleton<MainViewModel>();
             services.AddSingleton<IProcessRunner, ProcessRunner>();
             services.AddSingleton<INetworkConfigurationService, NetworkConfigurationService>();
+            services.AddSingleton<NetworkConfigurationViewModel>();
+            services.AddSingleton<MainViewModel>();
             services.AddSingleton<TcpServiceViewModel>();
             services.AddSingleton<DependencyChecker>();
             services.AddSingleton<HttpServiceView>();

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -153,12 +153,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
-        public MainViewModel(CsvService csvService, INetworkConfigurationService networkService, ILoggingService? logger = null, string? servicesFilePath = null)
+        public MainViewModel(CsvService csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, ILoggingService? logger = null, string? servicesFilePath = null)
         {
             _csvService = csvService;
             _networkService = networkService;
             _logger = logger;
-            NetworkConfig = new NetworkConfigurationViewModel(networkService, logger);
+            NetworkConfig = networkConfig;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceViewModel.ResolveService = (type, name) =>

--- a/DesktopApplicationTemplate.UI/Views/HomePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HomePage.xaml
@@ -10,36 +10,6 @@
         <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <StackPanel Margin="10" >
-        <Border Background="WhiteSmoke" CornerRadius="8" Padding="10" Margin="0,0,0,10">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Text="IP Address:" Grid.Row="0" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding NetworkConfig.IpAddress}" Grid.Row="0" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
-                <TextBlock Text="Subnet:" Grid.Row="1" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding NetworkConfig.SubnetMask}" Grid.Row="1" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
-                <TextBlock Text="Gateway:" Grid.Row="2" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding NetworkConfig.Gateway}" Grid.Row="2" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
-                <TextBlock Text="DNS 1:" Grid.Row="3" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding NetworkConfig.DnsPrimary}" Grid.Row="3" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
-                <TextBlock Text="DNS 2:" Grid.Row="4" Margin="0,0,5,5"/>
-                <TextBox Text="{Binding NetworkConfig.DnsSecondary}" Grid.Row="4" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
-                <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" HorizontalAlignment="Right">
-                    <Button Content="Refresh" Command="{Binding NetworkConfig.RefreshCommand}" Margin="0,5,5,0"/>
-                    <Button Content="Apply" Command="{Binding NetworkConfig.ApplyCommand}" Margin="0,5,0,0"/>
-                </StackPanel>
-            </Grid>
-        </Border>
         <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedService, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,0,0,5">
             <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14" Margin="0,0,10,0"/>
             <TextBlock Text="Associated Services:" FontStyle="Italic"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -357,7 +357,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void OpenSettings_Click(object sender, RoutedEventArgs e)
         {
-            var page = new SettingsPage(App.AppHost.Services.GetRequiredService<SettingsViewModel>());
+            var page = App.AppHost.Services.GetRequiredService<SettingsPage>();
             ContentFrame.Content = page;
         }
 

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
@@ -16,6 +16,36 @@
             <CheckBox Content="Run Application UI on startup" IsChecked="{Binding RunUIOnStartup}"/>
             <CheckBox Content="Run background services on startup" IsChecked="{Binding RunServicesOnStartup}"/>
             <CheckBox Content="Log TCP messages" IsChecked="{Binding LogTcpMessages}"/>
+            <Border Background="WhiteSmoke" CornerRadius="8" Padding="10" Margin="0,10,0,10">
+                <Grid x:Name="NetworkConfigGrid">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="IP Address:" Grid.Row="0" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding IpAddress}" Grid.Row="0" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                    <TextBlock Text="Subnet:" Grid.Row="1" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding SubnetMask}" Grid.Row="1" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                    <TextBlock Text="Gateway:" Grid.Row="2" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding Gateway}" Grid.Row="2" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                    <TextBlock Text="DNS 1:" Grid.Row="3" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding DnsPrimary}" Grid.Row="3" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                    <TextBlock Text="DNS 2:" Grid.Row="4" Margin="0,0,5,5"/>
+                    <TextBox Text="{Binding DnsSecondary}" Grid.Row="4" Grid.Column="1" Width="150" Margin="0,0,0,5"/>
+                    <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" HorizontalAlignment="Right">
+                        <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,5,5,0"/>
+                        <Button Content="Apply" Command="{Binding ApplyCommand}" Margin="0,5,0,0"/>
+                    </StackPanel>
+                </Grid>
+            </Border>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
                 <Button Content="Back" Width="80" Margin="0,0,5,0" Click="Back_Click"/>
                 <Button Content="Save" Width="80" Click="Save_Click"/>

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
@@ -7,15 +7,17 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class SettingsPage : Page
     {
         private readonly SettingsViewModel _viewModel;
-        public SettingsPage() : this(new SettingsViewModel())
-        {
-        }
-        public SettingsPage(SettingsViewModel vm)
+        private readonly NetworkConfigurationViewModel _networkViewModel;
+
+        public SettingsPage(SettingsViewModel settingsViewModel, NetworkConfigurationViewModel networkViewModel)
         {
             InitializeComponent();
-            _viewModel = vm;
+            _viewModel = settingsViewModel;
+            _networkViewModel = networkViewModel;
             DataContext = _viewModel;
+            NetworkConfigGrid.DataContext = _networkViewModel;
             _viewModel.Load();
+            _ = _networkViewModel.LoadAsync();
         }
 
         private void Save_Click(object sender, RoutedEventArgs e)
@@ -26,19 +28,19 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void Back_Click(object sender, RoutedEventArgs e)
         {
-            HandleBack();
+            NavigateBack();
         }
 
         private void Logo_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            HandleBack();
+            NavigateBack();
         }
 
-        private void HandleBack()
+        public void NavigateBack()
         {
             if (_viewModel.HasUnsavedChanges)
             {
-                var res = System.Windows.MessageBox.Show("Save changes?", "Settings", MessageBoxButton.YesNoCancel);
+                var res = MessageBox.Show("Save changes?", "Settings", MessageBoxButton.YesNoCancel);
                 if (res == MessageBoxResult.Cancel)
                     return;
                 if (res == MessageBoxResult.Yes)
@@ -47,8 +49,13 @@ namespace DesktopApplicationTemplate.UI.Views
                     Services.ThemeManager.ApplyTheme(_viewModel.DarkTheme);
                 }
             }
-            if (Parent is Frame frame)
-                frame.Content = new HomePage { DataContext = App.AppHost.Services.GetService(typeof(MainViewModel)) };
+
+            var mainWindow = Window.GetWindow(this) as MainView;
+            var mainViewModel = mainWindow?.DataContext as MainViewModel;
+            if (mainWindow != null && mainViewModel != null)
+            {
+                mainWindow.ContentFrame.Content = new HomePage { DataContext = mainViewModel };
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- move network settings UI to the settings page and bind to shared network configuration view model
- fix settings page back navigation to return to the home page
- register and inject network configuration view model and update tests

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: You must install or update .NET to run this application. Microsoft.WindowsDesktop.App 8.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a03f917608326bee02376d531933d