### PR TITLE
Persist per-service TCP options

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -100,14 +100,23 @@ namespace DesktopApplicationTemplate.Tests
             try
             {
                 var opt = host.Services.GetRequiredService<IOptions<TcpServiceOptions>>().Value;
-                opt.Host = "h";
-                opt.Port = 42;
-                opt.UseUdp = true;
-                opt.Mode = TcpServiceMode.Sending;
 
                 var services = new List<ServiceViewModel>
                 {
-                    new ServiceViewModel{DisplayName="TCP - One", ServiceType="TCP", IsActive=false, Order=0}
+                    new ServiceViewModel
+                    {
+                        DisplayName="TCP - One",
+                        ServiceType="TCP",
+                        IsActive=false,
+                        Order=0,
+                        TcpOptions = new TcpServiceOptions
+                        {
+                            Host = "h",
+                            Port = 42,
+                            UseUdp = true,
+                            Mode = TcpServiceMode.Sending
+                        }
+                    }
                 };
 
                 ServicePersistence.Save(services);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -21,27 +21,15 @@ namespace DesktopApplicationTemplate.UI.Services
             foreach (var s in services)
             {
                 TcpServiceOptions? tcp = null;
-                if (s.ServiceType == "TCP")
+                if (s.ServiceType == "TCP" && s.TcpOptions != null)
                 {
-                    try
+                    tcp = new TcpServiceOptions
                     {
-                        var opt = App.AppHost?.Services.GetService(typeof(IOptions<TcpServiceOptions>)) as IOptions<TcpServiceOptions>;
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            tcp = new TcpServiceOptions
-                            {
-                                Host = value.Host,
-                                Port = value.Port,
-                                UseUdp = value.UseUdp,
-                                Mode = value.Mode
-                            };
-                        }
-                    }
-                    catch
-                    {
-                        // ignore missing options during tests or early startup
-                    }
+                        Host = s.TcpOptions.Host,
+                        Port = s.TcpOptions.Port,
+                        UseUdp = s.TcpOptions.UseUdp,
+                        Mode = s.TcpOptions.Mode
+                    };
                 }
 
                 data.Add(new ServiceInfo

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -43,6 +43,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public ObservableCollection<string> AssociatedServices { get; } = new();
 
+        /// <summary>
+        /// TCP-specific configuration for this service, if applicable.
+        /// </summary>
+        public TcpServiceOptions? TcpOptions { get; set; }
+
         public static Func<string, string, ServiceViewModel?>? ResolveService { get; set; }
 
 
@@ -294,7 +299,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     DisplayName = info.DisplayName,
                     ServiceType = info.ServiceType,
                     IsActive = info.IsActive,
-                    Order = info.Order
+                    Order = info.Order,
+                    TcpOptions = info.TcpOptions
                 };
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -151,6 +151,24 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     AddMqttService(window.CreatedServiceName, window.MqttOptions ?? new MqttServiceOptions());
                 }
+                else if (window.CreatedServiceType == "TCP")
+                {
+                    var svc = new ServiceViewModel
+                    {
+                        DisplayName = $"TCP - {window.CreatedServiceName}",
+                        ServiceType = "TCP",
+                        IsActive = false,
+                        TcpOptions = window.TcpOptions
+                    };
+                    svc.SetColorsByType();
+                    svc.LogAdded += _viewModel.OnServiceLogAdded;
+                    svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
+                    GetOrCreateServicePage(svc);
+                    _viewModel.Services.Add(svc);
+                    _logger?.LogInformation("Service {Name} added", svc.DisplayName);
+                    _viewModel.SelectedService = svc;
+                    ServiceList.ScrollIntoView(svc);
+                }
                 else if (!string.IsNullOrWhiteSpace(window.CreatedServiceType))
                 {
                     var svc = new ServiceViewModel

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Reordered test-message controls above the topic list in `MqttTagSubscriptionsView` and aligned margins with design guidance.
 - MQTT service creation now occurs within the main window frame and returns to the previous view after completion, removing the popup window dependency.
 - Service context menus invoke a new `EditServiceCommand`; editing an MQTT service opens the connection view with current options preloaded.
+- `ServiceViewModel` now holds `TcpServiceOptions` so each TCP service retains its own configuration when persisted.
 - Consolidated `MqttTagSubscriptionsViewModel` to a single subscription collection and unified topic properties.
 - Simplified `MqttTagSubscriptionsView` layout, removing duplicate controls and redundant namespace declarations.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1097,3 +1097,11 @@ Effective Prompts / Instructions that worked: review design guidelines
 Decisions & Rationale: aligned with MVVM
 Action Items: verify layout
 Related Commits/PRs: (this PR)
+[2025-08-22 17:48] Topic: TCP options persistence
+Context: Persisted per-service TCP settings through ServicePersistence.
+Observations: Added TcpOptions property to ServiceViewModel and serialized/deserialized options.
+Codex Limitations noticed: Linux container lacks WindowsDesktop runtime; tests rely on CI.
+Effective Prompts / Instructions that worked: specify per-service options persistence.
+Decisions & Rationale: Store TcpServiceOptions per service for accurate reloads.
+Action Items: Monitor CI for Windows-specific behavior.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- [x] Code
- [x] UI/XAML
- [x] Tests
- [ ] DI registrations
- [x] Docs updated

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code


------
https://chatgpt.com/codex/tasks/task_e_68a8abcf2f3c8326b75cc0a7f0221dc7