### PR TITLE
Add navigation tests for TCP and FTP service workflows

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceNavigationTests.cs
@@ -9,6 +9,13 @@ using DesktopApplicationTemplate.UI.Views;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI;
+using System.IO;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests;
@@ -104,6 +111,62 @@ public class CreateServiceNavigationTests
         windowThread.Start();
         windowThread.Join();
     }
+
+    [Fact]
+    public void FtpAdvancedButton_NavigatesToAdvancedViewAndClosesOnSave()
+    {
+        var logger = new LoggingService(new NullRichTextLogger());
+        var vm = new FtpServerCreateViewModel(logger);
+        var view = new FtpServerCreateView { DataContext = vm };
+        var advView = new FtpServerAdvancedConfigView();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggingService>(logger);
+        services.AddSingleton(vm);
+        services.AddSingleton(view);
+        services.AddSingleton(advView);
+        services.AddOptions<FtpServerOptions>().Configure(o =>
+        {
+            o.Port = 2020;
+            o.RootPath = "/var";
+            o.AllowAnonymous = false;
+            o.Username = "u";
+            o.Password = "p";
+        });
+        var provider = services.BuildServiceProvider();
+
+        var thread = new Thread(() =>
+        {
+            var window = new CreateServiceWindow(new CreateServiceViewModel(), provider);
+            var pageField = typeof(CreateServiceWindow).GetField("_page", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var page = (CreateServicePage)pageField.GetValue(window)!;
+            var button = new Button { DataContext = new CreateServiceViewModel.ServiceTypeMetadata("FTP Server", "FTP Server", string.Empty) };
+            var click = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            click.Invoke(page, new object[] { button, new RoutedEventArgs() });
+
+            vm.Options.Port.Should().Be(2020);
+            vm.Options.RootPath.Should().Be("/var");
+            vm.Options.AllowAnonymous.Should().BeFalse();
+            vm.Options.Username.Should().Be("u");
+            vm.Options.Password.Should().Be("p");
+
+            vm.AdvancedConfigCommand.Execute(null);
+            window.ContentFrame.Content.Should().BeOfType<FtpServerAdvancedConfigView>();
+
+            var advVm = (FtpServerAdvancedConfigViewModel)advView.DataContext!;
+            advVm.CancelCommand.Execute(null);
+            window.ContentFrame.Content.Should().Be(view);
+
+            var evt = typeof(FtpServerCreateViewModel).GetField("ServerCreated", BindingFlags.Instance | BindingFlags.NonPublic);
+            var del = (Action<string, FtpServerOptions>?)evt?.GetValue(vm);
+            del?.Invoke("Svc", vm.Options);
+
+            window.DialogResult.Should().BeTrue();
+            window.IsVisible.Should().BeFalse();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
     [Fact]
     public void NavigateToTcp_SetsPropertiesAndOptions()
     {
@@ -136,6 +199,101 @@ public class CreateServiceNavigationTests
         windowThread.SetApartmentState(ApartmentState.STA);
         windowThread.Start();
         windowThread.Join();
+    }
+
+    [Fact]
+    public void TcpAdvancedButton_NavigatesToAdvancedView()
+    {
+        var logger = new LoggingService(new NullRichTextLogger());
+        var startup = new Mock<IStartupService>();
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggingService>(logger);
+        services.AddSingleton<IStartupService>(startup.Object);
+        services.AddSingleton<SaveConfirmationHelper>();
+        services.AddSingleton<TcpServiceMessagesViewModel>();
+        services.AddSingleton<TcpServiceViewModel>();
+        services.AddSingleton<TcpServiceView>();
+        services.AddSingleton<TcpCreateServiceViewModel>();
+        services.AddSingleton<TcpCreateServiceView>();
+        var provider = services.BuildServiceProvider();
+
+        var thread = new Thread(() =>
+        {
+            var vm = provider.GetRequiredService<TcpCreateServiceViewModel>();
+            var window = new CreateServiceWindow(new CreateServiceViewModel(), provider);
+            var pageField = typeof(CreateServiceWindow).GetField("_page", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var page = (CreateServicePage)pageField.GetValue(window)!;
+            var button = new Button { DataContext = new CreateServiceViewModel.ServiceTypeMetadata("TCP", "TCP", string.Empty) };
+            var click = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            click.Invoke(page, new object[] { button, new RoutedEventArgs() });
+
+            vm.Host = "h";
+            vm.Port = 1111;
+            vm.UseUdp = true;
+            vm.Mode = TcpServiceMode.Sending;
+
+            vm.AdvancedConfigCommand.Execute(null);
+            window.ContentFrame.Content.Should().BeOfType<TcpServiceView>();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void OnEditRequested_TcpService_NavigatesToTcpServiceView()
+    {
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var startup = new Mock<IStartupService>();
+            startup.Setup(s => s.RunStartupChecksAsync()).Returns(Task.CompletedTask);
+            startup.Setup(s => s.GetSettings()).Returns(new AppSettings());
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddSingleton<IRichTextLogger, NullRichTextLogger>();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<IStartupService>(startup.Object);
+                    s.AddSingleton<SaveConfirmationHelper>();
+                    s.AddSingleton<TcpServiceMessagesViewModel>();
+                    s.AddSingleton<TcpServiceViewModel>();
+                    s.AddSingleton<TcpServiceView>();
+                    s.AddSingleton<TcpServiceMessagesView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            prop!.GetSetMethod(true)!.Invoke(null, new object[] { host });
+
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var view = new MainView(mainVm);
+            var service = new ServiceViewModel
+            {
+                DisplayName = "TCP - Test",
+                ServiceType = "TCP",
+                TcpOptions = new TcpServiceOptions(),
+                ServicePage = new Page()
+            };
+            var editMethod = typeof(MainView).GetMethod("OnEditRequested", BindingFlags.Instance | BindingFlags.NonPublic);
+            editMethod!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<TcpServiceView>();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
     }
 
     [Fact]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Tests covering TCP advanced configuration navigation, TCP edit routing, and FTP server option preloading with dialog closure.
 - FTP server create and advanced configuration view models and views with validation and commands.
 - FTP server edit view model and view enabling updates to server configuration.
 - FTP server hosting service with start/stop methods, transfer events, and unit tests.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1283,3 +1283,12 @@ Effective Prompts / Instructions that worked: Direct request to handle TCP edits
 Decisions & Rationale: Reused TcpServiceViewModel and SaveServices to store options.
 Action Items: Run tests and monitor CI.
 Related Commits/PRs: (this PR)
+[2025-08-26 16:14] Topic: TCP and FTP navigation tests
+Context: Added unit tests for TCP advanced button, TCP edit navigation, and FTP server advanced dialog.
+Observations: Tests verify advanced views open, options preload, and dialogs close.
+Codex Limitations noticed: Linux environment lacks WindowsDesktop runtime; rely on CI for execution.
+Effective Prompts / Instructions that worked: direct request for navigation tests.
+Decisions & Rationale: Ensure advanced configuration and edit flows navigate correctly and persist options.
+Action Items: Monitor CI for Windows-specific issues.
+Related Commits/PRs: (this PR)
+


### PR DESCRIPTION
## What changed
- add tests for TCP advanced config and edit routing
- add FTP server advanced navigation test and document test additions
- update changelog and collaboration tips

## Validation
- `/usr/share/dotnet/dotnet test --settings tests.runsettings` *(fails: missing Microsoft.WindowsDesktop runtime; see logs)*


------
https://chatgpt.com/codex/tasks/task_e_68addc293c948326a4494d9a3c8dd867