### PR TITLE
feat: add MQTT service options model

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttServiceOptionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceOptionsTests.cs
@@ -1,0 +1,67 @@
+using DesktopApplicationTemplate.UI.Models;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class MqttServiceOptionsTests
+    {
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void Defaults_AreCorrect()
+        {
+            var options = new MqttServiceOptions();
+            Assert.Equal("localhost", options.Host);
+            Assert.Contains(1883, options.Ports);
+            Assert.Equal("mqtt", options.Protocol);
+            Assert.Equal(string.Empty, options.Username);
+            Assert.Equal(string.Empty, options.Password);
+            Assert.Equal("client1", options.ClientId);
+            Assert.Equal(60, options.KeepAlive);
+            Assert.True(options.CleanSession);
+            Assert.Equal(0, options.QoS);
+            Assert.False(options.RetainFlag);
+            Assert.Equal(5, options.ReconnectDelay);
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void Ports_Throws_When_OutOfRange()
+        {
+            var options = new MqttServiceOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.Ports = new[] { 0 });
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.Ports = new[] { 70000 });
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void KeepAlive_Throws_When_OutOfRange()
+        {
+            var options = new MqttServiceOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.KeepAlive = -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.KeepAlive = 70000);
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void QoS_Throws_When_OutOfRange()
+        {
+            var options = new MqttServiceOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.QoS = -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.QoS = 3);
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void ReconnectDelay_Throws_When_OutOfRange()
+        {
+            var options = new MqttServiceOptions();
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.ReconnectDelay = -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => options.ReconnectDelay = 4000);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Models/MqttServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Models/MqttServiceOptions.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+namespace DesktopApplicationTemplate.UI.Models
+{
+    /// <summary>
+    /// Options for configuring MQTT connectivity.
+    /// </summary>
+    public class MqttServiceOptions
+    {
+        private const int MinPort = 1;
+        private const int MaxPort = 65535;
+        private const int MinKeepAlive = 0;
+        private const int MaxKeepAlive = 65535;
+        private const int MinQoS = 0;
+        private const int MaxQoS = 2;
+        private const int MinReconnectDelay = 0;
+        private const int MaxReconnectDelay = 3600;
+
+        private IList<int> _ports = new List<int> { 1883 };
+        private int _keepAlive = 60;
+        private int _qos = 0;
+        private int _reconnectDelay = 5;
+
+        /// <summary>
+        /// Broker host name or IP address.
+        /// </summary>
+        public string Host { get; set; } = "localhost";
+
+        /// <summary>
+        /// TCP ports to connect to. 1883 is standard MQTT; 8883 is MQTT over TLS.
+        /// </summary>
+        public IList<int> Ports
+        {
+            get => _ports;
+            set
+            {
+                if (value == null || value.Count == 0)
+                    throw new ArgumentException("At least one port is required.", nameof(value));
+
+                foreach (var port in value)
+                {
+                    if (port < MinPort || port > MaxPort)
+                        throw new ArgumentOutOfRangeException(nameof(value), $"Port {port} must be between {MinPort} and {MaxPort}.");
+                }
+
+                _ports = value;
+            }
+        }
+
+        /// <summary>
+        /// Connection protocol, e.g., 'mqtt' or 'mqtts'.
+        /// </summary>
+        public string Protocol { get; set; } = "mqtt";
+
+        /// <summary>
+        /// Username for broker authentication.
+        /// </summary>
+        public string Username { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Password for broker authentication.
+        /// </summary>
+        public string Password { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Unique identifier for this client.
+        /// </summary>
+        public string ClientId { get; set; } = "client1";
+
+        /// <summary>
+        /// Path to the Certificate Authority certificate for TLS validation.
+        /// </summary>
+        public string? TlsCaCertificatePath { get; set; }
+
+        /// <summary>
+        /// Path to the client certificate used for TLS authentication.
+        /// </summary>
+        public string? TlsClientCertificatePath { get; set; }
+
+        /// <summary>
+        /// Path to the client private key used for TLS authentication.
+        /// </summary>
+        public string? TlsClientKeyPath { get; set; }
+
+        /// <summary>
+        /// Seconds between keep-alive packets; 0 disables keep-alive.
+        /// </summary>
+        public int KeepAlive
+        {
+            get => _keepAlive;
+            set
+            {
+                if (value < MinKeepAlive || value > MaxKeepAlive)
+                    throw new ArgumentOutOfRangeException(nameof(value), $"KeepAlive must be between {MinKeepAlive} and {MaxKeepAlive} seconds.");
+                _keepAlive = value;
+            }
+        }
+
+        /// <summary>
+        /// When true, the broker discards previous session state on connect.
+        /// </summary>
+        public bool CleanSession { get; set; } = true;
+
+        /// <summary>
+        /// Quality of Service level: 0 (At most once), 1 (At least once), or 2 (Exactly once).
+        /// </summary>
+        public int QoS
+        {
+            get => _qos;
+            set
+            {
+                if (value < MinQoS || value > MaxQoS)
+                    throw new ArgumentOutOfRangeException(nameof(value), $"QoS must be between {MinQoS} and {MaxQoS}.");
+                _qos = value;
+            }
+        }
+
+        /// <summary>
+        /// When true, published messages are retained by the broker.
+        /// </summary>
+        public bool RetainFlag { get; set; }
+
+        /// <summary>
+        /// Last will message sent if the client disconnects unexpectedly.
+        /// </summary>
+        public string? WillMessage { get; set; }
+
+        /// <summary>
+        /// Seconds to wait before attempting to reconnect.
+        /// </summary>
+        public int ReconnectDelay
+        {
+            get => _reconnectDelay;
+            set
+            {
+                if (value < MinReconnectDelay || value > MaxReconnectDelay)
+                    throw new ArgumentOutOfRangeException(nameof(value), $"ReconnectDelay must be between {MinReconnectDelay} and {MaxReconnectDelay} seconds.");
+                _reconnectDelay = value;
+            }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `/test` comment workflow to run CI on demand.
 - Created `CONTRIBUTING.md` and PR template enforcing CI-only testing with a CI badge in the README.
 - Introduced `AsyncRelayCommand` for asynchronous UI actions.
+- Introduced `MqttServiceOptions` for configuring MQTT connection parameters.
 
 ### Changed
 - CI workflow now runs on pushes to `feature/**` and `bugfix/**` branches and supports manual triggers, ensuring tests execute on GitHub.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -77,3 +77,11 @@ Effective Prompts / Instructions that worked: n/a
 Decisions & Rationale: Prefer removing stale classes to reduce maintenance and confusion.
 Action Items: Monitor builds for any lingering references.
 Related Commits/PRs: (this PR)
+[2025-08-14 14:01] Topic: MQTT service options
+Context: Introduced strongly typed options with defaults and bounds for MQTT configuration.
+Observations: Centralizes broker settings and guards against invalid ranges.
+Codex Limitations noticed: Original spec table unavailable; defaults inferred from common MQTT usage.
+Effective Prompts / Instructions that worked: Detailed property list with default and range guidance.
+Decisions & Rationale: Provide options model for future DI and configuration binding.
+Action Items: Wire options into service and configuration pipeline later.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- add `MqttServiceOptions` with defaults and bounds
- test MQTT options validation
- document MQTT options in changelog and tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_689deb8e396483269dfd1c624bea03ec