### PR TITLE
fix: add MQTT QoS enum using

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MqttCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttCreateServiceViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
+using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,3 +76,4 @@
 - Removed invalid `MouseDoubleClick` XAML handler and cleaned up ambiguous WPF references causing build failures.
 - Corrected service count bindings to use one-way mode, preventing runtime errors on read-only properties.
 - Resolved WPF build error by removing duplicate StackPanel from `MqttCreateServiceView` so the page hosts a single `ScrollViewer`.
+- Added missing `MQTTnet.Protocol` using in `MqttCreateServiceViewModel` to restore `MqttQualityOfServiceLevel` references.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -295,3 +295,12 @@ Effective Prompts / Instructions that worked: Following merge instructions to en
 Decisions & Rationale: Keep ScrollViewer with Grid as the sole content to maintain layout.
 Action Items: Monitor CI for other XAML compilation issues.
 Related Commits/PRs: (this PR)
+
+[2025-08-19 15:10] Topic: Mqtt QoS enum namespace
+Context: Build failed because `MqttCreateServiceViewModel` lacked the `MQTTnet.Protocol` import.
+Observations: Adding the using directive restored `MqttQualityOfServiceLevel` references.
+Codex Limitations noticed: `dotnet test` exposed additional WPF compile errors on Linux.
+Effective Prompts / Instructions that worked: n/a
+Decisions & Rationale: Ensure files referencing MQTT enums include `MQTTnet.Protocol`.
+Action Items: Rely on CI for full Windows validation.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- add missing `MQTTnet.Protocol` import to `MqttCreateServiceViewModel`
- document fix in changelog and collaboration tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: MqttEditConnectionView missing Owner/ShowDialog; requires CI on Windows)*

------
https://chatgpt.com/codex/tasks/task_e_68a492af082c8326bc854ac89a087eb0