### PR TITLE
Add File Observer service creation and edit flows

### DIFF
--- a/DesktopApplicationTemplate.Tests/FileObserverAdvancedConfigViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FileObserverAdvancedConfigViewModelTests.cs
@@ -1,0 +1,20 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class FileObserverAdvancedConfigViewModelTests
+{
+    [Fact]
+    public void BackCommand_RaisesBackRequested()
+    {
+        var options = new FileObserverServiceOptions();
+        var vm = new FileObserverAdvancedConfigViewModel(options);
+        var raised = false;
+        vm.BackRequested += () => raised = true;
+        vm.BackCommand.Execute(null);
+        raised.Should().BeTrue();
+    }
+}

--- a/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Threading;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+using DesktopApplicationTemplate.UI.Helpers;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class MainViewFileObserverNavigationTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void EditFileObserverService_ShowsEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<SaveConfirmationHelper>();
+                    s.AddSingleton<FileObserverViewModel>();
+                    s.AddSingleton<FileObserverView>();
+                    s.AddTransient<FileObserverEditServiceViewModel>();
+                    s.AddTransient<FileObserverEditServiceView>();
+                    s.AddTransient<FileObserverAdvancedConfigViewModel>();
+                    s.AddTransient<FileObserverAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "File Observer - Test",
+                ServiceType = "File Observer",
+                FileObserverOptions = new FileObserverServiceOptions { FilePath = "path" }
+            };
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<FileObserverEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -109,6 +109,12 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<HidEditServiceViewModel>();
             services.AddTransient<HidAdvancedConfigView>();
             services.AddTransient<HidAdvancedConfigViewModel>();
+            services.AddTransient<FileObserverCreateServiceView>();
+            services.AddTransient<FileObserverCreateServiceViewModel>();
+            services.AddTransient<FileObserverEditServiceView>();
+            services.AddTransient<FileObserverEditServiceViewModel>();
+            services.AddTransient<FileObserverAdvancedConfigView>();
+            services.AddTransient<FileObserverAdvancedConfigViewModel>();
             services.AddTransient<SettingsPage>();
 
 
@@ -119,6 +125,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddOptions<DesktopApplicationTemplate.UI.Services.FtpServerOptions>()
                 .BindConfiguration("FtpServer");
             services.AddOptions<HidServiceOptions>();
+            services.AddOptions<FileObserverServiceOptions>();
         }
 
         protected override async void OnStartup(StartupEventArgs e)

--- a/DesktopApplicationTemplate.UI/Services/FileObserverServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileObserverServiceOptions.cs
@@ -1,0 +1,42 @@
+namespace DesktopApplicationTemplate.UI.Services;
+
+/// <summary>
+/// Configuration options for File Observer services.
+/// </summary>
+public class FileObserverServiceOptions
+{
+    /// <summary>
+    /// Path to observe for file changes.
+    /// </summary>
+    public string FilePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Comma-separated list of image names to send.
+    /// </summary>
+    public string ImageNames { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether to send all images when triggered.
+    /// </summary>
+    public bool SendAllImages { get; set; }
+
+    /// <summary>
+    /// Whether to send only the first X images.
+    /// </summary>
+    public bool SendFirstX { get; set; }
+
+    /// <summary>
+    /// Number of images to send when <see cref="SendFirstX"/> is enabled.
+    /// </summary>
+    public int XCount { get; set; }
+
+    /// <summary>
+    /// Whether to send a TCP command.
+    /// </summary>
+    public bool SendTcpCommand { get; set; }
+
+    /// <summary>
+    /// TCP command string to send when <see cref="SendTcpCommand"/> is true.
+    /// </summary>
+    public string TcpCommand { get; set; } = string.Empty;
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverAdvancedConfigViewModel.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for editing advanced File Observer configuration.
+/// </summary>
+public class FileObserverAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+{
+    private readonly FileObserverServiceOptions _options;
+    private string _imageNames;
+    private bool _sendAll;
+    private bool _sendFirstX;
+    private int _xCount;
+    private bool _sendTcp;
+    private string _tcpCommand;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileObserverAdvancedConfigViewModel"/> class.
+    /// </summary>
+    public FileObserverAdvancedConfigViewModel(FileObserverServiceOptions options, ILoggingService? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _imageNames = options.ImageNames;
+        _sendAll = options.SendAllImages;
+        _sendFirstX = options.SendFirstX;
+        _xCount = options.XCount;
+        _sendTcp = options.SendTcpCommand;
+        _tcpCommand = options.TcpCommand;
+        Logger = logger;
+        SaveCommand = new RelayCommand(Save);
+        BackCommand = new RelayCommand(Back);
+    }
+
+    /// <inheritdoc />
+    public ILoggingService? Logger { get; set; }
+
+    /// <summary>
+    /// Command to save the configuration.
+    /// </summary>
+    public ICommand SaveCommand { get; }
+
+    /// <summary>
+    /// Command to navigate back without saving.
+    /// </summary>
+    public ICommand BackCommand { get; }
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<FileObserverServiceOptions>? Saved;
+
+    /// <summary>
+    /// Raised when navigation back is requested.
+    /// </summary>
+    public event Action? BackRequested;
+
+    /// <summary>
+    /// Comma-separated list of image names.
+    /// </summary>
+    public string ImageNames
+    {
+        get => _imageNames;
+        set { _imageNames = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Whether to send all images.
+    /// </summary>
+    public bool SendAllImages
+    {
+        get => _sendAll;
+        set { _sendAll = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Whether to send only the first X images.
+    /// </summary>
+    public bool SendFirstX
+    {
+        get => _sendFirstX;
+        set { _sendFirstX = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Number of images to send when <see cref="SendFirstX"/> is true.
+    /// </summary>
+    public int XCount
+    {
+        get => _xCount;
+        set { _xCount = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Whether to send a TCP command.
+    /// </summary>
+    public bool SendTcpCommand
+    {
+        get => _sendTcp;
+        set { _sendTcp = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// TCP command to send.
+    /// </summary>
+    public string TcpCommand
+    {
+        get => _tcpCommand;
+        set { _tcpCommand = value; OnPropertyChanged(); }
+    }
+
+    private void Save()
+    {
+        Logger?.Log("FileObserver advanced options start", LogLevel.Debug);
+        _options.ImageNames = ImageNames;
+        _options.SendAllImages = SendAllImages;
+        _options.SendFirstX = SendFirstX;
+        _options.XCount = XCount;
+        _options.SendTcpCommand = SendTcpCommand;
+        _options.TcpCommand = TcpCommand;
+        Logger?.Log("FileObserver advanced options finished", LogLevel.Debug);
+        Saved?.Invoke(_options);
+    }
+
+    private void Back()
+    {
+        Logger?.Log("FileObserver advanced options back", LogLevel.Debug);
+        BackRequested?.Invoke();
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverCreateServiceViewModel.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for creating a new File Observer service.
+/// </summary>
+public class FileObserverCreateServiceViewModel : ViewModelBase, ILoggingViewModel
+{
+    private string _serviceName = string.Empty;
+    private string _filePath = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileObserverCreateServiceViewModel"/> class.
+    /// </summary>
+    public FileObserverCreateServiceViewModel(ILoggingService? logger = null)
+    {
+        Logger = logger;
+        CreateCommand = new RelayCommand(Create);
+        CancelCommand = new RelayCommand(Cancel);
+        AdvancedConfigCommand = new RelayCommand(OpenAdvancedConfig);
+    }
+
+    /// <inheritdoc />
+    public ILoggingService? Logger { get; set; }
+
+    /// <summary>
+    /// Raised when the service is created.
+    /// </summary>
+    public event Action<string, FileObserverServiceOptions>? ServiceCreated;
+
+    /// <summary>
+    /// Raised when creation is cancelled.
+    /// </summary>
+    public event Action? Cancelled;
+
+    /// <summary>
+    /// Raised when advanced configuration is requested.
+    /// </summary>
+    public event Action<FileObserverServiceOptions>? AdvancedConfigRequested;
+
+    /// <summary>
+    /// Command to create the service.
+    /// </summary>
+    public ICommand CreateCommand { get; }
+
+    /// <summary>
+    /// Command to cancel creation.
+    /// </summary>
+    public ICommand CancelCommand { get; }
+
+    /// <summary>
+    /// Command to open advanced configuration.
+    /// </summary>
+    public ICommand AdvancedConfigCommand { get; }
+
+    /// <summary>
+    /// Name of the service.
+    /// </summary>
+    public string ServiceName
+    {
+        get => _serviceName;
+        set { _serviceName = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// File path to observe.
+    /// </summary>
+    public string FilePath
+    {
+        get => _filePath;
+        set { _filePath = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Current configuration options.
+    /// </summary>
+    public FileObserverServiceOptions Options { get; } = new();
+
+    private void Create()
+    {
+        Logger?.Log("FileObserver create options start", LogLevel.Debug);
+        Options.FilePath = FilePath;
+        Logger?.Log("FileObserver create options finished", LogLevel.Debug);
+        ServiceCreated?.Invoke(ServiceName, Options);
+    }
+
+    private void Cancel()
+    {
+        Logger?.Log("FileObserver create cancelled", LogLevel.Debug);
+        Cancelled?.Invoke();
+    }
+
+    private void OpenAdvancedConfig()
+    {
+        Logger?.Log("Opening FileObserver advanced config", LogLevel.Debug);
+        Options.FilePath = FilePath;
+        AdvancedConfigRequested?.Invoke(Options);
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverEditServiceViewModel.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for editing an existing File Observer service configuration.
+/// </summary>
+public class FileObserverEditServiceViewModel : FileObserverCreateServiceViewModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileObserverEditServiceViewModel"/> class.
+    /// </summary>
+    public FileObserverEditServiceViewModel(string serviceName, FileObserverServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
+    {
+        ServiceName = serviceName;
+        FilePath = options.FilePath;
+        Options.FilePath = options.FilePath;
+        Options.ImageNames = options.ImageNames;
+        Options.SendAllImages = options.SendAllImages;
+        Options.SendFirstX = options.SendFirstX;
+        Options.XCount = options.XCount;
+        Options.SendTcpCommand = options.SendTcpCommand;
+        Options.TcpCommand = options.TcpCommand;
+    }
+
+    /// <summary>
+    /// Command for saving the updated configuration.
+    /// </summary>
+    public ICommand SaveCommand => CreateCommand;
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<string, FileObserverServiceOptions>? ServiceUpdated
+    {
+        add => ServiceCreated += value;
+        remove => ServiceCreated -= value;
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -63,6 +63,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public HidServiceOptions? HidOptions { get; set; }
 
+        /// <summary>
+        /// File Observer-specific configuration for this service, if applicable.
+        /// </summary>
+        public FileObserverServiceOptions? FileObserverOptions { get; set; }
+
         public static Func<string, string, ServiceViewModel?>? ResolveService { get; set; }
 
 

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -14,6 +14,7 @@ namespace DesktopApplicationTemplate.UI.Views
         public event Action<string>? FtpServerSelected;
         public event Action<string>? HttpSelected;
         public event Action<string>? HidSelected;
+        public event Action<string>? FileObserverSelected;
         public event Action? Cancelled;
 
         public CreateServicePage(CreateServiceViewModel viewModel)
@@ -51,6 +52,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (meta.Type == "HID")
                 {
                     HidSelected?.Invoke(name);
+                    return;
+                }
+                if (meta.Type == "File Observer")
+                {
+                    FileObserverSelected?.Invoke(name);
                     return;
                 }
                 ServiceCreated?.Invoke(name, meta.Type);

--- a/DesktopApplicationTemplate.UI/Views/FileObserverAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverAdvancedConfigView.xaml
@@ -1,0 +1,42 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.FileObserverAdvancedConfigView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Image Names" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ImageNames}" Style="{StaticResource FormField}"/>
+
+        <CheckBox Grid.Row="1" Grid.ColumnSpan="2" Content="Send All Images" IsChecked="{Binding SendAllImages}" Margin="0,5"/>
+        <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Send First X Images" IsChecked="{Binding SendFirstX}" Margin="0,5"/>
+
+        <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,5">
+            <TextBlock Text="X Count" Style="{StaticResource FormLabel}"/>
+            <TextBox Text="{Binding XCount}" Width="60" Margin="5,0,0,0" Style="{StaticResource FormField}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,5">
+            <CheckBox Content="Send TCP Command" IsChecked="{Binding SendTcpCommand}" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding TcpCommand}" Width="150" Margin="10,0,0,0" Style="{StaticResource FormField}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save File Observer Advanced Configuration"/>
+            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to File Observer Configuration"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverAdvancedConfigView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverAdvancedConfigView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class FileObserverAdvancedConfigView : Page
+{
+    public FileObserverAdvancedConfigView(FileObserverAdvancedConfigViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
@@ -1,0 +1,30 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.FileObserverCreateServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="File Path" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath}" Style="{StaticResource FormField}"/>
+
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open File Observer Advanced Configuration"/>
+            <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create File Observer Service"/>
+            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel File Observer Creation"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class FileObserverCreateServiceView : Page
+{
+    public FileObserverCreateServiceView(FileObserverCreateServiceViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
@@ -1,0 +1,30 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.FileObserverEditServiceView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="File Path" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath}" Style="{StaticResource FormField}"/>
+
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open File Observer Advanced Configuration"/>
+            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save File Observer Service"/>
+            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel File Observer Edit"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class FileObserverEditServiceView : Page
+{
+    public FileObserverEditServiceView(FileObserverEditServiceViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -179,6 +179,7 @@ namespace DesktopApplicationTemplate.UI.Views
             page.FtpServerSelected += NavigateToFtpServer;
             page.HttpSelected += NavigateToHttp;
             page.HidSelected += NavigateToHid;
+            page.FileObserverSelected += NavigateToFileObserver;
             page.Cancelled += ShowHome;
             ShowPage(page);
         }
@@ -224,6 +225,45 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 var advVm = ActivatorUtilities.CreateInstance<HidAdvancedConfigViewModel>(App.AppHost.Services, opts);
                 var advView = App.AppHost.Services.GetRequiredService<HidAdvancedConfigView>();
+                advView.DataContext = advVm;
+                advVm.Saved += _ => ShowPage(view);
+                advVm.BackRequested += () => ShowPage(view);
+                ShowPage(advView);
+            };
+            ShowPage(view);
+        }
+
+        private void NavigateToFileObserver(string defaultName)
+        {
+            var vm = App.AppHost.Services.GetRequiredService<FileObserverCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceCreated += (name, options) =>
+            {
+                var svc = new ServiceViewModel
+                {
+                    DisplayName = $"File Observer - {name}",
+                    ServiceType = "File Observer",
+                    IsActive = false,
+                    FileObserverOptions = options
+                };
+                svc.SetColorsByType();
+                svc.LogAdded += _viewModel.OnServiceLogAdded;
+                svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
+                GetOrCreateServicePage(svc);
+                _viewModel.Services.Add(svc);
+                _logger?.LogInformation("Service {Name} added", svc.DisplayName);
+                _viewModel.SelectedService = svc;
+                ServiceList.ScrollIntoView(svc);
+                if (svc.ServicePage != null)
+                    ShowPage(svc.ServicePage);
+                _viewModel.SaveServices();
+            };
+            vm.Cancelled += ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<FileObserverCreateServiceView>(App.AppHost.Services, vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<FileObserverAdvancedConfigViewModel>(App.AppHost.Services, opts);
+                var advView = App.AppHost.Services.GetRequiredService<FileObserverAdvancedConfigView>();
                 advView.DataContext = advVm;
                 advVm.Saved += _ => ShowPage(view);
                 advVm.BackRequested += () => ShowPage(view);
@@ -505,6 +545,40 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 var advVm = ActivatorUtilities.CreateInstance<HidAdvancedConfigViewModel>(App.AppHost.Services, opts);
                 var advView = App.AppHost.Services.GetRequiredService<HidAdvancedConfigView>();
+                advView.DataContext = advVm;
+                advVm.Saved += _ => ShowPage(editView);
+                advVm.BackRequested += () => ShowPage(editView);
+                ShowPage(advView);
+            };
+            ShowPage(editView);
+            _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
+            return;
+        }
+
+        if (service.ServiceType == "File Observer")
+        {
+            var foPage = GetOrCreateServicePage(service);
+            var options = service.FileObserverOptions ?? new FileObserverServiceOptions();
+            var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(App.AppHost.Services, service.DisplayName.Split(" - ").Last(), options);
+            var editView = App.AppHost.Services.GetRequiredService<FileObserverEditServiceView>();
+            editView.DataContext = vm;
+            vm.ServiceUpdated += (name, opts) =>
+            {
+                service.DisplayName = $"File Observer - {name}";
+                service.FileObserverOptions = opts;
+                if (foPage != null)
+                    ShowPage(foPage);
+                _viewModel.SaveServices();
+            };
+            vm.Cancelled += () =>
+            {
+                if (foPage != null)
+                    ShowPage(foPage);
+            };
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<FileObserverAdvancedConfigViewModel>(App.AppHost.Services, opts);
+                var advView = App.AppHost.Services.GetRequiredService<FileObserverAdvancedConfigView>();
                 advView.DataContext = advVm;
                 advVm.Saved += _ => ShowPage(editView);
                 advVm.BackRequested += () => ShowPage(editView);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -158,3 +158,4 @@
 - Creating an FTP service now closes the selection window after saving.
 - Create service window now closes after service selection or cancellation, ensuring services are added and preventing blank windows.
 - FTP server creation view preloads options from configuration and logs navigation, ensuring the dialog closes after server creation.
+- Added File Observer create/edit/advanced configuration views with navigation and DI registration.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1357,3 +1357,12 @@ Effective Prompts / Instructions that worked: Follow MVVM/DI patterns and update
 Decisions & Rationale: Mirror existing service flows to maintain consistency and test navigation paths.
 Action Items: Monitor CI for Windows-specific behavior.
 Related Commits/PRs: (this PR)
+[2024-08-27 00:00] Topic: File Observer navigation
+Context: (summarize the scenario)
+Observations: Implemented File Observer create/edit/advanced views and navigation patterns.
+Codex Limitations noticed: PowerShell unavailable; could not run add-tip.ps1.
+Effective Prompts / Instructions that worked: Mirrored HID service patterns for consistency.
+Decisions & Rationale: Followed existing navigation and DI patterns to reduce risk.
+Action Items: Monitor integration with persistence layer in future.
+Related Commits/PRs: 
+


### PR DESCRIPTION
## What changed
- implement FileObserver create/edit/advanced config view models and views
- wire navigation for File Observer services with create/edit/advanced flows
- register File Observer services in DI and add tests
- document File Observer navigation in CHANGELOG and collaboration tips

## Validation
- `dotnet test --settings tests.runsettings` *(fails: command not found; environment lacks dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68adfa0c5cf4832684946d219bb8f584