### PR TITLE
Register TCP view models and bind options

### DIFF
--- a/DesktopApplicationTemplate.Tests/DiContainerTests.cs
+++ b/DesktopApplicationTemplate.Tests/DiContainerTests.cs
@@ -20,15 +20,24 @@ public class DiContainerTests
         services.AddSingleton<SaveConfirmationHelper>();
         services.AddSingleton<MqttService>();
         services.AddSingleton<MqttTagSubscriptionsViewModel>();
+        services.AddTransient<TcpCreateServiceViewModel>();
+        services.AddTransient<TcpServiceMessagesViewModel>();
         services.Configure<MqttServiceOptions>(o =>
         {
             o.Host = "localhost";
             o.Port = 1883;
             o.ClientId = "client";
         });
+        services.Configure<TcpServiceOptions>(o =>
+        {
+            o.Host = "localhost";
+            o.Port = 5000;
+            o.Mode = TcpServiceMode.Listening;
+        });
 
         using var provider = services.BuildServiceProvider();
-        var vm = provider.GetRequiredService<MqttTagSubscriptionsViewModel>();
-        Assert.NotNull(vm);
+        Assert.NotNull(provider.GetRequiredService<MqttTagSubscriptionsViewModel>());
+        Assert.NotNull(provider.GetRequiredService<TcpCreateServiceViewModel>());
+        Assert.NotNull(provider.GetRequiredService<TcpServiceMessagesViewModel>());
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpServiceOptionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceOptionsTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.UI.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class TcpServiceOptionsTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void Defaults_AreReasonable()
+    {
+        var options = new TcpServiceOptions();
+
+        Assert.Equal(string.Empty, options.Host);
+        Assert.Equal(0, options.Port);
+        Assert.False(options.UseUdp);
+        Assert.Equal(TcpServiceMode.Listening, options.Mode);
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    public void Bind_BindsValuesFromConfiguration()
+    {
+        var configDict = new Dictionary<string, string?>
+        {
+            ["TcpService:Host"] = "localhost",
+            ["TcpService:Port"] = "9000",
+            ["TcpService:UseUdp"] = "true",
+            ["TcpService:Mode"] = "Sending"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configDict)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.Configure<TcpServiceOptions>(configuration.GetSection("TcpService"));
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider
+            .GetRequiredService<IOptions<TcpServiceOptions>>().Value;
+
+        Assert.Equal("localhost", options.Host);
+        Assert.Equal(9000, options.Port);
+        Assert.True(options.UseUdp);
+        Assert.Equal(TcpServiceMode.Sending, options.Mode);
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -53,7 +53,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<TcpServiceView>();
             services.AddSingleton<TcpServiceViewModel>();
             services.AddSingleton<TcpServiceMessagesView>();
-            services.AddSingleton<TcpServiceMessagesViewModel>();
+            services.AddTransient<TcpServiceMessagesViewModel>();
             services.AddSingleton<DependencyChecker>();
             services.AddSingleton<HttpServiceView>();
             services.AddSingleton<HttpServiceViewModel>();
@@ -90,6 +90,7 @@ namespace DesktopApplicationTemplate.UI
             // Load strongly typed settings
             services.Configure<AppSettings>(configuration.GetSection("AppSettings"));
             services.Configure<MqttServiceOptions>(configuration.GetSection("MqttService"));
+            services.Configure<TcpServiceOptions>(configuration.GetSection("TcpService"));
         }
 
         protected override async void OnStartup(StartupEventArgs e)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Registered transient TCP view models and bound `TcpServiceOptions` configuration.
 - TCP service creation flow integrated into selection window with option persistence.
 - TCP service creation view and view model with configurable options and unit tests.
 - CSV creator now supports selecting an output directory and nested folder patterns when naming files.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1073,3 +1073,11 @@ Decisions & Rationale: Excluding dev from pull_request triggers avoids redundant
 Action Items: rely on CI for validation on other branches.
 Related Commits/PRs: (this PR)
 
+[2025-08-22 15:29] Topic: TCP DI options
+Context: Registered transient TCP view models and bound TcpServiceOptions to configuration.
+Observations: DI container updated; added tests ensuring options binding.
+Codex Limitations noticed: pwsh unavailable for add-tip script.
+Effective Prompts / Instructions that worked: user request to register TCP view models and options.
+Decisions & Rationale: use Configure to bind TcpServiceOptions and register view models as transient.
+Action Items: rely on CI for Windows-specific validation.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- Register `TcpCreateServiceViewModel` and `TcpServiceMessagesViewModel` as transient
- Bind `TcpServiceOptions` to configuration and cover with tests
- Extend DI container tests for TCP services
- Update changelog and collaboration log

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code

------
https://chatgpt.com/codex/tasks/task_e_68a88af8647c83269384c5beaffe029e