### PR TITLE
Fix FTP service creation bindings

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/FtpServerAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerAdvancedConfigView.xaml
@@ -19,10 +19,10 @@
         <CheckBox Grid.Row="0" Grid.ColumnSpan="2" Content="Allow Anonymous" IsChecked="{Binding AllowAnonymous}" Style="{StaticResource FormField}"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Username" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Username}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Password}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
             <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save FTP Advanced Options"/>

--- a/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
@@ -18,13 +18,13 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Port, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Root Path" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath}" Style="{StaticResource FormField}"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
             <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open FTP Advanced Configuration"/>

--- a/DesktopApplicationTemplate.UI/Views/FtpServerEditView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerEditView.xaml
@@ -18,13 +18,13 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Port, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Root Path" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath}" Style="{StaticResource FormField}"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
             <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open FTP Advanced Configuration"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -139,3 +139,4 @@
 - Resolved variable naming conflict in MainWindow edit workflow preventing CS0136 build errors.
 - FTP server creation and edit workflows now display correctly and default to an updated FTP service view with start/stop commands.
 - Legacy "FTP" service type now resolves to FTP Server, restoring default page navigation.
+- FTP server creation no longer freezes when selecting the service type; text fields update immediately so saving works without changing focus.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1213,3 +1213,11 @@ Effective Prompts / Instructions that worked: Examine service type strings and u
 Decisions & Rationale: Map legacy type to new "FTP Server" to maintain backward compatibility.
 Action Items: Run tests and monitor CI for Windows-specific behavior.
 Related Commits/PRs:
+[2025-08-26 14:05] Topic: FTP service creation freeze
+Context: Selecting FTP service in Add Service window failed to create service because text fields didn't update before save.
+Observations: Setting UpdateSourceTrigger=PropertyChanged on FTP server text boxes allows immediate validation and creation.
+Codex Limitations noticed: Linux environment lacks WPF runtime; relied on reasoning without full UI testing.
+Effective Prompts / Instructions that worked: Review binding defaults and ensure text updates without losing focus.
+Decisions & Rationale: Update bindings for FTP server views to avoid perceived freezes during service creation.
+Action Items: Monitor CI for Windows-specific behavior.
+Related Commits/PRs:


### PR DESCRIPTION
## What changed
- Ensure FTP server text boxes update immediately to prevent freezes during creation and editing
- Note FTP binding fix in changelog and collaboration tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing; see CI)*

------
https://chatgpt.com/codex/tasks/task_e_68adbd105c5c8326be4ef21ddc950f75