### PR TITLE
Fix FTP service creation closure and icon layout

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
@@ -81,6 +81,7 @@ public class CreateServiceNavigationTests
             window.CreatedServiceType.Should().Be("FTP Server");
             window.CreatedServiceName.Should().Be("Svc");
             window.FtpServerOptions.Should().Be(options);
+            window.DialogResult.Should().BeTrue();
         });
         windowThread.SetApartmentState(ApartmentState.STA);
         windowThread.Start();

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -5,19 +5,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class CreateServiceViewModel : ViewModelBase
     {
-        public record ServiceTypeMetadata(string Type, string DisplayText, string IconPath);
+        public record ServiceTypeMetadata(string Type, string DisplayText, string Icon);
 
         public ObservableCollection<ServiceTypeMetadata> ServiceTypes { get; } = new()
         {
-            new("HID", "HID", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("TCP", "TCP", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("HTTP", "HTTP", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("File Observer", "File Observer", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("Heartbeat", "Heartbeat", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("CSV Creator", "CSV Creator", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("SCP", "SCP", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("MQTT", "MQTT", "/Assets/DesktopTemplateLayout-Logo.png"),
-            new("FTP Server", "FTP Server", "/Assets/DesktopTemplateLayout-Logo.png")
+            new("HID", "HID", "🔌"),
+            new("TCP", "TCP", "🔗"),
+            new("HTTP", "HTTP", "🌐"),
+            new("File Observer", "File Observer", "📂"),
+            new("Heartbeat", "Heartbeat", "❤️"),
+            new("CSV Creator", "CSV Creator", "📄"),
+            new("SCP", "SCP", "📦"),
+            new("MQTT", "MQTT", "📡"),
+            new("FTP Server", "FTP Server", "🖥️")
         };
 
         private readonly HashSet<string> _existingNames;

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
@@ -16,7 +16,7 @@
         <ItemsControl Grid.Row="1" ItemsSource="{Binding ServiceTypes}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <WrapPanel HorizontalAlignment="Center"/>
+                    <WrapPanel Width="400" />
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
@@ -30,7 +30,7 @@
                                     </Border>
                                 </ControlTemplate>
                             </Button.Template>
-                            <Image Source="{Binding IconPath}" Width="40" Height="40"/>
+                            <TextBlock Text="{Binding Icon}" FontSize="40" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Button>
                         <TextBlock Text="{Binding DisplayText}" HorizontalAlignment="Center" Margin="0,5,0,0"/>
                     </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
@@ -80,6 +80,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 CreatedServiceType = "FTP Server";
                 FtpServerOptions = options;
                 DialogResult = true;
+                Close();
             };
             vm.AdvancedConfigRequested += opts =>
             {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,8 @@
 - Consolidated `MqttTagSubscriptionsViewModel` to a single subscription collection and unified topic properties.
 - Simplified `MqttTagSubscriptionsView` layout, removing duplicate controls and redundant namespace declarations.
 
+- Service selection window wraps service icons within bounds using a fixed-width panel.
+
 ### Removed
 - Placeholder "Desktop Template" text from the navigation bar.
 - Legacy GitHub workflows (`dotnet.yml`, `dotnet-desktop-ci.yml`, `ci.yml`).
@@ -141,3 +143,4 @@
 - Legacy "FTP" service type now resolves to FTP Server, restoring default page navigation.
 - Selecting FTP service in the add services window no longer freezes the application; FTP options apply before view creation ensuring the service is added.
 - FTP server creation no longer freezes when selecting the service type; text fields update immediately so saving works without changing focus.
+- Creating an FTP service now closes the selection window after saving.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1233,3 +1233,11 @@ Decisions & Rationale: Update bindings for FTP server views to avoid perceived f
 Action Items: Monitor CI for Windows-specific behavior.
 Related Commits/PRs:
 
+[2025-08-26 15:04] Topic: FTP service selection window wrap
+Context: Ensured FTP service creation closes the window and icons stay within the create service page.
+Observations: Added WrapPanel width for icon wrapping and invoked Close() after FTP server creation.
+Codex Limitations noticed: pwsh not available for add-tip script.
+Effective Prompts / Instructions that worked: User request highlighted window closure and layout issue.
+Decisions & Rationale: Use fixed-width WrapPanel and close dialog upon FTP service creation to restore expected workflow.
+Action Items: Run tests and monitor CI.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- keep service icons within create window using fixed-width WrapPanel
- ensure FTP service creation closes the create window
- document fix and add collaboration tip

## Testing
- `dotnet test --settings tests.runsettings` *(fails: requires Microsoft.WindowsDesktop.App 8.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68adcbccf3d083268c2d2f660fcff44b