### PR TITLE
Allow hostnames in network validators and fix MQTT tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
@@ -14,14 +14,14 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MqttEditConnectionViewModelTests
 {
-    private static MqttEditConnectionViewModel CreateViewModel(Mock<IMqttClient>? clientMock = null)
+    private static MqttEditConnectionViewModel CreateViewModel(Mock<IMqttClient>? clientMock = null, bool isConnected = false)
     {
         var client = clientMock ?? new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
         client.Setup(c => c.DisconnectAsync(It.IsAny<MqttClientDisconnectOptions?>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        client.SetupGet(c => c.IsConnected).Returns(true);
+        client.SetupGet(c => c.IsConnected).Returns(isConnected);
         var options = Microsoft.Extensions.Options.Options.Create(new MqttServiceOptions());
         var service = new MqttService(client.Object, options, Mock.Of<IMessageRoutingService>(), Mock.Of<ILoggingService>());
         return new MqttEditConnectionViewModel(service, options, Mock.Of<ILoggingService>());
@@ -57,9 +57,7 @@ public class MqttEditConnectionViewModelTests
             .ReturnsAsync(new MqttClientConnectResult());
         client.Setup(c => c.DisconnectAsync(It.IsAny<MqttClientDisconnectOptions?>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        var options = Microsoft.Extensions.Options.Options.Create(new MqttServiceOptions());
-        var service = new MqttService(client.Object, options, Mock.Of<IMessageRoutingService>(), Mock.Of<ILoggingService>());
-        var vm = new MqttEditConnectionViewModel(service, options);
+        var vm = CreateViewModel(client, true);
         var closed = false;
         vm.RequestClose += (_, _) => closed = true;
         await vm.ToggleSubscriptionAsync();

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -28,8 +28,11 @@ public class MqttServiceViewModelTests
         var client = clientMock ?? new Mock<IMqttClient>();
         client.Setup(c => c.PublishAsync(It.IsAny<MqttApplicationMessage>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientPublishResult(null, MqttClientPublishReasonCode.Success, null!, Array.Empty<MqttUserProperty>()));
-        client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MqttClientConnectResult());
+        if (clientMock is null)
+        {
+            client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new MqttClientConnectResult());
+        }
         var service = new MqttService(client.Object, options, routing.Object, logger);
         var helper = new SaveConfirmationHelper(logger);
         return new MqttServiceViewModel(service, routing.Object, helper, options, logger);

--- a/DesktopApplicationTemplate.UI/Helpers/InputValidators.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/InputValidators.cs
@@ -2,13 +2,15 @@ namespace DesktopApplicationTemplate.UI.Helpers
 {
     public static class InputValidators
     {
-        public static bool IsValidPartialIp(string? value)
+        public static bool IsValidHost(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
                 return true;
             if (value.EndsWith("."))
                 return true;
-            return System.Net.IPAddress.TryParse(value, out _);
+            if (System.Net.IPAddress.TryParse(value, out _))
+                return true;
+            return System.Uri.CheckHostName(value) != System.UriHostNameType.Unknown;
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServiceViewModel.cs
@@ -17,7 +17,7 @@ public class FtpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             set
             {
                 _host = value;
-                if (!InputValidators.IsValidPartialIp(value))
+                if (!InputValidators.IsValidHost(value))
                 {
                     AddError(nameof(Host), "Invalid host or IP address");
                     Logger?.Log("Invalid FTP host entered", LogLevel.Warning);

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttEditConnectionViewModel.cs
@@ -69,7 +69,7 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         set
         {
             if (_host == value) return;
-            if (!InputValidators.IsValidPartialIp(value))
+            if (!InputValidators.IsValidHost(value))
             {
                 AddError(nameof(Host), "Invalid host");
                 Logger?.Log("Invalid MQTT host entered", LogLevel.Warning);

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -80,7 +80,7 @@ public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel,
         {
             if (_options.Host == value)
                 return;
-            if (!InputValidators.IsValidPartialIp(value))
+            if (!InputValidators.IsValidHost(value))
             {
                 AddError(nameof(Host), "Invalid host");
                 Logger?.Log("Invalid MQTT host entered", LogLevel.Warning);

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpServiceViewModel.cs
@@ -16,7 +16,7 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
             get => _host;
             set
             {
-                if (InputValidators.IsValidPartialIp(value))
+                if (InputValidators.IsValidHost(value))
                     _host = value;
                 OnPropertyChanged();
             }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -72,7 +72,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             set
             {
                 _computerIp = value;
-                if (!InputValidators.IsValidPartialIp(value))
+                if (!InputValidators.IsValidHost(value))
                 {
                     AddError(nameof(ComputerIp), "Invalid IP address");
                     Logger?.Log("Invalid computer IP entered", LogLevel.Warning);
@@ -110,7 +110,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             set
             {
                 _serverIp = value;
-                if (!InputValidators.IsValidPartialIp(value))
+                if (!InputValidators.IsValidHost(value))
                 {
                     AddError(nameof(ServerIp), "Invalid IP address");
                     Logger?.Log("Invalid server IP entered", LogLevel.Warning);
@@ -129,7 +129,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
             set
             {
                 _serverGateway = value;
-                if (!InputValidators.IsValidPartialIp(value))
+                if (!InputValidators.IsValidHost(value))
                 {
                     AddError(nameof(ServerGateway), "Invalid IP address");
                     Logger?.Log("Invalid server gateway entered", LogLevel.Warning);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Added tests confirming the main view ignores non-Escape key presses and service persistence handles cyclical references.
 - Eliminated recursive logging in CSV service to prevent stack overflow and added guards that capture configuration snapshots on save failures.
 - Removed invalid `MouseDoubleClick` XAML handler and cleaned up ambiguous WPF references causing build failures.
+- Host validation now accepts domain names for all services, preventing connection errors when using non-IP hosts.
 - Corrected service count bindings to use one-way mode, preventing runtime errors on read-only properties.
 - Resolved WPF build error by removing duplicate StackPanel from `MqttCreateServiceView` so the page hosts a single `ScrollViewer`.
 - Added missing `MQTTnet.Protocol` using in `MqttCreateServiceViewModel` to restore `MqttQualityOfServiceLevel` references.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1002,3 +1002,11 @@ Effective Prompts / Instructions that worked:
 Decisions & Rationale: Updated tests and logging to reflect new behavior
 Action Items:
 Related Commits/PRs:
+[2025-08-21 13:38] Topic: Hostname validation for network services
+Context: Tests failed because hostnames were rejected by IP-only validation.
+Observations: Expanded validation to allow domain names and updated MQTT edit tests for connection state handling.
+Codex Limitations noticed: pwsh unavailable for add-tip script.
+Effective Prompts / Instructions that worked: user provided failing test output highlighting host requirement.
+Decisions & Rationale: Ensure host validation accepts both IP addresses and domain names to prevent false errors.
+Action Items: run tests.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- Accept domain names in host validation and update all networked view models
- Stabilize MQTT edit/service tests by honoring connection state and custom client behavior
- Document hostname validation fix in changelog and collaboration tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App not installed; rely on CI)*

------
https://chatgpt.com/codex/tasks/task_e_68a7205e70f48326be14e2cd39c4cd09