### PR TITLE
docs: document read-only workflow

### DIFF
--- a/CollaborationGuidelines.txt
+++ b/CollaborationGuidelines.txt
@@ -34,6 +34,11 @@ Miscellaneous Tips
 - Reuse existing services and view models instead of duplicating logic.
 - Maintain clear, purpose-driven variable names for readability and maintainability.
 
+Working in restricted environments
+----------------------------------
+- Review AGENTS and docs.
+- Note limitations (tests, writes) in PRs or collaboration log.
+
 [2025-08-15 10:00] Topic: MQTT options and DI
 Context: Introduced `MqttServiceOptions` with DI support and consolidated registrations using `IOptions`.
 Observations: Added `MessageRoutingService` and verified the service provider builds cleanly.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Section on working in restricted environments and reminder to log limitations in collaboration docs.
 - Documented Codex architecture and coding standards in `AGENTS.md`.
 - Each MQTT tag subscription now retains its own outgoing test message, and the test message box binds to the selected tag's message.
 - Wizard-style MQTT service creation view capturing broker, credentials, TLS, and will message options.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1,3 +1,12 @@
+[2025-08-20 18:51] Topic: Document read-only workflow
+Context: Added restricted-environment guidance and preamble about logging limitations.
+Observations: Guidelines now instruct contributors to review AGENTS/docs and note constraints.
+Codex Limitations noticed: dotnet CLI unavailable; tests could not run.
+Effective Prompts / Instructions that worked: User request to document read-only workflow.
+Decisions & Rationale: Promote transparency about environment constraints.
+Action Items: none
+Related Commits/PRs: (this PR)
+
 [2025-08-20 18:38] Topic: Codex architecture reference
 Context: Added "Architecture & Coding Standards" section to AGENTS.md.
 Observations: Section summarizes DI registration, testing, logging policies, and references Codex guidelines.
@@ -9,6 +18,8 @@ Related Commits/PRs: (this PR)
 
 # Collaboration & Debug Tips (Codex <-> Matt)
 Purpose: Running log of what worked, what broke, and why.
+
+Remember to record environment limitations (e.g., missing tests or write restrictions) in each log entry.
 
 [2025-08-20 17:33] Topic: Environment precedence docs
 Context: Clarified AGENTS instructions about following environment directives.


### PR DESCRIPTION
## What changed
- Document working in restricted environments in collaboration guidelines
- Remind contributors to log environment limitations in collaboration/debug tips
- Log change and update changelog

## Validation
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a618a45d4883269a8ffc9fa73ae7af