### PR TITLE
Disable auto-start by default

### DIFF
--- a/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/StartupServiceTests.cs
@@ -40,5 +40,28 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void AutoStart_DefaultsToFalse_WhenNotConfigured()
+        {
+            var inMemorySettings = new Dictionary<string, string?>
+            {
+                {"AppSettings:Environment", "Test"}
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(inMemorySettings)
+                .Build();
+
+            var startupService = new StartupService(configuration);
+
+            AppSettings settings = startupService.GetSettings();
+
+            Assert.False(settings.AutoStart);
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Configuration/appsettings.Beta.json
+++ b/DesktopApplicationTemplate.UI/Configuration/appsettings.Beta.json
@@ -3,6 +3,6 @@
   "ServerIP": "10.0.0.20",
   "ServerPort": 9010,
   "LogLevel": "Warning",
-  "AutoStart": true,
+  "AutoStart": false,
   "DefaultCSharpScriptPath": "Scripts/beta_script.cs"
 }

--- a/DesktopApplicationTemplate.UI/Configuration/appsettings.Production.json
+++ b/DesktopApplicationTemplate.UI/Configuration/appsettings.Production.json
@@ -3,6 +3,6 @@
   "ServerIP": "10.0.0.100",
   "ServerPort": 9020,
   "LogLevel": "Error",
-  "AutoStart": true,
+  "AutoStart": false,
   "DefaultCSharpScriptPath": "Scripts/prod_script.cs"
 }

--- a/DesktopApplicationTemplate.UI/Models/AppSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/AppSettings.cs
@@ -18,7 +18,7 @@ namespace DesktopApplicationTemplate.UI.Models
         public string LogLevel { get; set; } = "Debug";
 
         /// <summary>Gets or sets a value indicating whether services should start automatically.</summary>
-        public bool AutoStart { get; set; } = true;
+        public bool AutoStart { get; set; } = false;
 
         /// <summary>Gets or sets the path for the default C# script.</summary>
         public string DefaultCSharpScriptPath { get; set; } = string.Empty;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Integrated `CsvServiceView` page, embedding CSV Creator configuration within the main window.
 
 ### Changed
+- Default `AutoStart` is now disabled and all environment configuration files set `"AutoStart": false`.
 - CI workflow now runs on pushes to `feature/**` and `bugfix/**` branches and supports manual triggers, ensuring tests execute on GitHub.
 - `self-heal` workflow now monitors the unified `CI` pipeline.
 - `TcpServiceViewModel` now evaluates scripts asynchronously and streamlined server toggle logging.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -158,3 +158,12 @@ Effective Prompts / Instructions that worked: Reusing existing window layout ens
 Decisions & Rationale: Align CSV Creator with other services to simplify navigation.
 Action Items: Monitor CI for UI test reliability.
 Related Commits/PRs: (this PR)
+[2025-08-15 17:51] Topic: Auto-start default
+Context: AppSettings and configuration files now default AutoStart to disabled.
+Observations: StartupService leaves auto-start disabled unless explicitly enabled.
+Codex Limitations noticed: PowerShell unavailable; tip appended manually.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Disable auto-start by default to prevent unintended application launches.
+Action Items: Rely on CI to validate registry updates on Windows.
+Related Commits/PRs: (this PR)
+


### PR DESCRIPTION
## What changed
- Disable `AutoStart` by default in `AppSettings`
- Align environment configuration files with `"AutoStart": false`
- Add unit test ensuring startup settings keep auto-start disabled
- Document default auto-start change

## Validation
- [ ] All tests pass *(`dotnet` SDK unavailable; `dotnet test --settings tests.runsettings` failed)*
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code

------
https://chatgpt.com/codex/tasks/task_e_689f7317d95083269c58b44bcaad851c