### PR TITLE
Enable CSV service double-click editing and window dragging

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -128,5 +128,88 @@ namespace DesktopApplicationTemplate.Tests
             if (ex != null) throw ex;
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void OpenServiceEditor_NonCsv_SetsContentFrame()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new DesktopApplicationTemplate.UI.App();
+                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                    var network = new Mock<INetworkConfigurationService>();
+                    var networkVm = new NetworkConfigurationViewModel(network.Object);
+                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(configPath)), networkVm, network.Object, null, servicesPath);
+                    var view = new MainView(vm);
+                    var svc = new ServiceViewModel { DisplayName = "TCP - Test", ServiceType = "TCP" };
+                    svc.SetColorsByType();
+                    var method = typeof(MainView).GetMethod("OpenServiceEditor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    method?.Invoke(view, new object[] { svc });
+                    Assert.NotNull(view.ContentFrame.Content);
+                }
+                catch (Exception e) { ex = e; }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void OpenServiceEditor_CsvCreator_ShowsWindow()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new DesktopApplicationTemplate.UI.App();
+                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                    var network = new Mock<INetworkConfigurationService>();
+                    var networkVm = new NetworkConfigurationViewModel(network.Object);
+                    var csvVm = new CsvViewerViewModel(configPath);
+                    var vm = new MainViewModel(new CsvService(csvVm), networkVm, network.Object, null, servicesPath);
+                    var view = new MainView(vm);
+                    var svc = new ServiceViewModel { DisplayName = "CSV - Test", ServiceType = "CSV Creator" };
+                    svc.SetColorsByType();
+                    // Ensure window closes immediately to avoid blocking
+                    System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() => csvVm.CloseCommand.Execute(null)));
+                    var method = typeof(MainView).GetMethod("OpenServiceEditor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    method?.Invoke(view, new object[] { svc });
+                    Assert.NotNull(view); // method executed without exception
+                }
+                catch (Exception e) { ex = e; }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -76,7 +76,8 @@
                                     HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                                     PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown"
                                     PreviewMouseMove="ServiceItem_PreviewMouseMove"
-                                    AllowDrop="True" Drop="ServiceItem_Drop">
+                                    AllowDrop="True" Drop="ServiceItem_Drop"
+                                    MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown">
                                 <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
                                     <Border.ContextMenu>
                                         <ContextMenu>


### PR DESCRIPTION
## Summary
- Allow double-clicking a service item to open its editor, including CSV Creator config
- Restore window dragging by invoking `DragMove` on non-interactive areas
- Add unit tests covering the service editor helper method

## Testing
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_689b48c6304c8326b60b5755f09b1fc0