### PR TITLE
Simplify MQTT tag subscription view model

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
@@ -1,13 +1,9 @@
-using System.Collections.Generic;
-
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Helpers;
-
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -22,32 +18,24 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MqttTagSubscriptionsViewModelTests
 {
-    private static (MqttTagSubscriptionsViewModel vm, MqttService service) CreateViewModel(Mock<IMqttClient>? clientMock = null, IEnumerable<TagSubscription>? tags = null)
+    private static (MqttTagSubscriptionsViewModel vm, Mock<IMqttClient> client, MqttService service) CreateViewModel()
     {
-        var logger = Mock.Of<ILoggingService>();
-        var options = Options.Create(new MqttServiceOptions { Host = "localhost", Port = 1883, ClientId = "client" });
-        var routing = new Mock<IMessageRoutingService>();
-        var client = clientMock ?? new Mock<IMqttClient>();
+        var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
         client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
-        client.Setup(c => c.SubscribeAsync(It.IsAny<string>(), It.IsAny<MqttQualityOfServiceLevel>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientSubscribeResult());
+            .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MqttUserProperty>()));
         client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
+            .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), null!, Array.Empty<MqttUserProperty>()));
         client.Setup(c => c.UnsubscribeAsync(It.IsAny<MqttClientUnsubscribeOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientUnsubscribeResult(0, Array.Empty<MqttClientUnsubscribeResultItem>(), null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
-        var service = new MqttService(client.Object, options, routing.Object, logger);
-        if (tags != null)
-        {
-            foreach (var tag in tags)
-            {
-                service.UpdateTagSubscription(tag);
-            }
-        }
+            .ReturnsAsync(new MqttClientUnsubscribeResult(0, Array.Empty<MqttClientUnsubscribeResultItem>(), null!, Array.Empty<MqttUserProperty>()));
+
+        var logger = Mock.Of<ILoggingService>();
+        var options = Options.Create(new MqttServiceOptions { Host = "localhost", Port = 1883, ClientId = "client" });
+        var routing = Mock.Of<IMessageRoutingService>();
+        var service = new MqttService(client.Object, options, routing, logger);
         var vm = new MqttTagSubscriptionsViewModel(service);
-        return (vm, service);
+        return (vm, client, service);
     }
 
     [Fact]
@@ -55,248 +43,64 @@ public class MqttTagSubscriptionsViewModelTests
     public async Task ConnectAsync_InvokesClient()
     {
         if (!OperatingSystem.IsWindows()) return;
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientConnectResult());
-        var (vm, _) = CreateViewModel(client);
-        client.Setup(c => c.SubscribeAsync(It.IsAny<string>(), It.IsAny<MqttQualityOfServiceLevel>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientSubscribeResult());
+        var (vm, client, _) = CreateViewModel();
         await vm.ConnectAsync();
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public async Task TestTagEndpointCommand_Publishes_WhenValid()
-    public async Task ConnectAsync_SubscribesWithSelectedQoS()
+    public async Task AddTopicAsync_SubscribesAndAdds()
     {
         if (!OperatingSystem.IsWindows()) return;
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientConnectResult());
-        client.Setup(c => c.SubscribeAsync("t", MqttQualityOfServiceLevel.AtLeastOnce, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientSubscribeResult());
-        var vm = CreateViewModel(client);
-        vm.Topics.Add(new TagSubscription { Topic = "t", QoS = MqttQualityOfServiceLevel.AtLeastOnce });
-        await vm.ConnectAsync();
-        client.Verify(c => c.SubscribeAsync("t", MqttQualityOfServiceLevel.AtLeastOnce, It.IsAny<CancellationToken>()), Times.Once);
+        var (vm, client, _) = CreateViewModel();
+        vm.NewTopic = "t";
+        vm.NewQoS = MqttQualityOfServiceLevel.AtLeastOnce;
+        await ((AsyncRelayCommand)vm.AddTopicCommand).ExecuteAsync(null);
+
+        client.Verify(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains(vm.Subscriptions, s => s.Topic == "t" && s.QoS == MqttQualityOfServiceLevel.AtLeastOnce);
+        Assert.Equal(string.Empty, vm.NewTopic);
+        Assert.Contains(vm.SubscriptionResults, r => r.Topic == "t" && r.IsSuccess);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public async Task PublishTestAsync_Publishes_WhenValid()
+    public async Task RemoveTopicAsync_UnsubscribesAndRemoves()
     {
         if (!OperatingSystem.IsWindows()) return;
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientConnectResult());
-        var publishCalled = false;
-        client.Setup(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "t"), It.IsAny<CancellationToken>()))
-            .Callback(() => publishCalled = true)
-            .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
-        var (vm, _) = CreateViewModel(client);
+        var (vm, client, service) = CreateViewModel();
         var sub = new TagSubscription("t");
+        service.UpdateTagSubscription(sub);
         vm.Subscriptions.Add(sub);
         vm.SelectedSubscription = sub;
-        var vm = CreateViewModel(client);
-        var sub = new TagSubscription { Tag = "tag", Endpoint = "t", OutgoingMessage = "m" };
+        await ((AsyncRelayCommand)vm.RemoveTopicCommand).ExecuteAsync(null);
+        client.Verify(c => c.UnsubscribeAsync(It.IsAny<MqttClientUnsubscribeOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Empty(vm.Subscriptions);
+        Assert.Null(vm.SelectedSubscription);
+    }
+
+    [Fact]
+    [TestCategory("WindowsSafe")]
+    public async Task PublishTestMessageAsync_Publishes_WhenValid()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var (vm, client, _) = CreateViewModel();
+        var sub = new TagSubscription("t") { OutgoingMessage = "m" };
         vm.Subscriptions.Add(sub);
-        await ((AsyncRelayCommand<TagSubscription>)vm.TestTagEndpointCommand).ExecuteAsync(sub);
-        Assert.True(publishCalled);
-        var sub = new TagSubscription { Tag = "t", OutgoingMessage = "m" };
-        vm.TagSubscriptions.Add(sub);
         vm.SelectedSubscription = sub;
-        var sub = new TagSubscription { Topic = "t", QoS = MqttQualityOfServiceLevel.AtMostOnce };
-        vm.Topics.Add(sub);
-        vm.SelectedTopic = sub;
-        vm.TestMessage = "m";
-        vm.Subscriptions.Add(new TagSubscription { Topic = "t", OutgoingMessage = "m" });
-        vm.SelectedSubscription = vm.Subscriptions.First();
-        await vm.PublishTestAsync();
+        await ((AsyncRelayCommand)vm.PublishTestMessageCommand).ExecuteAsync(null);
         client.Verify(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "t"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     [TestCategory("WindowsSafe")]
-    public void TestTagEndpointCommand_CanExecute_ReturnsFalse_WhenEndpointOrMessageMissing()
+    public async Task TestTagEndpointCommand_Publishes_WhenValid()
     {
         if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
-        var sub = new TagSubscription { Tag = "t" };
-        vm.Subscriptions.Add(sub);
-        var cmd = vm.TestTagEndpointCommand;
-        Assert.False(cmd.CanExecute(sub));
-        sub.Endpoint = "e";
-        Assert.False(cmd.CanExecute(sub));
-        sub.Endpoint = string.Empty;
-        sub.OutgoingMessage = "m";
-        Assert.False(cmd.CanExecute(sub));
-        sub.Endpoint = "e";
-        Assert.True(cmd.CanExecute(sub));
-        sub.OutgoingMessage = string.Empty;
-        Assert.False(cmd.CanExecute(sub));
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MQTTnet.Packets.MqttUserProperty>()));
-        var (vm, _) = CreateViewModel(client);
-        await vm.PublishTestAsync();
-        client.Verify(c => c.PublishAsync(It.IsAny<MQTTnet.MqttApplicationMessage>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    [TestCategory("WindowsSafe")]
-    public void AddTag_AddsTagAndClearsInput()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
-        vm.NewTag = "tag";
-        vm.AddTagCommand.Execute(null);
-        Assert.Contains(vm.Subscriptions, s => s.Tag == "tag");
-        Assert.Equal(string.Empty, vm.NewTag);
-    public async Task AddTopic_AddsSubscriptionAndClearsInput()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var (vm, _) = CreateViewModel();
-        vm.NewTopic = "topic";
-        vm.AddTopicCommand.Execute(null);
-
-        Assert.Contains(vm.TagSubscriptions, t => t.Tag == "topic");
-        Assert.Contains(vm.Topics, t => t.Topic == "topic");
-        await vm.AddTopicAsync();
-        Assert.Contains(vm.Subscriptions, s => s.Topic == "topic");
-        Assert.Equal(string.Empty, vm.NewTopic);
-    }
-
-    [Fact]
-    [TestCategory("WindowsSafe")]
-    public void AddTag_IgnoresEmptyInput()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
-        vm.NewTag = "   ";
-        vm.AddTagCommand.Execute(null);
-    public async Task AddTopic_IgnoresEmptyInput()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var (vm, _) = CreateViewModel();
-        vm.NewTopic = "   ";
-        vm.AddTopicCommand.Execute(null);
-        var client = new Mock<IMqttClient>();
-        vm = CreateViewModel(client);
-        vm.NewTopic = "   ";
-        vm.AddTopicCommand.Execute(null);
-        Assert.Empty(vm.TagSubscriptions);
-        await vm.AddTopicAsync();
-        client.Verify(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()), Times.Never);
-        Assert.Empty(vm.Subscriptions);
-    }
-
-    [Fact]
-    [TestCategory("WindowsSafe")]
-    public void RemoveTag_RemovesSelectedSubscription()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
-        var sub = new TagSubscription { Tag = "t" };
-        vm.Subscriptions.Add(sub);
-        vm.SelectedSubscription = sub;
-        vm.RemoveTagCommand.Execute(null);
-        Assert.Empty(vm.Subscriptions);
-        Assert.Null(vm.SelectedSubscription);
-    public void RemoveTopic_RemovesSelectedSubscription()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var (vm, _) = CreateViewModel();
-        var tag = new TagSubscription("t");
-        vm.Subscriptions.Add(tag);
-        vm.SelectedSubscription = tag;
-        vm.RemoveTopicCommand.Execute(null);
-        var vm = CreateViewModel();
-        var sub = new TagSubscription { Tag = "t" };
-        vm.TagSubscriptions.Add(sub);
-        vm.SelectedSubscription = sub;
-        vm.RemoveTopicCommand.Execute(null);
-        Assert.Empty(vm.TagSubscriptions);
-        Assert.Null(vm.SelectedSubscription);
-
-    }
-    public async Task RemoveTopic_RemovesSelectedSubscription()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
-        var sub = new TagSubscription { Topic = "t", QoS = MqttQualityOfServiceLevel.AtMostOnce };
-        vm.Topics.Add(sub);
-        vm.SelectedTopic = sub;
-        vm.RemoveTopicCommand.Execute(null);
-        Assert.Empty(vm.Topics);
-        Assert.Null(vm.SelectedTopic);
-        vm.Subscriptions.Add(new TagSubscription { Topic = "t" });
-        vm.SelectedSubscription = vm.Subscriptions.First();
-        await vm.RemoveTopicAsync();
-        Assert.Empty(vm.Subscriptions);
-        Assert.Null(vm.SelectedSubscription);
-    }
-
-    [Fact]
-    [TestCategory("WindowsSafe")]
-    public void Constructor_PopulatesStylingMetadata()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var tag = new TagSubscription("t") { StatusColor = "Red", Icon = "icon.png" };
-        var (vm, _) = CreateViewModel(tags: new[] { tag });
-        var sub = Assert.Single(vm.Subscriptions);
-        Assert.Equal("Red", sub.StatusColor);
-        Assert.Equal("icon.png", sub.Icon);
-    public void SelectingTag_LoadsAndPersistsMessage()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var vm = CreateViewModel();
-        var sub1 = new TagSubscription { Tag = "t1", OutgoingMessage = "m1" };
-        var sub2 = new TagSubscription { Tag = "t2", OutgoingMessage = "m2" };
-        vm.TagSubscriptions.Add(sub1);
-        vm.TagSubscriptions.Add(sub2);
-
-        vm.SelectedSubscription = sub1;
-        Assert.Equal("m1", vm.SelectedSubscription?.OutgoingMessage);
-
-        vm.SelectedSubscription!.OutgoingMessage = "updated";
-        vm.SelectedSubscription = sub2;
-
-        Assert.Equal("updated", sub1.OutgoingMessage);
-        Assert.Equal("m2", vm.SelectedSubscription?.OutgoingMessage);
-    }
-      public async Task AddTopicAsync_RecordsSuccessResult()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientSubscribeResult(0, Array.Empty<MqttClientSubscribeResultItem>(), null!, Array.Empty<MqttUserProperty>()));
-        var vm = CreateViewModel(client);
-        vm.NewTopic = "a";
-        await vm.AddTopicAsync();
-        client.Verify(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()), Times.Once);
-        Assert.Contains(vm.SubscriptionResults, r => r.Topic == "a" && r.IsSuccess);
-    }
-
-    [Fact]
-    [TestCategory("WindowsSafe")]
-    public void TagSubscriptionChanged_RefreshesStyling()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var tag = new TagSubscription("t") { StatusColor = "Red" };
-        var (vm, service) = CreateViewModel(tags: new[] { tag });
-        service.UpdateTagSubscription(new TagSubscription("t") { StatusColor = "Blue" });
-        Assert.Equal("Blue", vm.Subscriptions.Single().StatusColor);
-    public async Task AddTopicAsync_RecordsFailureResult()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-        var client = new Mock<IMqttClient>();
-        client.Setup(c => c.SubscribeAsync(It.IsAny<MqttClientSubscribeOptions>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("fail"));
-        var vm = CreateViewModel(client);
-        vm.NewTopic = "a";
-        await vm.AddTopicAsync();
-        Assert.Contains(vm.SubscriptionResults, r => r.Topic == "a" && !r.IsSuccess);
-        Assert.Empty(vm.Subscriptions);
+        var (vm, client, _) = CreateViewModel();
+        var sub = new TagSubscription("tag") { Endpoint = "e", OutgoingMessage = "m" };
+        await ((AsyncRelayCommand<TagSubscription>)vm.TestTagEndpointCommand).ExecuteAsync(sub);
+        client.Verify(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "e"), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
+++ b/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
@@ -1,58 +1,118 @@
-
 using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.Models;
 
 /// <summary>
-/// Represents a subscription to a tag with test publish details.
+/// Represents an MQTT topic subscription with test publishing metadata.
 /// </summary>
 public class TagSubscription : INotifyPropertyChanged
 {
-    private string _tag = string.Empty;
+    private string _topic = string.Empty;
+    private MqttQualityOfServiceLevel _qoS;
+    private string _endpoint = string.Empty;
+    private string _outgoingMessage = string.Empty;
+    private string? _statusColor;
+    private string? _icon;
+
     /// <summary>
-    /// Identifier of the tag.
+    /// Initializes a new instance of the <see cref="TagSubscription"/> class.
     /// </summary>
-    public string Tag
+    public TagSubscription()
     {
-        get => _tag;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TagSubscription"/> class with the specified topic.
+    /// </summary>
+    public TagSubscription(string topic)
+    {
+        _topic = topic ?? throw new ArgumentNullException(nameof(topic));
+    }
+
+    /// <summary>
+    /// Gets or sets the MQTT topic.
+    /// </summary>
+    public string Topic
+    {
+        get => _topic;
         set
         {
-            _tag = value;
+            if (_topic == value) return;
+            _topic = value;
             OnPropertyChanged();
         }
     }
 
-    private string _endpoint = string.Empty;
     /// <summary>
-    /// MQTT endpoint used for testing this tag.
+    /// Gets or sets the quality of service level.
+    /// </summary>
+    public MqttQualityOfServiceLevel QoS
+    {
+        get => _qoS;
+        set
+        {
+            if (_qoS == value) return;
+            _qoS = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the endpoint for test publishing.
     /// </summary>
     public string Endpoint
     {
         get => _endpoint;
         set
         {
+            if (_endpoint == value) return;
             _endpoint = value;
             OnPropertyChanged();
         }
     }
 
-    private string _outgoingMessage = string.Empty;
     /// <summary>
-    /// Test message sent when validating the tag's endpoint.
+    /// Gets or sets the outgoing test message.
     /// </summary>
     public string OutgoingMessage
     {
         get => _outgoingMessage;
         set
         {
-            _outgoingMessage = value;
-            OnPropertyChanged();
-
             if (_outgoingMessage == value) return;
             _outgoingMessage = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OutgoingMessage)));
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the status color for UI display.
+    /// </summary>
+    public string? StatusColor
+    {
+        get => _statusColor;
+        set
+        {
+            if (_statusColor == value) return;
+            _statusColor = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the icon for UI display.
+    /// </summary>
+    public string? Icon
+    {
+        get => _icon;
+        set
+        {
+            if (_icon == value) return;
+            _icon = value;
+            OnPropertyChanged();
         }
     }
 
@@ -61,5 +121,4 @@ public class TagSubscription : INotifyPropertyChanged
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttTagSubscriptionsViewModel.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.Linq;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Helpers;
-
-
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using MQTTnet.Protocol;
@@ -16,22 +13,19 @@ using MQTTnet.Protocol;
 namespace DesktopApplicationTemplate.UI.ViewModels;
 
 /// <summary>
-/// View model for managing MQTT tag subscriptions and test messages.
+/// View model for managing MQTT topic subscriptions and test messages.
 /// </summary>
 public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingViewModel
 {
     private readonly MqttService _service;
+    private readonly AsyncRelayCommand _addTopicCommand;
+    private readonly AsyncRelayCommand _removeTopicCommand;
+    private readonly AsyncRelayCommand _publishTestMessageCommand;
     private readonly AsyncRelayCommand<TagSubscription> _testTagEndpointCommand;
 
-    private string _newTag = string.Empty;
     private TagSubscription? _selectedSubscription;
     private string _newTopic = string.Empty;
-    private TagSubscription? _selectedSubscription;
-    private string _testMessage = string.Empty;
-
     private MqttQualityOfServiceLevel _newQoS = MqttQualityOfServiceLevel.AtMostOnce;
-
-    private bool _isConnected;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttTagSubscriptionsViewModel"/> class.
@@ -40,159 +34,103 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     {
         _service = service ?? throw new ArgumentNullException(nameof(service));
 
-        Subscriptions = new ObservableCollection<TagSubscription>();
-        Subscriptions.CollectionChanged += OnSubscriptionsChanged;
-
-        AddTagCommand = new RelayCommand(AddTag);
-        RemoveTagCommand = new RelayCommand(RemoveTag, () => SelectedSubscription != null);
-
         Subscriptions = new ObservableCollection<TagSubscription>(_service.TagSubscriptions);
+        SubscriptionResults = new ObservableCollection<SubscriptionResult>();
         _service.TagSubscriptionChanged += OnTagSubscriptionChanged;
 
-        AddTopicCommand = new RelayCommand(AddTopic);
-        RemoveTopicCommand = new RelayCommand(RemoveTopic, () => SelectedSubscription != null);
-        TagSubscriptions = new ObservableCollection<TagSubscription>();
-        AddTopicCommand = new RelayCommand(AddTopic);
-        RemoveTopicCommand = new RelayCommand(RemoveTopic, () => SelectedSubscription != null);
-        Topics = new ObservableCollection<TagSubscription>();
-        AddTopicCommand = new RelayCommand(AddTopic);
-        RemoveTopicCommand = new RelayCommand(RemoveTopic, () => SelectedTopic != null);
-        Subscriptions = new ObservableCollection<TagSubscription>();
-        SubscriptionResults = new ObservableCollection<SubscriptionResult>();
-
-        AddTopicCommand = new AsyncRelayCommand(AddTopicAsync);
-        RemoveTopicCommand = new AsyncRelayCommand(RemoveTopicAsync, () => SelectedSubscription != null);
+        _addTopicCommand = new AsyncRelayCommand(AddTopicAsync, CanAddTopic);
+        _removeTopicCommand = new AsyncRelayCommand(RemoveTopicAsync, () => SelectedSubscription != null);
+        _publishTestMessageCommand = new AsyncRelayCommand(PublishTestMessageAsync, CanPublishTestMessage);
         ConnectCommand = new AsyncRelayCommand(ConnectAsync);
         _testTagEndpointCommand = new AsyncRelayCommand<TagSubscription>(TestTagEndpointAsync, CanTestTagEndpoint);
     }
-
-    private void OnSubscriptionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-        if (e.NewItems != null)
-        {
-            foreach (TagSubscription sub in e.NewItems)
-            {
-                sub.PropertyChanged += OnSubscriptionPropertyChanged;
-            }
-        }
-        if (e.OldItems != null)
-        {
-            foreach (TagSubscription sub in e.OldItems)
-            {
-                sub.PropertyChanged -= OnSubscriptionPropertyChanged;
-            }
-        }
-        _testTagEndpointCommand.RaiseCanExecuteChanged();
-    }
-
-    private void OnSubscriptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
-        => _testTagEndpointCommand.RaiseCanExecuteChanged();
 
     /// <inheritdoc />
     public ILoggingService? Logger { get; set; }
 
     /// <summary>
-    /// Tag subscriptions managed by this service.
+    /// Gets the current subscriptions.
     /// </summary>
-    public ObservableCollection<TagSubscription> Subscriptions { get; }
-    /// Tag subscriptions tracked by this service.
-    /// </summary>
-    public ObservableCollection<TagSubscription> Subscriptions { get; }
-    /// Subscriptions maintained by this service.
-    /// </summary>
-    public ObservableCollection<TagSubscription> TagSubscriptions { get; }
-    public ObservableCollection<TagSubscription> Topics { get; }
     public ObservableCollection<TagSubscription> Subscriptions { get; }
 
     /// <summary>
-    /// Results of subscription attempts for UI feedback.
+    /// Gets the results of subscription attempts for UI feedback.
     /// </summary>
     public ObservableCollection<SubscriptionResult> SubscriptionResults { get; }
 
     /// <summary>
-    /// Gets or sets the new tag entry.
+    /// Gets or sets the new topic to subscribe.
     /// </summary>
-    public string NewTag
+    public string NewTopic
     {
-        get => _newTag;
-        set { _newTag = value; OnPropertyChanged(); }
         get => _newTopic;
-        set { _newTopic = value; OnPropertyChanged(); }
+        set
+        {
+            if (_newTopic == value) return;
+            _newTopic = value;
+            OnPropertyChanged();
+            _addTopicCommand.RaiseCanExecuteChanged();
+        }
     }
 
     /// <summary>
-    /// Gets or sets the selected tag subscription.
-    /// </summary>
-    public TagSubscription? SelectedSubscription
-    {
-        get => _selectedSubscription;
-        set
-        {
-    /// Gets or sets the selected subscription.
-    /// </summary>
     /// Gets or sets the QoS level for new subscriptions.
     /// </summary>
     public MqttQualityOfServiceLevel NewQoS
     {
         get => _newQoS;
-        set { _newQoS = value; OnPropertyChanged(); }
+        set
+        {
+            if (_newQoS == value) return;
+            _newQoS = value;
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>
-    /// Gets or sets the selected subscription.
+    /// Gets or sets the currently selected subscription.
     /// </summary>
-
-    public TagSubscription? SelectedTopic
     public TagSubscription? SelectedSubscription
     {
         get => _selectedSubscription;
         set
         {
-            _selectedSubscription = value;
-            OnPropertyChanged();
-            ((RelayCommand)RemoveTagCommand).RaiseCanExecuteChanged();
-            if (_selectedSubscription != null)
-            {
-                _selectedSubscription.PropertyChanged -= SelectedSubscription_PropertyChanged;
-            }
-            _selectedSubscription = value;
-            if (_selectedSubscription != null)
-            {
-                _selectedSubscription.PropertyChanged += SelectedSubscription_PropertyChanged;
-            }
             if (_selectedSubscription == value) return;
+
             if (_selectedSubscription is not null)
+            {
                 _selectedSubscription.PropertyChanged -= SelectedSubscriptionOnPropertyChanged;
+            }
+
             _selectedSubscription = value;
             OnPropertyChanged();
-            ((AsyncRelayCommand)RemoveTopicCommand).RaiseCanExecuteChanged();
-            ((AsyncRelayCommand)PublishTestMessageCommand).RaiseCanExecuteChanged();
+            _removeTopicCommand.RaiseCanExecuteChanged();
+            _publishTestMessageCommand.RaiseCanExecuteChanged();
+
             if (_selectedSubscription is not null)
+            {
                 _selectedSubscription.PropertyChanged += SelectedSubscriptionOnPropertyChanged;
-        }
-    }
-
-
-    private void SelectedSubscriptionOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
-    {
-        if (e.PropertyName == nameof(TagSubscription.OutgoingMessage))
-        {
-            ((AsyncRelayCommand)PublishTestMessageCommand).RaiseCanExecuteChanged();
+            }
         }
     }
 
     /// <summary>
-    /// Command to add a tag subscription.
+    /// Command to add a topic subscription.
     /// </summary>
-    public ICommand AddTagCommand { get; }
+    public ICommand AddTopicCommand => _addTopicCommand;
 
     /// <summary>
     /// Command to remove the selected subscription.
     /// </summary>
-    public ICommand RemoveTagCommand { get; }
+    public ICommand RemoveTopicCommand => _removeTopicCommand;
 
     /// <summary>
-    /// Command to connect to the broker.
+    /// Command to publish the selected subscription's test message.
+    /// </summary>
+    public ICommand PublishTestMessageCommand => _publishTestMessageCommand;
+
+    /// <summary>
+    /// Command to connect to the MQTT broker.
     /// </summary>
     public ICommand ConnectCommand { get; }
 
@@ -201,32 +139,17 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// </summary>
     public ICommand TestTagEndpointCommand => _testTagEndpointCommand;
 
-    private void AddTag()
-    /// <summary>
-    /// Attempts to subscribe to the specified topic and records the result.
-    /// </summary>
-    public async Task AddTopicAsync()
-    {
-        if (string.IsNullOrWhiteSpace(NewTag))
-            return;
-        var sub = new TagSubscription { Tag = NewTag };
-        Subscriptions.Add(sub);
-        NewTag = string.Empty;
-    }
+    private bool CanAddTopic() => !string.IsNullOrWhiteSpace(NewTopic);
 
-    private void RemoveTag()
+    private async Task AddTopicAsync()
     {
-        if (SelectedSubscription is null)
+        if (string.IsNullOrWhiteSpace(NewTopic))
             return;
-        _service.UpdateTagSubscription(new TagSubscription(NewTopic));
-        TagSubscriptions.Add(new TagSubscription { Tag = NewTopic });
-        Topics.Add(new TagSubscription { Topic = NewTopic, QoS = MqttQualityOfServiceLevel.AtMostOnce });
-        NewTopic = string.Empty;
 
         try
         {
             await _service.SubscribeAsync(NewTopic, NewQoS).ConfigureAwait(false);
-            Subscriptions.Add(new TagSubscription { Topic = NewTopic, QoS = NewQoS });
+            Subscriptions.Add(new TagSubscription(NewTopic) { QoS = NewQoS });
             SubscriptionResults.Add(new SubscriptionResult(NewTopic, true, $"Subscribed to {NewTopic}"));
             NewTopic = string.Empty;
         }
@@ -236,15 +159,10 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         }
     }
 
-    /// <summary>
-    /// Removes the selected subscription and unsubscribes from the broker.
-    /// </summary>
-    public async Task RemoveTopicAsync()
+    private async Task RemoveTopicAsync()
     {
         if (SelectedSubscription is null)
             return;
-
-        TagSubscriptions.Remove(SelectedSubscription);
 
         try
         {
@@ -252,10 +170,24 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         }
         catch
         {
-            // ignore unsubscribe failures; UI already reflects removal
+            // ignore failures, UI already reflects removal
         }
+
         Subscriptions.Remove(SelectedSubscription);
         SelectedSubscription = null;
+    }
+
+    private bool CanPublishTestMessage()
+        => SelectedSubscription is not null && !string.IsNullOrWhiteSpace(SelectedSubscription.OutgoingMessage);
+
+    private async Task PublishTestMessageAsync()
+    {
+        if (!CanPublishTestMessage())
+            return;
+
+        Logger?.Log("MQTT test publish start", LogLevel.Debug);
+        await _service.PublishAsync(SelectedSubscription!.Topic, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
+        Logger?.Log("MQTT test publish finished", LogLevel.Debug);
     }
 
     private bool CanTestTagEndpoint(TagSubscription? sub)
@@ -265,40 +197,17 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     {
         if (!CanTestTagEndpoint(sub))
             return;
+
         Logger?.Log("MQTT tag test publish start", LogLevel.Debug);
         await _service.PublishAsync(sub!.Endpoint, sub.OutgoingMessage).ConfigureAwait(false);
         Logger?.Log("MQTT tag test publish finished", LogLevel.Debug);
     }
-    private bool CanPublishTest() => SelectedSubscription != null && !string.IsNullOrWhiteSpace(TestMessage);
-    private bool CanPublishTest() => SelectedSubscription != null && !string.IsNullOrWhiteSpace(SelectedSubscription.OutgoingMessage);
 
-    /// <summary>
-    /// Connects to the MQTT broker.
-    /// </summary>
-    public async Task ConnectAsync()
+    private async Task ConnectAsync()
     {
         Logger?.Log("MQTT connect start", LogLevel.Debug);
         await _service.ConnectAsync().ConfigureAwait(false);
         Logger?.Log("MQTT connect finished", LogLevel.Debug);
-    }
-        foreach (var topic in Topics)
-        {
-            await _service.SubscribeAsync(topic.Topic, topic.QoS).ConfigureAwait(false);
-        }
-        IsConnected = true;
-        Logger?.Log("MQTT connect finished", LogLevel.Debug);
-    }
-
-    /// <summary>
-    /// Publishes the test message to the selected topic.
-    /// </summary>
-    public async Task PublishTestAsync()
-    {
-        if (!CanPublishTest())
-            return;
-        Logger?.Log("MQTT test publish start", LogLevel.Debug);
-        await _service.PublishAsync(SelectedSubscription!.Topic, TestMessage).ConfigureAwait(false);
-        Logger?.Log("MQTT test publish finished", LogLevel.Debug);
     }
 
     private void OnTagSubscriptionChanged(object? sender, TagSubscription subscription)
@@ -312,18 +221,14 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         {
             existing.StatusColor = subscription.StatusColor;
             existing.Icon = subscription.Icon;
-        await _service.PublishAsync(SelectedSubscription!.Tag, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
-        await _service.PublishAsync(SelectedTopic!.Topic, TestMessage).ConfigureAwait(false);
-        await _service.PublishAsync(SelectedSubscription!.Topic, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
-        Logger?.Log("MQTT test publish finished", LogLevel.Debug);
+        }
     }
 
-    private void SelectedSubscription_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    private void SelectedSubscriptionOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(TagSubscription.OutgoingMessage))
         {
-            ((AsyncRelayCommand)PublishTestMessageCommand).RaiseCanExecuteChanged();
+            _publishTestMessageCommand.RaiseCanExecuteChanged();
         }
     }
 }
-

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Reordered test-message controls above the topic list in `MqttTagSubscriptionsView` and aligned margins with design guidance.
 - MQTT service creation now occurs within the main window frame and returns to the previous view after completion, removing the popup window dependency.
 - Service context menus invoke a new `EditServiceCommand`; editing an MQTT service opens the connection view with current options preloaded.
+- Consolidated `MqttTagSubscriptionsViewModel` to a single subscription collection and unified topic properties.
 
 ### Removed
 - Placeholder "Desktop Template" text from the navigation bar.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -8,6 +8,15 @@ Effective Prompts / Instructions that worked: n/a
 Decisions & Rationale: Use DI to share single logging service and helpers.
 Action Items: Monitor CI for Windows-specific behaviors.
 Related Commits/PRs: (this PR)
+
+[2025-08-23 18:00] Topic: MQTT ViewModel cleanup
+Context: Removed duplicate fields and unified topic subscription properties.
+Observations: View model now exposes a single subscriptions collection with NewTopic/NewQoS inputs and updated commands.
+Codex Limitations noticed: pwsh unavailable for add-tip script.
+Effective Prompts / Instructions that worked: Following user request to consolidate properties.
+Decisions & Rationale: Simplify state management and ensure commands reference consistent members.
+Action Items: Monitor CI for regression in MQTT subscription workflow.
+Related Commits/PRs: (this PR)
 [2025-08-19 16:11] Topic: AsyncRelayCommand namespace
 Context: Moved AsyncRelayCommand classes into Helpers namespace to match folder structure and updated tests.
 Observations: View models now import DesktopApplicationTemplate.UI.Helpers; tests compile without namespace ambiguity.


### PR DESCRIPTION
## What changed
- Collapse duplicate topic/tag collections into a single subscription list
- Expose NewTopic and NewQoS properties with updated commands
- Rewrite TagSubscription model and tests for unified topic subscriptions
- Document MQTT view model cleanup

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code


------
https://chatgpt.com/codex/tasks/task_e_68a4a951157083269d7b328a3c317aae