### PR TITLE
Refactor message routing service and streamline workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -47,8 +45,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Test
@@ -70,8 +66,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Verify formatting
@@ -88,8 +82,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - name: Install WPF workload
-        run: dotnet workload install wpf
       - name: Restore
         run: dotnet restore
       - name: Publish

--- a/.github/workflows/comment-test.yml
+++ b/.github/workflows/comment-test.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
-      - run: dotnet workload install wpf
       - run: dotnet restore
       - run: dotnet build -c Release --no-restore /warnaserror
       - run: dotnet test -c Release --no-build --logger "trx;LogFileName=test.trx"

--- a/DesktopApplicationTemplate.Tests/MessageRoutingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MessageRoutingServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using Xunit;
 
@@ -24,6 +25,29 @@ namespace DesktopApplicationTemplate.Tests
             var routing = new MessageRoutingService();
             var result = routing.ResolveTokens("{missing.Message}");
             Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        public void UpdateMessage_Throws_WhenServiceNameNullOrWhitespace()
+        {
+            var routing = new MessageRoutingService();
+
+            Assert.Throws<ArgumentException>(() => routing.UpdateMessage(" ", "msg"));
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        public void TryGetMessage_ReturnsLatestMessage()
+        {
+            var routing = new MessageRoutingService();
+            routing.UpdateMessage("svc", "first");
+            routing.UpdateMessage("svc", "second");
+
+            var found = routing.TryGetMessage("svc", out var message);
+
+            Assert.True(found);
+            Assert.Equal("second", message);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IMessageRoutingService.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Provides methods to track the latest messages per service and resolve token placeholders.
+    /// </summary>
+    public interface IMessageRoutingService
+    {
+        /// <summary>
+        /// Updates the latest message for the specified service.
+        /// </summary>
+        /// <param name="serviceName">The service name.</param>
+        /// <param name="message">The message to store.</param>
+        void UpdateMessage(string serviceName, string message);
+
+        /// <summary>
+        /// Attempts to retrieve the latest message for a service.
+        /// </summary>
+        /// <param name="serviceName">The service name.</param>
+        /// <param name="message">The stored message if found.</param>
+        /// <returns><c>true</c> if a message is registered; otherwise, <c>false</c>.</returns>
+        bool TryGetMessage(string serviceName, out string? message);
+
+        /// <summary>
+        /// Resolves <c>{ServiceName.Message}</c> tokens within the provided template.
+        /// </summary>
+        /// <param name="template">The template containing tokens.</param>
+        /// <returns>The template with tokens replaced by registered messages.</returns>
+        string ResolveTokens(string template);
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MessageRoutingService.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
@@ -6,21 +5,6 @@ using DesktopApplicationTemplate.Core.Services;
 
 namespace DesktopApplicationTemplate.UI.Services
 {
-    /// <summary>
-    /// Provides a simple mechanism for routing messages between services.
-    /// </summary>
-    public class MessageRoutingService
-    {
-        private readonly ILoggingService _logger;
-
-        public MessageRoutingService(ILoggingService logger)
-    public interface IMessageRoutingService
-    {
-        void UpdateMessage(string serviceName, string message);
-        bool TryGetMessage(string serviceName, out string? message);
-        string ResolveTokens(string template);
-    }
-
     /// <summary>
     /// Tracks latest messages per service and resolves token placeholders.
     /// </summary>
@@ -30,23 +14,16 @@ namespace DesktopApplicationTemplate.UI.Services
         private readonly ILoggingService? _logger;
         private static readonly Regex TokenRegex = new(@"\{([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageRoutingService"/> class.
+        /// </summary>
+        /// <param name="logger">Optional logging service.</param>
         public MessageRoutingService(ILoggingService? logger = null)
         {
             _logger = logger;
         }
 
-        /// <summary>
-        /// Routes a message from a source service to a destination service.
-        /// </summary>
-        /// <param name="source">The originating service.</param>
-        /// <param name="destination">The target service.</param>
-        /// <param name="message">The message to route.</param>
-        public void Route(string source, string destination, string message)
-        {
-            _logger.Log($"Routing message from {source} to {destination}", LogLevel.Debug);
-            MessageForwarder.Forward(destination, message);
-            _logger.Log("Message routed", LogLevel.Debug);
-        }
+        /// <inheritdoc/>
         public void UpdateMessage(string serviceName, string message)
         {
             if (string.IsNullOrWhiteSpace(serviceName))
@@ -56,15 +33,17 @@ namespace DesktopApplicationTemplate.UI.Services
             _logger?.Log($"Updated message for {serviceName}", LogLevel.Debug);
         }
 
+        /// <inheritdoc/>
         public bool TryGetMessage(string serviceName, out string? message)
             => _messages.TryGetValue(serviceName, out message);
 
+        /// <inheritdoc/>
         public string ResolveTokens(string template)
         {
             if (template is null)
                 throw new ArgumentNullException(nameof(template));
 
-            string result = TokenRegex.Replace(template, m =>
+            var result = TokenRegex.Replace(template, m =>
             {
                 var name = m.Groups[1].Value;
                 return _messages.TryGetValue(name, out var msg) ? msg : string.Empty;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,11 +28,13 @@
 - `self-heal` workflow now monitors the unified `CI` pipeline.
 - `TcpServiceViewModel` now evaluates scripts asynchronously and streamlined server toggle logging.
 - Refactored `MqttService` with a single options-based constructor, clean reconnect logic, and consolidated publish methods.
+- Simplified `MessageRoutingService` with a dedicated interface and thread-safe message tracking.
 
 ### Removed
 - Placeholder "Desktop Template" text from the navigation bar.
 - Legacy GitHub workflows (`dotnet.yml`, `dotnet-desktop-ci.yml`, `ci.yml`).
 - Unused `RichTextLogger` service and installer `CustomControl1` control.
+- WPF workload installation steps in GitHub workflows now that .NET 8 includes WPF.
 
 ### Fixed
 - Corrected logo resource path so the image renders in the navigation bar.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -159,3 +159,11 @@ Decisions & Rationale: Provide options model for future DI and configuration bin
 Action Items: Wire options into service and configuration pipeline later.
 
 Related Commits/PRs: (this PR)
+[2025-08-14 15:59] Topic: Message routing service cleanup
+Context: Refactored message routing service to remove legacy route method and expose interface; simplified workflows by dropping explicit WPF workload installation.
+Observations: .NET 8 SDK already includes WPF; ConcurrentDictionary ensures thread safety.
+Codex Limitations noticed: none
+Effective Prompts / Instructions that worked: Guidance to remove redundant workload installs.
+Decisions & Rationale: Introduced IMessageRoutingService and optional logging; rely on built-in WPF workload in SDK to streamline CI.
+Action Items: Monitor CI for future SDK changes.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## Summary
- refactor message routing service with new interface, optional logging, and thread-safe updates
- add unit tests for message routing
- drop redundant WPF workload installation from CI workflows

## Testing
- `dotnet test DesktopApplicationTemplate.sln --settings tests.runsettings` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e076874588326bb76156ef09042de