### PR TITLE
feat: enhance MQTT service options

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
@@ -26,13 +26,63 @@ namespace DesktopApplicationTemplate.Tests
                 .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MqttUserProperty>()));
 
             var service = new MqttService(client.Object);
-            await service.ConnectAsync("host", 1234, "id", null, null);
+            var options = new MqttServiceOptions { Host = "host", Port = 1234, ClientId = "id" };
+            await service.ConnectAsync(options);
             await service.SubscribeAsync(new[] { "topic" });
-            await service.PublishAsync("topic", "msg");
+            await service.PublishAsync("topic", "msg", MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce, true);
 
             client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             client.Verify(c => c.SubscribeAsync(It.Is<MqttClientSubscribeOptions>(o => o.TopicFilters.Any(f => f.Topic == "topic")), It.IsAny<CancellationToken>()), Times.Once);
-            client.Verify(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+            client.Verify(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.QualityOfServiceLevel == MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce && m.Retain == true), It.IsAny<CancellationToken>()), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task ConnectAsync_DisconnectsExistingConnection()
+        {
+            var client = new Mock<IMqttClient>();
+            client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientConnectResult());
+            client.Setup(c => c.DisconnectAsync(It.IsAny<MqttClientDisconnectOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new MqttService(client.Object);
+            var options = new MqttServiceOptions { Host = "host", Port = 1, ClientId = "id" };
+            await service.ConnectAsync(options);
+            await service.ConnectAsync(options);
+
+            client.Verify(c => c.DisconnectAsync(It.IsAny<MqttClientDisconnectOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task DisconnectAsync_UnsubscribesTopics()
+        {
+            var client = new Mock<IMqttClient>();
+            client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientConnectResult());
+            client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), null!, Array.Empty<MqttUserProperty>()));
+            client.Setup(c => c.UnsubscribeAsync(It.IsAny<MqttClientUnsubscribeOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientUnsubscribeResult(0, Array.Empty<MqttClientUnsubscribeResultItem>(), string.Empty, Array.Empty<MqttUserProperty>()));
+            client.Setup(c => c.DisconnectAsync(It.IsAny<MqttClientDisconnectOptions>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            client.SetupGet(c => c.IsConnected).Returns(true);
+
+            var service = new MqttService(client.Object);
+            var options = new MqttServiceOptions { Host = "host", Port = 1, ClientId = "id" };
+            await service.ConnectAsync(options);
+            await service.SubscribeAsync(new[] { "t1" });
+            await service.DisconnectAsync();
+
+            client.Verify(c => c.UnsubscribeAsync(It.Is<MqttClientUnsubscribeOptions>(o => o.TopicFilters.Contains("t1")), It.IsAny<CancellationToken>()), Times.Once);
+            client.Verify(c => c.DisconnectAsync(It.IsAny<MqttClientDisconnectOptions>(), It.IsAny<CancellationToken>()), Times.Once);
 
             ConsoleTestLogger.LogPass();
         }

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -1,8 +1,13 @@
-using MQTTnet;
-using MQTTnet.Client;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Services;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 
 namespace DesktopApplicationTemplate.UI.Services
 {
@@ -10,6 +15,10 @@ namespace DesktopApplicationTemplate.UI.Services
     {
         private readonly IMqttClient _client;
         private readonly ILoggingService? _logger;
+        private readonly HashSet<string> _subscriptions = new();
+        private MqttClientOptions? _clientOptions;
+        private MqttServiceOptions? _serviceOptions;
+        private Func<MqttClientDisconnectedEventArgs, Task>? _reconnectHandler;
 
         public MqttService(ILoggingService? logger = null)
         {
@@ -24,42 +33,170 @@ namespace DesktopApplicationTemplate.UI.Services
             _logger = logger;
         }
 
-        public async Task ConnectAsync(string host, int port, string clientId, string? user, string? pass)
+        public async Task ConnectAsync(MqttServiceOptions options, CancellationToken cancellationToken = default)
         {
+            if (options is null)
+                throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(options.Host))
+                throw new ArgumentException("Host cannot be null or whitespace.", nameof(options));
+
             _logger?.Log("MqttService connect start", LogLevel.Debug);
-            var options = new MqttClientOptionsBuilder()
-                .WithTcpServer(host, port)
-                .WithClientId(clientId);
 
-            if (!string.IsNullOrEmpty(user))
-                options = options.WithCredentials(user, pass);
+            await DisconnectAsync(cancellationToken).ConfigureAwait(false);
 
-            _logger?.Log($"Connecting to MQTT {host}:{port}", LogLevel.Debug);
-            await _client.ConnectAsync(options.Build());
-            _logger?.Log("MQTT connected", LogLevel.Debug);
-            _logger?.Log("MqttService connect finished", LogLevel.Debug);
+            _serviceOptions = options;
+
+            var builder = new MqttClientOptionsBuilder()
+                .WithClientId(options.ClientId)
+                .WithCleanSession(options.CleanSession)
+                .WithKeepAlivePeriod(TimeSpan.FromSeconds(options.KeepAliveSeconds));
+
+            if (options.ConnectionType == MqttConnectionType.WebSocket)
+            {
+                var scheme = options.UseTls ? "wss" : "ws";
+                builder.WithWebSocketServer(p => p.WithUri($"{scheme}://{options.Host}:{options.Port}"));
+            }
+            else
+            {
+                builder.WithTcpServer(options.Host, options.Port);
+                if (options.UseTls)
+                {
+                    builder.WithTlsOptions(o =>
+                    {
+                        o.UseTls();
+                        if (options.ClientCertificate is not null)
+                        {
+                            o.WithClientCertificates(new[] { new X509Certificate2(options.ClientCertificate) });
+                        }
+                    });
+                }
+            }
+
+            if (!string.IsNullOrEmpty(options.Username))
+            {
+                builder.WithCredentials(options.Username, options.Password);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.WillTopic))
+            {
+                builder.WithWillTopic(options.WillTopic)
+                       .WithWillPayload(options.WillPayload ?? string.Empty)
+                       .WithWillQualityOfServiceLevel(options.WillQualityOfService);
+                if (options.WillRetain)
+                {
+                    builder.WithWillRetain();
+                }
+            }
+
+            _clientOptions = builder.Build();
+
+            if (_reconnectHandler is not null)
+            {
+                _client.DisconnectedAsync -= _reconnectHandler;
+            }
+
+            if (options.ReconnectDelay.HasValue)
+            {
+                _reconnectHandler = async e =>
+                {
+                    _logger?.Log("MqttService reconnect start", LogLevel.Debug);
+                    await Task.Delay(options.ReconnectDelay.Value, CancellationToken.None).ConfigureAwait(false);
+                    try
+                    {
+                        await _client.ConnectAsync(_clientOptions!, CancellationToken.None).ConfigureAwait(false);
+                        if (_subscriptions.Count > 0)
+                        {
+                            var subscribeBuilder = new MqttClientSubscribeOptionsBuilder();
+                            foreach (var t in _subscriptions)
+                            {
+                                subscribeBuilder.WithTopicFilter(f => f.WithTopic(t));
+                            }
+                            await _client.SubscribeAsync(subscribeBuilder.Build(), CancellationToken.None).ConfigureAwait(false);
+                        }
+                        _logger?.Log("MqttService reconnect finished", LogLevel.Debug);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.Log($"MqttService reconnect error: {ex.Message}", LogLevel.Error);
+                    }
+                };
+                _client.DisconnectedAsync += _reconnectHandler;
+            }
+
+            try
+            {
+                await _client.ConnectAsync(_clientOptions, cancellationToken).ConfigureAwait(false);
+                _logger?.Log("MqttService connect finished", LogLevel.Debug);
+            }
+            catch (Exception ex)
+            {
+                _logger?.Log($"MqttService connect error: {ex.Message}", LogLevel.Error);
+                throw;
+            }
         }
 
-        public async Task SubscribeAsync(IEnumerable<string> topics)
+        public async Task DisconnectAsync(CancellationToken cancellationToken = default)
+        {
+            _logger?.Log("MqttService disconnect start", LogLevel.Debug);
+            try
+            {
+                if (_subscriptions.Count > 0 && _client.IsConnected)
+                {
+                    var unsubscribeBuilder = new MqttClientUnsubscribeOptionsBuilder();
+                    foreach (var t in _subscriptions)
+                    {
+                        unsubscribeBuilder.WithTopicFilter(t);
+                    }
+                    await _client.UnsubscribeAsync(unsubscribeBuilder.Build(), cancellationToken).ConfigureAwait(false);
+                    _subscriptions.Clear();
+                }
+
+                if (_client.IsConnected)
+                {
+                    await _client.DisconnectAsync(new MqttClientDisconnectOptions(), cancellationToken).ConfigureAwait(false);
+                }
+
+                _logger?.Log("MqttService disconnect finished", LogLevel.Debug);
+            }
+            catch (Exception ex)
+            {
+                _logger?.Log($"MqttService disconnect error: {ex.Message}", LogLevel.Error);
+                throw;
+            }
+        }
+
+        public async Task SubscribeAsync(IEnumerable<string> topics, CancellationToken cancellationToken = default)
         {
             foreach (var t in topics)
             {
                 _logger?.Log($"Subscribing to {t}", LogLevel.Debug);
-                await _client.SubscribeAsync(t);
+                var subscribeOptions = new MqttClientSubscribeOptionsBuilder()
+                    .WithTopicFilter(f => f.WithTopic(t))
+                    .Build();
+                await _client.SubscribeAsync(subscribeOptions, cancellationToken).ConfigureAwait(false);
+                _subscriptions.Add(t);
             }
         }
 
-        public async Task PublishAsync(string topic, string message)
+        public async Task PublishAsync(string topic, string message, MqttQualityOfServiceLevel qos = MqttQualityOfServiceLevel.AtMostOnce, bool retainFlag = false, CancellationToken cancellationToken = default)
         {
             _logger?.Log("MqttService publish start", LogLevel.Debug);
-            _logger?.Log($"Publishing to {topic}", LogLevel.Debug);
-            var msg = new MqttApplicationMessageBuilder()
-                .WithTopic(topic)
-                .WithPayload(message)
-                .Build();
-            await _client.PublishAsync(msg);
-            _logger?.Log("Publish complete", LogLevel.Debug);
-            _logger?.Log("MqttService publish finished", LogLevel.Debug);
+            try
+            {
+                var msg = new MqttApplicationMessageBuilder()
+                    .WithTopic(topic)
+                    .WithPayload(message)
+                    .WithQualityOfServiceLevel(qos)
+                    .WithRetainFlag(retainFlag)
+                    .Build();
+                await _client.PublishAsync(msg, cancellationToken).ConfigureAwait(false);
+                _logger?.Log("MqttService publish finished", LogLevel.Debug);
+            }
+            catch (Exception ex)
+            {
+                _logger?.Log($"MqttService publish error: {ex.Message}", LogLevel.Error);
+                throw;
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/MqttServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttServiceOptions.cs
@@ -1,0 +1,30 @@
+using System;
+using MQTTnet.Protocol;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public enum MqttConnectionType
+    {
+        Tcp,
+        WebSocket
+    }
+
+    public class MqttServiceOptions
+    {
+        public string Host { get; set; } = string.Empty;
+        public int Port { get; set; } = 1883;
+        public string ClientId { get; set; } = string.Empty;
+        public string? Username { get; set; }
+        public string? Password { get; set; }
+        public MqttConnectionType ConnectionType { get; set; } = MqttConnectionType.Tcp;
+        public bool UseTls { get; set; }
+        public byte[]? ClientCertificate { get; set; }
+        public string? WillTopic { get; set; }
+        public string? WillPayload { get; set; }
+        public MqttQualityOfServiceLevel WillQualityOfService { get; set; } = MqttQualityOfServiceLevel.AtMostOnce;
+        public bool WillRetain { get; set; }
+        public ushort KeepAliveSeconds { get; set; } = 60;
+        public bool CleanSession { get; set; } = true;
+        public TimeSpan? ReconnectDelay { get; set; }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -81,7 +81,15 @@ public class MqttServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAw
         public async Task ConnectAsync()
         {
             Logger?.Log("MQTT connect start", LogLevel.Debug);
-            await _service.ConnectAsync(Host, int.Parse(Port), ClientId, Username, Password);
+            var options = new MqttServiceOptions
+            {
+                Host = Host,
+                Port = int.Parse(Port),
+                ClientId = ClientId,
+                Username = string.IsNullOrWhiteSpace(Username) ? null : Username,
+                Password = string.IsNullOrWhiteSpace(Password) ? null : Password
+            };
+            await _service.ConnectAsync(options);
             await _service.SubscribeAsync(Topics);
             Logger?.Log("MQTT connected", LogLevel.Debug);
             Logger?.Log("MQTT connect finished", LogLevel.Debug);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Expanded MQTT service with option-based connections, TLS/WebSocket support, and structured logging.
 - Register `ILoggingService` and helper services with the DI container.
 - Refactored save/close confirmation helpers to use constructor injection.
 - Views now accept `ILoggingService` instances instead of creating loggers.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -9,6 +9,14 @@ Effective Prompts / Instructions that worked: n/a
 Decisions & Rationale: Use DI to share single logging service and helpers.
 Action Items: Monitor CI for Windows-specific behaviors.
 Related Commits/PRs: (this PR)
+[2025-08-14 14:08] Topic: MQTT service options
+Context: Added option-based MQTT service with reconnection and TLS/WebSocket support.
+Observations: MQTTnet API changes required using new builder patterns.
+Codex Limitations noticed: Missing WindowsDesktop runtime prevented executing tests.
+Effective Prompts / Instructions that worked: Following AGENTS.md to attempt local tests and update docs.
+Decisions & Rationale: Centralized connection settings via options and enabled auto-reconnect for resilience.
+Action Items: Ensure environment has WindowsDesktop runtime for full test coverage.
+Related Commits/PRs: (this PR)
 
 [2025-08-13 20:41] Topic: WPF workload in CI
 Context: GitHub Actions failed because the `windowsdesktop` workload is no longer recognized.


### PR DESCRIPTION
## What changed
- support option-based MQTT connections with TLS, WebSocket, will message, and auto reconnect
- add disconnect handling and QoS/retain publish controls
- document MQTT service improvements

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689deb9032908326b6d5b0ef06a58d64