### PR TITLE
Add FTP server edge case tests

### DIFF
--- a/DesktopApplicationTemplate.Service/Services/FtpServerService.cs
+++ b/DesktopApplicationTemplate.Service/Services/FtpServerService.cs
@@ -31,16 +31,32 @@ namespace DesktopApplicationTemplate.Service.Services
         public async Task StartAsync(CancellationToken cancellationToken = default)
         {
             _logger.LogInformation(EventIds.Starting, "Starting FTP server");
-            await _host.StartAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation(EventIds.Started, "FTP server started");
+            try
+            {
+                await _host.StartAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation(EventIds.Started, "FTP server started");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(EventIds.StartFailed, ex, "FTP server failed to start");
+                throw;
+            }
         }
 
         /// <inheritdoc />
         public async Task StopAsync(CancellationToken cancellationToken = default)
         {
             _logger.LogInformation(EventIds.Stopping, "Stopping FTP server");
-            await _host.StopAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation(EventIds.Stopped, "FTP server stopped");
+            try
+            {
+                await _host.StopAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation(EventIds.Stopped, "FTP server stopped");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(EventIds.StopFailed, ex, "FTP server failed to stop");
+                throw;
+            }
         }
 
         internal void RaiseFileReceived(string path, long size)
@@ -68,6 +84,8 @@ namespace DesktopApplicationTemplate.Service.Services
             public static readonly EventId Stopped = new(1003, nameof(Stopped));
             public static readonly EventId FileReceived = new(1004, nameof(FileReceived));
             public static readonly EventId FileSent = new(1005, nameof(FileSent));
+            public static readonly EventId StartFailed = new(1006, nameof(StartFailed));
+            public static readonly EventId StopFailed = new(1007, nameof(StopFailed));
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/FtpServerAdvancedConfigViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerAdvancedConfigViewModelTests.cs
@@ -47,4 +47,25 @@ public class FtpServerAdvancedConfigViewModelTests
         Assert.Equal("pass", saved.Password);
         ConsoleTestLogger.LogPass();
     }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void SaveCommand_DoesNotRaise_WhenInvalid()
+    {
+        var options = new FtpServerOptions();
+        var vm = new FtpServerAdvancedConfigViewModel(options)
+        {
+            AllowAnonymous = false,
+            Username = string.Empty,
+            Password = string.Empty
+        };
+        var raised = false;
+        vm.Saved += _ => raised = true;
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(raised);
+        ConsoleTestLogger.LogPass();
+    }
 }

--- a/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
@@ -47,6 +47,37 @@ public class FtpServerCreateViewModelTests
     [Fact]
     [TestCategory("CodexSafe")]
     [TestCategory("WindowsSafe")]
+    public void SettingEmptyServiceName_AddsError()
+    {
+        var vm = new FtpServerCreateViewModel();
+        vm.ServiceName = string.Empty;
+        Assert.True(vm.HasErrors);
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void SaveCommand_DoesNotRaise_WhenInvalid()
+    {
+        var vm = new FtpServerCreateViewModel
+        {
+            ServiceName = string.Empty,
+            Port = 21,
+            RootPath = "/tmp"
+        };
+        var raised = false;
+        vm.ServerCreated += (_, _) => raised = true;
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(raised);
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
     public void AdvancedCommand_RaisesRequested()
     {
         var vm = new FtpServerCreateViewModel();

--- a/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
@@ -62,5 +62,37 @@ public class FtpServerEditViewModelTests
         Assert.True(cancelled);
         ConsoleTestLogger.LogPass();
     }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void SettingInvalidPort_AddsError()
+    {
+        var options = new FtpServerOptions();
+        var vm = new FtpServerEditViewModel("ftp", options);
+        vm.Port = 0;
+        Assert.True(vm.HasErrors);
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void SaveCommand_DoesNotRaise_WhenInvalid()
+    {
+        var options = new FtpServerOptions();
+        var vm = new FtpServerEditViewModel("ftp", options)
+        {
+            Port = 0,
+            RootPath = "/tmp"
+        };
+        var raised = false;
+        vm.ServerUpdated += (_, _) => raised = true;
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(raised);
+        ConsoleTestLogger.LogPass();
+    }
 }
 

--- a/DesktopApplicationTemplate.Tests/FtpServerServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Services;
@@ -25,6 +26,27 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task StartAsync_LogsError_WhenHostThrows()
+        {
+            var host = new Mock<IFtpServerHost>();
+            var logger = new Mock<ILogger<FtpServerService>>();
+            host.Setup(h => h.StartAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException());
+            var service = new FtpServerService(host.Object, logger.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.StartAsync(CancellationToken.None));
+            logger.Verify(l => l.Log(
+                LogLevel.Error,
+                FtpServerService.EventIds.StartFailed,
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<InvalidOperationException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
         public async Task StopAsync_StopsHost()
         {
             var host = new Mock<IFtpServerHost>();
@@ -34,6 +56,27 @@ namespace DesktopApplicationTemplate.Tests
             await service.StopAsync(CancellationToken.None);
 
             host.Verify(h => h.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public async Task StopAsync_LogsError_WhenHostThrows()
+        {
+            var host = new Mock<IFtpServerHost>();
+            var logger = new Mock<ILogger<FtpServerService>>();
+            host.Setup(h => h.StopAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException());
+            var service = new FtpServerService(host.Object, logger.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.StopAsync(CancellationToken.None));
+            logger.Verify(l => l.Log(
+                LogLevel.Error,
+                FtpServerService.EventIds.StopFailed,
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<InvalidOperationException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+            ConsoleTestLogger.LogPass();
         }
 
         [Fact]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - FTP server edit view model and view enabling updates to server configuration.
 - FTP server hosting service with start/stop methods, transfer events, and unit tests.
 - FTP server view displaying live upload and download lists with server status.
+- Expanded tests for FtpServerService and FTP server view models covering start failures and invalid configurations.
 - Finalized TCP service creation with integrated message viewer for configuring endpoints and inspecting traffic.
 - Introduced TCP service creation and message viewer enabling configuration and inspection of TCP endpoint traffic.
 - Registered transient TCP view models and bound `TcpServiceOptions` configuration.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1163,3 +1163,12 @@ Effective Prompts / Instructions that worked: Followed DI checklist and options 
 Decisions & Rationale: Used AddOptions to bind FtpServerOptions and created DI test for resolution.
 Action Items: Monitor CI for Windows-specific test execution.
 Related Commits/PRs: (this PR)
+
+[2025-08-25 20:09] Topic: FTP server test coverage
+Context: Added tests for FTP server service and view models covering start failures and invalid configuration paths.
+Observations: Service now logs failures and view models suppress events when validation errors exist.
+Codex Limitations noticed: Linux environment lacks WindowsDesktop runtime; relied on CI for execution.
+Effective Prompts / Instructions that worked: Request to mock dependencies and validate edge cases.
+Decisions & Rationale: Improve reliability by logging errors and preventing invalid saves.
+Action Items: Monitor CI for Windows-specific behaviors.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- log FTP server start/stop failures
- test FTP service and view models against start errors and invalid configuration
- document FTP test coverage

## Validation
- `~/dotnet/dotnet test --settings tests.runsettings` *(fails: Unable to find package FubarDev.FtpServer >= 6.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acc23105748326b355e4caf23a209a