### PR TITLE
Register MQTT views and file dialog helper

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -46,6 +46,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<IRichTextLogger, NullRichTextLogger>();
             services.AddSingleton<ILoggingService, LoggingService>();
             services.AddSingleton<IMessageRoutingService, MessageRoutingService>();
+            services.AddSingleton<IFileDialogService, FileDialogService>();
             services.AddSingleton<SaveConfirmationHelper>();
             services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<MainViewModel>();
@@ -63,22 +64,22 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<HidViewModel>();
             services.AddSingleton<HidViews>();
             services.AddSingleton<MqttService>();
-            services.AddSingleton<MqttTagSubscriptionsView>();
-            services.AddSingleton<MqttTagSubscriptionsViewModel>();
             services.AddSingleton<FTPServiceView>();
             services.AddSingleton<FtpServiceViewModel>();
             services.AddSingleton<CsvViewerViewModel>();
             services.AddSingleton<CsvService>();
             services.AddSingleton<CsvServiceView>();
             services.AddSingleton<SettingsViewModel>();
-            services.AddTransient<MqttEditConnectionView>();
-            services.AddTransient<MqttEditConnectionViewModel>();
             services.AddTransient<SplashWindow>();
             services.AddTransient<CreateServiceWindow>();
             services.AddTransient<CreateServicePage>();
             services.AddTransient<CreateServiceViewModel>();
             services.AddTransient<MqttCreateServiceView>();
             services.AddTransient<MqttCreateServiceViewModel>();
+            services.AddTransient<MqttEditConnectionView>();
+            services.AddTransient<MqttEditConnectionViewModel>();
+            services.AddTransient<MqttTagSubscriptionsView>();
+            services.AddTransient<MqttTagSubscriptionsViewModel>();
             services.AddTransient<SettingsPage>();
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,11 +33,13 @@
 - MQTT view model now exposes will-message and connection options with validation and bindings in create/edit views.
 - Dedicated window for editing MQTT connection settings with update, cancel, and unsubscribe commands accessible from the topic subscription view.
 - MqttTagSubscriptionsView and view model for managing MQTT topic subscriptions displayed when adding new MQTT services.
+- File dialog service registered for TLS certificate selection in MQTT views.
 
 ### Changed
 - Updated `global.json` to require the .NET 8 SDK version `8.0.404`.
 - Default `AutoStart` is now disabled and all environment configuration files set `"AutoStart": false`.
 - CI workflow now runs on pushes to `feature/**` and `bugfix/**` branches and supports manual triggers, ensuring tests execute on GitHub.
+- `MqttCreateServiceView`, `MqttTagSubscriptionsView`, and `MqttEditConnectionView` along with their view models are now registered as transient services.
 - `self-heal` workflow now monitors the unified `CI` pipeline.
 - `TcpServiceViewModel` now evaluates scripts asynchronously and streamlined server toggle logging.
 - Refactored `MqttService` with a single options-based constructor, clean reconnect logic, and consolidated publish methods.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -312,3 +312,11 @@ Effective Prompts / Instructions that worked: Following AGENTS instructions to u
 Decisions & Rationale: Preserve existing event handlers while swapping views and save services after edits.
 Action Items: Ensure CI covers MQTT edit scenarios.
 Related Commits/PRs: (this PR)
+[2025-08-20 16:00] Topic: MQTT view registrations
+Context: Ensured new MQTT views and view models use transient lifetime and added file dialog helper to DI.
+Observations: Transient registration prevents state leakage; file picker service supports TLS certificate selection.
+Codex Limitations noticed: none
+Effective Prompts / Instructions that worked: Following AGENTS guidance and user request.
+Decisions & Rationale: Use transient lifetimes for views/view models and provide IFileDialogService for TLS cert browsing.
+Action Items: Monitor CI for DI regressions.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## Summary
- register file dialog service for TLS certificate browsing
- register MQTT creation, subscription, and connection edit views and viewmodels as transients
- document MQTT DI updates

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a49806395483268cd77c61f11467f7