### PR TITLE
Add cancel support to FTP server creation

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
@@ -36,6 +36,21 @@ public class FtpServerCreateViewModelTests
     [Fact]
     [TestCategory("CodexSafe")]
     [TestCategory("WindowsSafe")]
+    public void CancelCommand_RaisesCancelled()
+    {
+        var vm = new FtpServerCreateViewModel();
+        var cancelled = false;
+        vm.Cancelled += () => cancelled = true;
+
+        vm.CancelCommand.Execute(null);
+
+        Assert.True(cancelled);
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
     public void SettingInvalidPort_AddsError()
     {
         var vm = new FtpServerCreateViewModel();

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServerCreateViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServerCreateViewModel.cs
@@ -22,6 +22,7 @@ public class FtpServerCreateViewModel : ValidatableViewModelBase, ILoggingViewMo
     {
         Logger = logger;
         SaveCommand = new RelayCommand(Save);
+        CancelCommand = new RelayCommand(Cancel);
         AdvancedConfigCommand = new RelayCommand(OpenAdvancedConfig);
     }
 
@@ -38,6 +39,11 @@ public class FtpServerCreateViewModel : ValidatableViewModelBase, ILoggingViewMo
     public ICommand SaveCommand { get; }
 
     /// <summary>
+    /// Command for cancelling server creation.
+    /// </summary>
+    public ICommand CancelCommand { get; }
+
+    /// <summary>
     /// Command for launching the advanced configuration view.
     /// </summary>
     public ICommand AdvancedConfigCommand { get; }
@@ -46,6 +52,11 @@ public class FtpServerCreateViewModel : ValidatableViewModelBase, ILoggingViewMo
     /// Raised when the configuration is saved.
     /// </summary>
     public event Action<string, FtpServerOptions>? ServerCreated;
+
+    /// <summary>
+    /// Raised when creation is cancelled.
+    /// </summary>
+    public event Action? Cancelled;
 
     /// <summary>
     /// Raised when advanced configuration is requested.
@@ -112,6 +123,12 @@ public class FtpServerCreateViewModel : ValidatableViewModelBase, ILoggingViewMo
         Options.RootPath = RootPath;
         Logger?.Log("FTP server create options finished", LogLevel.Debug);
         ServerCreated?.Invoke(ServiceName, Options);
+    }
+
+    private void Cancel()
+    {
+        Logger?.Log("FTP server create options cancelled", LogLevel.Debug);
+        Cancelled?.Invoke();
     }
 
     private void OpenAdvancedConfig()

--- a/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
@@ -29,6 +29,7 @@
             <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open FTP Advanced Configuration"/>
                 <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save FTP Server"/>
+                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel FTP Server Creation"/>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Standalone `FilterWindow` in favor of inline filter popup.
 
 ### Fixed
+- FTP server create view model exposes a cancel command and event to allow aborting server setup.
 - Unsealed `FtpTransferEventArgs` to allow progress events to derive from it.
 - Newly created TCP and other services now display their pages after addition.
 - Corrected logo resource path so the image renders in the navigation bar.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1316,3 +1316,12 @@ Effective Prompts / Instructions that worked: User request to embed create views
 Decisions & Rationale: Replaced CreateServiceWindow navigation with in-frame page display.
 Action Items: Monitor CI for UI regressions.
 Related Commits/PRs: (this PR)
+[2025-08-26 16:49] Topic: FTP create cancellation
+Context: Added Cancel command and event to FtpServerCreateViewModel and view to resolve build error.
+Observations: Cancel button now returns to service selection via Cancelled event.
+Codex Limitations noticed: pwsh unavailable for add-tip script.
+Effective Prompts / Instructions that worked: follow MVVM pattern and logging guidelines.
+Decisions & Rationale: Align FTP create flow with other create view models.
+Action Items: Monitor CI for Windows-specific issues.
+Related Commits/PRs: (this PR)
+


### PR DESCRIPTION
## What changed
- add Cancel command and event to `FtpServerCreateViewModel`
- wire up Cancel button in `FtpServerCreateView`
- unit test for cancellation
- document FTP create cancellation

## Validation
- `dotnet test --settings tests.runsettings` *(fails: command not found; .NET SDK unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade5437df88326acdf0c3e7f1173fe