### PR TITLE
ci: skip checks for dev pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches:
       - main
-      - dev
+      # dev branch intentionally excluded so PRs targeting dev skip CI checks
   workflow_dispatch:
 
 jobs:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Updated `global.json` to require the .NET 8 SDK version `8.0.404`.
 - Default `AutoStart` is now disabled and all environment configuration files set `"AutoStart": false`.
 - CI workflow now runs on pushes to `feature/**` and `bugfix/**` branches and supports manual triggers, ensuring tests execute on GitHub.
+- CI workflow skips checks for pull requests targeting the `dev` branch to speed up integration.
 - `MqttCreateServiceView`, `MqttTagSubscriptionsView`, and `MqttEditConnectionView` along with their view models are now registered as transient services.
 - `self-heal` workflow now monitors the unified `CI` pipeline.
 - MQTT create, edit, and subscription views now follow design spacing with shared form styles and accessibility names.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1010,3 +1010,12 @@ Effective Prompts / Instructions that worked: user provided failing test output 
 Decisions & Rationale: Ensure host validation accepts both IP addresses and domain names to prevent false errors.
 Action Items: run tests.
 Related Commits/PRs: (this PR)
+[2025-08-21 14:11] Topic: Skip CI for dev pull requests
+Context: Pipeline ran unnecessarily on PRs targeting dev.
+Observations: Removed dev branch from pull_request trigger to bypass checks and build steps for dev PRs.
+Codex Limitations noticed: pwsh and dotnet CLI unavailable; tests not executed.
+Effective Prompts / Instructions that worked: user request to disable CI for dev pull requests.
+Decisions & Rationale: Excluding dev from pull_request triggers avoids redundant builds.
+Action Items: rely on CI for validation on other branches.
+Related Commits/PRs: (this PR)
+


### PR DESCRIPTION
## What changed
- skip CI checks for pull requests targeting `dev`
- document CI behavior change

## Validation
- `dotnet test --settings tests.runsettings` *(fails: dotnet CLI unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_68a728e9306083268be4e829ffde0c25