### PR TITLE
feat: add endpoint testing for tag subscriptions

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
@@ -1,7 +1,9 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Moq;
@@ -38,73 +40,82 @@ public class MqttTagSubscriptionsViewModelTests
         var vm = CreateViewModel(client);
         await vm.ConnectAsync();
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
-        Assert.True(vm.IsConnected);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public async Task PublishTestAsync_Publishes_WhenValid()
+    public async Task TestTagEndpointCommand_Publishes_WhenValid()
     {
         if (!OperatingSystem.IsWindows()) return;
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
-        client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
+        var publishCalled = false;
+        client.Setup(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "t"), It.IsAny<CancellationToken>()))
+            .Callback(() => publishCalled = true)
             .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
         var vm = CreateViewModel(client);
-        vm.Topics.Add("t");
-        vm.SelectedTopic = "t";
-        vm.TestMessage = "m";
-        await vm.PublishTestAsync();
-        client.Verify(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "t"), It.IsAny<CancellationToken>()), Times.Once);
+        var sub = new TagSubscription { Tag = "tag", Endpoint = "t", OutgoingMessage = "m" };
+        vm.Subscriptions.Add(sub);
+        await ((AsyncRelayCommand<TagSubscription>)vm.TestTagEndpointCommand).ExecuteAsync(sub);
+        Assert.True(publishCalled);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public async Task PublishTestAsync_DoesNothing_WhenInvalid()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
-        var vm = CreateViewModel(client);
-        await vm.PublishTestAsync();
-        client.Verify(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    [TestCategory("WindowsSafe")]
-    public void AddTopic_AddsTopicAndClearsInput()
+    public void TestTagEndpointCommand_CanExecute_ReturnsFalse_WhenEndpointOrMessageMissing()
     {
         if (!OperatingSystem.IsWindows()) return;
         var vm = CreateViewModel();
-        vm.NewTopic = "topic";
-        vm.AddTopicCommand.Execute(null);
-        Assert.Contains("topic", vm.Topics);
-        Assert.Equal(string.Empty, vm.NewTopic);
+        var sub = new TagSubscription { Tag = "t" };
+        vm.Subscriptions.Add(sub);
+        var cmd = vm.TestTagEndpointCommand;
+        Assert.False(cmd.CanExecute(sub));
+        sub.Endpoint = "e";
+        Assert.False(cmd.CanExecute(sub));
+        sub.Endpoint = string.Empty;
+        sub.OutgoingMessage = "m";
+        Assert.False(cmd.CanExecute(sub));
+        sub.Endpoint = "e";
+        Assert.True(cmd.CanExecute(sub));
+        sub.OutgoingMessage = string.Empty;
+        Assert.False(cmd.CanExecute(sub));
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public void AddTopic_IgnoresEmptyInput()
+    public void AddTag_AddsTagAndClearsInput()
     {
         if (!OperatingSystem.IsWindows()) return;
         var vm = CreateViewModel();
-        vm.NewTopic = "   ";
-        vm.AddTopicCommand.Execute(null);
-        Assert.Empty(vm.Topics);
+        vm.NewTag = "tag";
+        vm.AddTagCommand.Execute(null);
+        Assert.Contains(vm.Subscriptions, s => s.Tag == "tag");
+        Assert.Equal(string.Empty, vm.NewTag);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public void RemoveTopic_RemovesSelectedTopic()
+    public void AddTag_IgnoresEmptyInput()
     {
         if (!OperatingSystem.IsWindows()) return;
         var vm = CreateViewModel();
-        vm.Topics.Add("t");
-        vm.SelectedTopic = "t";
-        vm.RemoveTopicCommand.Execute(null);
-        Assert.Empty(vm.Topics);
-        Assert.Null(vm.SelectedTopic);
+        vm.NewTag = "   ";
+        vm.AddTagCommand.Execute(null);
+        Assert.Empty(vm.Subscriptions);
+    }
+
+    [Fact]
+    [TestCategory("WindowsSafe")]
+    public void RemoveTag_RemovesSelectedSubscription()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var vm = CreateViewModel();
+        var sub = new TagSubscription { Tag = "t" };
+        vm.Subscriptions.Add(sub);
+        vm.SelectedSubscription = sub;
+        vm.RemoveTagCommand.Execute(null);
+        Assert.Empty(vm.Subscriptions);
+        Assert.Null(vm.SelectedSubscription);
     }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -26,4 +26,42 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
+
+    /// <summary>
+    /// An <see cref="ICommand"/> implementation that executes asynchronous delegates with a parameter.
+    /// </summary>
+    /// <typeparam name="T">Type of parameter passed to the command.</typeparam>
+    public class AsyncRelayCommand<T> : ICommand
+    {
+        private readonly Func<T?, Task> _execute;
+        private readonly Predicate<T?>? _canExecute;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
+        /// </summary>
+        public AsyncRelayCommand(Func<T?, Task> execute, Predicate<T?>? canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        /// <inheritdoc />
+        public bool CanExecute(object? parameter) => _canExecute?.Invoke((T?)parameter) ?? true;
+
+        /// <inheritdoc />
+        public async void Execute(object? parameter) => await ExecuteAsync((T?)parameter);
+
+        /// <summary>
+        /// Executes the command asynchronously with the provided parameter.
+        /// </summary>
+        public Task ExecuteAsync(T? parameter) => _execute(parameter);
+
+        /// <inheritdoc />
+        public event EventHandler? CanExecuteChanged;
+
+        /// <summary>
+        /// Notifies that the ability to execute has changed.
+        /// </summary>
+        public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
 }

--- a/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
+++ b/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace DesktopApplicationTemplate.UI.Models;
+
+/// <summary>
+/// Represents a subscription to a tag with test publish details.
+/// </summary>
+public class TagSubscription : INotifyPropertyChanged
+{
+    private string _tag = string.Empty;
+    /// <summary>
+    /// Identifier of the tag.
+    /// </summary>
+    public string Tag
+    {
+        get => _tag;
+        set
+        {
+            _tag = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private string _endpoint = string.Empty;
+    /// <summary>
+    /// MQTT endpoint used for testing this tag.
+    /// </summary>
+    public string Endpoint
+    {
+        get => _endpoint;
+        set
+        {
+            _endpoint = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private string _outgoingMessage = string.Empty;
+    /// <summary>
+    /// Test message sent when validating the tag's endpoint.
+    /// </summary>
+    public string OutgoingMessage
+    {
+        get => _outgoingMessage;
+        set
+        {
+            _outgoingMessage = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -12,28 +12,34 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
             <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80"/>
             <Grid Width="200" Margin="10,0,0,0">
-                <TextBox Text="{Binding NewTopic}" x:Name="NewTopicBox" ToolTip="Topic to subscribe"/>
-                <TextBlock Text="New Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
+                <TextBox Text="{Binding NewTag}" x:Name="NewTagBox" ToolTip="Tag to subscribe"/>
+                <TextBlock Text="New Tag" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
                            VerticalAlignment="Center"
-                           Visibility="{Binding Text, ElementName=NewTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                           Visibility="{Binding Text, ElementName=NewTagBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
-            <Button Content="Add" Command="{Binding AddTopicCommand}" Width="50" Margin="5,0,0,0"/>
-            <Button Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0"/>
+            <Button Content="Add" Command="{Binding AddTagCommand}" Width="50" Margin="5,0,0,0"/>
+            <Button Content="Remove" Command="{Binding RemoveTagCommand}" Width="70" Margin="5,0,0,0"/>
         </StackPanel>
-        <ListBox Grid.Row="1" ItemsSource="{Binding Topics}" SelectedItem="{Binding SelectedTopic}"/>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
-            <Grid Width="200">
-                <TextBox Text="{Binding TestMessage}" x:Name="TestMessageBox" ToolTip="Message to send"/>
-                <TextBlock Text="Test Message" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                           VerticalAlignment="Center"
-                           Visibility="{Binding Text, ElementName=TestMessageBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            </Grid>
-            <Button Content="Send" Command="{Binding PublishTestMessageCommand}" Width="60" Margin="5,0,0,0"/>
-        </StackPanel>
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Subscriptions}" SelectedItem="{Binding SelectedSubscription}"
+                  AutoGenerateColumns="False" HeadersVisibility="Column" CanUserAddRows="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Tag" Binding="{Binding Tag}" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Endpoint" Binding="{Binding Endpoint, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTextColumn Header="Message" Binding="{Binding OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTemplateColumn Header="Test">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Test" Width="50"
+                                    Command="{Binding DataContext.TestTagEndpointCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                    CommandParameter="{Binding}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - MQTT view model now exposes will-message and connection options with validation and bindings in create/edit views.
 - Dedicated window for editing MQTT connection settings with update, cancel, and unsubscribe commands accessible from the topic subscription view.
 - MqttTagSubscriptionsView and view model for managing MQTT topic subscriptions displayed when adding new MQTT services.
+- Tag subscriptions now include per-tag endpoints with in-row test publishing.
 - xUnit tests for MQTT create, subscription, and connection edit view models covering validation, command behavior, and option mapping.
 - MqttService tests now verify TLS and credential configuration alongside will messages and keep-alive options.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -329,3 +329,12 @@ Effective Prompts / Instructions that worked: Following AGENTS guidance and user
 Decisions & Rationale: Use transient lifetimes for views/view models and provide IFileDialogService for TLS cert browsing.
 Action Items: Monitor CI for DI regressions.
 Related Commits/PRs: (this PR)
+[2025-08-19 15:54] Topic: Tag subscription endpoint testing
+Context: Added per-tag endpoint field and test command in subscriptions view.
+Observations: Command publishes tag message to its endpoint via new row Test button.
+Codex Limitations noticed: Linux environment cannot render WPF; rely on CI.
+Effective Prompts / Instructions that worked: user request to expose TestTagEndpointCommand.
+Decisions & Rationale: Enable validating tag routing by publishing configured message to its endpoint.
+Action Items: Monitor CI for layout or command binding issues.
+Related Commits/PRs: (this PR)
+


### PR DESCRIPTION
## What changed
- add endpoint and message fields to tag subscriptions
- allow testing tag endpoints via `TestTagEndpointCommand`
- show per-tag Test button in subscriptions view
- unit tests for tag endpoint command and validation

## Validation
- `~/.dotnet/dotnet test --settings tests.runsettings` *(fails: missing Microsoft.WindowsDesktop.App on linux)*

------
https://chatgpt.com/codex/tasks/task_e_68a49ce1b1f88326884d92ba54d212a9