### PR TITLE
chore: add cross-platform build workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,22 +9,50 @@ on:
 jobs:
   build-test:
     runs-on: windows-latest   # Needed for .NET Desktop SDK
-
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_NOLOGO: 1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup .NET 8.0 Desktop SDK
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
-          include-prerelease: false
+          global-json-file: global.json
 
-      - name: Install dependencies
-        run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore DesktopApplicationTemplate.sln
 
       - name: Build solution
-        run: dotnet build --configuration Release
+        run: dotnet build DesktopApplicationTemplate.sln --configuration Release -bl:build.binlog
 
       - name: Run unit tests
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        run: dotnet test DesktopApplicationTemplate.sln --configuration Release --no-build --logger "trx;LogFileName=test_results.trx" --results-directory TestResults
+        continue-on-error: true
+
+      - name: Upload build and test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-test-artifacts
+          path: |
+            build.binlog
+            TestResults
+
+      - name: Comment on test failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ Unit tests failed. Review artifacts for details: ${runUrl}`
+            });
+
+      - name: Fail if tests failed
+        if: failure()
+        run: exit 1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- enable Windows targeting when building on non-Windows hosts
- collect build and test artifacts in CI and comment when tests fail

## Testing
- `dotnet test DesktopApplicationTemplate.sln --configuration Release --logger "trx;LogFileName=test_results.trx" --results-directory TestResults` *(fails: You must install or update .NET to run this application.)*

------
https://chatgpt.com/codex/tasks/task_e_689b487828b08326802ea08d809065c8