### PR TITLE
test: marshal WPF shutdown to dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -47,19 +45,23 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Test
-        run: dotnet test -c Release --no-build --collect:"XPlat Code Coverage" --results-directory TestResults
+        id: test
+        continue-on-error: true
+        run: dotnet test -c Release --collect:"XPlat Code Coverage" --results-directory TestResults
       - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |
             TestResults
             **/coverage.cobertura.xml
+      - name: Fail if tests failed
+        if: steps.test.outcome == 'failure'
+        run: exit 1
 
   quality:
     runs-on: windows-latest
@@ -70,8 +72,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Verify formatting
@@ -88,8 +88,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Publish

--- a/CollaborationAndDebugTips.txt
+++ b/CollaborationAndDebugTips.txt
@@ -33,3 +33,21 @@ Miscellaneous Tips
 - Favor async/await patterns to keep the UI responsive and avoid deadlocks.
 - Reuse existing services and view models instead of duplicating logic.
 - Maintain clear, purpose-driven variable names for readability and maintainability.
+
+[2025-08-13 23:14] Topic: WPF test dispatcher shutdown
+Context: SettingsPageNavigationTests crashed when calling Application.Current.Shutdown directly.
+Observations: WPF requires invoking Shutdown on the owning dispatcher; direct calls raised cross-thread InvalidOperationException.
+Codex Limitations noticed: Local container lacks the .NET SDK to run tests.
+Effective Prompts / Instructions that worked: Provided failing stack trace to guide dispatcher-based fix.
+Decisions & Rationale: Wrap shutdown logic in dispatcher invocation to marshal to the UI thread.
+Action Items: Verify on Windows CI that tests pass with the updated dispatcher call.
+Related Commits/PRs:
+
+[2025-08-14 00:30] Topic: WPF Application aliasing
+Context: Build failed due to ambiguous `Application` reference when WinForms implicit usings were enabled.
+Observations: Using a namespace alias for `System.Windows.Application` removed the ambiguity.
+Codex Limitations noticed: dotnet SDK unavailable in container to recompile locally.
+Effective Prompts / Instructions that worked: Compiler error output identifying conflicting `Application` types.
+Decisions & Rationale: Alias the WPF `Application` and refer to it explicitly in tests.
+Action Items: Ensure CI builds succeed on Windows runners.
+Related Commits/PRs: (this PR)

--- a/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
@@ -6,8 +6,7 @@ using Moq;
 using System;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Windows;
+using WpfApplication = System.Windows.Application;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -26,7 +25,7 @@ namespace DesktopApplicationTemplate.Tests
             {
                 try
                 {
-                    if (System.Windows.Application.Current == null)
+                    if (WpfApplication.Current == null)
                         new DesktopApplicationTemplate.UI.App();
 
                     var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
@@ -50,7 +49,8 @@ namespace DesktopApplicationTemplate.Tests
                 catch (Exception e) { ex = e; }
                 finally
                 {
-                    System.Windows.Application.Current?.Shutdown();
+                    var dispatcher = WpfApplication.Current?.Dispatcher;
+                    dispatcher?.Invoke(() => WpfApplication.Current?.Shutdown());
                 }
             });
             thread.SetApartmentState(ApartmentState.STA);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,11 @@
 - Placeholder "Desktop Template" text from the navigation bar.
 - Legacy GitHub workflows (`dotnet.yml`, `dotnet-desktop-ci.yml`, `ci.yml`).
 - Unused `RichTextLogger` service and installer `CustomControl1` control.
+- WPF workload installation steps from CI workflow and setup script.
 
 ### Fixed
 - Corrected logo resource path so the image renders in the navigation bar.
-- Updated GitHub workflows to install the WPF workload instead of the deprecated windowsdesktop workload.
+- CI test job now builds projects before executing to ensure test assemblies are available.
+- Test job now uploads results even when tests fail so failures are visible.
+- Settings page navigation test now shuts down the WPF application on its dispatcher to prevent cross-thread crashes.
+- Resolved ambiguous `Application` reference in settings navigation test when Windows Forms implicit using was enabled.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -9,7 +9,6 @@ Effective Prompts / Instructions that worked: n/a
 Decisions & Rationale: Use DI to share single logging service and helpers.
 Action Items: Monitor CI for Windows-specific behaviors.
 Related Commits/PRs: (this PR)
-
 [2025-08-13 20:41] Topic: WPF workload in CI
 Context: GitHub Actions failed because the `windowsdesktop` workload is no longer recognized.
 Observations: Replacing it with the `wpf` workload restores pipeline compatibility.
@@ -76,4 +75,37 @@ Codex Limitations noticed: none
 Effective Prompts / Instructions that worked: n/a
 Decisions & Rationale: Prefer removing stale classes to reduce maintenance and confusion.
 Action Items: Monitor builds for any lingering references.
+Related Commits/PRs: (this PR)
+[2025-08-13 21:15] Topic: WPF workload install guard
+Context: Running setup on non-Windows environments attempted to install the `wpf` workload and failed.
+Observations: WPF workload is only supported on Windows; attempting installation elsewhere causes errors.
+Codex Limitations noticed: `dotnet` unavailable in container, preventing local validation.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Setup script skips WPF workload installation when `OS` is not `Windows_NT`.
+Action Items: Ensure Windows dev environments continue installing the workload.
+Related Commits/PRs: (this PR)
+[2025-08-13 21:43] Topic: CI test job build
+Context: The `test` job ran `dotnet test` with `--no-build` and failed to find the test assembly.
+Observations: Job checks out fresh code without build artifacts, so Release binaries were missing.
+Codex Limitations noticed: `dotnet` unavailable in container, preventing local execution.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Removed `--no-build` so the test job compiles before running.
+Action Items: Monitor CI performance; consider artifact sharing to avoid redundant builds.
+Related Commits/PRs: (this PR)
+[2025-08-13 22:03] Topic: Remove WPF workload installs
+Context: CI and setup scripts redundantly installed the WPF workload already bundled with .NET 8.
+Observations: Removing install steps simplified the pipeline and setup script, and test job now always uploads results.
+Codex Limitations noticed: dotnet SDK unavailable locally for validation.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Rely on built-in WPF support and surface test failures via artifact upload.
+Action Items: Monitor CI to ensure failures are reported and artifacts persist.
+Related Commits/PRs: (this PR)
+
+[2025-08-14 00:30] Topic: WPF Application ambiguity
+Context: Build failed when both WPF and WinForms implicit usings introduced conflicting `Application` types.
+Observations: Explicitly qualifying the WPF `Application` resolved the ambiguity and restored compilation.
+Codex Limitations noticed: dotnet SDK unavailable locally for validation.
+Effective Prompts / Instructions that worked: Error log pinpointing ambiguous type reference.
+Decisions & Rationale: Alias `System.Windows.Application` and use it directly in the test.
+Action Items: Verify CI builds and tests succeed on Windows runners.
 Related Commits/PRs: (this PR)

--- a/setup.sh
+++ b/setup.sh
@@ -8,18 +8,6 @@ git config core.hooksPath .githooks
 git lfs install
 
 dotnet restore
-
-if [ -z "$SKIP_WORKLOAD" ]; then
-    echo "Checking for wpf workload..."
-    if ! dotnet workload list | grep -q wpf; then
-        echo "Installing wpf workload..."
-        dotnet workload install wpf
-    else
-        echo "wpf workload already installed."
-    fi
-else
-    echo "SKIP_WORKLOAD set - skipping wpf workload installation."
-fi
 dotnet build DesktopApplicationTemplate.sln
 dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
 dotnet test DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj


### PR DESCRIPTION
## Summary
- call `Application.Current.Shutdown` via dispatcher in `SettingsPageNavigationTests`
- note dispatcher shutdown fix in changelog and tips
- alias WPF `Application` to avoid WinForms ambiguity

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689d0005be6083269cdbb3d8d5d930f4