### PR TITLE
fix: resolve page variable name conflict

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -315,7 +315,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
             if (service.ServiceType == "FTP Server")
             {
-                var page = GetOrCreateServicePage(service);
+                var ftpPage = GetOrCreateServicePage(service);
                 var options = service.FtpOptions ?? new FtpServerOptions();
                 var vm = ActivatorUtilities.CreateInstance<FtpServerEditViewModel>(App.AppHost.Services, service.DisplayName.Split(" - ").Last(), options);
                 var editView = App.AppHost.Services.GetRequiredService<FtpServerEditView>();
@@ -330,14 +330,14 @@ namespace DesktopApplicationTemplate.UI.Views
                     opt.AllowAnonymous = opts.AllowAnonymous;
                     opt.Username = opts.Username;
                     opt.Password = opts.Password;
-                    if (page != null)
-                        ShowPage(page);
+                    if (ftpPage != null)
+                        ShowPage(ftpPage);
                     _viewModel.SaveServices();
                 };
                 vm.Cancelled += () =>
                 {
-                    if (page != null)
-                        ShowPage(page);
+                    if (ftpPage != null)
+                        ShowPage(ftpPage);
                 };
                 vm.AdvancedConfigRequested += opts =>
                 {
@@ -353,10 +353,10 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            var page = GetOrCreateServicePage(service);
-            if (page != null)
+            var servicePage = GetOrCreateServicePage(service);
+            if (servicePage != null)
             {
-                ShowPage(page);
+                ShowPage(servicePage);
                 _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
             }
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -136,3 +136,4 @@
 - Registered FTP server service and view models in DI and bound FtpServer options from configuration.
 - Downgraded FubarDev FTP server packages to version 3.1.2 to resolve missing NuGet feeds.
 - FTP server create and edit windows now launch with advanced configuration access.
+- Resolved variable naming conflict in MainWindow edit workflow preventing CS0136 build errors.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1189,3 +1189,11 @@ Effective Prompts / Instructions that worked: Error logs indicating missing pack
 Decisions & Rationale: Use latest available package to unblock builds.
 Action Items: Rely on CI for Windows-specific validation.
 Related Commits/PRs: (this PR)
+[2025-08-26 12:59] Topic: CS0136 variable conflict in MainWindow
+Context: Build failed due to nested 'page' variables in MainWindow edit workflow.
+Observations: Renamed inner variable to ftpPage and outer variable to servicePage to avoid shadowing.
+Codex Limitations noticed: Linux environment lacks Microsoft.WindowsDesktop runtime; tests aborted.
+Effective Prompts / Instructions that worked: User request to fix build error and AGENTS guidance to run tests.
+Decisions & Rationale: Use intention-revealing names and maintain edit workflow logic.
+Action Items: Monitor CI for full test run.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- [x] Code
- [ ] UI/XAML
- [ ] Tests
- [ ] DI registrations
- [x] Docs updated

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [x] Removed stale code

`dotnet test --settings tests.runsettings` fails: Microsoft.WindowsDesktop.App runtime is missing in the container; relying on CI.

------
https://chatgpt.com/codex/tasks/task_e_68adaef41db883268726bff50b4a4955