### PR TITLE
feat: separate MQTT advanced settings

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.Tests;

--- a/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Threading;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class MainViewMqttNavigationTests
+{
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void CreateMqttService_Advanced_Back_ReturnsToCreateView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddTransient<MqttCreateServiceViewModel>();
+                    s.AddTransient<MqttCreateServiceView>();
+                    s.AddTransient<MqttAdvancedConfigViewModel>();
+                    s.AddTransient<MqttAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("NavigateToMqtt", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { "Test" });
+
+            view.ContentFrame.Content.Should().BeOfType<MqttCreateServiceView>();
+            var createView = (MqttCreateServiceView)view.ContentFrame.Content;
+            var vm = (MqttCreateServiceViewModel)createView.DataContext;
+            vm.AdvancedConfigCommand.Execute(null);
+
+            view.ContentFrame.Content.Should().BeOfType<MqttAdvancedConfigView>();
+            var advView = (MqttAdvancedConfigView)view.ContentFrame.Content;
+            var advVm = (MqttAdvancedConfigViewModel)advView.DataContext;
+            advVm.BackCommand.Execute(null);
+
+            view.ContentFrame.Content.Should().BeOfType<MqttCreateServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void EditMqttService_ShowsEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<MqttTagSubscriptionsViewModel>();
+                    s.AddSingleton<MqttTagSubscriptionsView>();
+                    s.AddTransient<MqttEditServiceViewModel>();
+                    s.AddTransient<MqttEditServiceView>();
+                    s.AddTransient<MqttAdvancedConfigViewModel>();
+                    s.AddTransient<MqttAdvancedConfigView>();
+                    s.Configure<MqttServiceOptions>(o =>
+                    {
+                        o.Host = "h";
+                        o.Port = 1;
+                        o.ClientId = "c";
+                    });
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "MQTT - Test",
+                ServiceType = "MQTT"
+            };
+
+            var view = new MainView(mainVm);
+            var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<MqttEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+}

--- a/DesktopApplicationTemplate.Tests/MqttAdvancedConfigViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttAdvancedConfigViewModelTests.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Linq;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using MQTTnet.Protocol;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class MqttAdvancedConfigViewModelTests
+{
+    [Fact]
+    public void SaveCommand_Raises_Saved_WithUpdatedOptions()
+    {
+        var tempCert = Path.GetTempFileName();
+        File.WriteAllBytes(tempCert, new byte[] { 1, 2, 3 });
+        var options = new MqttServiceOptions();
+        var vm = new MqttAdvancedConfigViewModel(options);
+        vm.UseTls = true;
+        vm.ClientCertificatePath = tempCert;
+        vm.WillTopic = "topic";
+        vm.WillPayload = "payload";
+        vm.WillQualityOfService = MqttQualityOfServiceLevel.AtLeastOnce;
+        vm.WillRetain = true;
+        vm.KeepAliveSeconds = 30;
+        vm.CleanSession = false;
+        vm.ReconnectDelaySeconds = 10;
+        MqttServiceOptions? received = null;
+        vm.Saved += o => received = o;
+
+        vm.SaveCommand.Execute(null);
+
+        File.Delete(tempCert);
+        Assert.NotNull(received);
+        Assert.True(received!.UseTls);
+        Assert.Equal("topic", received.WillTopic);
+        Assert.Equal("payload", received.WillPayload);
+        Assert.Equal(MqttQualityOfServiceLevel.AtLeastOnce, received.WillQualityOfService);
+        Assert.True(received.WillRetain);
+        Assert.Equal((ushort)30, received.KeepAliveSeconds);
+        Assert.False(received.CleanSession);
+        Assert.Equal(System.TimeSpan.FromSeconds(10), received.ReconnectDelay);
+        Assert.NotNull(received.ClientCertificate);
+        Assert.True(new byte[] { 1, 2, 3 }.SequenceEqual(received.ClientCertificate!));
+    }
+
+    [Fact]
+    public void BackCommand_Raises_BackRequested()
+    {
+        var vm = new MqttAdvancedConfigViewModel(new MqttServiceOptions());
+        var called = false;
+        vm.BackRequested += () => called = true;
+
+        vm.BackCommand.Execute(null);
+
+        Assert.True(called);
+    }
+}

--- a/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
@@ -19,6 +19,8 @@ public class MqttCreateServiceViewModelTests
         vm.Host = "host";
         vm.Port = 1234;
         vm.ClientId = "client";
+        vm.Username = "user";
+        vm.Password = "pass";
         MqttServiceOptions? received = null;
         string? name = null;
         vm.ServiceCreated += (n, o) => { name = n; received = o; };
@@ -57,15 +59,15 @@ public class MqttCreateServiceViewModelTests
         vm.ClientId = "client";
         vm.Username = "user";
         vm.Password = "pass";
-        vm.UseTls = true;
-        vm.ClientCertificatePath = tempCert;
-        vm.WillTopic = "wt";
-        vm.WillPayload = "wp";
-        vm.WillQualityOfService = MqttQualityOfServiceLevel.AtLeastOnce;
-        vm.WillRetain = true;
-        vm.KeepAliveSeconds = 15;
-        vm.CleanSession = false;
-        vm.ReconnectDelaySeconds = 5;
+        vm.Options.UseTls = true;
+        vm.Options.WillTopic = "wt";
+        vm.Options.WillPayload = "wp";
+        vm.Options.WillQualityOfService = MqttQualityOfServiceLevel.AtLeastOnce;
+        vm.Options.WillRetain = true;
+        vm.Options.KeepAliveSeconds = 15;
+        vm.Options.CleanSession = false;
+        vm.Options.ReconnectDelay = TimeSpan.FromSeconds(5);
+        vm.Options.ClientCertificate = File.ReadAllBytes(tempCert);
         MqttServiceOptions? received = null;
         vm.ServiceCreated += (_, o) => received = o;
 
@@ -101,9 +103,9 @@ public class MqttCreateServiceViewModelTests
         vm.ClientId = "client";
         vm.Username = "";
         vm.Password = " ";
-        vm.WillTopic = "";
-        vm.WillPayload = null;
-        vm.ReconnectDelaySeconds = -1;
+        vm.Options.WillTopic = "";
+        vm.Options.WillPayload = null;
+        vm.Options.ReconnectDelay = null;
         MqttServiceOptions? received = null;
         vm.ServiceCreated += (_, o) => received = o;
 

--- a/DesktopApplicationTemplate.Tests/MqttViewsAccessibilityTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttViewsAccessibilityTests.cs
@@ -32,7 +32,7 @@ namespace DesktopApplicationTemplate.Tests
                         new DesktopApplicationTemplate.UI.App();
                     var view = new MqttCreateServiceView(new MqttCreateServiceViewModel(), new Mock<ILoggingService>().Object);
                     var create = (Button)view.FindName("CreateButton");
-                    Assert.Equal("Create MQTT Connection", AutomationProperties.GetName(create));
+                    Assert.Equal("Create MQTT Service", AutomationProperties.GetName(create));
                 }
                 catch (Exception e) { ex = e; }
                 finally { Application.Current?.Shutdown(); }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -85,6 +85,10 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<CreateServiceViewModel>();
             services.AddTransient<MqttCreateServiceView>();
             services.AddTransient<MqttCreateServiceViewModel>();
+            services.AddTransient<MqttEditServiceView>();
+            services.AddTransient<MqttEditServiceViewModel>();
+            services.AddTransient<MqttAdvancedConfigView>();
+            services.AddTransient<MqttAdvancedConfigViewModel>();
             services.AddTransient<TcpCreateServiceView>();
             services.AddTransient<TcpCreateServiceViewModel>();
             services.AddTransient<TcpEditServiceView>();

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttAdvancedConfigViewModel.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
+using MQTTnet.Protocol;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for editing advanced MQTT configuration.
+/// </summary>
+public class MqttAdvancedConfigViewModel : ViewModelBase
+{
+    private readonly MqttServiceOptions _options;
+    private bool _useTls;
+    private string? _clientCertificatePath;
+    private string? _willTopic;
+    private string? _willPayload;
+    private MqttQualityOfServiceLevel _willQualityOfService = MqttQualityOfServiceLevel.AtMostOnce;
+    private bool _willRetain;
+    private ushort _keepAliveSeconds = 60;
+    private bool _cleanSession = true;
+    private int _reconnectDelaySeconds;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MqttAdvancedConfigViewModel"/> class.
+    /// </summary>
+    public MqttAdvancedConfigViewModel(MqttServiceOptions options, ILoggingService? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _useTls = options.UseTls;
+        _willTopic = options.WillTopic;
+        _willPayload = options.WillPayload;
+        _willQualityOfService = options.WillQualityOfService;
+        _willRetain = options.WillRetain;
+        _keepAliveSeconds = options.KeepAliveSeconds;
+        _cleanSession = options.CleanSession;
+        _reconnectDelaySeconds = options.ReconnectDelay?.Seconds ?? 0;
+        Logger = logger;
+        SaveCommand = new RelayCommand(Save);
+        BackCommand = new RelayCommand(Back);
+        QoSLevels = Enum.GetValues(typeof(MqttQualityOfServiceLevel)).Cast<MqttQualityOfServiceLevel>().ToArray();
+    }
+
+    /// <summary>
+    /// Available MQTT quality of service levels.
+    /// </summary>
+    public IReadOnlyList<MqttQualityOfServiceLevel> QoSLevels { get; }
+
+    /// <inheritdoc />
+    public ILoggingService? Logger { get; set; }
+
+    /// <summary>
+    /// Command to save the configuration.
+    /// </summary>
+    public ICommand SaveCommand { get; }
+
+    /// <summary>
+    /// Command to navigate back without saving.
+    /// </summary>
+    public ICommand BackCommand { get; }
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<MqttServiceOptions>? Saved;
+
+    /// <summary>
+    /// Raised when navigation back is requested.
+    /// </summary>
+    public event Action? BackRequested;
+
+    /// <summary>
+    /// Whether TLS should be used for the connection.
+    /// </summary>
+    public bool UseTls
+    {
+        get => _useTls;
+        set { _useTls = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Path to the client certificate used for TLS authentication.
+    /// </summary>
+    public string? ClientCertificatePath
+    {
+        get => _clientCertificatePath;
+        set { _clientCertificatePath = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Will topic published on unexpected disconnect.
+    /// </summary>
+    public string? WillTopic
+    {
+        get => _willTopic;
+        set { _willTopic = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Will message payload.
+    /// </summary>
+    public string? WillPayload
+    {
+        get => _willPayload;
+        set { _willPayload = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Quality of service level for the will message.
+    /// </summary>
+    public MqttQualityOfServiceLevel WillQualityOfService
+    {
+        get => _willQualityOfService;
+        set { _willQualityOfService = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Whether the will message should be retained.
+    /// </summary>
+    public bool WillRetain
+    {
+        get => _willRetain;
+        set { _willRetain = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Keep alive interval in seconds.
+    /// </summary>
+    public ushort KeepAliveSeconds
+    {
+        get => _keepAliveSeconds;
+        set { _keepAliveSeconds = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Whether a clean session should be used.
+    /// </summary>
+    public bool CleanSession
+    {
+        get => _cleanSession;
+        set { _cleanSession = value; OnPropertyChanged(); }
+    }
+
+    /// <summary>
+    /// Reconnect delay in seconds.
+    /// </summary>
+    public int ReconnectDelaySeconds
+    {
+        get => _reconnectDelaySeconds;
+        set { _reconnectDelaySeconds = value; OnPropertyChanged(); }
+    }
+
+    private void Save()
+    {
+        Logger?.Log("MQTT advanced options start", LogLevel.Debug);
+        _options.UseTls = UseTls;
+        _options.WillTopic = string.IsNullOrWhiteSpace(WillTopic) ? null : WillTopic;
+        _options.WillPayload = string.IsNullOrWhiteSpace(WillPayload) ? null : WillPayload;
+        _options.WillQualityOfService = WillQualityOfService;
+        _options.WillRetain = WillRetain;
+        _options.KeepAliveSeconds = KeepAliveSeconds;
+        _options.CleanSession = CleanSession;
+        _options.ReconnectDelay = ReconnectDelaySeconds > 0 ? TimeSpan.FromSeconds(ReconnectDelaySeconds) : null;
+        if (!string.IsNullOrWhiteSpace(ClientCertificatePath) && File.Exists(ClientCertificatePath))
+        {
+            _options.ClientCertificate = File.ReadAllBytes(ClientCertificatePath);
+        }
+        else
+        {
+            _options.ClientCertificate = null;
+        }
+        Logger?.Log("MQTT advanced options finished", LogLevel.Debug);
+        Saved?.Invoke(_options);
+    }
+
+    private void Back()
+    {
+        Logger?.Log("MQTT advanced options back", LogLevel.Debug);
+        BackRequested?.Invoke();
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttEditServiceViewModel.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model for editing an existing MQTT service configuration.
+/// </summary>
+public class MqttEditServiceViewModel : MqttCreateServiceViewModel
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MqttEditServiceViewModel"/> class.
+    /// </summary>
+    public MqttEditServiceViewModel(string serviceName, MqttServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
+    {
+        if (options == null) throw new ArgumentNullException(nameof(options));
+        ServiceName = serviceName;
+        Host = options.Host;
+        Port = options.Port;
+        ClientId = options.ClientId;
+        Username = options.Username;
+        Password = options.Password;
+        Options.Host = options.Host;
+        Options.Port = options.Port;
+        Options.ClientId = options.ClientId;
+        Options.Username = options.Username;
+        Options.Password = options.Password;
+        Options.UseTls = options.UseTls;
+        Options.ClientCertificate = options.ClientCertificate;
+        Options.WillTopic = options.WillTopic;
+        Options.WillPayload = options.WillPayload;
+        Options.WillQualityOfService = options.WillQualityOfService;
+        Options.WillRetain = options.WillRetain;
+        Options.KeepAliveSeconds = options.KeepAliveSeconds;
+        Options.CleanSession = options.CleanSession;
+        Options.ReconnectDelay = options.ReconnectDelay;
+    }
+
+    /// <summary>
+    /// Command for saving the updated configuration.
+    /// </summary>
+    public ICommand SaveCommand => CreateCommand;
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<string, MqttServiceOptions>? ServiceUpdated
+    {
+        add => ServiceCreated += value;
+        remove => ServiceCreated -= value;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml
@@ -1,0 +1,57 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.MqttAdvancedConfigView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Use TLS" Style="{StaticResource FormLabel}"/>
+        <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding UseTls}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Client Certificate" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ClientCertificatePath}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Will Topic" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding WillTopic}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Will Payload" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding WillPayload}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Will QoS" Style="{StaticResource FormLabel}"/>
+        <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding QoSLevels}" SelectedItem="{Binding WillQualityOfService}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="5" Grid.Column="0" Text="Will Retain" Style="{StaticResource FormLabel}"/>
+        <CheckBox Grid.Row="5" Grid.Column="1" IsChecked="{Binding WillRetain}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="6" Grid.Column="0" Text="Keep Alive" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding KeepAliveSeconds}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="7" Grid.Column="0" Text="Clean Session" Style="{StaticResource FormLabel}"/>
+        <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding CleanSession}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="8" Grid.Column="0" Text="Reconnect Delay" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding ReconnectDelaySeconds}" Style="{StaticResource FormField}"/>
+
+        <StackPanel Grid.Row="9" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save MQTT Advanced Configuration"/>
+            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to MQTT Configuration"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class MqttAdvancedConfigView : Page
+{
+    public MqttAdvancedConfigView(MqttAdvancedConfigViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="DesktopApplicationTemplate.UI.Views.MqttCreateServiceView"
+<Page x:Class="DesktopApplicationTemplate.UI.Views.MqttEditServiceView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -38,10 +38,10 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Password}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0" >
+            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open MQTT Advanced Configuration"/>
-                <Button x:Name="CreateButton" Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create MQTT Service"/>
-                <Button x:Name="CancelButton" Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel MQTT Creation"/>
+                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save MQTT Service"/>
+                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel MQTT Edit"/>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class MqttEditServiceView : Page
+{
+    public MqttEditServiceView(MqttEditServiceViewModel vm, ILoggingService logger)
+    {
+        InitializeComponent();
+        DataContext = vm;
+        vm.Logger = logger;
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -162,3 +162,4 @@
 - Create service window now closes after service selection or cancellation, ensuring services are added and preventing blank windows.
 - FTP server creation view preloads options from configuration and logs navigation, ensuring the dialog closes after server creation.
 - Added File Observer create/edit/advanced configuration views with navigation and DI registration.
+- MQTT service creation and edit views now separate advanced configuration into a dedicated page with navigation tests.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1399,3 +1399,11 @@ Effective Prompts / Instructions that worked: User request to separate advanced 
 Decisions & Rationale: Extract advanced fields to dedicated view models to keep runtime view focused.
 Action Items: Monitor CI for UI behavior.
 Related Commits/PRs: (this PR)
+[2025-08-27 20:00] Topic: MQTT advanced config navigation
+Context: Split MQTT advanced settings into a separate view with create/edit workflows and tests.
+Observations: Navigation hooks show the advanced page and return on save or back; DI registers new views and view models.
+Codex Limitations noticed: Linux environment lacks WindowsDesktop runtime; rely on CI for WPF execution.
+Effective Prompts / Instructions that worked: Follow MVVM patterns and update docs/tests per AGENTS guidance.
+Decisions & Rationale: Isolate advanced settings to keep primary forms focused and maintain consistency with other services.
+Action Items: Monitor CI for Windows-specific issues.
+Related Commits/PRs:


### PR DESCRIPTION
## What changed
- split MQTT advanced options into dedicated advanced config view and view model
- add MQTT edit service view mirroring create view
- wire up navigation and DI registrations with unit tests
- document MQTT advanced navigation

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b51dcc48326a7366429f068f7ed