### PR TITLE
Fix SCP advanced config view references

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/FilterPanel.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FilterPanel.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="DesktopApplicationTemplate.UI.Views.FilterPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib">
+             xmlns:sys="clr-namespace:System;assembly=System.Runtime">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -808,11 +808,9 @@ namespace DesktopApplicationTemplate.UI.Views
             };
             vm.AdvancedConfigRequested += opts =>
             {
-            var advVm = ActivatorUtilities.CreateInstance<ScpAdvancedConfigViewModel>(App.AppHost.Services, opts);
-            var advView = App.AppHost.Services.GetRequiredService<ScpAdvancedConfigView>();
-            advView.Initialize(advVm);
                 var advVm = ActivatorUtilities.CreateInstance<ScpAdvancedConfigViewModel>(App.AppHost.Services, opts);
-                var advView = ActivatorUtilities.CreateInstance<ScpAdvancedConfigView>(App.AppHost.Services, advVm);
+                var advView = App.AppHost.Services.GetRequiredService<ScpAdvancedConfigView>();
+                advView.Initialize(advVm);
                 advVm.Saved += _ => ShowPage(editView);
                 advVm.BackRequested += () => ShowPage(editView);
                 ShowPage(advView);

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -5,7 +5,7 @@
       xmlns:mqtt="clr-namespace:MQTTnet.Protocol;assembly=MQTTnet"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:sys="clr-namespace:System;assembly=mscorlib"
+      xmlns:sys="clr-namespace:System;assembly=System.Runtime"
       mc:Ignorable="d">
     <Page.Resources>
         <ObjectDataProvider x:Key="QoSValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -167,3 +167,4 @@
 - FTP server creation view preloads options from configuration and logs navigation, ensuring the dialog closes after server creation.
 - Added File Observer create/edit/advanced configuration views with navigation and DI registration.
 - MQTT service creation and edit views now separate advanced configuration into a dedicated page with navigation tests.
+- Corrected SCP advanced configuration handler by removing duplicate variable declarations and updated XAML System namespace references to use System.Runtime, resolving build errors.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1441,3 +1441,12 @@ Effective Prompts / Instructions that worked: Followed AGENTS guidelines for DI 
 Decisions & Rationale: Use ActivatorUtilities to supply runtime parameters and logging while allowing DI for remaining services.
 Action Items: Monitor CI for Windows-specific issues.
 Related Commits/PRs: (this PR)
+
+[2025-08-27 01:50] Topic: SCP advanced config build errors
+Context: Main window contained duplicate variable declarations and XAML referenced mscorlib causing System.Object build failures.
+Observations: Removed duplicate advVm/advView declarations and switched XAML sys namespace to System.Runtime.
+Codex Limitations noticed: Unit tests failed to compile due to read-only ClickCount, full WPF validation requires CI.
+Effective Prompts / Instructions that worked: Search for duplicate variable names and follow AGENTS guidelines to update docs.
+Decisions & Rationale: Clean redundant declarations and modernize System namespace references for .NET 8 compatibility.
+Action Items: Monitor CI for remaining test issues.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- fix duplicate variable declarations in SCP advanced config navigation
- use System.Runtime XAML namespace for sys types
- document SCP advanced config fix

## Validation
- `dotnet test --settings tests.runsettings` *(fails: Property or indexer 'MouseButtonEventArgs.ClickCount' cannot be assigned to -- it is read only)*


------
https://chatgpt.com/codex/tasks/task_e_68ae61749e7c8326bdd595f9d703c744