### PR TITLE
chore: broaden CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,22 +2,26 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - feature/**
+      - bugfix/**
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '8.0.404'
-    - name: Restore
-      run: dotnet restore
-    - name: Build
-      run: dotnet build DesktopApplicationTemplate.sln --configuration Release
-    - name: Test
-      run: dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build --settings tests.runsettings
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build DesktopApplicationTemplate.sln --configuration Release --no-restore
+      - name: Test
+        run: dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --configuration Release --no-build --settings tests.runsettings

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Updated unit tests to inject mock loggers.
 - Application logo displayed in the main window navigation bar.
 
+### Changed
+- CI workflow now runs on pushes to `feature/**` and `bugfix/**` branches and supports manual triggers, ensuring tests execute on GitHub.
+
 ### Removed
 - Placeholder "Desktop Template" text from the navigation bar.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -27,3 +27,12 @@ Effective Prompts / Instructions that worked: Providing exact asset location.
 Decisions & Rationale: Use root-relative resource paths for WPF assets.
 Action Items: Ensure future asset references include leading slash.
 Related Commits/PRs: (this PR)
+
+[2025-08-13 18:09] Topic: CI runs on feature branches
+Context: Enabled GitHub Actions to execute tests on pushes to `feature/**` and `bugfix/**` branches.
+Observations: Codex can push code to trigger remote tests without local execution.
+Codex Limitations noticed: `dotnet test` cannot run `net8.0-windows` tests on Linux.
+Effective Prompts / Instructions that worked: Configuring push patterns and `workflow_dispatch`.
+Decisions & Rationale: Use GitHub-hosted runners to centralize validation.
+Action Items: Monitor CI runs for unexpected failures.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- CI runs for feature/ and bugfix/ branches
- allow manual workflow dispatch and fix test command
- docs: record CI change

## Validation
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --no-build --settings tests.runsettings` *(fails: The argument ... is invalid. net8.0-windows tests cannot run on linux)*

------
https://chatgpt.com/codex/tasks/task_e_689cd413d7948326847b5b35bf818fa3