### PR TITLE
Persist log entries across restarts with reload support

### DIFF
--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -90,5 +90,40 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("WindowsSafe")]
+        public async Task Reload_ReplaysEntriesFromExistingFile()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                var first = new LoggingService(new Mock<IRichTextLogger>().Object, path);
+                first.Log("persisted", LogLevel.Error);
+                await Task.Delay(50);
+
+                var uiLogger = new Mock<IRichTextLogger>();
+                var second = new LoggingService(uiLogger.Object, path);
+                var entries = new List<LogEntry>();
+                second.LogAdded += e => entries.Add(e);
+
+                second.Reload();
+
+                Assert.Contains(entries, e => e.Message.Contains("persisted"));
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(path))
+                        File.Delete(path);
+                }
+                catch
+                {
+                }
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -22,7 +22,7 @@ namespace DesktopApplicationTemplate.UI.Services
             {
                 _minimumLevel = value;
                 Log($"Minimum level changed to {value}", LogLevel.Debug);
-                UpdateLogDisplay();
+                Reload();
             }
         }
 
@@ -32,6 +32,7 @@ namespace DesktopApplicationTemplate.UI.Services
         {
             _richTextLogger = richTextLogger;
             _logFilePath = logFilePath;
+            Reload();
         }
 
         public void Log(string message, LogLevel level)
@@ -63,6 +64,61 @@ namespace DesktopApplicationTemplate.UI.Services
             LogLevel.Critical => System.Windows.Media.Brushes.DarkRed,
             _ => System.Windows.Media.Brushes.Black
         };
+
+        public void Reload()
+        {
+            _logEntries.Clear();
+            try
+            {
+                if (File.Exists(_logFilePath))
+                {
+                    foreach (var line in File.ReadLines(_logFilePath))
+                    {
+                        if (string.IsNullOrWhiteSpace(line))
+                            continue;
+                        var entry = ParseLine(line);
+                        _logEntries.Add(entry);
+                    }
+                }
+            }
+            catch
+            {
+                // ignore loading errors
+            }
+
+            UpdateLogDisplay();
+            foreach (var entry in _logEntries.Where(e => e.Level >= MinimumLevel))
+            {
+                LogAdded?.Invoke(entry);
+            }
+        }
+
+        private static LogEntry ParseLine(string line)
+        {
+            var level = LogLevel.Debug;
+            try
+            {
+                var firstClose = line.IndexOf(']');
+                var secondOpen = line.IndexOf('[', firstClose + 1);
+                var secondClose = line.IndexOf(']', secondOpen + 1);
+                if (secondOpen >= 0 && secondClose > secondOpen)
+                {
+                    var levelText = line.Substring(secondOpen + 1, secondClose - secondOpen - 1);
+                    Enum.TryParse(levelText, out level);
+                }
+            }
+            catch
+            {
+                // ignore parsing errors
+            }
+
+            return new LogEntry
+            {
+                Message = line,
+                Level = level,
+                Color = LevelToColor(level)
+            };
+        }
 
         private void UpdateLogDisplay()
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -178,6 +178,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             Filters.PropertyChanged += (_, __) => ApplyFilters();
             LoadServices();
             ApplyFilters();
+            if (_logger is LoggingService concreteLogger)
+            {
+                concreteLogger.Reload();
+            }
         }
 
         private void ApplyNetworkConfiguration(NetworkConfiguration config)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Introduced `MqttServiceOptions` for configuring MQTT connection parameters.
 - Unit tests covering default service name generation for all service types.
 - Integrated `CsvServiceView` page, embedding CSV Creator configuration within the main window.
+- Logging service loads existing log file on startup and can reload entries when the minimum level changes.
 
 ### Changed
 - Updated `global.json` to require the .NET 8 SDK version `8.0.404`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -176,3 +176,12 @@ Decisions & Rationale: Ensure consistent SDK version across developers and CI.
 Action Items: Install .NET SDK 8.0.404 locally and validate tests on Windows CI.
 Related Commits/PRs: (this PR)
 
+[2025-08-19 00:00] Topic: Log reload behavior
+Context: Logging service now reloads previous session entries and respects minimum level changes.
+Observations: Replaying log file entries keeps UI history after restart.
+Codex Limitations noticed: None
+Effective Prompts / Instructions that worked: Specifying constructor loading and reload method.
+Decisions & Rationale: Read log file at startup and expose reload for level filter updates.
+Action Items: Monitor duplicate entries when reloading filters.
+Related Commits/PRs: (this PR)
+


### PR DESCRIPTION
## What changed
- Load existing log file on LoggingService construction and expose `Reload` to replay entries
- Reload logs when minimum level changes and on MainViewModel startup
- Add regression test ensuring logs survive service restart
- Document log reload behavior

## Validation
- `dotnet test --settings tests.runsettings` *(fails: property 'MouseDoubleClick' not in WPF namespace)*

------
https://chatgpt.com/codex/tasks/task_e_689f8a0d907c8326bac401e5c7546fe1