### PR TITLE
refactor: streamline MQTT subscriptions view

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -1,16 +1,13 @@
 <Page x:Class="DesktopApplicationTemplate.UI.Views.MqttTagSubscriptionsView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       xmlns:models="clr-namespace:DesktopApplicationTemplate.UI.Models"
       xmlns:mqtt="clr-namespace:MQTTnet.Protocol;assembly=MQTTnet"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:mqtt="clr-namespace:MQTTnet.Protocol;assembly=MQTTnet"
       xmlns:sys="clr-namespace:System;assembly=mscorlib"
       mc:Ignorable="d">
     <Page.Resources>
-        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
         <ObjectDataProvider x:Key="QoSValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
             <ObjectDataProvider.MethodParameters>
                 <x:Type TypeName="mqtt:MqttQualityOfServiceLevel" />
@@ -20,100 +17,38 @@
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        <!-- Connection bar -->
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-            <Button x:Name="ConnectButton" Content="Connect" Command="{Binding ConnectCommand}" Width="80" AutomationProperties.Name="Connect MQTT"/>
-            <Grid Width="200" Margin="10,0,0,0">
-                <TextBox Text="{Binding NewTag}" x:Name="NewTagBox" ToolTip="Tag to subscribe"/>
-                <TextBlock Text="New Tag" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                <TextBox Text="{Binding NewTopic}" x:Name="NewTopicBox" ToolTip="Topic to subscribe" Style="{StaticResource FormField}"/>
-                <TextBlock Text="New Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                           VerticalAlignment="Center"
-                           Visibility="{Binding Text, ElementName=NewTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            </Grid>
-            <Button x:Name="AddButton" Content="Add" Command="{Binding AddTopicCommand}" Width="50" Margin="5,0,0,0" AutomationProperties.Name="Add Topic"/>
-            <Button x:Name="RemoveButton" Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0" AutomationProperties.Name="Remove Topic"/>
+            <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80" AutomationProperties.Name="Connect MQTT"/>
+            <TextBox Text="{Binding NewTopic}" Width="200" Margin="10,0,0,0" x:Name="NewTopicBox" ToolTip="Topic to subscribe"/>
+            <ComboBox Width="100" Margin="5,0,0,0"
+                      ItemsSource="{StaticResource QoSValues}"
+                      SelectedItem="{Binding NewQoS}"/>
+            <Button Content="Add" Command="{Binding AddTopicCommand}" Width="50" Margin="5,0,0,0"/>
+            <Button Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0"/>
         </StackPanel>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
-        <ListBox Grid.Row="1" ItemsSource="{Binding Subscriptions}" SelectedItem="{Binding SelectedSubscription}">
-            <ListBox.ItemTemplate>
-                <DataTemplate DataType="{x:Type models:TagSubscription}">
-                    <Border BorderBrush="{Binding StatusColor}" BorderThickness="2" CornerRadius="4" Padding="4" Margin="0,2">
-                        <StackPanel Orientation="Horizontal">
-                            <Image Source="{Binding Icon}" Width="16" Height="16" Margin="0,0,5,0"
-                                   Visibility="{Binding Icon, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-                            <TextBlock Text="{Binding Topic}"/>
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-
-        <ListBox Grid.Row="1" ItemsSource="{Binding TagSubscriptions}" SelectedItem="{Binding SelectedSubscription}" DisplayMemberPath="Tag"/>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
-            <Grid Width="200">
-                <TextBox Text="{Binding TestMessage}" x:Name="TestMessageBox" ToolTip="Message to send" Style="{StaticResource FormField}"/>
-                <TextBox Text="{Binding SelectedSubscription.OutgoingMessage, UpdateSourceTrigger=PropertyChanged}" x:Name="TestMessageBox" ToolTip="Message to send"/>
-        <ListBox Grid.Row="1" ItemsSource="{Binding Topics}" SelectedItem="{Binding SelectedTopic}">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Topic}" Width="150"/>
-                        <ComboBox SelectedValue="{Binding QoS}" SelectedValuePath="Tag" Width="120" Margin="5,0,0,0">
-                            <ComboBoxItem Content="At Most Once" Tag="{x:Static mqtt:MqttQualityOfServiceLevel.AtMostOnce}"/>
-                            <ComboBoxItem Content="At Least Once" Tag="{x:Static mqtt:MqttQualityOfServiceLevel.AtLeastOnce}"/>
-                            <ComboBoxItem Content="Exactly Once" Tag="{x:Static mqtt:MqttQualityOfServiceLevel.ExactlyOnce}"/>
-                        </ComboBox>
-        <Grid Grid.Row="0" Margin="0,0,0,10">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-            <StackPanel Orientation="Horizontal">
-                <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80"/>
-                <Grid Width="200" Margin="10,0,0,0">
-                    <TextBox Text="{Binding NewTopic}" x:Name="NewTopicBox" ToolTip="Topic to subscribe"/>
-                    <TextBlock Text="New Topic" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                               VerticalAlignment="Center"
-                               Visibility="{Binding Text, ElementName=NewTopicBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-                </Grid>
-                <ComboBox Width="100" Margin="5,0,0,0" ItemsSource="{Binding Source={StaticResource QoSValues}}" SelectedItem="{Binding NewQoS}"/>
-                <Button Content="Add" Command="{Binding AddTopicCommand}" Width="50" Margin="5,0,0,0"/>
-                <Button Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0"/>
-            </StackPanel>
-            <ItemsControl Grid.Column="1" ItemsSource="{Binding SubscriptionResults}" ItemTemplate="{DynamicResource SubscriptionResultTemplate}" HorizontalAlignment="Right" />
-        </Grid>
-        <ListBox Grid.Row="1" ItemsSource="{Binding Subscriptions}" SelectedItem="{Binding SelectedSubscription}">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Topic}" />
-                        <TextBlock Text="{Binding QoS}" Margin="5,0,0,0" />
-                    </StackPanel>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
-            <Grid Width="200">
-                <TextBox Text="{Binding SelectedSubscription.OutgoingMessage}" x:Name="TestMessageBox" ToolTip="Message to send"/>
-                <TextBlock Text="Test Message" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
-                           VerticalAlignment="Center"
-                           Visibility="{Binding Text, ElementName=NewTagBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            </Grid>
-            <Button Content="Add" Command="{Binding AddTagCommand}" Width="50" Margin="5,0,0,0"/>
-            <Button Content="Remove" Command="{Binding RemoveTagCommand}" Width="70" Margin="5,0,0,0"/>
-        </StackPanel>
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Subscriptions}" SelectedItem="{Binding SelectedSubscription}"
-                  AutoGenerateColumns="False" HeadersVisibility="Column" CanUserAddRows="False">
+        <!-- Subscriptions list -->
+        <DataGrid Grid.Row="1"
+                  ItemsSource="{Binding Subscriptions}"
+                  SelectedItem="{Binding SelectedSubscription}"
+                  AutoGenerateColumns="False"
+                  HeadersVisibility="Column"
+                  CanUserAddRows="False">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Tag" Binding="{Binding Tag}" IsReadOnly="True"/>
-                <DataGridTextColumn Header="Endpoint" Binding="{Binding Endpoint, UpdateSourceTrigger=PropertyChanged}"/>
-                <DataGridTextColumn Header="Message" Binding="{Binding OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTextColumn Header="Topic" Binding="{Binding Topic}" IsReadOnly="True"/>
+                <DataGridComboBoxColumn Header="QoS"
+                                        SelectedItemBinding="{Binding QoS}"
+                                        ItemsSource="{StaticResource QoSValues}"/>
+                <DataGridTextColumn Header="Endpoint"
+                                    Binding="{Binding Endpoint, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTextColumn Header="Message"
+                                    Binding="{Binding OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"/>
                 <DataGridTemplateColumn Header="Test">
                     <DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate>
+                        <DataTemplate DataType="{x:Type models:TagSubscription}">
                             <Button Content="Test" Width="50"
                                     Command="{Binding DataContext.TestTagEndpointCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                     CommandParameter="{Binding}"/>
@@ -122,8 +57,18 @@
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-            <Button x:Name="SendButton" Content="Send" Command="{Binding PublishTestMessageCommand}" Width="60" Margin="5,0,0,0" AutomationProperties.Name="Send Test Message"/>
+        <!-- Test message bar -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
+            <TextBox Text="{Binding SelectedSubscription.OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"
+                     Width="200"
+                     x:Name="TestMessageBox"
+                     ToolTip="Message to send"/>
+            <Button Content="Send" Command="{Binding PublishTestMessageCommand}" Width="60" Margin="5,0,0,0"/>
+            <Button Content="Test"
+                    Command="{Binding TestTagEndpointCommand}"
+                    CommandParameter="{Binding SelectedSubscription}"
+                    Width="60"
+                    Margin="5,0,0,0"/>
         </StackPanel>
-        <ListBox Grid.Row="2" ItemsSource="{Binding Topics}" SelectedItem="{Binding SelectedTopic}"/>
     </Grid>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@
 - MQTT service creation now occurs within the main window frame and returns to the previous view after completion, removing the popup window dependency.
 - Service context menus invoke a new `EditServiceCommand`; editing an MQTT service opens the connection view with current options preloaded.
 - Consolidated `MqttTagSubscriptionsViewModel` to a single subscription collection and unified topic properties.
+- Simplified `MqttTagSubscriptionsView` layout, removing duplicate controls and redundant namespace declarations.
 
 ### Removed
 - Placeholder "Desktop Template" text from the navigation bar.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -423,3 +423,11 @@ Effective Prompts / Instructions that worked: Following request to capture resul
 Decisions & Rationale: Store per-topic QoS and message; visualize subscription outcomes for user clarity.
 Action Items: Monitor CI for UI styling discrepancies.
 Related Commits/PRs: (this PR)
+[2025-08-19 16:52] Topic: Mqtt subscriptions view cleanup
+Context: Removed redundant namespace and duplicate controls from MqttTagSubscriptionsView.
+Observations: Simplified grid with connection bar, subscription list, and test message bar. Build fails on Linux with MqttService.cs errors.
+Codex Limitations noticed: WPF project fails to build in Linux environment.
+Effective Prompts / Instructions that worked: Following user request to consolidate layout and bindings.
+Decisions & Rationale: Streamlined view to match cleaned view model and remove duplicate definitions.
+Action Items: Verify XAML on Windows CI.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## Summary
- remove duplicate namespace declarations and controls from MqttTagSubscriptionsView
- collapse subscriptions view into connection bar, subscription grid, and test message row
- document view cleanup in changelog and tips

## Testing
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(fails: MqttService.cs modifier errors)*
- `dotnet test --settings tests.runsettings` *(fails: MqttService.cs modifier errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aaa87ed08326a0a1e8ab29521291