### PR TITLE
Enable on-demand CI tests and document CI-only policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What changed
+- [ ] Code
+- [ ] UI/XAML
+- [ ] Tests
+- [ ] DI registrations
+- [ ] Docs updated
+
+## Validation
+- [ ] CI green
+- [ ] No deadlocks; async only
+- [ ] No unsafe collection access
+- [ ] Removed stale code

--- a/.github/workflows/comment-test.yml
+++ b/.github/workflows/comment-test.yml
@@ -1,0 +1,32 @@
+name: PR Comment Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  run-on-comment:
+    if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/test')
+    runs-on: windows-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - run: dotnet workload install windowsdesktop
+      - run: dotnet restore
+      - run: dotnet build -c Release --no-restore /warnaserror
+      - run: dotnet test -c Release --no-build --logger "trx;LogFileName=test.trx"
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            **/TestResults/*.trx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+- Use feature or bugfix branches and open pull requests against `main` or `dev`.
+- Codex MUST NOT run tests locally. All validation occurs via GitHub Actions.
+- Ensure the CI workflow is green before requesting a review.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DesktopApplicationTemplate
 
+![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)
+
 This repository contains a basic WPF UI application, a Windows Service and unit tests.
 
 ## Prerequisites

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Updated unit tests to inject mock loggers.
 - Application logo displayed in the main window navigation bar.
 - Consolidated GitHub Actions into a single `CI` workflow and introduced `AGENTS.md` with instructions to review collaboration docs.
+- Added `/test` comment workflow to run CI on demand.
+- Created `CONTRIBUTING.md` and PR template enforcing CI-only testing with a CI badge in the README.
 
 ### Changed
 - CI workflow now runs on pushes to `feature/**` and `bugfix/**` branches and supports manual triggers, ensuring tests execute on GitHub.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -44,3 +44,11 @@ Effective Prompts / Instructions that worked: n/a
 Decisions & Rationale: Single pipeline with build, test, quality, and packaging jobs.
 Action Items: Monitor self-heal integration with new pipeline.
 Related Commits/PRs: (this PR)
+[2025-08-13 18:50] Topic: On-demand CI via /test comment
+Context: Enabled `/test` comment workflow and documented CI-only testing policy.
+Observations: CI can run without local test execution.
+Codex Limitations noticed: Tests cannot run on Linux container; rely on GitHub Actions.
+Effective Prompts / Instructions that worked: Using comment trigger pattern from user guidance.
+Decisions & Rationale: Centralize validation in CI and enforce via docs and PR template.
+Action Items: Ensure branch protection requires CI.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## Summary
- add `/test` PR comment workflow to trigger build and tests
- document CI-only testing in CONTRIBUTING and PR template
- show CI status badge in README

## Testing
- ⚠️ no tests run (CI-only policy)

------
https://chatgpt.com/codex/tasks/task_e_689cdde044388326acf770d4f3bb888b