### PR TITLE
Preload FTP options and log create service navigation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -147,3 +147,4 @@
 - FTP server creation no longer freezes when selecting the service type; text fields update immediately so saving works without changing focus.
 - Creating an FTP service now closes the selection window after saving.
 - Create service window now closes after service selection or cancellation, ensuring services are added and preventing blank windows.
+- FTP server creation view preloads options from configuration and logs navigation, ensuring the dialog closes after server creation.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -12,6 +12,15 @@ Decisions & Rationale: Use event-driven navigation and injection to decouple vie
 Action Items: Verify navigation on Windows CI.
 Related Commits/PRs: (this PR)
 
+[2025-08-26 16:05] Topic: FTP server create navigation logging
+Context: Ensure FTP server creation preloads options and logs navigation to confirm the dialog closes after save.
+Observations: View model options seeded from configuration; logs surround view navigation and server creation closure.
+Codex Limitations noticed: Linux environment lacks WindowsDesktop runtime; rely on CI for full validation.
+Effective Prompts / Instructions that worked: User request to populate options and add logging.
+Decisions & Rationale: Inject logger and copy IOptions<FtpServerOptions> into the view model before loading the view.
+Action Items: Monitor CI for Windows-specific behavior.
+Related Commits/PRs: (this PR)
+
 [2025-08-26 10:00] Topic: FTP server creation flow
 Context: Ftp server create and edit windows failed to open from service selection or edit commands.
 Observations: Added dedicated navigation in CreateServiceWindow and MainWindow, enabling advanced configuration.


### PR DESCRIPTION
## What changed
- preload `FtpServerCreateViewModel` from `IOptions<FtpServerOptions>`
- add navigation and server creation logging in `CreateServiceWindow`
- test FTP window closes and options copy from configuration
- document FTP navigation logging

## Validation
- `~/.dotnet/dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 not found; rely on CI)*

------
https://chatgpt.com/codex/tasks/task_e_68adda8e41848326a145fbc7e82003aa