### PR TITLE
Add HID service navigation and advanced configuration

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServicePageTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServicePageTests.cs
@@ -51,6 +51,25 @@ public class CreateServicePageTests
     }
 
     [Fact]
+    public void ServiceType_Click_RaisesHidSelected()
+    {
+        string? receivedName = null;
+        var thread = new Thread(() =>
+        {
+            var vm = new CreateServiceViewModel();
+            var page = new CreateServicePage(vm);
+            page.HidSelected += name => receivedName = name;
+            var button = new Button { DataContext = new CreateServiceViewModel.ServiceTypeMetadata("HID", "HID", string.Empty) };
+            var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            method.Invoke(page, new object[] { button, new RoutedEventArgs() });
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        receivedName.Should().Be("HID1");
+    }
+
+    [Fact]
     public void ServiceType_Click_RaisesServiceCreated_ForHttp()
     {
         string? receivedName = null;

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
+using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -104,6 +105,57 @@ public class MainViewCreateNavigationTests
             method!.Invoke(view, new object[] { "Test" });
 
             view.ContentFrame.Content.Should().BeOfType<FtpServerCreateView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void NavigateToHid_ShowsCreateView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<SaveConfirmationHelper>();
+                    s.AddSingleton<HidViewModel>();
+                    s.AddSingleton<HidViews>();
+                    s.AddTransient<HidCreateServiceViewModel>();
+                    s.AddTransient<HidCreateServiceView>();
+                    s.AddTransient<HidAdvancedConfigViewModel>();
+                    s.AddTransient<HidAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("NavigateToHid", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { "Test" });
+
+            view.ContentFrame.Content.Should().BeOfType<HidCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
         thread.SetApartmentState(ApartmentState.STA);

--- a/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Threading;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+using DesktopApplicationTemplate.UI.Helpers;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class MainViewHidNavigationTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void EditHidService_ShowsEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<SaveConfirmationHelper>();
+                    s.AddSingleton<HidViewModel>();
+                    s.AddSingleton<HidViews>();
+                    s.AddTransient<HidEditServiceViewModel>();
+                    s.AddTransient<HidEditServiceView>();
+                    s.AddTransient<HidAdvancedConfigViewModel>();
+                    s.AddTransient<HidAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "HID - Test",
+                ServiceType = "HID",
+                HidOptions = new HidServiceOptions { MessageTemplate = "msg" }
+            };
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<HidEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -103,6 +103,12 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<MqttEditConnectionViewModel>();
             services.AddTransient<MqttTagSubscriptionsView>();
             services.AddTransient<MqttTagSubscriptionsViewModel>();
+            services.AddTransient<HidCreateServiceView>();
+            services.AddTransient<HidCreateServiceViewModel>();
+            services.AddTransient<HidEditServiceView>();
+            services.AddTransient<HidEditServiceViewModel>();
+            services.AddTransient<HidAdvancedConfigView>();
+            services.AddTransient<HidAdvancedConfigViewModel>();
             services.AddTransient<SettingsPage>();
 
 
@@ -112,6 +118,7 @@ namespace DesktopApplicationTemplate.UI
             services.Configure<TcpServiceOptions>(configuration.GetSection("TcpService"));
             services.AddOptions<DesktopApplicationTemplate.UI.Services.FtpServerOptions>()
                 .BindConfiguration("FtpServer");
+            services.AddOptions<HidServiceOptions>();
         }
 
         protected override async void OnStartup(StartupEventArgs e)

--- a/DesktopApplicationTemplate.UI/Services/HidServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Services/HidServiceOptions.cs
@@ -1,0 +1,33 @@
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Configuration options for HID services.
+    /// </summary>
+    public class HidServiceOptions
+    {
+        /// <summary>
+        /// Message template sent by the HID device.
+        /// </summary>
+        public string MessageTemplate { get; set; } = string.Empty;
+
+        /// <summary>
+        /// USB protocol version.
+        /// </summary>
+        public string UsbProtocol { get; set; } = "2.0";
+
+        /// <summary>
+        /// Service name to forward messages to.
+        /// </summary>
+        public string AttachedService { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Debounce time in milliseconds.
+        /// </summary>
+        public int DebounceTimeMs { get; set; }
+
+        /// <summary>
+        /// Key down duration in milliseconds.
+        /// </summary>
+        public int KeyDownTimeMs { get; set; }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/HidAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidAdvancedConfigViewModel.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for editing advanced HID configuration.
+/// </summary>
+public class HidAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+{
+    private readonly HidServiceOptions _options;
+    private int _debounceTime;
+    private int _keyDownTime;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HidAdvancedConfigViewModel"/> class.
+    /// </summary>
+    public HidAdvancedConfigViewModel(HidServiceOptions options, ILoggingService? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _debounceTime = options.DebounceTimeMs;
+        _keyDownTime = options.KeyDownTimeMs;
+        Logger = logger;
+        SaveCommand = new RelayCommand(Save);
+        BackCommand = new RelayCommand(Back);
+    }
+
+    /// <inheritdoc />
+    public ILoggingService? Logger { get; set; }
+
+    /// <summary>
+    /// Command to save the configuration.
+    /// </summary>
+    public ICommand SaveCommand { get; }
+
+    /// <summary>
+    /// Command to navigate back without saving.
+    /// </summary>
+    public ICommand BackCommand { get; }
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<HidServiceOptions>? Saved;
+
+    /// <summary>
+    /// Raised when navigation back is requested.
+    /// </summary>
+    public event Action? BackRequested;
+
+    /// <summary>
+    /// Debounce time in milliseconds.
+    /// </summary>
+    public int DebounceTimeMs
+    {
+        get => _debounceTime;
+        set { _debounceTime = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Key down duration in milliseconds.
+    /// </summary>
+    public int KeyDownTimeMs
+    {
+        get => _keyDownTime;
+        set { _keyDownTime = value; OnPropertyChanged(); }
+    }
+
+    private void Save()
+    {
+        Logger?.Log("HID advanced options start", LogLevel.Debug);
+        _options.DebounceTimeMs = DebounceTimeMs;
+        _options.KeyDownTimeMs = KeyDownTimeMs;
+        Logger?.Log("HID advanced options finished", LogLevel.Debug);
+        Saved?.Invoke(_options);
+    }
+
+    private void Back()
+    {
+        Logger?.Log("HID advanced options back", LogLevel.Debug);
+        BackRequested?.Invoke();
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/HidCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidCreateServiceViewModel.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for creating a new HID service.
+/// </summary>
+public class HidCreateServiceViewModel : ViewModelBase, ILoggingViewModel
+{
+    private string _serviceName = string.Empty;
+    private string _messageTemplate = string.Empty;
+    private string _selectedUsbProtocol = "2.0";
+    private string _attachedService = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HidCreateServiceViewModel"/> class.
+    /// </summary>
+    public HidCreateServiceViewModel(ILoggingService? logger = null)
+    {
+        Logger = logger;
+        CreateCommand = new RelayCommand(Create);
+        CancelCommand = new RelayCommand(Cancel);
+        AdvancedConfigCommand = new RelayCommand(OpenAdvancedConfig);
+        UsbProtocols = new[] { "2.0", "3.0" };
+    }
+
+    /// <inheritdoc />
+    public ILoggingService? Logger { get; set; }
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<string, HidServiceOptions>? ServiceCreated;
+
+    /// <summary>
+    /// Raised when creation is cancelled.
+    /// </summary>
+    public event Action? Cancelled;
+
+    /// <summary>
+    /// Raised when advanced configuration is requested.
+    /// </summary>
+    public event Action<HidServiceOptions>? AdvancedConfigRequested;
+
+    /// <summary>
+    /// Command to create the service.
+    /// </summary>
+    public ICommand CreateCommand { get; }
+
+    /// <summary>
+    /// Command to cancel creation.
+    /// </summary>
+    public ICommand CancelCommand { get; }
+
+    /// <summary>
+    /// Command to open advanced configuration.
+    /// </summary>
+    public ICommand AdvancedConfigCommand { get; }
+
+    /// <summary>
+    /// Available USB protocol options.
+    /// </summary>
+    public IReadOnlyList<string> UsbProtocols { get; }
+
+    /// <summary>
+    /// Name of the service.
+    /// </summary>
+    public string ServiceName
+    {
+        get => _serviceName;
+        set { _serviceName = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Message template for the HID service.
+    /// </summary>
+    public string MessageTemplate
+    {
+        get => _messageTemplate;
+        set { _messageTemplate = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Selected USB protocol.
+    /// </summary>
+    public string SelectedUsbProtocol
+    {
+        get => _selectedUsbProtocol;
+        set { _selectedUsbProtocol = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Name of the service to forward messages to.
+    /// </summary>
+    public string AttachedService
+    {
+        get => _attachedService;
+        set { _attachedService = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Current configuration options.
+    /// </summary>
+    public HidServiceOptions Options { get; } = new();
+
+    private void Create()
+    {
+        Logger?.Log("HID create options start", LogLevel.Debug);
+        Options.MessageTemplate = MessageTemplate;
+        Options.UsbProtocol = SelectedUsbProtocol;
+        Options.AttachedService = AttachedService;
+        Logger?.Log("HID create options finished", LogLevel.Debug);
+        ServiceCreated?.Invoke(ServiceName, Options);
+    }
+
+    private void Cancel()
+    {
+        Logger?.Log("HID create cancelled", LogLevel.Debug);
+        Cancelled?.Invoke();
+    }
+
+    private void OpenAdvancedConfig()
+    {
+        Logger?.Log("Opening HID advanced config", LogLevel.Debug);
+        Options.MessageTemplate = MessageTemplate;
+        Options.UsbProtocol = SelectedUsbProtocol;
+        Options.AttachedService = AttachedService;
+        AdvancedConfigRequested?.Invoke(Options);
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/HidEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidEditServiceViewModel.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for editing an existing HID service configuration.
+/// </summary>
+public class HidEditServiceViewModel : HidCreateServiceViewModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HidEditServiceViewModel"/> class.
+    /// </summary>
+    public HidEditServiceViewModel(string serviceName, HidServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
+    {
+        ServiceName = serviceName;
+        MessageTemplate = options.MessageTemplate;
+        SelectedUsbProtocol = options.UsbProtocol;
+        AttachedService = options.AttachedService;
+        Options.MessageTemplate = options.MessageTemplate;
+        Options.UsbProtocol = options.UsbProtocol;
+        Options.AttachedService = options.AttachedService;
+        Options.DebounceTimeMs = options.DebounceTimeMs;
+        Options.KeyDownTimeMs = options.KeyDownTimeMs;
+    }
+
+    /// <summary>
+    /// Command for saving the updated configuration.
+    /// </summary>
+    public ICommand SaveCommand => CreateCommand;
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<string, HidServiceOptions>? ServiceUpdated
+    {
+        add => ServiceCreated += value;
+        remove => ServiceCreated -= value;
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -58,6 +58,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public HttpServiceOptions? HttpOptions { get; set; }
 
+        /// <summary>
+        /// HID-specific configuration for this service, if applicable.
+        /// </summary>
+        public HidServiceOptions? HidOptions { get; set; }
+
         public static Func<string, string, ServiceViewModel?>? ResolveService { get; set; }
 
 

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -13,6 +13,7 @@ namespace DesktopApplicationTemplate.UI.Views
         public event Action<string>? TcpSelected;
         public event Action<string>? FtpServerSelected;
         public event Action<string>? HttpSelected;
+        public event Action<string>? HidSelected;
         public event Action? Cancelled;
 
         public CreateServicePage(CreateServiceViewModel viewModel)
@@ -45,6 +46,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (meta.Type == "HTTP")
                 {
                     HttpSelected?.Invoke(name);
+                    return;
+                }
+                if (meta.Type == "HID")
+                {
+                    HidSelected?.Invoke(name);
                     return;
                 }
                 ServiceCreated?.Invoke(name, meta.Type);

--- a/DesktopApplicationTemplate.UI/Views/HidAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidAdvancedConfigView.xaml
@@ -1,0 +1,29 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.HidAdvancedConfigView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Debounce (ms)" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding DebounceTimeMs}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Key Down (ms)" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding KeyDownTimeMs}" Style="{StaticResource FormField}"/>
+
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HID Advanced Configuration"/>
+            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to HID Configuration"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/HidAdvancedConfigView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HidAdvancedConfigView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class HidAdvancedConfigView : Page
+{
+    public HidAdvancedConfigView(HidAdvancedConfigViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml
@@ -1,0 +1,40 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.HidCreateServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid Margin="20">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Message Template" Style="{StaticResource FormLabel}"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding MessageTemplate}" Style="{StaticResource FormField}" Height="80" AcceptsReturn="True"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="USB Protocol" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding UsbProtocols}" SelectedItem="{Binding SelectedUsbProtocol}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Attached Service" Style="{StaticResource FormLabel}"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AttachedService}" Style="{StaticResource FormField}"/>
+
+            <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HID Advanced Configuration"/>
+                <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create HID Service"/>
+                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HID Creation"/>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class HidCreateServiceView : Page
+{
+    public HidCreateServiceView(HidCreateServiceViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml
@@ -1,0 +1,40 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.HidEditServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid Margin="20">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Message Template" Style="{StaticResource FormLabel}"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding MessageTemplate}" Style="{StaticResource FormField}" Height="80" AcceptsReturn="True"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="USB Protocol" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="2" Grid.Column="1" ItemsSource="{Binding UsbProtocols}" SelectedItem="{Binding SelectedUsbProtocol}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Attached Service" Style="{StaticResource FormLabel}"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AttachedService}" Style="{StaticResource FormField}"/>
+
+            <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HID Advanced Configuration"/>
+                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HID Service"/>
+                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HID Edit"/>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class HidEditServiceView : Page
+{
+    public HidEditServiceView(HidEditServiceViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- HID service creation, edit, and advanced configuration views with navigation tests.
 - Save Configuration and Back buttons for advanced edit pages to enable saving and navigation.
 - TCP messages view now groups incoming data, script output, and results into left-to-right panels.
 - FTP service view displays active transfer progress, connected client count, and status indicator.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1349,3 +1349,11 @@ Effective Prompts / Instructions that worked: Followed MVVM and DI registration 
 Decisions & Rationale: Mirror TCP and FTP patterns to maintain consistent service workflows.
 Action Items: Monitor CI for Windows-specific issues.
 Related Commits/PRs:
+[2025-08-27 18:00] Topic: HID service navigation
+Context: Added HID create, edit, and advanced configuration flows with DI registration and tests.
+Observations: Navigation now routes HID services through dedicated views with back/advanced options.
+Codex Limitations noticed: Linux environment lacks WindowsDesktop runtime; rely on CI for WPF verification.
+Effective Prompts / Instructions that worked: Follow MVVM/DI patterns and update docs/tests per AGENTS guidelines.
+Decisions & Rationale: Mirror existing service flows to maintain consistency and test navigation paths.
+Action Items: Monitor CI for Windows-specific behavior.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- HID service creation, edit, and advanced configuration view models and views
- Navigation hooks for HID services including create and edit flows
- DI registrations and unit tests for HID navigation
- Docs updated with HID guidance

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68adf75fedb48326ad0c82bb3cb3181b