### PR TITLE
Handle legacy FTP service type for navigation

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -227,5 +227,81 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        [TestCategory("CodexSafe")]
+        [TestCategory("WindowsSafe")]
+        public void SaveAndLoad_PreservesLegacyFtpOptions()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s => s.Configure<FtpServerOptions>(_ => { }))
+                .Build();
+            var setter = typeof(App).GetProperty("AppHost", BindingFlags.Static | BindingFlags.Public)!
+                .GetSetMethod(true)!;
+            setter.Invoke(null, new object[] { host });
+
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            string oldPath = ServicePersistence.FilePath;
+            ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
+
+            try
+            {
+                var opt = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
+
+                var services = new List<ServiceViewModel>
+                {
+                    new ServiceViewModel
+                    {
+                        DisplayName = "FTP - One",
+                        ServiceType = "FTP",
+                        IsActive = false,
+                        Order = 0,
+                        FtpOptions = new FtpServerOptions
+                        {
+                            Port = 21,
+                            RootPath = "/srv",
+                            AllowAnonymous = true,
+                            Username = "u",
+                            Password = "p"
+                        }
+                    }
+                };
+
+                ServicePersistence.Save(services);
+
+                // mutate options to verify load restores
+                opt.Port = 100;
+                opt.RootPath = "changed";
+                opt.AllowAnonymous = false;
+                opt.Username = null;
+                opt.Password = null;
+
+                var loaded = ServicePersistence.Load();
+                var info = Assert.Single(loaded);
+                Assert.NotNull(info.FtpOptions);
+                Assert.Equal(21, info.FtpOptions!.Port);
+                Assert.Equal("/srv", info.FtpOptions.RootPath);
+                Assert.True(info.FtpOptions.AllowAnonymous);
+                Assert.Equal("u", info.FtpOptions.Username);
+                Assert.Equal("p", info.FtpOptions.Password);
+
+                // global options restored
+                Assert.Equal(21, opt.Port);
+                Assert.Equal("/srv", opt.RootPath);
+                Assert.True(opt.AllowAnonymous);
+                Assert.Equal("u", opt.Username);
+                Assert.Equal("p", opt.Password);
+            }
+            finally
+            {
+                ServicePersistence.FilePath = oldPath;
+                Directory.Delete(tempDir, true);
+                setter.Invoke(null, new object[] { null! });
+                host.Dispose();
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -33,7 +33,7 @@ namespace DesktopApplicationTemplate.UI.Services
                     };
                 }
 
-                if (s.ServiceType == "FTP Server" && s.FtpOptions != null)
+                if ((s.ServiceType == "FTP Server" || s.ServiceType == "FTP") && s.FtpOptions != null)
                 {
                     ftp = new FtpServerOptions
                     {
@@ -121,7 +121,7 @@ namespace DesktopApplicationTemplate.UI.Services
                             // ignore missing options during tests or early startup
                         }
                     }
-                    if (info.ServiceType == "FTP Server" && info.FtpOptions != null)
+                    if ((info.ServiceType == "FTP Server" || info.ServiceType == "FTP") && info.FtpOptions != null)
                     {
                         try
                         {

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -123,7 +123,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 "Heartbeat" => (WpfBrushes.LightPink, WpfBrushes.DeepPink),
                 "SCP" => (WpfBrushes.LightCyan, WpfBrushes.CadetBlue),
                 "MQTT" => (WpfBrushes.LightGoldenrodYellow, WpfBrushes.Goldenrod),
-                "FTP Server" => (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
+                "FTP Server" or "FTP" => (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
                 _ => (WpfBrushes.LightGray, WpfBrushes.Gray)
             };
             OnPropertyChanged(nameof(BackgroundColor));

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -90,7 +90,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 "Heartbeat" => App.AppHost.Services.GetRequiredService<HeartbeatView>(),
                 "SCP" => App.AppHost.Services.GetRequiredService<SCPServiceView>(),
                 "MQTT" => App.AppHost.Services.GetRequiredService<MqttTagSubscriptionsView>(),
-                "FTP Server" => App.AppHost.Services.GetRequiredService<FTPServiceView>(),
+                "FTP Server" or "FTP" => App.AppHost.Services.GetRequiredService<FTPServiceView>(),
                 "CSV Creator" => App.AppHost.Services.GetRequiredService<CsvServiceView>(),
                 _ => null
             };
@@ -169,7 +169,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     _viewModel.SelectedService = svc;
                     ServiceList.ScrollIntoView(svc);
                 }
-                else if (window.CreatedServiceType == "FTP Server")
+                else if (window.CreatedServiceType == "FTP Server" || window.CreatedServiceType == "FTP")
                 {
                     var svc = new ServiceViewModel
                     {
@@ -195,6 +195,8 @@ namespace DesktopApplicationTemplate.UI.Views
                     _logger?.LogInformation("Service {Name} added", svc.DisplayName);
                     _viewModel.SelectedService = svc;
                     ServiceList.ScrollIntoView(svc);
+                    if (svc.ServicePage != null)
+                        ShowPage(svc.ServicePage);
                 }
                 else if (!string.IsNullOrWhiteSpace(window.CreatedServiceType))
                 {
@@ -312,7 +314,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            if (service.ServiceType == "FTP Server")
+            if (service.ServiceType == "FTP Server" || service.ServiceType == "FTP")
             {
                 var ftpPage = GetOrCreateServicePage(service);
                 var options = service.FtpOptions ?? new FtpServerOptions();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,3 +138,4 @@
 - FTP server create and edit windows now launch with advanced configuration access.
 - Resolved variable naming conflict in MainWindow edit workflow preventing CS0136 build errors.
 - FTP server creation and edit workflows now display correctly and default to an updated FTP service view with start/stop commands.
+- Legacy "FTP" service type now resolves to FTP Server, restoring default page navigation.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1205,3 +1205,11 @@ Effective Prompts / Instructions that worked: User request to surface FTP create
 Decisions & Rationale: Treat FTP as FTP Server, streamline DI registrations, and consolidate views.
 Action Items: Monitor CI for Windows-specific regressions.
 Related Commits/PRs:
+[2025-08-26 13:44] Topic: FTP type fallback
+Context: Existing services used "FTP" type causing navigation failures.
+Observations: Added alias handling so legacy "FTP" services resolve to FTP Server and display the default view.
+Codex Limitations noticed: Linux environment cannot run WPF; relied on tests and CI.
+Effective Prompts / Instructions that worked: Examine service type strings and update comparison logic.
+Decisions & Rationale: Map legacy type to new "FTP Server" to maintain backward compatibility.
+Action Items: Run tests and monitor CI for Windows-specific behavior.
+Related Commits/PRs:


### PR DESCRIPTION
## What changed
- Treat legacy `FTP` service type as `FTP Server` across navigation and persistence
- Show FTP service page immediately after creation
- Save/load FTP options for legacy type with new unit test
- Document FTP type fallback in changelog and collaboration tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing; relies on CI)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8fae1a883268e99d8b109a9c603