### PR TITLE
Refactor logging service injection and update tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,5 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build DesktopApplicationTemplate.sln --configuration Release
-    - name: Test Unit
-      run: dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build --settings tests.runsettings
-    - name: Test Codex
+    - name: Test
       run: dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build --settings tests.runsettings

--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service.Services;
 
 namespace DesktopApplicationTemplate.Service
 {
@@ -25,6 +27,7 @@ namespace DesktopApplicationTemplate.Service
             return builder.ConfigureServices((hostContext, services) =>
             {
                 services.AddHostedService<Worker>(); // register the background service
+                services.AddSingleton<ILoggingService, LoggingService>();
             });
         }
     }

--- a/DesktopApplicationTemplate.Service/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.Service/Services/LoggingService.cs
@@ -1,0 +1,13 @@
+using System;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.Service.Services
+{
+    public class LoggingService : ILoggingService
+    {
+        public void Log(string message, LogLevel level)
+        {
+            Console.WriteLine($"[{level}] {message}");
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/CloseConfirmationHelperTests.cs
+++ b/DesktopApplicationTemplate.Tests/CloseConfirmationHelperTests.cs
@@ -1,5 +1,7 @@
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Core.Services;
+using Moq;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -11,7 +13,9 @@ namespace DesktopApplicationTemplate.Tests
         public void Show_ReturnsTrue_WhenSuppressed()
         {
             SettingsViewModel.CloseConfirmationSuppressed = true;
-            var result = CloseConfirmationHelper.Show();
+            var logger = new Mock<ILoggingService>();
+            var helper = new CloseConfirmationHelper(logger.Object);
+            var result = helper.Show();
             Assert.True(result);
             SettingsViewModel.CloseConfirmationSuppressed = false;
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 using System;
 using Moq;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 using System.Threading;
 using DesktopApplicationTemplate.Core.Services;
 
@@ -20,7 +21,9 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("WindowsSafe")]
         public void BrowseCommand_InitialPathEmpty_DoesNotThrow()
         {
-            var vm = new FtpServiceViewModel(new StubFileDialogService());
+            var logger = new Mock<ILoggingService>();
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new FtpServiceViewModel(helper, new StubFileDialogService());
             vm.BrowseCommand.Execute(null);
             Assert.Equal("stub.txt", vm.LocalPath);
 
@@ -34,7 +37,8 @@ namespace DesktopApplicationTemplate.Tests
         {
             var mock = new Mock<IFtpService>();
             var logger = new Mock<ILoggingService>();
-            var vm = new FtpServiceViewModel { Service = mock.Object, Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new FtpServiceViewModel(helper) { Service = mock.Object, Logger = logger.Object };
             vm.LocalPath = "local";
             vm.RemotePath = "remote";
 
@@ -53,7 +57,8 @@ namespace DesktopApplicationTemplate.Tests
         public void SettingInvalidHost_AddsError()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new FtpServiceViewModel { Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new FtpServiceViewModel(helper) { Logger = logger.Object };
             vm.Host = "bad_host";
 
             Assert.True(vm.HasErrors);
@@ -68,7 +73,8 @@ namespace DesktopApplicationTemplate.Tests
         public void SettingInvalidPort_AddsError()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new FtpServiceViewModel { Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new FtpServiceViewModel(helper) { Logger = logger.Object };
             vm.Port = "abc";
 
             Assert.True(vm.HasErrors);
@@ -82,7 +88,8 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("WindowsSafe")]
         public void PartialHost_WithTrailingDot_DoesNotError()
         {
-            var vm = new FtpServiceViewModel();
+            var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
+            var vm = new FtpServiceViewModel(helper);
             vm.Host = "192.168.";
 
             Assert.False(vm.HasErrors);

--- a/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using Moq;
 
 namespace DesktopApplicationTemplate.Tests
@@ -20,7 +21,8 @@ namespace DesktopApplicationTemplate.Tests
             };
 
             var logger = new Mock<ILoggingService>();
-            var vm = new HidViewModel { Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new HidViewModel(helper) { Logger = logger.Object };
             vm.AvailableServices.Add("Target");
             vm.AttachedService = "Target";
             vm.MessageTemplate = "test";

--- a/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
+++ b/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
@@ -1,5 +1,7 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.Tests;
+using DesktopApplicationTemplate.Core.Services;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -37,7 +39,8 @@ public class HttpServiceNetworkTests
             listener.Stop();
         });
 
-        var vm = new HttpServiceViewModel { Url = $"http://localhost:{port}/" };
+        var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
+        var vm = new HttpServiceViewModel(helper) { Url = $"http://localhost:{port}/" };
         await vm.SendRequestAsync();
 
         await respondTask;
@@ -63,7 +66,8 @@ public class HttpServiceNetworkTests
                 Content = new StringContent("ok")
             });
 
-        var vm = new HttpServiceViewModel { Url = "http://localhost/", SelectedMethod = "POST", RequestBody = "data", MessageHandler = handlerMock.Object };
+        var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
+        var vm = new HttpServiceViewModel(helper) { Url = "http://localhost/", SelectedMethod = "POST", RequestBody = "data", MessageHandler = handlerMock.Object };
         vm.Headers.Add(new HttpServiceViewModel.HeaderItem { Key = "X-Test", Value = "1" });
 
         await vm.SendRequestAsync();

--- a/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
+++ b/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
@@ -1,12 +1,15 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 using System;
 using System.Linq;
 using System.Threading;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Xunit;
+using Moq;
+using DesktopApplicationTemplate.Core.Services;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -27,8 +30,11 @@ namespace DesktopApplicationTemplate.Tests
                     if (System.Windows.Application.Current == null)
                         new DesktopApplicationTemplate.UI.App();
 
-                    var viewModel = new HttpServiceViewModel();
-                    var view = new HttpServiceView(viewModel);
+                    var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
+                    var viewModel = new HttpServiceViewModel(helper);
+                    var logger = new LoggingService(new NullRichTextLogger());
+                    viewModel.Logger = logger;
+                    var view = new HttpServiceView(viewModel, logger);
 
                     var targetItem = view.LogLevelBox.Items
                         .OfType<ComboBoxItem>()
@@ -48,8 +54,8 @@ namespace DesktopApplicationTemplate.Tests
                             Array.Empty<object>())
                     });
 
-                    var logger = Assert.IsType<LoggingService>(viewModel.Logger);
-                    Assert.Equal(LogLevel.Error, logger.MinimumLevel);
+                    var concrete = Assert.IsType<LoggingService>(viewModel.Logger);
+                    Assert.Equal(LogLevel.Error, concrete.MinimumLevel);
                 }
                 catch (Exception e)
                 {

--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using Moq;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using MQTTnet.Client;
 using Moq;
 using Xunit;
@@ -20,7 +21,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 return;
             }
-            var vm = new MqttServiceViewModel();
+            var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
+            var vm = new MqttServiceViewModel(helper);
             vm.NewTopic = "test/topic";
             vm.AddTopicCommand.Execute(null);
             Assert.Contains("test/topic", vm.Topics);
@@ -40,7 +42,8 @@ namespace DesktopApplicationTemplate.Tests
             client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), string.Empty, Array.Empty<MqttUserProperty>()));
             var service = new MqttService(client.Object, logger.Object);
-            var vm = new MqttServiceViewModel(service, logger.Object) { Host = "127.0.0.1", Port = "1883", ClientId = "c" };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new MqttServiceViewModel(helper, service, logger.Object) { Host = "127.0.0.1", Port = "1883", ClientId = "c" };
 
             await vm.ConnectAsync();
 

--- a/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScpServiceViewModelTests.cs
@@ -1,4 +1,7 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.Core.Services;
+using Moq;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -9,7 +12,8 @@ namespace DesktopApplicationTemplate.Tests
         [TestCategory("CodexSafe")]
         public void DefaultPort_Is22()
         {
-            var vm = new ScpServiceViewModel();
+            var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
+            var vm = new ScpServiceViewModel(helper);
             Assert.Equal("22", vm.Port);
 
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Moq;
@@ -17,7 +18,8 @@ namespace DesktopApplicationTemplate.Tests
         public void TcpService_ToggleServer_LogsMessage()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new TcpServiceViewModel { Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new TcpServiceViewModel(helper) { Logger = logger.Object };
             vm.ComputerIp = "127.0.0.1";
             vm.ListeningPort = "5000";
 
@@ -34,7 +36,8 @@ namespace DesktopApplicationTemplate.Tests
         public async Task HttpService_InvalidUrl_LogsWarning()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new HttpServiceViewModel { Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new HttpServiceViewModel(helper) { Logger = logger.Object };
             vm.Url = string.Empty;
 
             await vm.SendRequestAsync();
@@ -58,7 +61,8 @@ namespace DesktopApplicationTemplate.Tests
                     Content = new StringContent("ok")
                 });
 
-            var vm = new HttpServiceViewModel { Logger = logger.Object, MessageHandler = handler.Object, Url = "http://localhost/" };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new HttpServiceViewModel(helper) { Logger = logger.Object, MessageHandler = handler.Object, Url = "http://localhost/" };
 
             await vm.SendRequestAsync();
 
@@ -75,7 +79,8 @@ namespace DesktopApplicationTemplate.Tests
         public void HttpService_SetInvalidUrl_AddsError()
         {
             var logger = new Mock<ILoggingService>();
-            var vm = new HttpServiceViewModel { Logger = logger.Object };
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new HttpServiceViewModel(helper) { Logger = logger.Object };
             vm.Url = "htp://bad";
 
             Assert.True(vm.HasErrors);

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -44,7 +45,10 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<NetworkConfigurationViewModel>();
             services.AddSingleton<IRichTextLogger, NullRichTextLogger>();
             services.AddSingleton<ILoggingService, LoggingService>();
+            services.AddSingleton<SaveConfirmationHelper>();
+            services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<MainViewModel>();
+            services.AddSingleton<TcpServiceView>();
             services.AddSingleton<TcpServiceViewModel>();
             services.AddSingleton<DependencyChecker>();
             services.AddSingleton<HttpServiceView>();

--- a/DesktopApplicationTemplate.UI/Helpers/CloseConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/CloseConfirmationHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -6,22 +7,27 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
-    public static class CloseConfirmationHelper
+    public class CloseConfirmationHelper
     {
-        public static ILoggingService? Logger { get; set; }
+        private readonly ILoggingService _logger;
 
-        public static bool CloseConfirmationSuppressed
+        public CloseConfirmationHelper(ILoggingService logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public bool CloseConfirmationSuppressed
         {
             get => SettingsViewModel.CloseConfirmationSuppressed;
             set => SettingsViewModel.CloseConfirmationSuppressed = value;
         }
 
-        public static bool Show()
+        public bool Show()
         {
-            Logger?.Log("Displaying close confirmation", LogLevel.Debug);
+            _logger.Log("Displaying close confirmation", LogLevel.Debug);
             if (CloseConfirmationSuppressed)
             {
-                Logger?.Log("Close confirmation suppressed", LogLevel.Debug);
+                _logger.Log("Close confirmation suppressed", LogLevel.Debug);
                 return true;
             }
 
@@ -37,7 +43,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 settingsVm.Save();
             }
 
-            Logger?.Log(result ? "Close confirmed" : "Close canceled", LogLevel.Debug);
+            _logger.Log(result ? "Close confirmed" : "Close canceled", LogLevel.Debug);
             return result;
         }
     }

--- a/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/SaveConfirmationHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -6,37 +7,37 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
-    public static class SaveConfirmationHelper
+    public class SaveConfirmationHelper
     {
-        public static ILoggingService? Logger { get; set; }
-        /// <summary>
-        /// Gets or sets a value indicating whether the save confirmation dialog
-        /// should be suppressed. This simply forwards to
-        /// <see cref="SettingsViewModel.SaveConfirmationSuppressed"/> so callers
-        /// do not need to depend on <see cref="SettingsViewModel"/> directly.
-        /// </summary>
-        public static bool SaveConfirmationSuppressed
+        private readonly ILoggingService _logger;
+
+        public SaveConfirmationHelper(ILoggingService logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public bool SaveConfirmationSuppressed
         {
             get => SettingsViewModel.SaveConfirmationSuppressed;
             set => SettingsViewModel.SaveConfirmationSuppressed = value;
         }
 
-        public static event Action? SaveConfirmed;
+        public event Action? SaveConfirmed;
 
-        public static void Show()
+        public void Show()
         {
-            Logger?.Log("Displaying save confirmation", LogLevel.Debug);
+            _logger.Log("Displaying save confirmation", LogLevel.Debug);
             if (SaveConfirmationSuppressed)
             {
-                Logger?.Log("Confirmation suppressed", LogLevel.Debug);
+                _logger.Log("Confirmation suppressed", LogLevel.Debug);
                 SaveConfirmed?.Invoke();
-                Logger?.Log("Save confirmed via suppression", LogLevel.Debug);
+                _logger.Log("Save confirmed via suppression", LogLevel.Debug);
                 return;
             }
 
             var window = new SaveConfirmationWindow
             {
-                Owner = System.Windows.Application.Current.MainWindow
+                Owner = Application.Current.MainWindow
             };
             if (window.ShowDialog() == true)
             {
@@ -48,7 +49,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 }
 
                 SaveConfirmed?.Invoke();
-                Logger?.Log("Save confirmed via dialog", LogLevel.Debug);
+                _logger.Log("Save confirmed via dialog", LogLevel.Debug);
             }
         }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverViewModel.cs
@@ -78,8 +78,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand BrowseCommand { get; }
         public ICommand SaveCommand { get; }
 
-        public FileObserverViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public FileObserverViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             AddObserverCommand = new RelayCommand(AddObserver);
             RemoveObserverCommand = new RelayCommand(RemoveObserver);
             BrowseCommand = new RelayCommand(BrowseFilePath);
@@ -129,7 +132,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         // OnPropertyChanged inherited from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -74,9 +74,11 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
         public IFtpService? Service { get; set; }
 
         private readonly IFileDialogService _fileDialog;
+        private readonly SaveConfirmationHelper _saveHelper;
 
-        public FtpServiceViewModel(IFileDialogService? fileDialog = null)
+        public FtpServiceViewModel(SaveConfirmationHelper saveHelper, IFileDialogService? fileDialog = null)
         {
+            _saveHelper = saveHelper;
             _fileDialog = fileDialog ?? new FileDialogService();
             BrowseCommand = new RelayCommand(Browse);
             TransferCommand = new RelayCommand(async () => await TransferAsync());
@@ -101,7 +103,7 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             Logger?.Log("Finished FTP transfer", LogLevel.Debug);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HeartbeatViewModel.cs
@@ -50,8 +50,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand BuildCommand { get; }
         public ICommand SaveCommand { get; }
 
-        public HeartbeatViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public HeartbeatViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             BuildCommand = new RelayCommand(BuildMessage);
             SaveCommand = new RelayCommand(Save);
         }
@@ -70,7 +73,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             FinalMessage = msg;
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         // OnPropertyChanged from ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -66,8 +66,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand BuildCommand { get; }
         public ICommand SaveCommand { get; }
 
-        public HidViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public HidViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             BuildCommand = new RelayCommand(BuildMessage);
             SaveCommand = new RelayCommand(Save);
         }
@@ -87,7 +90,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private void Save()
         {
             Logger?.Log("Saving HID configuration", LogLevel.Debug);
-            SaveConfirmationHelper.Show();
+            _saveHelper.Show();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpServiceViewModel.cs
@@ -99,8 +99,11 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         /// </summary>
         public HttpMessageHandler? MessageHandler { get; set; }
 
-        public HttpServiceViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public HttpServiceViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             SendCommand = new RelayCommand(async () => await SendRequestAsync());
             AddHeaderCommand = new RelayCommand(() => Headers.Add(new HeaderItem()));
             RemoveHeaderCommand = new RelayCommand(() =>
@@ -111,7 +114,7 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             SaveCommand = new RelayCommand(Save);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public async Task SendRequestAsync()
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -64,9 +64,11 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAw
         public ILoggingService? Logger { get; set; }
 
         private readonly MqttService _service;
+        private readonly SaveConfirmationHelper _saveHelper;
 
-        public MqttServiceViewModel(MqttService? service = null, ILoggingService? logger = null)
+        public MqttServiceViewModel(SaveConfirmationHelper saveHelper, MqttService? service = null, ILoggingService? logger = null)
         {
+            _saveHelper = saveHelper;
             Logger = logger;
             _service = service ?? new MqttService(logger);
             AddTopicCommand = new RelayCommand(() => { if(!string.IsNullOrWhiteSpace(NewTopic)){Topics.Add(NewTopic); NewTopic = string.Empty;} });
@@ -95,7 +97,7 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAw
             Logger?.Log("MQTT publish finished", LogLevel.Debug);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -52,8 +52,11 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
 
         public ILoggingService? Logger { get; set; }
 
-        public ScpServiceViewModel()
+        private readonly SaveConfirmationHelper _saveHelper;
+
+        public ScpServiceViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             BrowseCommand = new RelayCommand(Browse);
             TransferCommand = new RelayCommand(async () => await TransferAsync());
             SaveCommand = new RelayCommand(Save);
@@ -77,7 +80,7 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
             Logger?.Log("SCP transfer finished", LogLevel.Debug);
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -195,6 +195,8 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
         public ICommand ToggleServerCommand { get; }
         public ICommand TestScriptCommand { get; }
 
+        private readonly SaveConfirmationHelper _saveHelper;
+
         public string StatusMessage
         {
             get => _statusMessage;
@@ -217,8 +219,9 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
 
         public ICommand SaveCommand { get; }
 
-        public TcpServiceViewModel()
+        public TcpServiceViewModel(SaveConfirmationHelper saveHelper)
         {
+            _saveHelper = saveHelper;
             StatusMessage = "Chappie is initializing...";
             IsServerRunning = false;
             SaveCommand = new RelayCommand(Save);
@@ -279,7 +282,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             }
         }
 
-        private void Save() => SaveConfirmationHelper.Show();
+        private void Save() => _saveHelper.Show();
 
         public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
         {

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 using DesktopApplicationTemplate.Core.Services;
 
@@ -10,37 +9,37 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class FTPServiceView : Page
     {
         private readonly FtpServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
-        public FTPServiceView(FtpServiceViewModel vm)
+        private readonly ILoggingService _logger;
+        public FTPServiceView(FtpServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;
             DataContext = vm;
-            var uiLogger = new RichTextLogger(LogBox, Dispatcher);
-            _logger = new LoggingService(uiLogger);
+            _logger = logger;
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
-                switch (item.Content?.ToString())
+                if (_logger is LoggingService concrete)
                 {
-                    case "Warning":
-                        _logger.MinimumLevel = LogLevel.Warning;
-                        break;
-                    case "Error":
-                        _logger.MinimumLevel = LogLevel.Error;
-                        break;
-                    case "Debug":
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
-                    default:
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
+                    switch (item.Content?.ToString())
+                    {
+                        case "Warning":
+                            concrete.MinimumLevel = LogLevel.Warning;
+                            break;
+                        case "Error":
+                            concrete.MinimumLevel = LogLevel.Error;
+                            break;
+                        case "Debug":
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                        default:
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                    }
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -13,7 +13,6 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 using DesktopApplicationTemplate.Core.Services;
 
@@ -25,18 +24,15 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class HttpServiceView : Page
     {
         private readonly ViewModels.HttpServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
+        private readonly ILoggingService _logger;
 
-        public HttpServiceView(ViewModels.HttpServiceViewModel viewModel)
+        public HttpServiceView(ViewModels.HttpServiceViewModel viewModel, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = viewModel;
             DataContext = _viewModel;
-            var uiLogger = new RichTextLogger(LogBox, Dispatcher);
-            _logger = new LoggingService(uiLogger);
+            _logger = logger;
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)
@@ -49,20 +45,23 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
-                switch (item.Content?.ToString())
+                if (_logger is LoggingService concrete)
                 {
-                    case "Warning":
-                        _logger.MinimumLevel = LogLevel.Warning;
-                        break;
-                    case "Error":
-                        _logger.MinimumLevel = LogLevel.Error;
-                        break;
-                    case "Debug":
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
-                    default:
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
+                    switch (item.Content?.ToString())
+                    {
+                        case "Warning":
+                            concrete.MinimumLevel = LogLevel.Warning;
+                            break;
+                        case "Error":
+                            concrete.MinimumLevel = LogLevel.Error;
+                            break;
+                        case "Debug":
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                        default:
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                    }
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MQTTServiceView.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 using DesktopApplicationTemplate.Core.Services;
 
@@ -10,17 +9,14 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class MQTTServiceView : Page
     {
         private readonly MqttServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
-        public MQTTServiceView(MqttServiceViewModel vm)
+        private readonly ILoggingService _logger;
+        public MQTTServiceView(MqttServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;
             DataContext = vm;
-            var uiLogger = new RichTextLogger(LogBox, Dispatcher);
-            _logger = new LoggingService(uiLogger);
+            _logger = logger;
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void Help_Click(object sender, System.Windows.RoutedEventArgs e)
@@ -33,20 +29,23 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
-                switch (item.Content?.ToString())
+                if (_logger is LoggingService concrete)
                 {
-                    case "Warning":
-                        _logger.MinimumLevel = LogLevel.Warning;
-                        break;
-                    case "Error":
-                        _logger.MinimumLevel = LogLevel.Error;
-                        break;
-                    case "Debug":
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
-                    default:
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
+                    switch (item.Content?.ToString())
+                    {
+                        case "Warning":
+                            concrete.MinimumLevel = LogLevel.Warning;
+                            break;
+                        case "Error":
+                            concrete.MinimumLevel = LogLevel.Error;
+                            break;
+                        case "Debug":
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                        default:
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                    }
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -81,16 +81,14 @@ namespace DesktopApplicationTemplate.UI.Views
 
             svc.ServicePage = svc.ServiceType switch
             {
-                "TCP" => new TcpServiceView(
-                    App.AppHost.Services.GetRequiredService<TcpServiceViewModel>(),
-                    App.AppHost.Services.GetRequiredService<IStartupService>()),
+                "TCP" => App.AppHost.Services.GetRequiredService<TcpServiceView>(),
                 "HTTP" => App.AppHost.Services.GetRequiredService<HttpServiceView>(),
                 "File Observer" => App.AppHost.Services.GetRequiredService<FileObserverView>(),
                 "HID" => App.AppHost.Services.GetRequiredService<HidViews>(),
-                "Heartbeat" => new HeartbeatView(App.AppHost.Services.GetRequiredService<HeartbeatViewModel>()),
-                "SCP" => new SCPServiceView(App.AppHost.Services.GetRequiredService<ScpServiceViewModel>()),
-                "MQTT" => new MQTTServiceView(App.AppHost.Services.GetRequiredService<MqttServiceViewModel>()),
-                "FTP" => new FTPServiceView(App.AppHost.Services.GetRequiredService<FtpServiceViewModel>()),
+                "Heartbeat" => App.AppHost.Services.GetRequiredService<HeartbeatView>(),
+                "SCP" => App.AppHost.Services.GetRequiredService<SCPServiceView>(),
+                "MQTT" => App.AppHost.Services.GetRequiredService<MQTTServiceView>(),
+                "FTP" => App.AppHost.Services.GetRequiredService<FTPServiceView>(),
                 _ => null
             };
 

--- a/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SCPServiceView.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 
 using DesktopApplicationTemplate.Core.Services;
 
@@ -10,37 +9,37 @@ namespace DesktopApplicationTemplate.UI.Views
     public partial class SCPServiceView : Page
     {
         private readonly ScpServiceViewModel _viewModel;
-        private readonly LoggingService _logger;
-        public SCPServiceView(ScpServiceViewModel vm)
+        private readonly ILoggingService _logger;
+        public SCPServiceView(ScpServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;
             DataContext = vm;
-            var uiLogger = new RichTextLogger(LogBox, Dispatcher);
-            _logger = new LoggingService(uiLogger);
+            _logger = logger;
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
         }
 
         private void LogLevelBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
-                switch (item.Content?.ToString())
+                if (_logger is LoggingService concrete)
                 {
-                    case "Warning":
-                        _logger.MinimumLevel = LogLevel.Warning;
-                        break;
-                    case "Error":
-                        _logger.MinimumLevel = LogLevel.Error;
-                        break;
-                    case "Debug":
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
-                    default:
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
+                    switch (item.Content?.ToString())
+                    {
+                        case "Warning":
+                            concrete.MinimumLevel = LogLevel.Warning;
+                            break;
+                        case "Error":
+                            concrete.MinimumLevel = LogLevel.Error;
+                            break;
+                        case "Debug":
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                        default:
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                    }
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml.cs
@@ -2,7 +2,6 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.Core.Services;
 using System.Windows.Controls;
 
@@ -12,20 +11,17 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         private readonly TcpServiceViewModel _viewModel;
         private readonly IStartupService _startupService;
-        private readonly LoggingService _logger;
+        private readonly ILoggingService _logger;
 
-        public TcpServiceView(TcpServiceViewModel viewModel, IStartupService startupService)
+        public TcpServiceView(TcpServiceViewModel viewModel, IStartupService startupService, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = viewModel;
             _startupService = startupService;
+            _logger = logger;
 
             DataContext = _viewModel;
-            var uiLogger = new RichTextLogger(LogBox, Dispatcher);
-            _logger = new LoggingService(uiLogger);
             _viewModel.Logger = _logger;
-            SaveConfirmationHelper.Logger = _logger;
-            CloseConfirmationHelper.Logger = _logger;
 
             Loaded += MainWindow_Loaded;
         }
@@ -48,20 +44,23 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (LogLevelBox.SelectedItem is ComboBoxItem item)
             {
-                switch (item.Content?.ToString())
+                if (_logger is LoggingService concrete)
                 {
-                    case "Warning":
-                        _logger.MinimumLevel = LogLevel.Warning;
-                        break;
-                    case "Error":
-                        _logger.MinimumLevel = LogLevel.Error;
-                        break;
-                    case "Debug":
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
-                    default:
-                        _logger.MinimumLevel = LogLevel.Debug;
-                        break;
+                    switch (item.Content?.ToString())
+                    {
+                        case "Warning":
+                            concrete.MinimumLevel = LogLevel.Warning;
+                            break;
+                        case "Error":
+                            concrete.MinimumLevel = LogLevel.Error;
+                            break;
+                        case "Debug":
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                        default:
+                            concrete.MinimumLevel = LogLevel.Debug;
+                            break;
+                    }
                 }
             }
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Register `ILoggingService` and helper services with the DI container.
+- Refactored save/close confirmation helpers to use constructor injection.
+- Views now accept `ILoggingService` instances instead of creating loggers.
+- Updated unit tests to inject mock loggers.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1,0 +1,11 @@
+# Collaboration & Debug Tips (Codex <-> Matt)
+Purpose: Running log of what worked, what broke, and why.
+
+[2025-08-13 17:00] Topic: Logging DI refactor
+Context: Introduced constructor injection for logging services and confirmation helpers.
+Observations: Simplifies testing and removes static logger state.
+Codex Limitations noticed: Unable to execute Windows-specific tests in container.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Use DI to share single logging service and helpers.
+Action Items: Monitor CI for Windows-specific behaviors.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- inject `ILoggingService` into helpers and views
- register logging services and helpers in DI
- update tests and workflow to use DI-provided loggers
- document logging DI changes

## Validation
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build --settings tests.runsettings` *(fails: The argument ... DesktopApplicationTemplate.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_689cc61e6ab48326b97ea4213f8a4463