### PR TITLE
docs: add FTP changelog and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 This repository contains a basic WPF UI application, a Windows Service and unit tests.
 
 See `CollaborationGuidelines.txt` for tips on working with the repository. A running log of past collaboration decisions lives in `docs/CollaborationAndDebugTips.txt`.
+## Basic usage
+1. Run `dotnet run --project DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` to launch the UI.
+2. Use **Add Service** to configure components like FTP or TCP.
+3. Select a service to edit settings or open its related windows to monitor activity.
+
 
 ## Prerequisites
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 ### Added
+- Comprehensive FTP server support with hosting service, configuration views, and live transfer monitoring.
+- New FTP server windows for creating, editing, and tracking transfers.
 - FTP server create and advanced configuration view models and views with validation and commands.
 - FTP server edit view model and view enabling updates to server configuration.
 - FTP server hosting service with start/stop methods, transfer events, and unit tests.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1172,3 +1172,11 @@ Effective Prompts / Instructions that worked: Request to mock dependencies and v
 Decisions & Rationale: Improve reliability by logging errors and preventing invalid saves.
 Action Items: Monitor CI for Windows-specific behaviors.
 Related Commits/PRs: (this PR)
+[2025-08-25 20:47] Topic: FTP server windows setup
+Context: Documenting how to initialize FTP server support and related windows.
+Observations: Running setup script enables FTP server creation/edit windows; ensure options are registered.
+Codex Limitations noticed: Linux container lacks WindowsDesktop runtime; rely on CI.
+Effective Prompts / Instructions that worked: Ask for DI registrations and window descriptions.
+Decisions & Rationale: Document process via tip entry to guide future configuration.
+Action Items: Run tests and review changelog.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- summarize FTP server support and windows in changelog
- log FTP server setup tip
- document basic usage in README

## Validation
- `dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj --settings tests.runsettings` *(fails: Unable to find package FubarDev.FtpServer)*

------
https://chatgpt.com/codex/tasks/task_e_68accb1850488326b5d5009b370ea4a0