### PR TITLE
Route TCP and FTP service creation through configuration views

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Threading;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class MainViewCreateNavigationTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void NavigateToTcp_ShowsCreateView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddTransient<TcpCreateServiceViewModel>();
+                    s.AddTransient<TcpCreateServiceView>();
+                    s.AddOptions<TcpServiceOptions>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("NavigateToTcp", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { "Test" });
+
+            view.ContentFrame.Content.Should().BeOfType<TcpCreateServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void NavigateToFtpServer_ShowsCreateView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddTransient<FtpServerCreateViewModel>();
+                    s.AddTransient<FtpServerCreateView>();
+                    s.AddOptions<FtpServerOptions>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("NavigateToFtpServer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { "Test" });
+
+            view.ContentFrame.Content.Should().BeOfType<FtpServerCreateView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class FtpServerCreateView : Page
+{
+    public FtpServerCreateView(FtpServerCreateViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -212,8 +212,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 _viewModel.SaveServices();
             };
             vm.Cancelled += ShowCreateServiceSelectionPage;
-            var view = App.AppHost.Services.GetRequiredService<TcpCreateServiceView>();
-            view.DataContext = vm;
+            var view = ActivatorUtilities.CreateInstance<TcpCreateServiceView>(App.AppHost.Services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advView = App.AppHost.Services.GetRequiredService<TcpServiceView>();
@@ -252,8 +251,7 @@ namespace DesktopApplicationTemplate.UI.Views
             vm.Options.Username = opts.Username;
             vm.Options.Password = opts.Password;
 
-            var view = App.AppHost.Services.GetRequiredService<FtpServerCreateView>();
-            view.DataContext = vm;
+            var view = ActivatorUtilities.CreateInstance<FtpServerCreateView>(App.AppHost.Services, vm);
             vm.ServerCreated += (name, options) =>
             {
                 _logger?.LogInformation("FTP server {Name} created", name);

--- a/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class TcpCreateServiceView : Page
+{
+    public TcpCreateServiceView(TcpCreateServiceViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Standalone `FilterWindow` in favor of inline filter popup.
 
 ### Fixed
+- Selecting TCP or FTP server from the add service page now opens their configuration views prior to creation.
 - FTP server create view model exposes a cancel command and event to allow aborting server setup.
 - Unsealed `FtpTransferEventArgs` to allow progress events to derive from it.
 - Newly created TCP and other services now display their pages after addition.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1325,3 +1325,11 @@ Decisions & Rationale: Align FTP create flow with other create view models.
 Action Items: Monitor CI for Windows-specific issues.
 Related Commits/PRs: (this PR)
 
+[2025-08-26 17:14] Topic: TCP/FTP creation navigation
+Context: Ensure selecting TCP or FTP server opens configuration views before adding services.
+Observations: Added view constructors with DI, updated navigation to use ActivatorUtilities, and introduced navigation tests.
+Codex Limitations noticed: none
+Effective Prompts / Instructions that worked: request to route service selections through create views.
+Decisions & Rationale: Inject view models and logging via constructors to guarantee required fields and consistent setup.
+Action Items: Monitor CI.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## Summary
- Instantiate TCP and FTP server creation flows with `ActivatorUtilities` so users configure required fields before services are added
- Add navigation tests verifying the create views are shown for TCP and FTP selections
- Document routing change in changelog and collaboration tips

## Testing
- `dotnet test DesktopApplicationTemplate/DesktopApplicationTemplate.sln --settings DesktopApplicationTemplate/tests.runsettings` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade9a011588326b4814464d303006b