### PR TITLE
Enable TCP advanced settings navigation

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.Tests
         {
             var logger = new Mock<ILoggingService>();
             var helper = new SaveConfirmationHelper(logger.Object);
-            var vm = new TcpServiceViewModel(helper) { Logger = logger.Object };
+            var vm = new TcpServiceViewModel(helper, new TcpServiceMessagesViewModel()) { Logger = logger.Object };
             vm.ComputerIp = "127.0.0.1";
             vm.ListeningPort = "5000";
 

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -30,4 +30,41 @@ public class TcpServiceMessagesViewModelTests
 
         vm.Logs.Should().BeEmpty();
     }
+
+    [Fact]
+    public void OpenAdvancedSettingsCommand_RaisesEvent()
+    {
+        var vm = new TcpServiceMessagesViewModel();
+        var raised = false;
+        vm.AdvancedSettingsRequested += (_, _) => raised = true;
+
+        vm.OpenAdvancedSettingsCommand.Execute(null);
+
+        raised.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateScript_SetsScriptContent()
+    {
+        var vm = new TcpServiceMessagesViewModel();
+
+        vm.UpdateScript("print('hi')");
+
+        vm.ScriptContent.Should().Be("print('hi')");
+    }
+
+    [Fact]
+    public void UpdateNetworkSettings_SetsProperties()
+    {
+        var vm = new TcpServiceMessagesViewModel();
+
+        vm.UpdateNetworkSettings("1.1.1.1", "1000", "2.2.2.2", "3.3.3.3", "2000", true);
+
+        vm.ComputerIp.Should().Be("1.1.1.1");
+        vm.ListeningPort.Should().Be("1000");
+        vm.ServerIp.Should().Be("2.2.2.2");
+        vm.ServerGateway.Should().Be("3.3.3.3");
+        vm.ServerPort.Should().Be("2000");
+        vm.IsUdp.Should().BeTrue();
+    }
 }

--- a/DesktopApplicationTemplate.Tests/TcpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceViewModelTests.cs
@@ -1,0 +1,51 @@
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Helpers;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class TcpServiceViewModelTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void SettingScriptContent_UpdatesMessagesViewModel()
+    {
+        var logger = new Mock<ILoggingService>();
+        var helper = new SaveConfirmationHelper(logger.Object);
+        var messages = new TcpServiceMessagesViewModel();
+        var vm = new TcpServiceViewModel(helper, messages);
+
+        vm.ScriptContent = "test";
+
+        messages.ScriptContent.Should().Be("test");
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void SettingNetworkProperties_UpdatesMessagesViewModel()
+    {
+        var logger = new Mock<ILoggingService>();
+        var helper = new SaveConfirmationHelper(logger.Object);
+        var messages = new TcpServiceMessagesViewModel();
+        var vm = new TcpServiceViewModel(helper, messages);
+
+        vm.ComputerIp = "1.2.3.4";
+        vm.ListeningPort = "1000";
+        vm.ServerIp = "5.6.7.8";
+        vm.ServerGateway = "9.9.9.9";
+        vm.ServerPort = "2000";
+        vm.IsUdp = true;
+
+        messages.ComputerIp.Should().Be("1.2.3.4");
+        messages.ListeningPort.Should().Be("1000");
+        messages.ServerIp.Should().Be("5.6.7.8");
+        messages.ServerGateway.Should().Be("9.9.9.9");
+        messages.ServerPort.Should().Be("2000");
+        messages.IsUdp.Should().BeTrue();
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
@@ -49,11 +51,64 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <summary>Command to refresh log display.</summary>
         public ICommand RefreshLogCommand { get; }
 
+        /// <summary>Command to open advanced TCP settings.</summary>
+        public ICommand OpenAdvancedSettingsCommand { get; }
+
+        /// <summary>Raised when the advanced settings view should open.</summary>
+        public event EventHandler? AdvancedSettingsRequested;
+
+        /// <summary>Current script content.</summary>
+        public string ScriptContent { get; private set; } = string.Empty;
+
+        /// <summary>Computer IP for incoming connections.</summary>
+        public string ComputerIp { get; private set; } = string.Empty;
+
+        /// <summary>Listening port for the server.</summary>
+        public string ListeningPort { get; private set; } = string.Empty;
+
+        /// <summary>Destination server IP.</summary>
+        public string ServerIp { get; private set; } = string.Empty;
+
+        /// <summary>Gateway for the destination server.</summary>
+        public string ServerGateway { get; private set; } = string.Empty;
+
+        /// <summary>Destination server port.</summary>
+        public string ServerPort { get; private set; } = string.Empty;
+
+        /// <summary>Whether UDP mode is enabled.</summary>
+        public bool IsUdp { get; private set; }
+
         public TcpServiceMessagesViewModel()
         {
             ClearLogCommand = new RelayCommand(ClearLogs);
             ExportLogCommand = new RelayCommand(ExportLogs);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
+            OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
+        }
+
+        /// <summary>Updates the stored script content.</summary>
+        /// <param name="script">New script text.</param>
+        public void UpdateScript(string script)
+        {
+            ScriptContent = script ?? string.Empty;
+            OnPropertyChanged(nameof(ScriptContent));
+        }
+
+        /// <summary>Updates network and scripting settings.</summary>
+        public void UpdateNetworkSettings(string computerIp, string listeningPort, string serverIp, string serverGateway, string serverPort, bool isUdp)
+        {
+            ComputerIp = computerIp ?? string.Empty;
+            ListeningPort = listeningPort ?? string.Empty;
+            ServerIp = serverIp ?? string.Empty;
+            ServerGateway = serverGateway ?? string.Empty;
+            ServerPort = serverPort ?? string.Empty;
+            IsUdp = isUdp;
+            OnPropertyChanged(nameof(ComputerIp));
+            OnPropertyChanged(nameof(ListeningPort));
+            OnPropertyChanged(nameof(ServerIp));
+            OnPropertyChanged(nameof(ServerGateway));
+            OnPropertyChanged(nameof(ServerPort));
+            OnPropertyChanged(nameof(IsUdp));
         }
 
         private void ClearLogs()

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -109,6 +109,24 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     navm.UpdateNetworkConfiguration(_viewModel.NetworkConfig.CurrentConfiguration);
                 }
+
+                if (svc.ServiceType == "TCP" && svc.ServicePage.DataContext is TcpServiceMessagesViewModel tcpVm)
+                {
+                    tcpVm.AdvancedSettingsRequested += (_, _) =>
+                    {
+                        var settingsView = App.AppHost.Services.GetRequiredService<TcpServiceView>();
+                        if (settingsView.DataContext is TcpServiceViewModel tvm)
+                        {
+                            tvm.RequestClose += (_, _) =>
+                            {
+                                if (svc.ServicePage != null)
+                                    ShowPage(svc.ServicePage);
+                                _viewModel.SaveServices();
+                            };
+                        }
+                        ShowPage(settingsView);
+                    };
+                }
             }
 
             return svc.ServicePage;

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -32,6 +32,7 @@
                 <Button Content="Export Log" Command="{Binding ExportLogCommand}" Margin="10,0,0,0" Width="100"/>
                 <Button Content="Clear Log" Command="{Binding ClearLogCommand}" Margin="10,0,0,0" Width="100"/>
                 <Button Content="Update Log" Command="{Binding RefreshLogCommand}" Margin="10,0,0,0" Width="100"/>
+                <Button Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Margin="10,0,0,0" Width="150"/>
             </StackPanel>
             <ListBox ItemsSource="{Binding DisplayLogs}" Height="200">
                 <ListBox.ItemTemplate>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Tag subscriptions now allow per-topic QoS selection with forwarding to the MQTT client.
 - Subscribe/unsubscribe support for MQTT topics with QoS selection and visual feedback for subscription results.
 - View and view model for displaying TCP service messages with log-level filtering and log management commands.
+- TCP messages view can navigate to advanced settings and reflects script and network configuration updates.
 
 - File dialog service registered for TLS certificate selection in MQTT views.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -3,6 +3,15 @@ Purpose: Running log of what worked, what broke, and why.
 
 Remember to record environment limitations (e.g., missing tests or write restrictions) in each log entry.
 
+[2025-08-22 13:57] Topic: TCP message navigation
+Context: Added command to open TCP advanced settings and synced messages with script/network changes.
+Observations: Messages view model raises navigation events and tracks latest configuration.
+Codex Limitations noticed: Linux environment lacks WPF runtime; navigation untested locally.
+Effective Prompts / Instructions that worked: User request to expose navigation command and update view models.
+Decisions & Rationale: Use event-driven navigation and injection to decouple views.
+Action Items: Verify navigation on Windows CI.
+Related Commits/PRs: (this PR)
+
 [2025-08-22 13:51] Topic: TCP service messages view
 Context: Added view and view model for displaying TCP messages with log filtering and navigation update.
 Observations: Introduced TcpServiceMessagesViewModel with observable collections and log-level controls; MainWindow now loads messages view for TCP services.


### PR DESCRIPTION
## What changed
- add navigation command from TCP messages view to advanced settings
- sync TCP message view model when scripts or network settings change
- cover new behavior with unit tests and docs

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing; see CI)*

------
https://chatgpt.com/codex/tasks/task_e_68a8769689d0832694217d59a7a16681