### PR TITLE
Ensure CreateService window closes after selection

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
@@ -114,9 +114,52 @@ public class CreateServiceNavigationTests
             window.CreatedServiceType.Should().Be("TCP");
             window.CreatedServiceName.Should().Be("Svc");
             window.TcpOptions.Should().Be(options);
+            window.DialogResult.Should().BeTrue();
         });
         windowThread.SetApartmentState(ApartmentState.STA);
         windowThread.Start();
         windowThread.Join();
+    }
+
+    [Fact]
+    public void ServiceCreated_ClosesWindow()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        var thread = new Thread(() =>
+        {
+            var window = new CreateServiceWindow(new CreateServiceViewModel(), services);
+            var pageField = typeof(CreateServiceWindow).GetField("_page", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var page = (CreateServicePage)pageField.GetValue(window)!;
+            var button = new Button { DataContext = new CreateServiceViewModel.ServiceTypeMetadata("HTTP", "HTTP", string.Empty) };
+            var click = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            click.Invoke(page, new object[] { button, new RoutedEventArgs() });
+
+            window.CreatedServiceType.Should().Be("HTTP");
+            window.DialogResult.Should().BeTrue();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    public void Cancel_Click_ClosesWindow()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        var thread = new Thread(() =>
+        {
+            var window = new CreateServiceWindow(new CreateServiceViewModel(), services);
+            var pageField = typeof(CreateServiceWindow).GetField("_page", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var page = (CreateServicePage)pageField.GetValue(window)!;
+            var cancel = typeof(CreateServicePage).GetMethod("Cancel_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            cancel.Invoke(page, new object[] { new Button(), new RoutedEventArgs() });
+
+            window.DialogResult.Should().BeFalse();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServiceWindow.xaml.cs
@@ -27,8 +27,13 @@ namespace DesktopApplicationTemplate.UI.Views
                 CreatedServiceName = name;
                 CreatedServiceType = type;
                 DialogResult = true;
+                Close();
             };
-            _page.Cancelled += () => DialogResult = false;
+            _page.Cancelled += () =>
+            {
+                DialogResult = false;
+                Close();
+            };
             _page.MqttSelected += NavigateToMqtt;
             _page.TcpSelected += NavigateToTcp;
             _page.FtpServerSelected += NavigateToFtpServer;
@@ -45,6 +50,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 CreatedServiceType = "MQTT";
                 MqttOptions = options;
                 DialogResult = true;
+                Close();
             };
             vm.Cancelled += () => ContentFrame.Content = _page;
             var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(_services, vm);
@@ -61,6 +67,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 CreatedServiceType = "TCP";
                 TcpOptions = options;
                 DialogResult = true;
+                Close();
             };
             vm.Cancelled += () => ContentFrame.Content = _page;
             var view = _services.GetRequiredService<TcpCreateServiceView>();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -144,3 +144,4 @@
 - Selecting FTP service in the add services window no longer freezes the application; FTP options apply before view creation ensuring the service is added.
 - FTP server creation no longer freezes when selecting the service type; text fields update immediately so saving works without changing focus.
 - Creating an FTP service now closes the selection window after saving.
+- Create service window now closes after service selection or cancellation, ensuring services are added and preventing blank windows.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1241,3 +1241,11 @@ Effective Prompts / Instructions that worked: User request highlighted window cl
 Decisions & Rationale: Use fixed-width WrapPanel and close dialog upon FTP service creation to restore expected workflow.
 Action Items: Run tests and monitor CI.
 Related Commits/PRs:
+[2025-08-26 15:14] Topic: Create service window closure
+Context: Selection window remained open with blank content and services weren't added.
+Observations: Setting DialogResult without Close() left window displayed.
+Codex Limitations noticed: Required .NET SDK 8.0.404 unavailable; tests deferred to CI.
+Effective Prompts / Instructions that worked: Request to ensure service creation closes dialog.
+Decisions & Rationale: Invoke Close() after setting DialogResult on create or cancel events.
+Action Items: Rely on CI for full WPF validation.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- [x] Code
- [ ] UI/XAML
- [x] Tests
- [ ] DI registrations
- [x] Docs updated

## Validation
- [ ] All tests pass
- [x] No deadlocks; async only
- [x] No unsafe collection access
- [x] Removed stale code

Unable to run `dotnet test` locally: required SDK 8.0.404 is missing; see CI for full test results.

------
https://chatgpt.com/codex/tasks/task_e_68adce52957083269ce7fd7164db9921