### PR TITLE
Remove logger null checks in service views and add log level test

### DIFF
--- a/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
+++ b/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
@@ -1,0 +1,71 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Services;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class LogLevelSelectionTests
+    {
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public void HttpServiceView_LogLevelSelection_UpdatesLogger()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+
+            Exception? ex = null;
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    if (System.Windows.Application.Current == null)
+                        new DesktopApplicationTemplate.UI.App();
+
+                    var viewModel = new HttpServiceViewModel();
+                    var view = new HttpServiceView(viewModel);
+
+                    var targetItem = view.LogLevelBox.Items
+                        .OfType<ComboBoxItem>()
+                        .First(i => (string?)i.Content == "Error");
+                    view.LogLevelBox.SelectedItem = targetItem;
+
+                    var method = typeof(HttpServiceView).GetMethod(
+                        "LogLevelBox_SelectionChanged",
+                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+                    method?.Invoke(view, new object[]
+                    {
+                        view.LogLevelBox,
+                        new SelectionChangedEventArgs(
+                            Selector.SelectionChangedEvent,
+                            Array.Empty<object>(),
+                            Array.Empty<object>())
+                    });
+
+                    var logger = Assert.IsType<LoggingService>(viewModel.Logger);
+                    Assert.Equal(LogLevel.Error, logger.MinimumLevel);
+                }
+                catch (Exception e)
+                {
+                    ex = e;
+                }
+                finally
+                {
+                    System.Windows.Application.Current?.Shutdown();
+                }
+            });
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+            if (ex != null) throw ex;
+
+            ConsoleTestLogger.LogPass();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -22,9 +22,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -44,9 +44,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -28,9 +28,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -22,9 +22,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -44,9 +44,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())


### PR DESCRIPTION
## Summary
- remove redundant logger null checks in LogLevelBox selection handlers across service views
- ensure logger injected via constructors remains readonly
- add test verifying HttpServiceView log level selection updates logger

## Testing
- `dotnet test` *(fails: Testhost process... You must install or update .NET to run this application. Framework 'Microsoft.WindowsDesktop.App' version '8.0.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cbd6a39008326a1a4beeff24fa78e