### PR TITLE
Persist TCP service options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Registered transient TCP view models and bound `TcpServiceOptions` configuration.
 - TCP service creation flow integrated into selection window with option persistence.
 - TCP service creation view and view model with configurable options and unit tests.
+- Service persistence now saves and restores `TcpServiceOptions` for TCP services.
 - CSV creator now supports selecting an output directory and nested folder patterns when naming files.
 - WebSocket path configuration with TLS disabled when using WebSockets.
 - Connection edit window toggles subscribe/unsubscribe with color cues and highlights missing fields.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1081,3 +1081,11 @@ Effective Prompts / Instructions that worked: user request to register TCP view 
 Decisions & Rationale: use Configure to bind TcpServiceOptions and register view models as transient.
 Action Items: rely on CI for Windows-specific validation.
 Related Commits/PRs: (this PR)
+[2025-08-22 15:36] Topic: TCP service options persistence
+Context: Persisting TCP configuration alongside service metadata.
+Observations: Serializing TcpServiceOptions in ServicePersistence retains host, port, UDP flag, and mode per service.
+Codex Limitations noticed: pwsh unavailable, appended entry manually.
+Effective Prompts / Instructions that worked: user request to serialize TcpServiceOptions and associate when loading.
+Decisions & Rationale: copy options from DI into ServiceInfo and restore them during load.
+Action Items: add tests and changelog entry.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- persist `TcpServiceOptions` in service save/load helpers
- cover TCP option persistence with tests
- document TCP service option persistence

## Validation
- `~/.dotnet/dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88d39932083269362dc2947f61e69