### PR TITLE
test: verify double-click navigation for service edits

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
@@ -13,6 +13,8 @@ using Moq;
 using Xunit;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -60,6 +62,71 @@ public class MainViewCsvNavigationTests
             method!.Invoke(view, new object[] { "Test" });
 
             view.ContentFrame.Content.Should().BeOfType<CsvCreateServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void DoubleClickCsvService_OpensEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<CsvViewerViewModel>();
+                    s.AddSingleton<CsvService>();
+                    s.AddSingleton<CsvServiceView>();
+                    s.AddTransient<CsvEditServiceViewModel>();
+                    s.AddTransient<CsvEditServiceView>();
+                    s.AddTransient<CsvAdvancedConfigViewModel>();
+                    s.AddTransient<CsvAdvancedConfigView>();
+                    s.AddOptions<CsvServiceOptions>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "CSV Creator - Test",
+                ServiceType = "CSV Creator",
+                CsvOptions = new CsvServiceOptions { OutputPath = "out" }
+            };
+
+            var view = new MainView(mainVm);
+            var border = new Border { DataContext = service };
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Border.MouseLeftButtonDownEvent,
+                ClickCount = 2
+            };
+            var method = typeof(MainView).GetMethod("ServiceItem_MouseLeftButtonDown", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { border, args });
+
+            view.ContentFrame.Content.Should().BeOfType<CsvEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
         thread.SetApartmentState(ApartmentState.STA);

--- a/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
 using DesktopApplicationTemplate.UI.Helpers;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -67,6 +69,70 @@ public class MainViewFileObserverNavigationTests
             var view = new MainView(mainVm);
             var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<FileObserverEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+       thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void DoubleClickFileObserverService_OpensEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<SaveConfirmationHelper>();
+                    s.AddSingleton<FileObserverViewModel>();
+                    s.AddSingleton<FileObserverView>();
+                    s.AddTransient<FileObserverEditServiceViewModel>();
+                    s.AddTransient<FileObserverEditServiceView>();
+                    s.AddTransient<FileObserverAdvancedConfigViewModel>();
+                    s.AddTransient<FileObserverAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "File Observer - Test",
+                ServiceType = "File Observer",
+                FileObserverOptions = new FileObserverServiceOptions { FilePath = "path" }
+            };
+
+            var view = new MainView(mainVm);
+            var border = new Border { DataContext = service };
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Border.MouseLeftButtonDownEvent,
+                ClickCount = 2
+            };
+            var method = typeof(MainView).GetMethod("ServiceItem_MouseLeftButtonDown", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { border, args });
 
             view.ContentFrame.Content.Should().BeOfType<FileObserverEditServiceView>();
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
 using DesktopApplicationTemplate.UI.Helpers;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -114,6 +116,69 @@ public class MainViewHeartbeatNavigationTests
             var view = new MainView(mainVm);
             var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<HeartbeatEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void DoubleClickHeartbeatService_OpensEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<HeartbeatViewModel>();
+                    s.AddSingleton<HeartbeatView>();
+                    s.AddTransient<HeartbeatEditServiceViewModel>();
+                    s.AddTransient<HeartbeatEditServiceView>();
+                    s.AddTransient<HeartbeatAdvancedConfigViewModel>();
+                    s.AddTransient<HeartbeatAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "Heartbeat - Test",
+                ServiceType = "Heartbeat",
+                HeartbeatOptions = new HeartbeatServiceOptions { BaseMessage = "msg" }
+            };
+
+            var view = new MainView(mainVm);
+            var border = new Border { DataContext = service };
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Border.MouseLeftButtonDownEvent,
+                ClickCount = 2
+            };
+            var method = typeof(MainView).GetMethod("ServiceItem_MouseLeftButtonDown", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { border, args });
 
             view.ContentFrame.Content.Should().BeOfType<HeartbeatEditServiceView>();
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
 using DesktopApplicationTemplate.UI.Helpers;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -67,6 +69,70 @@ public class MainViewHidNavigationTests
             var view = new MainView(mainVm);
             var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<HidEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void DoubleClickHidService_OpensEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<SaveConfirmationHelper>();
+                    s.AddSingleton<HidViewModel>();
+                    s.AddSingleton<HidViews>();
+                    s.AddTransient<HidEditServiceViewModel>();
+                    s.AddTransient<HidEditServiceView>();
+                    s.AddTransient<HidAdvancedConfigViewModel>();
+                    s.AddTransient<HidAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "HID - Test",
+                ServiceType = "HID",
+                HidOptions = new HidServiceOptions { MessageTemplate = "msg" }
+            };
+
+            var view = new MainView(mainVm);
+            var border = new Border { DataContext = service };
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Border.MouseLeftButtonDownEvent,
+                ClickCount = 2
+            };
+            var method = typeof(MainView).GetMethod("ServiceItem_MouseLeftButtonDown", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { border, args });
 
             view.ContentFrame.Content.Should().BeOfType<HidEditServiceView>();
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -113,6 +115,69 @@ public class MainViewHttpNavigationTests
             var view = new MainView(mainVm);
             var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<HttpEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void DoubleClickHttpService_OpensEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<HttpServiceViewModel>();
+                    s.AddSingleton<HttpServiceView>();
+                    s.AddTransient<HttpEditServiceViewModel>();
+                    s.AddTransient<HttpEditServiceView>();
+                    s.AddTransient<HttpAdvancedConfigViewModel>();
+                    s.AddTransient<HttpAdvancedConfigView>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "HTTP - Test",
+                ServiceType = "HTTP",
+                HttpOptions = new HttpServiceOptions { BaseUrl = "http://example" }
+            };
+
+            var view = new MainView(mainVm);
+            var border = new Border { DataContext = service };
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Border.MouseLeftButtonDownEvent,
+                ClickCount = 2
+            };
+            var method = typeof(MainView).GetMethod("ServiceItem_MouseLeftButtonDown", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { border, args });
 
             view.ContentFrame.Content.Should().BeOfType<HttpEditServiceView>();
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -43,6 +45,8 @@ public class MainViewScpNavigationTests
                 {
                     s.AddLogging();
                     s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<ScpServiceViewModel>();
+                    s.AddSingleton<SCPServiceView>();
                     s.AddTransient<ScpEditServiceViewModel>();
                     s.AddTransient<ScpEditServiceView>();
                     s.AddTransient<ScpAdvancedConfigViewModel>();
@@ -64,6 +68,70 @@ public class MainViewScpNavigationTests
             var view = new MainView(mainVm);
             var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             method!.Invoke(view, new object[] { service });
+
+            view.ContentFrame.Content.Should().BeOfType<ScpEditServiceView>();
+            ConsoleTestLogger.LogPass();
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+    }
+
+    [Fact]
+    [TestCategory("CodexSafe")]
+    [TestCategory("WindowsSafe")]
+    public void DoubleClickScpService_OpensEditView()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var thread = new Thread(() =>
+        {
+            var logger = new LoggingService(new NullRichTextLogger());
+            var fileDialog = new Mock<IFileDialogService>();
+            var csvVm = new CsvViewerViewModel(fileDialog.Object);
+            var csvService = new CsvService(csvVm);
+            var netSvc = new Mock<INetworkConfigurationService>();
+            netSvc.Setup(s => s.GetConfigurationAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new NetworkConfiguration());
+            var netVm = new NetworkConfigurationViewModel(netSvc.Object, logger);
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllText(tempFile, string.Empty);
+            var mainVm = new MainViewModel(csvService, netVm, netSvc.Object, logger, tempFile);
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(s =>
+                {
+                    s.AddLogging();
+                    s.AddSingleton<ILoggingService>(logger);
+                    s.AddSingleton<ScpServiceViewModel>();
+                    s.AddSingleton<SCPServiceView>();
+                    s.AddTransient<ScpEditServiceViewModel>();
+                    s.AddTransient<ScpEditServiceView>();
+                    s.AddTransient<ScpAdvancedConfigViewModel>();
+                    s.AddTransient<ScpAdvancedConfigView>();
+                    s.AddOptions<ScpServiceOptions>();
+                })
+                .Build();
+            var prop = typeof(App).GetProperty("AppHost");
+            var setter = prop!.GetSetMethod(true);
+            setter!.Invoke(null, new object[] { host });
+
+            var service = new ServiceViewModel
+            {
+                DisplayName = "SCP - Test",
+                ServiceType = "SCP",
+                ScpOptions = new ScpServiceOptions { Host = "h" }
+            };
+
+            var view = new MainView(mainVm);
+            var border = new Border { DataContext = service };
+            var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left)
+            {
+                RoutedEvent = Border.MouseLeftButtonDownEvent,
+                ClickCount = 2
+            };
+            var method = typeof(MainView).GetMethod("ServiceItem_MouseLeftButtonDown", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            method!.Invoke(view, new object[] { border, args });
 
             view.ContentFrame.Content.Should().BeOfType<ScpEditServiceView>();
             ConsoleTestLogger.LogPass();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Navigation helpers for HTTP, HID, File Observer, Heartbeat, CSV Creator, and SCP services with tests ensuring double-click opens their edit views.
 - SCP service creation, edit, and advanced configuration views with navigation tests.
 - HID service creation, edit, and advanced configuration views with navigation tests.
 - CSV service creation and edit views with advanced configuration and navigation tests.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -12,6 +12,15 @@ Decisions & Rationale: Use event-driven navigation and injection to decouple vie
 Action Items: Verify navigation on Windows CI.
 Related Commits/PRs: (this PR)
 
+[2025-08-26 20:54] Topic: Service edit double-click tests
+Context: Ensured double-clicking a service item opens its edit view.
+Observations: Added navigation helpers tests for HTTP, HID, File Observer, Heartbeat, CSV Creator, and SCP services.
+Codex Limitations noticed: Linux environment cannot run WPF tests; rely on CI.
+Effective Prompts / Instructions that worked: Followed AGENTS guidelines and user request for double-click verification.
+Decisions & Rationale: Invoked double-click handler via reflection and registered service views in DI for accuracy.
+Action Items: Monitor CI for Windows-specific UI behavior.
+Related Commits/PRs:
+
 [2025-08-26 16:05] Topic: FTP server create navigation logging
 Context: Ensure FTP server creation preloads options and logs navigation to confirm the dialog closes after save.
 Observations: View model options seeded from configuration; logs surround view navigation and server creation closure.


### PR DESCRIPTION
## Summary
- add tests confirming double-click opens edit view for HTTP, HID, File Observer, Heartbeat, CSV Creator, and SCP services
- document navigation helper coverage in changelog and collaboration tips

## Testing
- `dotnet test -s tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1dc5da2c832693810f6a31afc36a