### PR TITLE
ci: add self-healing .NET 8 desktop pipeline

### DIFF
--- a/.github/workflows/dotnet-desktop-ci.yml
+++ b/.github/workflows/dotnet-desktop-ci.yml
@@ -1,0 +1,113 @@
+name: .NET 8.0 Desktop CI/CD
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['v*']
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install windowsdesktop workload
+        run: dotnet workload install windowsdesktop
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build -c Release --no-restore
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            **/bin/Release/**
+            !**/obj/**
+
+  test:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install windowsdesktop workload
+        run: dotnet workload install windowsdesktop
+      - name: Restore
+        run: dotnet restore
+      - name: Test
+        run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage" --results-directory TestResults
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            TestResults
+            **/coverage.cobertura.xml
+
+  quality:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install windowsdesktop workload
+        run: dotnet workload install windowsdesktop
+      - name: Restore
+        run: dotnet restore
+      - name: Verify formatting
+        run: dotnet format --verify-no-changes
+      - name: Build with warnings as errors
+        run: dotnet build -c Release /p:TreatWarningsAsErrors=true
+
+  package:
+    runs-on: windows-latest
+    needs: [test, quality]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install windowsdesktop workload
+        run: dotnet workload install windowsdesktop
+      - name: Restore
+        run: dotnet restore
+      - name: Publish
+        run: dotnet publish -c Release -o out
+      - name: Archive package
+        run: Compress-Archive -Path out -DestinationPath MyApp.zip
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-package
+          path: MyApp.zip
+
+  deploy:
+    runs-on: windows-latest
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: app-package
+          path: .
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: MyApp.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -1,0 +1,39 @@
+name: Self Heal
+
+on:
+  workflow_run:
+    workflows: ['.NET 8.0 Desktop CI/CD']
+    types:
+      - completed
+
+jobs:
+  self-heal:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+      - name: Download self-heal state
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-selfheal-state
+          path: .codex-selfheal
+        continue-on-error: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install requests PyGithub openai
+      - name: Run Codex repair
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python tools/selfheal/repair_with_codex.py
+      - name: Upload self-heal state
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-selfheal-state
+          path: .codex-selfheal/state.json

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+.codex-selfheal/

--- a/DesktopApplication.Installer/DesktopApplication.Installer.csproj
+++ b/DesktopApplication.Installer/DesktopApplication.Installer.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="FluentFTP" Version="53.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
-    <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.0" />
+    <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.25103.5738" />
     <Resource Include="Themes/BubblyWindow.xaml" />
     <Resource Include="..\DesktopApplicationTemplate.UI\Themes\LightTheme.xaml" />
     <Resource Include="..\DesktopApplicationTemplate.UI\Themes\DarkTheme.xaml" />

--- a/DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
+++ b/DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<UseWindowsService>true</UseWindowsService>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentFTP" Version="53.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
-    <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.0" />
+    <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.25103.5738" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />

--- a/DesktopApplicationTemplate.UI/Helpers/AutoStart.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AutoStart.cs
@@ -25,13 +25,13 @@ namespace DesktopApplicationTemplate.UI.Helpers
 
         public static void DisableAutoStart()
         {
-            using RegistryKey key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath, true);
+            using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath, true);
             key?.DeleteValue(AppName, false);
         }
 
         public static bool IsAutoStartEnabled()
         {
-            using RegistryKey key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath);
+            using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath);
             string? value = key?.GetValue(AppName) as string;
             return !string.IsNullOrEmpty(value);
         }

--- a/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
         }
 
-        public System.Windows.Media.Color ChosenColor => (System.Windows.Media.Color)ColorCanvas.SelectedColor;
+        public System.Windows.Media.Color ChosenColor => ColorCanvas.SelectedColor ?? System.Windows.Media.Colors.Transparent;
 
         private void Ok_Click(object sender, RoutedEventArgs e)
         {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,11 @@
 <Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>

--- a/tools/selfheal/repair_with_codex.py
+++ b/tools/selfheal/repair_with_codex.py
@@ -1,0 +1,109 @@
+import io
+import json
+import os
+import subprocess
+import zipfile
+
+import requests
+from github import Github
+from openai import OpenAI
+
+WORKFLOW_NAME = ".NET 8.0 Desktop CI/CD"
+BRANCH = "dev"
+STATE_FILE = ".codex-selfheal/state.json"
+
+
+def load_state() -> dict:
+    if os.path.exists(STATE_FILE):
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_state(state: dict) -> None:
+    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f)
+
+
+def main() -> None:
+    token = os.environ.get("GITHUB_TOKEN")
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    repo_name = os.environ.get("GITHUB_REPOSITORY")
+    if not all([token, openai_key, repo_name]):
+        print("Required environment variables are missing")
+        return
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+    workflow = next((wf for wf in repo.get_workflows() if wf.name == WORKFLOW_NAME), None)
+    if workflow is None:
+        print("Workflow not found")
+        return
+
+    runs = workflow.get_runs(branch=BRANCH)
+    failed_run = next((r for r in runs if r.conclusion == "failure"), None)
+    if failed_run is None:
+        print("No failed workflow run found")
+        return
+
+    sha = failed_run.head_sha
+    state = load_state()
+    attempts = state.get(sha, 0)
+    if attempts >= 3:
+        print("Maximum self-heal attempts reached for this commit")
+        return
+    state[sha] = attempts + 1
+    save_state(state)
+
+    headers = {"Authorization": f"token {token}"}
+    logs_resp = requests.get(failed_run.logs_url, headers=headers)
+    logs_resp.raise_for_status()
+    if logs_resp.headers.get("Content-Type", "").startswith("application/zip"):
+        with zipfile.ZipFile(io.BytesIO(logs_resp.content)) as z:
+            log_text = "".join(z.read(name).decode("utf-8", errors="ignore") for name in z.namelist())
+    else:
+        log_text = logs_resp.content.decode("utf-8", errors="ignore")
+    log_excerpt = log_text[-15000:]
+
+    prompt = f"""
+Repository: {repo.full_name}
+Branch: {BRANCH}
+Pipeline file: {workflow.path}
+
+Failure Logs:
+{log_excerpt}
+
+Return a unified diff patch that fixes the minimal root cause. Add or update regression tests when the failure is functional. Avoid unrelated refactors and preserve public APIs when possible. Ensure 'dotnet build', 'dotnet test', and 'dotnet format --verify-no-changes' pass locally.
+"""
+
+    client = OpenAI(api_key=openai_key)
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        temperature=0,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    patch = response.choices[0].message.content.strip()
+    if not patch or "diff --git" not in patch:
+        print("No valid diff received")
+        return
+
+    with open("fix.patch", "w", encoding="utf-8") as f:
+        f.write(patch)
+
+    subprocess.run(["git", "apply", "fix.patch"], check=True)
+    subprocess.run(["git", "add", "-A"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "commit",
+            "-m",
+            "fix: self-heal pipeline failure (automated by Codex)",
+        ],
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", BRANCH], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add multi-stage .NET desktop CI/CD pipeline with packaging and release
- introduce self-heal workflow and Codex-based repair script
- enforce warnings-as-errors and update Windows-specific targets

## Testing
- `dotnet build -c Release`
- `dotnet format --verify-no-changes` *(fails: whitespace formatting issues)*
- `dotnet test -c Release --no-build` *(fails: requires Microsoft.WindowsDesktop.App runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689b57fb1b188326abcf442840050c2b