### PR TITLE
Ensure FTP client disconnects on upload failure

### DIFF
--- a/DesktopApplicationTemplate.Service/Services/FtpService.cs
+++ b/DesktopApplicationTemplate.Service/Services/FtpService.cs
@@ -30,17 +30,20 @@ namespace DesktopApplicationTemplate.UI.Services
             _logger?.Log($"Connecting to FTP {_client.Host}:{_client.Port}", LogLevel.Debug);
             try
             {
-                await _client.Connect(token);
+                await _client.Connect(token).ConfigureAwait(false);
                 _logger?.Log($"Uploading {localPath} -> {remotePath}", LogLevel.Debug);
-                await _client.UploadFile(localPath, remotePath, FtpRemoteExists.Overwrite, true, FtpVerify.None, null, token);
-                await _client.Disconnect(token);
+                await _client.UploadFile(localPath, remotePath, FtpRemoteExists.Overwrite, true, FtpVerify.None, null, token).ConfigureAwait(false);
                 _logger?.Log("Upload finished", LogLevel.Debug);
-                _logger?.Log("FTP upload completed", LogLevel.Debug);
             }
             catch (Exception ex)
             {
                 _logger?.Log($"FTP upload failed: {ex.Message}", LogLevel.Error);
                 throw;
+            }
+            finally
+            {
+                await _client.Disconnect(token).ConfigureAwait(false);
+                _logger?.Log("FTP upload completed", LogLevel.Debug);
             }
         }
     }

--- a/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceTests.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.UI.Services;
 using FluentFTP;
 using Moq;
+using System;
 using System.Threading;
 using Xunit;
 
@@ -26,6 +27,28 @@ namespace DesktopApplicationTemplate.Tests
 
             client.Verify(c => c.Connect(It.IsAny<CancellationToken>()), Times.Once);
             client.Verify(c => c.UploadFile("local","remote", FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<FtpVerify>(), It.IsAny<IProgress<FtpProgress>?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            client.Verify(c => c.Disconnect(It.IsAny<CancellationToken>()), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task UploadAsync_DisconnectsOnFailure()
+        {
+            var client = new Mock<FluentFTP.IAsyncFtpClient>();
+            client.SetupGet(c => c.Host).Returns("host");
+            client.SetupGet(c => c.Port).Returns(21);
+            client.Setup(c => c.Connect(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            client.Setup(c => c.UploadFile(It.IsAny<string>(), It.IsAny<string>(), FtpRemoteExists.Overwrite, It.IsAny<bool>(), It.IsAny<FtpVerify>(), It.IsAny<IProgress<FtpProgress>?>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Upload failed"));
+            client.Setup(c => c.Disconnect(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var service = new FtpService(client.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.UploadAsync("local", "remote"));
 
             client.Verify(c => c.Disconnect(It.IsAny<CancellationToken>()), Times.Once);
 


### PR DESCRIPTION
## Summary
- Guarantee FTP client disconnects by placing it in a `finally` block
- Ensure upload flow is wrapped in try-catch for clear error logging
- Add unit test confirming disconnect runs even when upload throws

## Testing
- `dotnet build`
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cbd4827cc8326955ceb8ba7ccf8fe