### PR TITLE
feat: exclude LFS files from size pre-commit

### DIFF
--- a/.githooks/pre-commit-block-large
+++ b/.githooks/pre-commit-block-large
@@ -4,13 +4,22 @@
 
 set -euo pipefail
 
-MAX_SIZE_BYTES=$((5 * 1024 * 1024)) # 5 MB
+# Maximum allowed file size for non-LFS tracked files
+MAX_SIZE_BYTES=$((10 * 1024 * 1024)) # 10 MB
+
+# Cache list of files tracked by Git LFS to avoid repeated calls
+lfs_tracked_files=$(git lfs ls-files --name-only 2>/dev/null || true)
 
 # Get list of files staged for commit
 staged_files=$(git diff --cached --name-only --diff-filter=ACM)
 
 for staged_file in $staged_files; do
     if [ -f "$staged_file" ]; then
+        # Skip size validation for files tracked by Git LFS
+        if printf '%s\n' "$lfs_tracked_files" | grep -Fxq "$staged_file"; then
+            continue
+        fi
+
         file_size=$(wc -c <"$staged_file")
         if [ "$file_size" -gt "$MAX_SIZE_BYTES" ]; then
             size_in_mb=$((file_size / 1024 / 1024))


### PR DESCRIPTION
## Summary
- skip size validation for Git LFS tracked files
- raise non-LFS size limit to 10MB in pre-commit hook

## Testing
- `.githooks/pre-commit-block-large` with an 11MB text file (fails)
- `.githooks/pre-commit-block-large` with an 11MB LFS-tracked png (passes)
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App 8.0.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4bf25dc8326b9928329c38bf026