### PR TITLE
docs: clarify environment precedence in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,5 @@
 - `CollaborationGuidelines.txt` provides collaboration practices, while `docs/CollaborationAndDebugTips.txt` is a running log of what worked, what broke, and why.
 - Update those documents when your changes add context or new guidance.
 - After modifying code, attempt to run `dotnet test` with `tests.runsettings` and share the results; if the environment lacks Windows desktop support, note the limitation and rely on CI.
+
+Follow system/user environment instructions. When they conflict (e.g., read-only mode), note the limitation and skip the step.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - File dialog service registered for TLS certificate selection in MQTT views.
 
 ### Changed
+- Clarified environment instruction precedence in `AGENTS.md`.
 - Renamed root `CollaborationAndDebugTips.txt` to `CollaborationGuidelines.txt` and clarified distinction from `docs/CollaborationAndDebugTips.txt`.
 - Updated `global.json` to require the .NET 8 SDK version `8.0.404`.
 - Default `AutoStart` is now disabled and all environment configuration files set `"AutoStart": false`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1,6 +1,15 @@
 # Collaboration & Debug Tips (Codex <-> Matt)
 Purpose: Running log of what worked, what broke, and why.
 
+[2025-08-20 17:33] Topic: Environment precedence docs
+Context: Clarified AGENTS instructions about following environment directives.
+Observations: Added paragraph to note limitations when instructions conflict, such as read-only mode.
+Codex Limitations noticed: none
+Effective Prompts / Instructions that worked: User request to clarify environment precedence.
+Decisions & Rationale: Document conflict handling so steps are skipped instead of failing.
+Action Items: none
+Related Commits/PRs: (this PR)
+
 [2025-08-20 13:35] Topic: QoS ItemsSource binding
 Context: Clicking MQTT service crashed because QoS enum provider was assigned directly to ItemsSource.
 Observations: Binding through resource source and restoring send button accessibility prevents runtime ArgumentException.


### PR DESCRIPTION
## What changed
- [ ] Code
- [ ] UI/XAML
- [ ] Tests
- [ ] DI registrations
- [x] Docs updated

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code

Attempted `dotnet test --settings tests.runsettings` but `dotnet` was not found in the container; relying on CI for validation.

------
https://chatgpt.com/codex/tasks/task_e_68a60689aff08326af55ce0952e33340