### PR TITLE
Add folder browsing and tokenized CSV paths

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -164,6 +164,33 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void RecordLog_UsesServiceAndMessageTokens()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                var vm = new CsvViewerViewModel(configPath);
+                vm.Configuration.FileNamePattern = Path.Combine(tempDir, "{service}.{message}/output_{index}.csv");
+                var svc = new CsvService(vm);
+
+                svc.RecordLog("TCP1", "message");
+
+                var expected = Path.Combine(tempDir, "TCP1.message", "output_0.csv");
+                Assert.True(File.Exists(expected));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
         [TestCategory("WindowsSafe")]
         public void CsvServiceView_LoadsInto_ContentFrame()
         {

--- a/DesktopApplicationTemplate.Tests/CsvViewerViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvViewerViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Services;
 using FluentAssertions;
 using Xunit;
 
@@ -27,6 +28,27 @@ public class CsvViewerViewModelTests
             }
         }
     }
+
+    private class StubFileDialogService : IFileDialogService
+    {
+        public string? Folder { get; set; }
+        public string? OpenFile() => null;
+        public string? SelectFolder() => Folder;
+    }
+
+    [Fact]
+    public void BrowseCommand_UpdatesFileNamePattern()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var dialog = new StubFileDialogService { Folder = temp };
+        var vm = new CsvViewerViewModel(fileDialog: dialog);
+        vm.Configuration.FileNamePattern = "output_{index}.csv";
+
+        vm.BrowseCommand.Execute(null);
+
+        vm.Configuration.FileNamePattern.Should().StartWith(temp);
+    }
+}
 
 #if DEBUG
     [Fact]

--- a/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServiceViewModelTests.cs
@@ -14,6 +14,7 @@ namespace DesktopApplicationTemplate.Tests
         private class StubFileDialogService : IFileDialogService
         {
             public string? OpenFile() => "stub.txt";
+            public string? SelectFolder() => null;
         }
 
         [Fact]

--- a/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Win32;
+using System.IO;
 
 namespace DesktopApplicationTemplate.UI.Services
 {
@@ -8,6 +9,19 @@ namespace DesktopApplicationTemplate.UI.Services
         {
             var dialog = new Microsoft.Win32.OpenFileDialog();
             return dialog.ShowDialog() == true ? dialog.FileName : null;
+        }
+
+        public string? SelectFolder()
+        {
+            var dialog = new OpenFileDialog
+            {
+                CheckFileExists = false,
+                CheckPathExists = true,
+                FileName = "Folder Selection"
+            };
+            return dialog.ShowDialog() == true
+                ? Path.GetDirectoryName(dialog.FileName)
+                : null;
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
@@ -3,5 +3,6 @@ namespace DesktopApplicationTemplate.UI.Services
     public interface IFileDialogService
     {
         string? OpenFile();
+        string? SelectFolder();
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/CsvServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvServiceView.xaml
@@ -22,6 +22,7 @@
                            VerticalAlignment="Center"
                            Visibility="{Binding Text, ElementName=PatternBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
+            <Button Content="Browse" Command="{Binding BrowseCommand}" Width="60" Margin="5,0,0,0"/>
         </StackPanel>
         <DataGrid Grid.Row="1" ItemsSource="{Binding Configuration.Columns}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedColumn}">
             <DataGrid.Columns>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - MqttService tests now verify TLS and credential configuration alongside will messages and keep-alive options.
 - Tag subscriptions now allow per-topic QoS selection with forwarding to the MQTT client.
 - Subscribe/unsubscribe support for MQTT topics with QoS selection and visual feedback for subscription results.
+- CSV creator supports folder selection and `{service}`/`{message}` tokens for file naming.
 
 - File dialog service registered for TLS certificate selection in MQTT views.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1002,3 +1002,11 @@ Effective Prompts / Instructions that worked:
 Decisions & Rationale: Updated tests and logging to reflect new behavior
 Action Items:
 Related Commits/PRs:
+[2025-08-21 13:37] Topic: CSV folder token support
+Context: Added folder browse button and service/message tokens for CSV file paths.
+Observations: CSV files can now be organized under tokenized directories via the Browse command.
+Codex Limitations noticed: dotnet CLI unavailable; tests not executed.
+Effective Prompts / Instructions that worked: User request for configurable folder structures.
+Decisions & Rationale: Introduced SelectFolder dialog service and token replacement in CsvService.
+Action Items: rely on CI for verification.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- Add Browse button to CSV creator for selecting output directory
- Support `{service}` and `{message}` tokens with directory creation in CSV paths
- Extend file dialog service with folder selection and unit tests

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code

------
https://chatgpt.com/codex/tasks/task_e_68a71fd240408326ad0806c1d66a405e