### PR TITLE
Add TCP service messages view with log filtering

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -1,0 +1,33 @@
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class TcpServiceMessagesViewModelTests
+{
+    [Fact]
+    public void DisplayLogs_RespectsLogLevelFilter()
+    {
+        var vm = new TcpServiceMessagesViewModel();
+        vm.Logs.Add(new LogEntry { Message = "a", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Debug });
+        vm.Logs.Add(new LogEntry { Message = "b", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Error });
+
+        vm.LogLevelFilter = DesktopApplicationTemplate.Core.Services.LogLevel.Error;
+
+        vm.DisplayLogs.Should().ContainSingle().Which.Message.Should().Be("b");
+    }
+
+    [Fact]
+    public void ClearLogCommand_RemovesLogs()
+    {
+        var vm = new TcpServiceMessagesViewModel();
+        vm.Logs.Add(new LogEntry { Message = "test" });
+
+        vm.ClearLogCommand.Execute(null);
+
+        vm.Logs.Should().BeEmpty();
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -52,6 +52,8 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<TcpServiceView>();
             services.AddSingleton<TcpServiceViewModel>();
+            services.AddSingleton<TcpServiceMessagesView>();
+            services.AddSingleton<TcpServiceMessagesViewModel>();
             services.AddSingleton<DependencyChecker>();
             services.AddSingleton<HttpServiceView>();
             services.AddSingleton<HttpServiceViewModel>();

--- a/DesktopApplicationTemplate.UI/Models/TcpMessageRow.cs
+++ b/DesktopApplicationTemplate.UI/Models/TcpMessageRow.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.Models
+{
+    /// <summary>
+    /// Represents a single TCP message exchange including incoming and outgoing data.
+    /// </summary>
+    public class TcpMessageRow
+    {
+        /// <summary>Incoming message content.</summary>
+        public string IncomingMessage { get; set; } = string.Empty;
+
+        /// <summary>IP address of the sender.</summary>
+        public string IncomingIp { get; set; } = string.Empty;
+
+        /// <summary>Outgoing message content.</summary>
+        public string OutgoingMessage { get; set; } = string.Empty;
+
+        /// <summary>Service associated with the outgoing message.</summary>
+        public string ConnectedService { get; set; } = string.Empty;
+
+        /// <summary>Result of sending the outgoing message.</summary>
+        public string Result { get; set; } = string.Empty;
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -1,0 +1,73 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Models;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    /// <summary>
+    /// View model for displaying TCP service messages and associated logs.
+    /// </summary>
+    public class TcpServiceMessagesViewModel : ViewModelBase, ILoggingViewModel
+    {
+        private LogLevel _logLevelFilter = LogLevel.Debug;
+
+        /// <summary>Collection of TCP message rows.</summary>
+        public ObservableCollection<TcpMessageRow> Messages { get; } = new();
+
+        /// <summary>Collection of log entries.</summary>
+        public ObservableCollection<LogEntry> Logs { get; } = new();
+
+        /// <inheritdoc />
+        public ILoggingService? Logger { get; set; }
+
+        /// <summary>Gets or sets the minimum log level to display.</summary>
+        public LogLevel LogLevelFilter
+        {
+            get => _logLevelFilter;
+            set
+            {
+                if (_logLevelFilter == value) return;
+                _logLevelFilter = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DisplayLogs));
+            }
+        }
+
+        /// <summary>Logs matching the current <see cref="LogLevelFilter"/>.</summary>
+        public IEnumerable<LogEntry> DisplayLogs => Logs.Where(l => l.Level >= LogLevelFilter);
+
+        /// <summary>Command to clear displayed logs.</summary>
+        public ICommand ClearLogCommand { get; }
+
+        /// <summary>Command to export displayed logs to a file.</summary>
+        public ICommand ExportLogCommand { get; }
+
+        /// <summary>Command to refresh log display.</summary>
+        public ICommand RefreshLogCommand { get; }
+
+        public TcpServiceMessagesViewModel()
+        {
+            ClearLogCommand = new RelayCommand(ClearLogs);
+            ExportLogCommand = new RelayCommand(ExportLogs);
+            RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
+        }
+
+        private void ClearLogs()
+        {
+            Logs.Clear();
+            OnPropertyChanged(nameof(DisplayLogs));
+            Logger?.Log("TCP logs cleared", LogLevel.Debug);
+        }
+
+        private void ExportLogs()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "tcp_logs.txt");
+            File.WriteAllLines(path, DisplayLogs.Select(l => l.Message));
+            Logger?.Log($"TCP logs exported to {path}", LogLevel.Debug);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -83,7 +83,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
             svc.ServicePage = svc.ServiceType switch
             {
-                "TCP" => App.AppHost.Services.GetRequiredService<TcpServiceView>(),
+                "TCP" => App.AppHost.Services.GetRequiredService<TcpServiceMessagesView>(),
                 "HTTP" => App.AppHost.Services.GetRequiredService<HttpServiceView>(),
                 "File Observer" => App.AppHost.Services.GetRequiredService<FileObserverView>(),
                 "HID" => App.AppHost.Services.GetRequiredService<HidViews>(),

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -1,0 +1,45 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.TcpServiceMessagesView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <DataGrid Grid.Row="0" ItemsSource="{Binding Messages}" AutoGenerateColumns="False" Margin="0,0,0,10">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Incoming Message" Binding="{Binding IncomingMessage}" Width="*"/>
+                <DataGridTextColumn Header="Incoming IP" Binding="{Binding IncomingIp}" Width="*"/>
+                <DataGridTextColumn Header="Outgoing Message" Binding="{Binding OutgoingMessage}" Width="*"/>
+                <DataGridTextColumn Header="Connected Service" Binding="{Binding ConnectedService}" Width="*"/>
+                <DataGridTextColumn Header="Outgoing Result" Binding="{Binding Result}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <StackPanel Grid.Row="1" Orientation="Vertical">
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                <TextBlock Text="Log Level" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <ComboBox Width="150" SelectedValue="{Binding LogLevelFilter, Mode=TwoWay}">
+                    <ComboBoxItem Content="Debug"/>
+                    <ComboBoxItem Content="Warning"/>
+                    <ComboBoxItem Content="Error"/>
+                    <ComboBoxItem Content="Critical"/>
+                </ComboBox>
+                <Button Content="Export Log" Command="{Binding ExportLogCommand}" Margin="10,0,0,0" Width="100"/>
+                <Button Content="Clear Log" Command="{Binding ClearLogCommand}" Margin="10,0,0,0" Width="100"/>
+                <Button Content="Update Log" Command="{Binding RefreshLogCommand}" Margin="10,0,0,0" Width="100"/>
+            </StackPanel>
+            <ListBox ItemsSource="{Binding DisplayLogs}" Height="200">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -1,0 +1,17 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    /// <summary>
+    /// Interaction logic for TcpServiceMessagesView.xaml
+    /// </summary>
+    public partial class TcpServiceMessagesView : Page
+    {
+        public TcpServiceMessagesView(TcpServiceMessagesViewModel viewModel)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - MqttService tests now verify TLS and credential configuration alongside will messages and keep-alive options.
 - Tag subscriptions now allow per-topic QoS selection with forwarding to the MQTT client.
 - Subscribe/unsubscribe support for MQTT topics with QoS selection and visual feedback for subscription results.
+- View and view model for displaying TCP service messages with log-level filtering and log management commands.
 
 - File dialog service registered for TLS certificate selection in MQTT views.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -3,6 +3,15 @@ Purpose: Running log of what worked, what broke, and why.
 
 Remember to record environment limitations (e.g., missing tests or write restrictions) in each log entry.
 
+[2025-08-22 13:51] Topic: TCP service messages view
+Context: Added view and view model for displaying TCP messages with log filtering and navigation update.
+Observations: Introduced TcpServiceMessagesViewModel with observable collections and log-level controls; MainWindow now loads messages view for TCP services.
+Codex Limitations noticed: Linux environment lacks WPF runtime; rely on CI for visual validation.
+Effective Prompts / Instructions that worked: Followed design XML and AGENTS.md for MVVM structure.
+Decisions & Rationale: Separate messages display from configuration and surface logs immediately.
+Action Items: Monitor CI for WPF rendering and navigation.
+Related Commits/PRs: (this PR)
+
 [2025-08-22 13:45] Topic: TCP service creation navigation
 Context: Wired TCP selection through create service window.
 Observations: Page raises TcpSelected and window navigates to TCP view storing options.


### PR DESCRIPTION
## What changed
- Display TCP message exchanges in new `TcpServiceMessagesView`
- Filter/export/clear TCP logs via `TcpServiceMessagesViewModel`
- Navigate to messages view after TCP service setup
- Register view and view model with DI and update docs

## Validation
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a8750f9ea08326b668139356869d16