### PR TITLE
Inject logging service and helpers via DI

### DIFF
--- a/CollaborationAndDebugTips.txt
+++ b/CollaborationAndDebugTips.txt
@@ -1,0 +1,4 @@
+# Collaboration And Debug Tips
+- Incorporating services into dependency injection ensures views and view models remain testable and modular.
+- When refactoring static helpers, replace shared state with constructor injection to simplify unit testing.
+- Logging services that interact with UI elements can be initialized after construction to maintain DI compatibility.

--- a/DesktopApplicationTemplate.Service/Services/ILoggingService.cs
+++ b/DesktopApplicationTemplate.Service/Services/ILoggingService.cs
@@ -1,13 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Services
 {
     public interface ILoggingService
     {
+        /// <summary>
+        /// Gets or sets the minimum log level that will be processed.
+        /// </summary>
+        LogLevel MinimumLevel { get; set; }
+
+        /// <summary>
+        /// Logs a message at the specified level.
+        /// </summary>
         void Log(string message, LogLevel level);
     }
 

--- a/DesktopApplicationTemplate.Tests/CloseConfirmationHelperTests.cs
+++ b/DesktopApplicationTemplate.Tests/CloseConfirmationHelperTests.cs
@@ -1,5 +1,7 @@
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -11,7 +13,9 @@ namespace DesktopApplicationTemplate.Tests
         public void Show_ReturnsTrue_WhenSuppressed()
         {
             SettingsViewModel.CloseConfirmationSuppressed = true;
-            var result = CloseConfirmationHelper.Show();
+            var logger = new Mock<ILoggingService>();
+            var helper = new CloseConfirmationHelper(logger.Object);
+            var result = helper.Show();
             Assert.True(result);
             SettingsViewModel.CloseConfirmationSuppressed = false;
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using Xunit;
 using System;
 using Moq;
@@ -19,7 +20,8 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("WindowsSafe")]
         public void BrowseCommand_InitialPathEmpty_DoesNotThrow()
         {
-            var vm = new FtpServiceViewModel(new StubFileDialogService());
+            var logger = new Mock<ILoggingService>();
+            var vm = new FtpServiceViewModel(new SaveConfirmationHelper(logger.Object), new StubFileDialogService());
             vm.BrowseCommand.Execute(null);
             Assert.Equal("stub.txt", vm.LocalPath);
 
@@ -33,7 +35,7 @@ namespace DesktopApplicationTemplate.Tests
         {
             var mock = new Mock<IFtpService>();
             var logger = new Mock<ILoggingService>();
-            var vm = new FtpServiceViewModel { Service = mock.Object, Logger = logger.Object };
+            var vm = new FtpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Service = mock.Object, Logger = logger.Object };
             vm.LocalPath = "local";
             vm.RemotePath = "remote";
 
@@ -52,7 +54,7 @@ namespace DesktopApplicationTemplate.Tests
         public void SettingInvalidHost_AddsError()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new FtpServiceViewModel { Logger = logger.Object };
+            var vm = new FtpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object };
             vm.Host = "bad_host";
 
             Assert.True(vm.HasErrors);
@@ -67,7 +69,7 @@ namespace DesktopApplicationTemplate.Tests
         public void SettingInvalidPort_AddsError()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new FtpServiceViewModel { Logger = logger.Object };
+            var vm = new FtpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object };
             vm.Port = "abc";
 
             Assert.True(vm.HasErrors);
@@ -81,7 +83,8 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("WindowsSafe")]
         public void PartialHost_WithTrailingDot_DoesNotError()
         {
-            var vm = new FtpServiceViewModel();
+            var logger = new Mock<ILoggingService>();
+            var vm = new FtpServiceViewModel(new SaveConfirmationHelper(logger.Object));
             vm.Host = "192.168.";
 
             Assert.False(vm.HasErrors);

--- a/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using Moq;
 
 namespace DesktopApplicationTemplate.Tests
@@ -19,7 +20,7 @@ namespace DesktopApplicationTemplate.Tests
             };
 
             var logger = new Mock<ILoggingService>();
-            var vm = new HidViewModel { Logger = logger.Object };
+            var vm = new HidViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object };
             vm.AvailableServices.Add("Target");
             vm.AttachedService = "Target";
             vm.MessageTemplate = "test";

--- a/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
+++ b/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
@@ -1,4 +1,6 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Tests;
 using System.Net;
 using System.Net.Sockets;
@@ -37,7 +39,8 @@ public class HttpServiceNetworkTests
             listener.Stop();
         });
 
-        var vm = new HttpServiceViewModel { Url = $"http://localhost:{port}/" };
+        var logger = new Mock<ILoggingService>();
+        var vm = new HttpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Url = $"http://localhost:{port}/" };
         await vm.SendRequestAsync();
 
         await respondTask;
@@ -63,7 +66,8 @@ public class HttpServiceNetworkTests
                 Content = new StringContent("ok")
             });
 
-        var vm = new HttpServiceViewModel { Url = "http://localhost/", SelectedMethod = "POST", RequestBody = "data", MessageHandler = handlerMock.Object };
+        var logger2 = new Mock<ILoggingService>();
+        var vm = new HttpServiceViewModel(new SaveConfirmationHelper(logger2.Object)) { Url = "http://localhost/", SelectedMethod = "POST", RequestBody = "data", MessageHandler = handlerMock.Object };
         vm.Headers.Add(new HttpServiceViewModel.HeaderItem { Key = "X-Test", Value = "1" });
 
         await vm.SendRequestAsync();

--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -30,7 +30,8 @@ namespace DesktopApplicationTemplate.Tests
                 try
                 {
                     var box = new System.Windows.Controls.RichTextBox();
-                    var service = new LoggingService(box, Dispatcher.CurrentDispatcher);
+                    var service = new LoggingService();
+                    service.Initialize(box, Dispatcher.CurrentDispatcher);
 
                     service.Log("test", level);
 
@@ -68,7 +69,8 @@ namespace DesktopApplicationTemplate.Tests
                 try
                 {
                     var box = new System.Windows.Controls.RichTextBox();
-                    var service = new LoggingService(box, Dispatcher.CurrentDispatcher, path);
+                    var service = new LoggingService(path);
+                    service.Initialize(box, Dispatcher.CurrentDispatcher);
                     service.Log("file-test", LogLevel.Debug);
                     var content = File.ReadAllText(path);
                     Assert.Contains("file-test", content);
@@ -109,7 +111,8 @@ namespace DesktopApplicationTemplate.Tests
                 try
                 {
                     var box = new System.Windows.Controls.RichTextBox();
-                    var service = new LoggingService(box, Dispatcher.CurrentDispatcher);
+                    var service = new LoggingService();
+                    service.Initialize(box, Dispatcher.CurrentDispatcher);
                     service.Log("debug", LogLevel.Debug);
                     service.Log("error", LogLevel.Error);
                     service.MinimumLevel = LogLevel.Error;

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using MQTTnet.Client;
 using Moq;
 using Xunit;
@@ -19,7 +20,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 return;
             }
-            var vm = new MqttServiceViewModel();
+            var logger = new Mock<ILoggingService>();
+            var vm = new MqttServiceViewModel(new SaveConfirmationHelper(logger.Object));
             vm.NewTopic = "test/topic";
             vm.AddTopicCommand.Execute(null);
             Assert.Contains("test/topic", vm.Topics);
@@ -39,7 +41,7 @@ namespace DesktopApplicationTemplate.Tests
             client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), string.Empty, Array.Empty<MqttUserProperty>()));
             var service = new MqttService(client.Object, logger.Object);
-            var vm = new MqttServiceViewModel(service, logger.Object) { Host = "127.0.0.1", Port = "1883", ClientId = "c" };
+            var vm = new MqttServiceViewModel(new SaveConfirmationHelper(logger.Object), service, logger.Object) { Host = "127.0.0.1", Port = "1883", ClientId = "c" };
 
             await vm.ConnectAsync();
 

--- a/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
@@ -1,4 +1,7 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
+using Moq;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -9,7 +12,8 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("CodexSafe")]
         public void DefaultPort_Is22()
         {
-            var vm = new ScpServiceViewModel();
+            var logger = new Mock<ILoggingService>();
+            var vm = new ScpServiceViewModel(new SaveConfirmationHelper(logger.Object));
             Assert.Equal("22", vm.Port);
 
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Moq;
@@ -17,7 +18,7 @@ namespace DesktopApplicationTemplate.Tests
         public void TcpService_ToggleServer_LogsMessage()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new TcpServiceViewModel { Logger = logger.Object };
+            var vm = new TcpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object };
             vm.ComputerIp = "127.0.0.1";
             vm.ListeningPort = "5000";
 
@@ -34,7 +35,7 @@ namespace DesktopApplicationTemplate.Tests
         public async Task HttpService_InvalidUrl_LogsWarning()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new HttpServiceViewModel { Logger = logger.Object };
+            var vm = new HttpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object };
             vm.Url = string.Empty;
 
             await vm.SendRequestAsync();
@@ -58,7 +59,7 @@ namespace DesktopApplicationTemplate.Tests
                     Content = new StringContent("ok")
                 });
 
-            var vm = new HttpServiceViewModel { Logger = logger.Object, MessageHandler = handler.Object, Url = "http://localhost/" };
+            var vm = new HttpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object, MessageHandler = handler.Object, Url = "http://localhost/" };
 
             await vm.SendRequestAsync();
 
@@ -75,7 +76,7 @@ namespace DesktopApplicationTemplate.Tests
         public void HttpService_SetInvalidUrl_AddsError()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new HttpServiceViewModel { Logger = logger.Object };
+            var vm = new HttpServiceViewModel(new SaveConfirmationHelper(logger.Object)) { Logger = logger.Object };
             vm.Url = "htp://bad";
 
             Assert.True(vm.HasErrors);

--- a/DesktopApplicationTemplate.Tests/TestLogger.cs
+++ b/DesktopApplicationTemplate.Tests/TestLogger.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
 using System.Collections.Generic;
 
 namespace DesktopApplicationTemplate.Tests
@@ -7,9 +8,14 @@ namespace DesktopApplicationTemplate.Tests
     {
         public List<(string Message, LogLevel Level)> Entries { get; } = new();
 
+        public LogLevel MinimumLevel { get; set; } = LogLevel.Debug;
+
+        public event Action<LogEntry>? LogAdded;
+
         public void Log(string message, LogLevel level)
         {
             Entries.Add((message, level));
+            LogAdded?.Invoke(new LogEntry { Message = message, Level = level, Color = System.Windows.Media.Brushes.Black });
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -38,6 +38,9 @@ namespace DesktopApplicationTemplate.UI
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
             services.AddSingleton<MainView>();
+            services.AddTransient<ILoggingService, LoggingService>();
+            services.AddSingleton<SaveConfirmationHelper>();
+            services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<IStartupService, StartupService>();
             services.AddSingleton<IProcessRunner, ProcessRunner>();
             services.AddSingleton<INetworkConfigurationService, NetworkConfigurationService>();

--- a/DesktopApplicationTemplate.UI/Helpers/CloseConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/CloseConfirmationHelper.cs
@@ -1,27 +1,32 @@
-using System.Windows;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
+using System.Windows;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
-    public static class CloseConfirmationHelper
+    public class CloseConfirmationHelper
     {
-        public static ILoggingService? Logger { get; set; }
+        private readonly ILoggingService? _logger;
 
-        public static bool CloseConfirmationSuppressed
+        public CloseConfirmationHelper(ILoggingService? logger = null)
+        {
+            _logger = logger;
+        }
+
+        public bool CloseConfirmationSuppressed
         {
             get => SettingsViewModel.CloseConfirmationSuppressed;
             set => SettingsViewModel.CloseConfirmationSuppressed = value;
         }
 
-        public static bool Show()
+        public bool Show()
         {
-            Logger?.Log("Displaying close confirmation", LogLevel.Debug);
+            _logger?.Log("Displaying close confirmation", LogLevel.Debug);
             if (CloseConfirmationSuppressed)
             {
-                Logger?.Log("Close confirmation suppressed", LogLevel.Debug);
+                _logger?.Log("Close confirmation suppressed", LogLevel.Debug);
                 return true;
             }
 
@@ -37,7 +42,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 settingsVm.Save();
             }
 
-            Logger?.Log(result ? "Close confirmed" : "Close canceled", LogLevel.Debug);
+            _logger?.Log(result ? "Close confirmed" : "Close canceled", LogLevel.Debug);
             return result;
         }
     }

--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -1,42 +1,47 @@
+using System;
 using System.Windows;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
-    public static class SaveConfirmationHelper
+    public class SaveConfirmationHelper
     {
-        public static ILoggingService? Logger { get; set; }
+        private readonly ILoggingService? _logger;
+
+        public SaveConfirmationHelper(ILoggingService? logger = null)
+        {
+            _logger = logger;
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether the save confirmation dialog
-        /// should be suppressed. This simply forwards to
-        /// <see cref="SettingsViewModel.SaveConfirmationSuppressed"/> so callers
-        /// do not need to depend on <see cref="SettingsViewModel"/> directly.
+        /// should be suppressed. This forwards to <see cref="SettingsViewModel.SaveConfirmationSuppressed"/>.
         /// </summary>
-        public static bool SaveConfirmationSuppressed
+        public bool SaveConfirmationSuppressed
         {
             get => SettingsViewModel.SaveConfirmationSuppressed;
             set => SettingsViewModel.SaveConfirmationSuppressed = value;
         }
 
-        public static event Action? SaveConfirmed;
+        public event Action? SaveConfirmed;
 
-        public static void Show()
+        public void Show()
         {
-            Logger?.Log("Displaying save confirmation", LogLevel.Debug);
+            _logger?.Log("Displaying save confirmation", LogLevel.Debug);
             if (SaveConfirmationSuppressed)
             {
-                Logger?.Log("Confirmation suppressed", LogLevel.Debug);
+                _logger?.Log("Confirmation suppressed", LogLevel.Debug);
                 SaveConfirmed?.Invoke();
-                Logger?.Log("Save confirmed via suppression", LogLevel.Debug);
+                _logger?.Log("Save confirmed via suppression", LogLevel.Debug);
                 return;
             }
 
             var window = new SaveConfirmationWindow
             {
-                Owner = System.Windows.Application.Current.MainWindow
+                Owner = Application.Current.MainWindow
             };
             if (window.ShowDialog() == true)
             {
@@ -48,7 +53,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 }
 
                 SaveConfirmed?.Invoke();
-                Logger?.Log("Save confirmed via dialog", LogLevel.Debug);
+                _logger?.Log("Save confirmed via dialog", LogLevel.Debug);
             }
         }
     }

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -12,8 +12,8 @@ namespace DesktopApplicationTemplate.UI.Services
 {
     public class LoggingService : ILoggingService
     {
-        private readonly WpfRichTextBox _outputRichTextBox;
-        private readonly Dispatcher _dispatcher;
+        private WpfRichTextBox? _outputRichTextBox;
+        private Dispatcher? _dispatcher;
         private readonly string _logFilePath;
         private readonly List<LogEntry> _logEntries = new();
 
@@ -31,11 +31,15 @@ namespace DesktopApplicationTemplate.UI.Services
 
         public event Action<LogEntry>? LogAdded;
 
-        public LoggingService(WpfRichTextBox outputRichTextBox, Dispatcher dispatcher, string logFilePath = "app.log")
+        public LoggingService(string logFilePath = "app.log")
+        {
+            _logFilePath = logFilePath;
+        }
+
+        public void Initialize(WpfRichTextBox outputRichTextBox, Dispatcher dispatcher)
         {
             _outputRichTextBox = outputRichTextBox;
             _dispatcher = dispatcher;
-            _logFilePath = logFilePath;
         }
 
         public void Log(string message, LogLevel level)
@@ -46,7 +50,7 @@ namespace DesktopApplicationTemplate.UI.Services
 
             _logEntries.Add(entry);
 
-            if (level >= MinimumLevel)
+            if (level >= MinimumLevel && _dispatcher != null && _outputRichTextBox != null)
             {
                 _dispatcher.Invoke(() =>
                 {
@@ -80,6 +84,9 @@ namespace DesktopApplicationTemplate.UI.Services
 
         private void UpdateLogDisplay()
         {
+            if (_dispatcher == null || _outputRichTextBox == null)
+                return;
+
             _dispatcher.Invoke(() =>
             {
                 _outputRichTextBox.Document.Blocks.Clear();

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -78,8 +78,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand BrowseCommand { get; }
         public ICommand SaveCommand { get; }
 
-        public FileObserverViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public FileObserverViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             AddObserverCommand = new RelayCommand(AddObserver);
             RemoveObserverCommand = new RelayCommand(RemoveObserver);
             BrowseCommand = new RelayCommand(BrowseFilePath);
@@ -129,7 +132,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         // OnPropertyChanged inherited from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -72,9 +72,11 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
         public IFtpService? Service { get; set; }
 
         private readonly IFileDialogService _fileDialog;
+        private readonly SaveConfirmationHelper _saveHelper;
 
-        public FtpServiceViewModel(IFileDialogService? fileDialog = null)
+        public FtpServiceViewModel(SaveConfirmationHelper saveHelper, IFileDialogService? fileDialog = null)
         {
+            _saveHelper = saveHelper;
             _fileDialog = fileDialog ?? new FileDialogService();
             BrowseCommand = new RelayCommand(Browse);
             TransferCommand = new RelayCommand(async () => await TransferAsync());
@@ -99,7 +101,7 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             Logger?.Log("Finished FTP transfer", LogLevel.Debug);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
@@ -50,8 +50,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand BuildCommand { get; }
         public ICommand SaveCommand { get; }
 
-        public HeartbeatViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public HeartbeatViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             BuildCommand = new RelayCommand(BuildMessage);
             SaveCommand = new RelayCommand(Save);
         }
@@ -70,7 +73,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             FinalMessage = msg;
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         // OnPropertyChanged from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -65,8 +65,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand BuildCommand { get; }
         public ICommand SaveCommand { get; }
 
-        public HidViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public HidViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             BuildCommand = new RelayCommand(BuildMessage);
             SaveCommand = new RelayCommand(Save);
         }
@@ -86,7 +89,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private void Save()
         {
             Logger?.Log("Saving HID configuration", LogLevel.Debug);
-            SaveConfirmationHelper.Show();
+            _saveHelper.Show();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -99,8 +99,11 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         /// </summary>
         public HttpMessageHandler? MessageHandler { get; set; }
 
-        public HttpServiceViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public HttpServiceViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             SendCommand = new RelayCommand(async () => await SendRequestAsync());
             AddHeaderCommand = new RelayCommand(() => Headers.Add(new HeaderItem()));
             RemoveHeaderCommand = new RelayCommand(() =>
@@ -111,7 +114,7 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             SaveCommand = new RelayCommand(Save);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public async Task SendRequestAsync()
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -63,9 +63,11 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAw
         public ILoggingService? Logger { get; set; }
 
         private readonly MqttService _service;
+        private readonly SaveConfirmationHelper _saveHelper;
 
-        public MqttServiceViewModel(MqttService? service = null, ILoggingService? logger = null)
+        public MqttServiceViewModel(SaveConfirmationHelper saveHelper, MqttService? service = null, ILoggingService? logger = null)
         {
+            _saveHelper = saveHelper;
             Logger = logger;
             _service = service ?? new MqttService(logger);
             AddTopicCommand = new RelayCommand(() => { if(!string.IsNullOrWhiteSpace(NewTopic)){Topics.Add(NewTopic); NewTopic = string.Empty;} });
@@ -94,7 +96,7 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAw
             Logger?.Log("MQTT publish finished", LogLevel.Debug);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -51,8 +51,11 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
 
         public ILoggingService? Logger { get; set; }
 
-        public ScpServiceViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public ScpServiceViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             BrowseCommand = new RelayCommand(Browse);
             TransferCommand = new RelayCommand(async () => await TransferAsync());
             SaveCommand = new RelayCommand(Save);
@@ -76,7 +79,7 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
             Logger?.Log("SCP transfer finished", LogLevel.Debug);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -195,6 +195,8 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
         public ICommand ToggleServerCommand { get; }
         public ICommand TestScriptCommand { get; }
 
+        private readonly SaveConfirmationHelper _saveHelper;
+
         public string StatusMessage
         {
             get => _statusMessage;
@@ -217,8 +219,9 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
 
         public ICommand SaveCommand { get; }
 
-        public TcpServiceViewModel()
+        public TcpServiceViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             StatusMessage = "Chappie is initializing...";
             IsServerRunning = false;
             SaveCommand = new RelayCommand(Save);
@@ -279,7 +282,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             }
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -1,30 +1,25 @@
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
     public partial class FTPServiceView : Page
     {
         private readonly FtpServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
-        public FTPServiceView(FtpServiceViewModel vm)
+        private readonly ILoggingService _logger;
+        public FTPServiceView(FtpServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;
             DataContext = vm;
-            _logger = new LoggingService(LogBox, Dispatcher);
+            _logger = logger;
+            (logger as LoggingService)?.Initialize(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -1,19 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -23,17 +10,16 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class HttpServiceView : Page
     {
         private readonly ViewModels.HttpServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
+        private readonly ILoggingService _logger;
 
-        public HttpServiceView(ViewModels.HttpServiceViewModel viewModel)
+        public HttpServiceView(ViewModels.HttpServiceViewModel viewModel, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = viewModel;
             DataContext = _viewModel;
-            _logger = new LoggingService(LogBox, Dispatcher);
+            _logger = logger;
+            (logger as LoggingService)?.Initialize(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)
@@ -44,9 +30,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -1,23 +1,21 @@
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
     public partial class MQTTServiceView : Page
     {
         private readonly MqttServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
-        public MQTTServiceView(MqttServiceViewModel vm)
+        private readonly ILoggingService _logger;
+        public MQTTServiceView(MqttServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;
             DataContext = vm;
-            _logger = new LoggingService(LogBox, Dispatcher);
+            _logger = logger;
+            (logger as LoggingService)?.Initialize(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -28,9 +26,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -82,14 +82,23 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 "TCP" => new TcpServiceView(
                     App.AppHost.Services.GetRequiredService<TcpServiceViewModel>(),
-                    App.AppHost.Services.GetRequiredService<IStartupService>()),
-                "HTTP" => App.AppHost.Services.GetRequiredService<HttpServiceView>(),
+                    App.AppHost.Services.GetRequiredService<IStartupService>(),
+                    App.AppHost.Services.GetRequiredService<ILoggingService>()),
+                "HTTP" => new HttpServiceView(
+                    App.AppHost.Services.GetRequiredService<HttpServiceViewModel>(),
+                    App.AppHost.Services.GetRequiredService<ILoggingService>()),
                 "File Observer" => App.AppHost.Services.GetRequiredService<FileObserverView>(),
                 "HID" => App.AppHost.Services.GetRequiredService<HidViews>(),
                 "Heartbeat" => new HeartbeatView(App.AppHost.Services.GetRequiredService<HeartbeatViewModel>()),
-                "SCP" => new SCPServiceView(App.AppHost.Services.GetRequiredService<ScpServiceViewModel>()),
-                "MQTT" => new MQTTServiceView(App.AppHost.Services.GetRequiredService<MqttServiceViewModel>()),
-                "FTP" => new FTPServiceView(App.AppHost.Services.GetRequiredService<FtpServiceViewModel>()),
+                "SCP" => new SCPServiceView(
+                    App.AppHost.Services.GetRequiredService<ScpServiceViewModel>(),
+                    App.AppHost.Services.GetRequiredService<ILoggingService>()),
+                "MQTT" => new MQTTServiceView(
+                    App.AppHost.Services.GetRequiredService<MqttServiceViewModel>(),
+                    App.AppHost.Services.GetRequiredService<ILoggingService>()),
+                "FTP" => new FTPServiceView(
+                    App.AppHost.Services.GetRequiredService<FtpServiceViewModel>(),
+                    App.AppHost.Services.GetRequiredService<ILoggingService>()),
                 _ => null
             };
 

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -1,30 +1,25 @@
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
     public partial class SCPServiceView : Page
     {
         private readonly ScpServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
-        public SCPServiceView(ScpServiceViewModel vm)
+        private readonly ILoggingService _logger;
+        public SCPServiceView(ScpServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;
             DataContext = vm;
-            _logger = new LoggingService(LogBox, Dispatcher);
+            _logger = logger;
+            (logger as LoggingService)?.Initialize(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_logger == null)
-                return;
-
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
                 switch (item.Content?.ToString())

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -2,7 +2,6 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.UI.Helpers;
 using System.Windows.Controls;
 
 namespace DesktopApplicationTemplate.UI.Views
@@ -11,19 +10,18 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         private readonly TcpServiceViewModel _viewModel;
         private readonly IStartupService _startupService;
-        private readonly LoggingService _logger;
+        private readonly ILoggingService _logger;
 
-        public TcpServiceView(TcpServiceViewModel viewModel, IStartupService startupService)
+        public TcpServiceView(TcpServiceViewModel viewModel, IStartupService startupService, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = viewModel;
             _startupService = startupService;
 
             DataContext = _viewModel;
-            _logger = new LoggingService(LogBox, Dispatcher);
+            _logger = logger;
+            (logger as LoggingService)?.Initialize(LogBox, Dispatcher);
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
 
             Loaded += MainWindow_Loaded;
         }


### PR DESCRIPTION
## Summary
- Register logging service and confirmation helpers in the DI container.
- Inject `ILoggingService` into views and view models, eliminating static logger assignments.
- Convert confirmation helpers to instance classes with constructor-injected loggers and update tests accordingly.

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App runtime not available)*

------
https://chatgpt.com/codex/tasks/task_e_689cc025d90083268930284e04d8ad40