### PR TITLE
feat: redesign main window layout

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 using Moq;
 using System.IO;
 using Xunit;
@@ -65,6 +66,64 @@ namespace DesktopApplicationTemplate.Tests
             logger.Verify(l => l.Log(It.Is<string>(m => m.Contains("Removing service")), It.IsAny<LogLevel>()), Times.Once);
             logger.Verify(l => l.Log(It.Is<string>(m => m.Contains("Service removed")), It.IsAny<LogLevel>()), Times.Once);
 
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void ClearLogs_RemovesEntries()
+        {
+            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+            var csv = new CsvService(new CsvViewerViewModel(configPath));
+            var network = new Mock<INetworkConfigurationService>();
+            var networkVm = new NetworkConfigurationViewModel(network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object);
+            vm.AllLogs.Add(new LogEntry { Message = "Test", Color = System.Windows.Media.Brushes.Black });
+            vm.ClearLogs();
+            Assert.Empty(vm.AllLogs);
+
+            var svc = new ServiceViewModel { DisplayName = "HTTP - Test", ServiceType = "HTTP" };
+            svc.Logs.Add(new LogEntry { Message = "Svc", Color = System.Windows.Media.Brushes.Black });
+            vm.Services.Add(svc);
+            vm.SelectedService = svc;
+            vm.ClearLogs();
+            Assert.Empty(svc.Logs);
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task ExportLogsAsync_CreatesFile()
+        {
+            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+            var csv = new CsvService(new CsvViewerViewModel(configPath));
+            var network = new Mock<INetworkConfigurationService>();
+            var networkVm = new NetworkConfigurationViewModel(network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object);
+            vm.AllLogs.Add(new LogEntry { Message = "Export", Color = System.Windows.Media.Brushes.Black });
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".txt");
+            await vm.ExportLogsAsync(path);
+            Assert.True(File.Exists(path));
+            File.Delete(path);
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void RefreshLogs_RaisesPropertyChanged()
+        {
+            var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+            var csv = new CsvService(new CsvViewerViewModel(configPath));
+            var network = new Mock<INetworkConfigurationService>();
+            var networkVm = new NetworkConfigurationViewModel(network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object);
+            bool raised = false;
+            vm.PropertyChanged += (s, e) => { if (e.PropertyName == nameof(MainViewModel.DisplayLogs)) raised = true; };
+            vm.RefreshLogs();
+            Assert.True(raised);
             ConsoleTestLogger.LogPass();
         }
     }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -3,7 +3,6 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d"
         Title="MainView" Width="800" Height="600"
@@ -25,113 +24,133 @@
         </Grid.RowDefinitions>
 
         <!-- Top Bar -->
-        <Grid Grid.Row="0" Margin="10">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <Image Grid.Column="1" Source="pack://application:,,,/Resources/Logo.png" Height="60" HorizontalAlignment="Left" VerticalAlignment="Center"/>
-            <Button Grid.Column="0" Content="🏠" Width="30" Height="30" Click="HomeButton_Click"/>
-            <Button Grid.Column="2" Content="⚙" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Top" Click="OpenSettings_Click"/>
-        </Grid>
+        <Border Grid.Row="0" Background="#00C2C2" Height="40" Margin="5" CornerRadius="15">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button Grid.Column="0" Content="🏠" Width="30" Height="30" Margin="5" Click="HomeButton_Click"/>
+                <Image Grid.Column="1" Source="pack://application:,,,/Resources/Logo.png" Height="30" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                <Button Grid.Column="2" Content="⚙" Width="30" Height="30" Margin="5" Click="OpenSettings_Click"/>
+            </Grid>
+        </Border>
 
         <!-- Main Content -->
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="230"/>
+                <ColumnDefinition Width="300"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <!-- Left Panel -->
-            <Grid Grid.Column="0" Margin="10">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
-            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Grid.Row="0">
-                <Button Content="+" Width="30" Click="AddService_Click"/>
-                <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click"/>
-            </StackPanel>
+            <Border Grid.Column="0" Background="#E6E6E6" CornerRadius="3" Margin="10">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-            <StackPanel Orientation="Horizontal" Margin="0,10" Grid.Row="1">
-                <TextBlock Text="Services" FontWeight="Bold" />
-                <Button Content="🔍" Width="20" Margin="5,0,0,0" Click="OpenFilter_Click"/>
-            </StackPanel>
-            <ListBox x:Name="ServiceList" Grid.Row="2" ItemsSource="{Binding FilteredServices}"
-                     SelectedItem="{Binding SelectedService}"
-                     BorderThickness="0"
-                     MaxHeight="350"
-                     HorizontalContentAlignment="Stretch"
-                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                     ScrollViewer.VerticalScrollBarVisibility="Auto"
-                     SelectionChanged="ServiceList_SelectionChanged">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <Border CornerRadius="8"
-                                    BorderBrush="{Binding BorderColor}"
-                                    Background="{Binding BackgroundColor}"
-                                    BorderThickness="2" Padding="5" Margin="2"
-                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                    PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown"
-                                    PreviewMouseMove="ServiceItem_PreviewMouseMove"
-                                    AllowDrop="True" Drop="ServiceItem_Drop"
-                                    MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown">
-                                <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
-                                    <Border.ContextMenu>
-                                        <ContextMenu>
-                                            <MenuItem Header="Edit Service" Click="EditServiceMenu_Click" />
-                                            <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
-                                            <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
-                                            <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
-                                        </ContextMenu>
-                                    </Border.ContextMenu>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
+                    <StackPanel Orientation="Horizontal" Grid.Row="0">
+                        <Button Content="☰" Width="30" Click="OpenFilter_Click"/>
+                        <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click"/>
+                        <Button Content="+" Width="30" Margin="5,0,0,0" Click="AddService_Click"/>
+                    </StackPanel>
 
-                                        <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" FontWeight="Bold"/>
-                                        <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}"
-                                                      Style="{StaticResource ToggleSwitchStyle}"/>
-                                    </Grid>
+                    <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,10,0,10">
+                        <TextBlock Text="ACTIVE SERVICES:" FontWeight="Bold"/>
+                        <TextBlock Text="{Binding CurrentActiveServices}" Margin="5,0,0,0"/>
+                        <TextBlock Text="/" Margin="2,0,0,0"/>
+                        <TextBlock Text="{Binding ServicesCreated}" Margin="2,0,0,0"/>
+                    </StackPanel>
+
+                    <ListBox x:Name="ServiceList" Grid.Row="2" ItemsSource="{Binding FilteredServices}"
+                             SelectedItem="{Binding SelectedService}"
+                             BorderThickness="0"
+                             MaxHeight="350"
+                             HorizontalContentAlignment="Stretch"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             SelectionChanged="ServiceList_SelectionChanged">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="8"
+                                        BorderBrush="{Binding BorderColor}"
+                                        Background="{Binding BackgroundColor}"
+                                        BorderThickness="2" Padding="5" Margin="2"
+                                        HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                                        PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown"
+                                        PreviewMouseMove="ServiceItem_PreviewMouseMove"
+                                        AllowDrop="True" Drop="ServiceItem_Drop"
+                                        MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown">
+                                    <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
+                                        <Border.ContextMenu>
+                                            <ContextMenu>
+                                                <MenuItem Header="Edit Service" Click="EditServiceMenu_Click" />
+                                                <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
+                                                <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
+                                                <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
+                                            </ContextMenu>
+                                        </Border.ContextMenu>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBlock Text="{Binding DisplayName}" VerticalAlignment="Center" FontWeight="Bold"/>
+                                            <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}"
+                                                          Style="{StaticResource ToggleSwitchStyle}"/>
+                                        </Grid>
+                                    </Border>
                                 </Border>
-                            </Border>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-            </ListBox>
-        </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Grid>
+            </Border>
 
             <!-- Right Panel -->
+            <Border Grid.Column="1" Background="#E6E6E6" CornerRadius="5" Margin="10">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
 
-            <StackPanel Grid.Column="1" Margin="10">
-            <Frame x:Name="ContentFrame" NavigationUIVisibility="Hidden" />
-            <TextBlock Text="{Binding SelectedService.DisplayName}" FontWeight="Bold" FontSize="14"/>
-            <TextBlock Text="Services Created:" />
-            <TextBlock Text="{Binding ServicesCreated}" />
-            <TextBlock Text="Current Active Services:" />
-            <TextBlock Text="{Binding CurrentActiveServices}" />
-            <StackPanel Orientation="Horizontal" Margin="0,5,0,5">
-                <TextBlock Text="Log Level:" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                <ComboBox x:Name="GlobalLogLevelBox" Width="120" SelectionChanged="GlobalLogLevelBox_SelectionChanged" SelectedIndex="0">
-                    <ComboBoxItem Content="All"/>
-                    <ComboBoxItem Content="Debug"/>
-                    <ComboBoxItem Content="Warning"/>
-                    <ComboBoxItem Content="Error"/>
-                </ComboBox>
-            </StackPanel>
-            <ListBox ItemsSource="{Binding DisplayLogs}" Height="150">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-            </StackPanel>
+                    <Frame x:Name="ContentFrame" Grid.Row="0" NavigationUIVisibility="Hidden" />
+
+                    <StackPanel Grid.Row="1" Margin="10">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="LOG LEVEL" FontWeight="Bold" VerticalAlignment="Center"/>
+                            <ComboBox x:Name="GlobalLogLevelBox" Width="120" Margin="10,0,0,0"
+                                      SelectionChanged="GlobalLogLevelBox_SelectionChanged" SelectedIndex="0">
+                                <ComboBoxItem Content="All"/>
+                                <ComboBoxItem Content="Debug"/>
+                                <ComboBoxItem Content="Warning"/>
+                                <ComboBoxItem Content="Error"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,10,0,10">
+                            <Button Content="Export Log" Background="#CCCCFF" Margin="0,0,10,0" Click="ExportLog_Click"/>
+                            <Button Content="Clear Log" Background="#FFCCCC" Margin="0,0,10,0" Click="ClearLog_Click"/>
+                            <Button Content="Update Log" Background="#FFFFCC" Click="UpdateLog_Click"/>
+                        </StackPanel>
+                        <ListBox ItemsSource="{Binding DisplayLogs}" Height="150">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </StackPanel>
+                </Grid>
+            </Border>
 
             <ResizeGrip Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
         </Grid>
     </Grid>
 </Window>
+

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Views;
 using System.Windows.Input;
 using System.Windows.Controls.Primitives;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -412,6 +413,39 @@ namespace DesktopApplicationTemplate.UI.Views
 
                 _logger?.LogInformation("Global log level set to {Level}", _viewModel.LogLevelFilter);
             }
+        }
+
+        internal async Task ExportLogsInternalAsync()
+        {
+            _logger?.LogInformation("Export log button clicked");
+            await _viewModel.ExportLogsAsync();
+        }
+
+        private async void ExportLog_Click(object sender, RoutedEventArgs e)
+        {
+            await ExportLogsInternalAsync();
+        }
+
+        internal void ClearLogsInternal()
+        {
+            _logger?.LogInformation("Clear log button clicked");
+            _viewModel.ClearLogs();
+        }
+
+        private void ClearLog_Click(object sender, RoutedEventArgs e)
+        {
+            ClearLogsInternal();
+        }
+
+        internal void RefreshLogsInternal()
+        {
+            _logger?.LogInformation("Update log button clicked");
+            _viewModel.RefreshLogs();
+        }
+
+        private void UpdateLog_Click(object sender, RoutedEventArgs e)
+        {
+            RefreshLogsInternal();
         }
 
     }


### PR DESCRIPTION
## Summary
- redesign main window layout with active service summary and log controls
- add log management APIs for clearing, exporting and refreshing logs
- cover log APIs with unit tests

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e92adcc83269f1bc17d84af9ef0