### PR TITLE
feat: add mqtt subscription feedback

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
@@ -1,11 +1,15 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Moq;
 using MQTTnet.Client;
+using MQTTnet.Protocol;
+using MQTTnet.Packets;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -23,6 +27,10 @@ public class MqttTagSubscriptionsViewModelTests
             .ReturnsAsync(new MqttClientConnectResult());
         client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
+        client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
+        client.Setup(c => c.UnsubscribeAsync(It.IsAny<MqttClientUnsubscribeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MqttClientUnsubscribeResult(0, Array.Empty<MqttClientUnsubscribeResultItem>(), null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
         var service = new MqttService(client.Object, options, routing.Object, logger);
         return new MqttTagSubscriptionsViewModel(service);
     }
@@ -52,9 +60,8 @@ public class MqttTagSubscriptionsViewModelTests
         client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
         var vm = CreateViewModel(client);
-        vm.Topics.Add("t");
-        vm.SelectedTopic = "t";
-        vm.TestMessage = "m";
+        vm.Subscriptions.Add(new TagSubscription { Topic = "t", OutgoingMessage = "m" });
+        vm.SelectedSubscription = vm.Subscriptions.First();
         await vm.PublishTestAsync();
         client.Verify(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "t"), It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -74,37 +81,69 @@ public class MqttTagSubscriptionsViewModelTests
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public void AddTopic_AddsTopicAndClearsInput()
+    public async Task AddTopic_AddsSubscriptionAndClearsInput()
     {
         if (!OperatingSystem.IsWindows()) return;
         var vm = CreateViewModel();
         vm.NewTopic = "topic";
-        vm.AddTopicCommand.Execute(null);
-        Assert.Contains("topic", vm.Topics);
+        await vm.AddTopicAsync();
+        Assert.Contains(vm.Subscriptions, s => s.Topic == "topic");
         Assert.Equal(string.Empty, vm.NewTopic);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public void AddTopic_IgnoresEmptyInput()
+    public async Task AddTopic_IgnoresEmptyInput()
     {
         if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
+        var client = new Mock<IMqttClient>();
+        var vm = CreateViewModel(client);
         vm.NewTopic = "   ";
-        vm.AddTopicCommand.Execute(null);
-        Assert.Empty(vm.Topics);
+        await vm.AddTopicAsync();
+        client.Verify(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Empty(vm.Subscriptions);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public void RemoveTopic_RemovesSelectedTopic()
+    public async Task RemoveTopic_RemovesSelectedSubscription()
     {
         if (!OperatingSystem.IsWindows()) return;
         var vm = CreateViewModel();
-        vm.Topics.Add("t");
-        vm.SelectedTopic = "t";
-        vm.RemoveTopicCommand.Execute(null);
-        Assert.Empty(vm.Topics);
-        Assert.Null(vm.SelectedTopic);
+        vm.Subscriptions.Add(new TagSubscription { Topic = "t" });
+        vm.SelectedSubscription = vm.Subscriptions.First();
+        await vm.RemoveTopicAsync();
+        Assert.Empty(vm.Subscriptions);
+        Assert.Null(vm.SelectedSubscription);
+    }
+
+    [Fact]
+    [TestCategory("WindowsSafe")]
+    public async Task AddTopicAsync_RecordsSuccessResult()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var client = new Mock<IMqttClient>();
+        client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), null!, Array.Empty<MqttUserProperty>()));
+        var vm = CreateViewModel(client);
+        vm.NewTopic = "a";
+        await vm.AddTopicAsync();
+        client.Verify(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(vm.SubscriptionResults, r => r.Topic == "a" && r.IsSuccess);
+    }
+
+    [Fact]
+    [TestCategory("WindowsSafe")]
+    public async Task AddTopicAsync_RecordsFailureResult()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var client = new Mock<IMqttClient>();
+        client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("fail"));
+        var vm = CreateViewModel(client);
+        vm.NewTopic = "a";
+        await vm.AddTopicAsync();
+        Assert.Contains(vm.SubscriptionResults, r => r.Topic == "a" && !r.IsSuccess);
+        Assert.Empty(vm.Subscriptions);
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml
+++ b/DesktopApplicationTemplate.UI/App.xaml
@@ -6,6 +6,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/ToggleSwitch.xaml" />
                 <ResourceDictionary Source="Themes/BubblyWindow.xaml" />
+                <ResourceDictionary Source="Themes/MqttTagSubscriptionsView.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <Style TargetType="TextBox">
                 <Setter Property="Height" Value="24" />

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -34,6 +34,7 @@
     <Resource Include="Themes/LightTheme.xaml" />
     <Resource Include="Themes/DarkTheme.xaml" />
     <Resource Include="Themes/ToggleSwitch.xaml" />
+    <Resource Include="Themes/MqttTagSubscriptionsView.xaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopApplicationTemplate.UI/Models/SubscriptionResult.cs
+++ b/DesktopApplicationTemplate.UI/Models/SubscriptionResult.cs
@@ -1,0 +1,32 @@
+namespace DesktopApplicationTemplate.UI.Models;
+
+/// <summary>
+/// Represents the outcome of a subscription attempt.
+/// </summary>
+public class SubscriptionResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubscriptionResult"/> class.
+    /// </summary>
+    public SubscriptionResult(string topic, bool isSuccess, string message)
+    {
+        Topic = topic;
+        IsSuccess = isSuccess;
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets the topic involved in the subscription.
+    /// </summary>
+    public string Topic { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the subscription succeeded.
+    /// </summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets the message to display.
+    /// </summary>
+    public string Message { get; }
+}

--- a/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
+++ b/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel;
+using MQTTnet.Protocol;
+
+namespace DesktopApplicationTemplate.UI.Models;
+
+/// <summary>
+/// Represents a topic subscription with QoS and an outgoing test message.
+/// </summary>
+public class TagSubscription : INotifyPropertyChanged
+{
+    private string _topic = string.Empty;
+    private MqttQualityOfServiceLevel _qos;
+    private string _outgoingMessage = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the topic.
+    /// </summary>
+    public string Topic
+    {
+        get => _topic;
+        set
+        {
+            if (_topic == value) return;
+            _topic = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Topic)));
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the quality of service level.
+    /// </summary>
+    public MqttQualityOfServiceLevel QoS
+    {
+        get => _qos;
+        set
+        {
+            if (_qos == value) return;
+            _qos = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(QoS)));
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the outgoing message used for test publishing.
+    /// </summary>
+    public string OutgoingMessage
+    {
+        get => _outgoingMessage;
+        set
+        {
+            if (_outgoingMessage == value) return;
+            _outgoingMessage = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OutgoingMessage)));
+        }
+    }
+
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+}

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.Options;
 using MQTTnet;
 using MQTTnet.Client;
+using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.Services;
 
@@ -134,6 +135,80 @@ public class MqttService
                 await Task.Delay(opts.ReconnectDelay.Value, token).ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    /// Subscribes to a topic with the specified quality of service level.
+    /// </summary>
+    /// <param name="topic">The topic to subscribe to.</param>
+    /// <param name="qos">The desired QoS level.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The MQTT subscribe result when successful.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topic"/> is null or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the broker rejects the subscription.</exception>
+    public async Task<MqttClientSubscribeResult> SubscribeAsync(string topic, MqttQualityOfServiceLevel qos, CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(topic))
+            throw new ArgumentException("Topic cannot be null or whitespace.", nameof(topic));
+
+        _logger.Log("MQTT subscribe start", LogLevel.Debug);
+
+        var filter = new MqttTopicFilterBuilder()
+            .WithTopic(topic)
+            .WithQualityOfServiceLevel(qos)
+            .Build();
+        var options = new MqttClientSubscribeOptionsBuilder()
+            .WithTopicFilter(filter)
+            .Build();
+
+        var result = await _client.SubscribeAsync(options, token).ConfigureAwait(false);
+
+        var success = true;
+        foreach (var item in result.Items)
+        {
+            if (item.ResultCode != MqttClientSubscribeResultCode.GrantedQoS0 &&
+                item.ResultCode != MqttClientSubscribeResultCode.GrantedQoS1 &&
+                item.ResultCode != MqttClientSubscribeResultCode.GrantedQoS2)
+            {
+                success = false;
+                break;
+            }
+        }
+
+        if (!success)
+        {
+            var codes = string.Join(',', result.Items.Select(i => i.ResultCode));
+            _logger.Log($"MQTT subscribe failed: {codes}", LogLevel.Error);
+            throw new InvalidOperationException($"Subscription failed: {codes}");
+        }
+
+        _logger.Log("MQTT subscribe finished", LogLevel.Debug);
+        return result;
+    }
+
+    /// <summary>
+    /// Unsubscribes from a topic.
+    /// </summary>
+    /// <param name="topic">The topic to unsubscribe from.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The MQTT unsubscribe result when successful.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="topic"/> is null or whitespace.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the broker rejects the request.</exception>
+    public async Task<MqttClientUnsubscribeResult> UnsubscribeAsync(string topic, CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(topic))
+            throw new ArgumentException("Topic cannot be null or whitespace.", nameof(topic));
+
+        _logger.Log("MQTT unsubscribe start", LogLevel.Debug);
+
+        var options = new MqttClientUnsubscribeOptionsBuilder()
+            .WithTopicFilter(topic)
+            .Build();
+
+        var result = await _client.UnsubscribeAsync(options, token).ConfigureAwait(false);
+
+        _logger.Log("MQTT unsubscribe finished", LogLevel.Debug);
+        return result;
     }
 
     /// <summary>

--- a/DesktopApplicationTemplate.UI/Themes/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/MqttTagSubscriptionsView.xaml
@@ -1,0 +1,20 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataTemplate x:Key="SubscriptionResultTemplate">
+        <Border CornerRadius="4" Padding="5" Margin="2" BorderThickness="1">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Background" Value="#99FF99" />
+                    <Setter Property="BorderBrush" Value="#80FF00" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsSuccess}" Value="False">
+                            <Setter Property="Background" Value="#FFCCCC" />
+                            <Setter Property="BorderBrush" Value="#FF0000" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <TextBlock Text="{Binding Message}" Foreground="Black"/>
+        </Border>
+    </DataTemplate>
+</ResourceDictionary>

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttTagSubscriptionsViewModel.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
+using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
 
@@ -16,8 +18,8 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     private readonly MqttService _service;
 
     private string _newTopic = string.Empty;
-    private string? _selectedTopic;
-    private string _testMessage = string.Empty;
+    private MqttQualityOfServiceLevel _newQoS = MqttQualityOfServiceLevel.AtMostOnce;
+    private TagSubscription? _selectedSubscription;
     private bool _isConnected;
 
     /// <summary>
@@ -27,9 +29,11 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     {
         _service = service ?? throw new ArgumentNullException(nameof(service));
 
-        Topics = new ObservableCollection<string>();
-        AddTopicCommand = new RelayCommand(AddTopic);
-        RemoveTopicCommand = new RelayCommand(RemoveTopic, () => SelectedTopic != null);
+        Subscriptions = new ObservableCollection<TagSubscription>();
+        SubscriptionResults = new ObservableCollection<SubscriptionResult>();
+
+        AddTopicCommand = new AsyncRelayCommand(AddTopicAsync);
+        RemoveTopicCommand = new AsyncRelayCommand(RemoveTopicAsync, () => SelectedSubscription != null);
         ConnectCommand = new AsyncRelayCommand(ConnectAsync);
         PublishTestMessageCommand = new AsyncRelayCommand(PublishTestAsync, CanPublishTest);
     }
@@ -40,7 +44,12 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// <summary>
     /// Topics subscribed to by this service.
     /// </summary>
-    public ObservableCollection<string> Topics { get; }
+    public ObservableCollection<TagSubscription> Subscriptions { get; }
+
+    /// <summary>
+    /// Results of subscription attempts for UI feedback.
+    /// </summary>
+    public ObservableCollection<SubscriptionResult> SubscriptionResults { get; }
 
     /// <summary>
     /// Gets or sets the new topic entry.
@@ -52,30 +61,38 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     }
 
     /// <summary>
-    /// Gets or sets the selected topic.
+    /// Gets or sets the QoS level for new subscriptions.
     /// </summary>
-    public string? SelectedTopic
+    public MqttQualityOfServiceLevel NewQoS
     {
-        get => _selectedTopic;
-        set
-        {
-            _selectedTopic = value;
-            OnPropertyChanged();
-            ((RelayCommand)RemoveTopicCommand).RaiseCanExecuteChanged();
-            ((AsyncRelayCommand)PublishTestMessageCommand).RaiseCanExecuteChanged();
-        }
+        get => _newQoS;
+        set { _newQoS = value; OnPropertyChanged(); }
     }
 
     /// <summary>
-    /// Gets or sets the test message sent to the selected topic.
+    /// Gets or sets the selected subscription.
     /// </summary>
-    public string TestMessage
+    public TagSubscription? SelectedSubscription
     {
-        get => _testMessage;
+        get => _selectedSubscription;
         set
         {
-            _testMessage = value;
+            if (_selectedSubscription == value) return;
+            if (_selectedSubscription is not null)
+                _selectedSubscription.PropertyChanged -= SelectedSubscriptionOnPropertyChanged;
+            _selectedSubscription = value;
             OnPropertyChanged();
+            ((AsyncRelayCommand)RemoveTopicCommand).RaiseCanExecuteChanged();
+            ((AsyncRelayCommand)PublishTestMessageCommand).RaiseCanExecuteChanged();
+            if (_selectedSubscription is not null)
+                _selectedSubscription.PropertyChanged += SelectedSubscriptionOnPropertyChanged;
+        }
+    }
+
+    private void SelectedSubscriptionOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TagSubscription.OutgoingMessage))
+        {
             ((AsyncRelayCommand)PublishTestMessageCommand).RaiseCanExecuteChanged();
         }
     }
@@ -109,23 +126,48 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// </summary>
     public ICommand PublishTestMessageCommand { get; }
 
-    private void AddTopic()
+    /// <summary>
+    /// Attempts to subscribe to the specified topic and records the result.
+    /// </summary>
+    public async Task AddTopicAsync()
     {
         if (string.IsNullOrWhiteSpace(NewTopic))
             return;
-        Topics.Add(NewTopic);
-        NewTopic = string.Empty;
+
+        try
+        {
+            await _service.SubscribeAsync(NewTopic, NewQoS).ConfigureAwait(false);
+            Subscriptions.Add(new TagSubscription { Topic = NewTopic, QoS = NewQoS });
+            SubscriptionResults.Add(new SubscriptionResult(NewTopic, true, $"Subscribed to {NewTopic}"));
+            NewTopic = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            SubscriptionResults.Add(new SubscriptionResult(NewTopic, false, ex.Message));
+        }
     }
 
-    private void RemoveTopic()
+    /// <summary>
+    /// Removes the selected subscription and unsubscribes from the broker.
+    /// </summary>
+    public async Task RemoveTopicAsync()
     {
-        if (SelectedTopic is null)
+        if (SelectedSubscription is null)
             return;
-        Topics.Remove(SelectedTopic);
-        SelectedTopic = null;
+
+        try
+        {
+            await _service.UnsubscribeAsync(SelectedSubscription.Topic).ConfigureAwait(false);
+        }
+        catch
+        {
+            // ignore unsubscribe failures; UI already reflects removal
+        }
+        Subscriptions.Remove(SelectedSubscription);
+        SelectedSubscription = null;
     }
 
-    private bool CanPublishTest() => SelectedTopic != null && !string.IsNullOrWhiteSpace(TestMessage);
+    private bool CanPublishTest() => SelectedSubscription != null && !string.IsNullOrWhiteSpace(SelectedSubscription.OutgoingMessage);
 
     /// <summary>
     /// Connects to the MQTT broker.
@@ -146,7 +188,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         if (!CanPublishTest())
             return;
         Logger?.Log("MQTT test publish start", LogLevel.Debug);
-        await _service.PublishAsync(SelectedTopic!, TestMessage).ConfigureAwait(false);
+        await _service.PublishAsync(SelectedSubscription!.Topic, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
         Logger?.Log("MQTT test publish finished", LogLevel.Debug);
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -4,9 +4,16 @@
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:mqtt="clr-namespace:MQTTnet.Protocol;assembly=MQTTnet"
+      xmlns:sys="clr-namespace:System;assembly=mscorlib"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <ObjectDataProvider x:Key="QoSValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="mqtt:MqttQualityOfServiceLevel" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
     </Page.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -14,21 +21,38 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80"/>
-            <Grid Width="200" Margin="10,0,0,0">
-                <TextBox Text="{Binding NewTopic}" x:Name="NewTopicBox" ToolTip="Topic to subscribe"/>
-                <TextBlock Text="New Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                           VerticalAlignment="Center"
-                           Visibility="{Binding Text, ElementName=NewTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            </Grid>
-            <Button Content="Add" Command="{Binding AddTopicCommand}" Width="50" Margin="5,0,0,0"/>
-            <Button Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0"/>
-        </StackPanel>
-        <ListBox Grid.Row="1" ItemsSource="{Binding Topics}" SelectedItem="{Binding SelectedTopic}"/>
+        <Grid Grid.Row="0" Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <StackPanel Orientation="Horizontal">
+                <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80"/>
+                <Grid Width="200" Margin="10,0,0,0">
+                    <TextBox Text="{Binding NewTopic}" x:Name="NewTopicBox" ToolTip="Topic to subscribe"/>
+                    <TextBlock Text="New Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                               VerticalAlignment="Center"
+                               Visibility="{Binding Text, ElementName=NewTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                </Grid>
+                <ComboBox Width="100" Margin="5,0,0,0" ItemsSource="{Binding Source={StaticResource QoSValues}}" SelectedItem="{Binding NewQoS}"/>
+                <Button Content="Add" Command="{Binding AddTopicCommand}" Width="50" Margin="5,0,0,0"/>
+                <Button Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0"/>
+            </StackPanel>
+            <ItemsControl Grid.Column="1" ItemsSource="{Binding SubscriptionResults}" ItemTemplate="{DynamicResource SubscriptionResultTemplate}" HorizontalAlignment="Right" />
+        </Grid>
+        <ListBox Grid.Row="1" ItemsSource="{Binding Subscriptions}" SelectedItem="{Binding SelectedSubscription}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Topic}" />
+                        <TextBlock Text="{Binding QoS}" Margin="5,0,0,0" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
             <Grid Width="200">
-                <TextBox Text="{Binding TestMessage}" x:Name="TestMessageBox" ToolTip="Message to send"/>
+                <TextBox Text="{Binding SelectedSubscription.OutgoingMessage}" x:Name="TestMessageBox" ToolTip="Message to send"/>
                 <TextBlock Text="Test Message" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=TestMessageBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - MqttTagSubscriptionsView and view model for managing MQTT topic subscriptions displayed when adding new MQTT services.
 - xUnit tests for MQTT create, subscription, and connection edit view models covering validation, command behavior, and option mapping.
 - MqttService tests now verify TLS and credential configuration alongside will messages and keep-alive options.
+- Subscribe/unsubscribe support for MQTT topics with QoS selection and visual feedback for subscription results.
 
 - File dialog service registered for TLS certificate selection in MQTT views.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -329,3 +329,11 @@ Effective Prompts / Instructions that worked: Following AGENTS guidance and user
 Decisions & Rationale: Use transient lifetimes for views/view models and provide IFileDialogService for TLS cert browsing.
 Action Items: Monitor CI for DI regressions.
 Related Commits/PRs: (this PR)
+[2025-08-19 15:55] Topic: MQTT subscription result bubbles
+Context: Added Subscribe/Unsubscribe APIs, QoS-aware tag subscription model, and UI feedback bubbles.
+Observations: Async commands allow subscription attempts with success/failure notifications.
+Codex Limitations noticed: Linux environment cannot render WPF; rely on CI.
+Effective Prompts / Instructions that worked: Following request to capture results and update docs.
+Decisions & Rationale: Store per-topic QoS and message; visualize subscription outcomes for user clarity.
+Action Items: Monitor CI for UI styling discrepancies.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- add MQTT subscribe/unsubscribe APIs with error handling
- track per-topic QoS and message in TagSubscription model
- show subscription result bubbles in tag subscription view
- tests for subscription results
- docs updated

## Validation
- `dotnet test DesktopApplicationTemplate.sln --settings tests.runsettings` *(fails: missing Microsoft.WindowsDesktop.App on Linux)*


------
https://chatgpt.com/codex/tasks/task_e_68a49cc4eb188326948ac02c574465c1