### PR TITLE
feat: add TCP service creation navigation

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class CreateServiceNavigationTests
+{
+    [Fact]
+    public void ServiceType_Click_RaisesTcpSelected()
+    {
+        string? receivedName = null;
+        var thread = new Thread(() =>
+        {
+            var vm = new CreateServiceViewModel();
+            var page = new CreateServicePage(vm);
+            page.TcpSelected += name => receivedName = name;
+            var button = new Button { DataContext = new CreateServiceViewModel.ServiceTypeMetadata("TCP", "TCP", string.Empty) };
+            var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            method.Invoke(page, new object[] { button, new RoutedEventArgs() });
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        receivedName.Should().Be("TCP1");
+    }
+
+    [Fact]
+    public void NavigateToTcp_SetsPropertiesAndOptions()
+    {
+        var vm = new TcpCreateServiceViewModel();
+        var view = new TcpCreateServiceView();
+        var services = new ServiceCollection();
+        services.AddSingleton(vm);
+        services.AddSingleton(view);
+        var provider = services.BuildServiceProvider();
+
+        var windowThread = new Thread(() =>
+        {
+            var window = new CreateServiceWindow(new CreateServiceViewModel(), provider);
+            var pageField = typeof(CreateServiceWindow).GetField("_page", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var page = (CreateServicePage)pageField.GetValue(window)!;
+            var button = new Button { DataContext = new CreateServiceViewModel.ServiceTypeMetadata("TCP", "TCP", string.Empty) };
+            var click = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            click.Invoke(page, new object[] { button, new RoutedEventArgs() });
+
+            var options = new TcpServiceOptions { Host = "h", Port = 1, Mode = TcpServiceMode.Listening };
+            var evt = typeof(TcpCreateServiceViewModel).GetField("ServiceCreated", BindingFlags.Instance | BindingFlags.NonPublic);
+            var del = (Action<string, TcpServiceOptions>?)evt?.GetValue(vm);
+            del?.Invoke("Svc", options);
+
+            window.CreatedServiceType.Should().Be("TCP");
+            window.CreatedServiceName.Should().Be("Svc");
+            window.TcpOptions.Should().Be(options);
+        });
+        windowThread.SetApartmentState(ApartmentState.STA);
+        windowThread.Start();
+        windowThread.Join();
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -10,6 +10,7 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly CreateServiceViewModel _viewModel;
         public event Action<string, string>? ServiceCreated;
         public event Action<string>? MqttSelected;
+        public event Action<string>? TcpSelected;
         public event Action? Cancelled;
 
         public CreateServicePage(CreateServiceViewModel viewModel)
@@ -27,6 +28,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (meta.Type == "MQTT")
                 {
                     MqttSelected?.Invoke(name);
+                    return;
+                }
+                if (meta.Type == "TCP")
+                {
+                    TcpSelected?.Invoke(name);
                     return;
                 }
                 ServiceCreated?.Invoke(name, meta.Type);

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
@@ -11,6 +11,7 @@ namespace DesktopApplicationTemplate.UI.Views
         public string CreatedServiceName { get; private set; } = string.Empty;
         public string CreatedServiceType { get; private set; } = string.Empty;
         public MqttServiceOptions? MqttOptions { get; private set; }
+        public TcpServiceOptions? TcpOptions { get; private set; }
 
         private readonly IServiceProvider _services;
         private readonly CreateServicePage _page;
@@ -28,6 +29,7 @@ namespace DesktopApplicationTemplate.UI.Views
             };
             _page.Cancelled += () => DialogResult = false;
             _page.MqttSelected += NavigateToMqtt;
+            _page.TcpSelected += NavigateToTcp;
             ContentFrame.Content = _page;
         }
 
@@ -44,6 +46,23 @@ namespace DesktopApplicationTemplate.UI.Views
             };
             vm.Cancelled += () => ContentFrame.Content = _page;
             var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(_services, vm);
+            ContentFrame.Content = view;
+        }
+
+        private void NavigateToTcp(string defaultName)
+        {
+            var vm = _services.GetRequiredService<TcpCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceCreated += (name, options) =>
+            {
+                CreatedServiceName = name;
+                CreatedServiceType = "TCP";
+                TcpOptions = options;
+                DialogResult = true;
+            };
+            vm.Cancelled += () => ContentFrame.Content = _page;
+            var view = _services.GetRequiredService<TcpCreateServiceView>();
+            view.DataContext = vm;
             ContentFrame.Content = view;
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- TCP service creation flow integrated into selection window with option persistence.
 - TCP service creation view and view model with configurable options and unit tests.
 - CSV creator now supports selecting an output directory and nested folder patterns when naming files.
 - WebSocket path configuration with TLS disabled when using WebSockets.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -3,6 +3,15 @@ Purpose: Running log of what worked, what broke, and why.
 
 Remember to record environment limitations (e.g., missing tests or write restrictions) in each log entry.
 
+[2025-08-22 13:45] Topic: TCP service creation navigation
+Context: Wired TCP selection through create service window.
+Observations: Page raises TcpSelected and window navigates to TCP view storing options.
+Codex Limitations noticed: Linux container lacks WPF runtime; tests rely on CI.
+Effective Prompts / Instructions that worked: user request to extend service creation.
+Decisions & Rationale: Mirror MQTT flow for navigation and option persistence.
+Action Items: Monitor CI for integration.
+Related Commits/PRs: (this PR)
+
 [2025-08-22 13:39] Topic: TCP service creation view
 Context: Added TCP create view model, view, options, DI registrations, and tests.
 Observations: View model mirrors MQTT pattern and raises create/cancel events.


### PR DESCRIPTION
## What changed
- handle TCP selection in create service page and window
- add tests for TCP create navigation
- document TCP create window integration

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 not installed; rely on CI)*

------
https://chatgpt.com/codex/tasks/task_e_68a873eba0e48326bc7222eb87046e7a