### PR TITLE
Prevent CSV log recursion and guard configuration saves

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -93,5 +93,36 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void AppendRow_WithoutIndexPlaceholder_UsesSingleFile()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
+                var vm = new CsvViewerViewModel(configPath);
+
+                var filePath = Path.Combine(tempDir, "output.csv");
+                vm.Configuration.FileNamePattern = filePath;
+                var service = new CsvService(vm);
+
+                service.AppendRow(new[] { "x", "y" });
+                service.AppendRow(new[] { "z", "w" });
+
+                Assert.True(File.Exists(filePath));
+                var files = Directory.GetFiles(tempDir, "*.csv");
+                Assert.Single(files);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.Tests/CsvViewerViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvViewerViewModelTests.cs
@@ -27,4 +27,24 @@ public class CsvViewerViewModelTests
             }
         }
     }
+
+#if DEBUG
+    [Fact]
+    public void DebugSaveCommand_WritesConfiguration()
+    {
+        var temp = Path.GetTempFileName();
+        try
+        {
+            var vm = new CsvViewerViewModel(temp);
+            vm.Configuration.Columns.Clear();
+            vm.DebugSaveCommand.Execute(null);
+            File.Exists(temp).Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(temp))
+                File.Delete(temp);
+        }
+    }
+#endif
 }

--- a/DesktopApplicationTemplate.UI/Services/CsvService.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvService.cs
@@ -11,14 +11,12 @@ namespace DesktopApplicationTemplate.UI.Services
     public class CsvService
     {
         private readonly CsvViewerViewModel _viewModel;
-        private readonly ILoggingService? _logger;
         private int _index = 0;
         private bool _headerWritten;
 
-        public CsvService(CsvViewerViewModel vm, ILoggingService? logger = null)
+        public CsvService(CsvViewerViewModel vm)
         {
             _viewModel = vm;
-            _logger = logger;
         }
 
         public void EnsureColumnsForService(string serviceName)
@@ -26,13 +24,11 @@ namespace DesktopApplicationTemplate.UI.Services
             if (!_viewModel.Configuration.Columns.Any(c => c.Name == serviceName))
             {
                 _viewModel.Configuration.Columns.Add(new CsvColumnConfig { Name = serviceName, Service = serviceName });
-                _logger?.Log($"Added CSV column for service {serviceName}", LogLevel.Debug);
             }
             string sent = $"{serviceName} Sent";
             if (!_viewModel.Configuration.Columns.Any(c => c.Name == sent))
             {
                 _viewModel.Configuration.Columns.Add(new CsvColumnConfig { Name = sent, Service = serviceName });
-                _logger?.Log($"Added CSV column for service {sent}", LogLevel.Debug);
             }
             _viewModel.Save();
         }
@@ -46,7 +42,6 @@ namespace DesktopApplicationTemplate.UI.Services
             foreach (var col in toRemove)
             {
                 _viewModel.Configuration.Columns.Remove(col);
-                _logger?.Log($"Removed CSV column {col.Name}", LogLevel.Debug);
             }
             if (toRemove.Count > 0)
             {
@@ -66,7 +61,6 @@ namespace DesktopApplicationTemplate.UI.Services
             if (index >= 0)
                 columns[index] = message.Replace(',', ' ');
             AppendRow(columns);
-            _logger?.Log($"Recorded log for {serviceName}: {message}", LogLevel.Debug);
         }
 
         public void AppendRow(IEnumerable<string?> values)
@@ -74,7 +68,6 @@ namespace DesktopApplicationTemplate.UI.Services
             string fileName = BuildFileName();
             var line = string.Join(',', values.Select(v => v ?? string.Empty));
             File.AppendAllText(fileName, line + System.Environment.NewLine, Encoding.UTF8);
-            _logger?.Log($"Appended row to {fileName}", LogLevel.Debug);
         }
 
         private void EnsureHeader()
@@ -86,7 +79,6 @@ namespace DesktopApplicationTemplate.UI.Services
             {
                 var header = string.Join(',', _viewModel.Configuration.Columns.Select(c => c.Name));
                 File.AppendAllText(fileName, header + System.Environment.NewLine, Encoding.UTF8);
-                _logger?.Log($"Wrote CSV header to {fileName}", LogLevel.Debug);
             }
             _headerWritten = true;
         }
@@ -95,7 +87,7 @@ namespace DesktopApplicationTemplate.UI.Services
         {
             string pattern = _viewModel.Configuration.FileNamePattern;
             string name = pattern.Replace("{index}", _index.ToString());
-            if (!name.Contains("{index}"))
+            if (pattern.Contains("{index}"))
                 _index++;
             return name;
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -15,6 +15,7 @@ using WpfBrushes = System.Windows.Media.Brushes;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.Core.Services;
+using System.Text.Json.Serialization;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -22,7 +23,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         public string DisplayName { get; set; } = string.Empty;
         public string ServiceType { get; set; } = string.Empty;
-        public Page? Page { get; set; }
+        [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 
         private WpfBrush _backgroundColor = WpfBrushes.LightGray;
@@ -38,7 +39,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _borderColor;
             set { _borderColor = value; OnPropertyChanged(); }
         }
-        public Page? ServicePage { get; set; }
+        [JsonIgnore] public Page? ServicePage { get; set; }
 
         public ObservableCollection<string> AssociatedServices { get; } = new();
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,3 +53,7 @@
 - Guarded CSV viewer configuration serialization to prevent stack overflow when saving empty data.
 - Main window sizes to content so UI elements are no longer clipped at the edges.
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.
+- Service and settings persistence now ignore reference cycles during JSON serialization to avoid stack overflow when saving configuration.
+- CSV service now increments file index only when `FileNamePattern` contains `{index}`.
+- Added tests confirming the main view ignores non-Escape key presses and service persistence handles cyclical references.
+- Eliminated recursive logging in CSV service to prevent stack overflow and added guards that capture configuration snapshots on save failures.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -96,3 +96,30 @@ Effective Prompts / Instructions that worked: Reviewing AGENTS and project files
 Decisions & Rationale: Verify `.csproj` files for needed packages and read AGENTS instructions before coding.
 Action Items: Add package references when introducing new libraries and document dependency checks in changelog.
 Related Commits/PRs: (this PR)
+[2025-08-14 19:14] Topic: Reference-safe configuration saves
+Context: Avoided stack overflow during configuration persistence by guarding JSON serialization.
+Observations: Used ReferenceHandler.IgnoreCycles for settings and service persistence to prevent recursive writes when CSV configuration updates.
+Codex Limitations noticed: PowerShell unavailable; appended entry manually.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Standardize cycle-safe JSON options across services.
+Action Items: Monitor CI for serialization regressions.
+Related Commits/PRs: (this PR)
+
+
+[2025-08-17 12:00] Topic: CSV file naming and key handling
+Context: Adjusted CSV service file naming to respect `{index}` placeholder and confirmed main window only responds to Escape key.
+Observations: Incrementing index only when placeholder is present prevents runaway file creation; added regression tests for key handling and cyclic service persistence.
+Codex Limitations noticed: Linux environment lacks WPF runtime, preventing full test execution.
+Effective Prompts / Instructions that worked: Reviewing AGENTS instructions and prior changelog before editing.
+Decisions & Rationale: Follow placeholder presence to advance index and ensure keyboard events remain scoped to Escape.
+Action Items: Rely on CI to execute Windows-specific tests.
+Related Commits/PRs: (this PR)
+
+[2025-08-17 18:00] Topic: CSV logging recursion
+Context: Stack overflow occurred when CSV service logged its own writes.
+Observations: Logging within CsvService re-entered LoggingService and triggered infinite RecordLog loops.
+Codex Limitations noticed: cannot catch StackOverflowException reliably; rely on snapshot then fail fast.
+Effective Prompts / Instructions that worked: request to wrap saves and add debug command.
+Decisions & Rationale: Removed internal logging from CsvService and added serialization guards producing dump files on overflow.
+Action Items: Use DebugSaveCommand for minimal reproduction and examine dump files if Environment.FailFast is triggered.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- stop CsvService from logging its own writes to avoid recursive log loops
- add fail-fast guards and debug dump generation when saving CSV config, settings, or services
- expose `DebugSaveCommand` for CSV viewer to reproduce save issues under test
- annotate service navigation properties with `JsonIgnore`
- document stack overflow mitigation in changelog and collaboration tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e3431e4ec832686b0ae9fb0861e6b