### PR TITLE
Fix TCP option restore and register pack URI

### DIFF
--- a/DesktopApplicationTemplate.UI/PackUriSchemeInitializer.cs
+++ b/DesktopApplicationTemplate.UI/PackUriSchemeInitializer.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace DesktopApplicationTemplate.UI
+{
+    /// <summary>
+    /// Ensures the WPF pack URI scheme is registered so resource dictionaries
+    /// can be loaded in unit tests without a running application.
+    /// </summary>
+    internal static class PackUriSchemeInitializer
+    {
+        [ModuleInitializer]
+        internal static void Initialize()
+        {
+            if (UriParser.GetSyntax("pack") is null)
+            {
+                UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "pack", -1);
+            }
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -145,17 +145,16 @@ namespace DesktopApplicationTemplate.UI.Services
                     {
                         try
                         {
-                            var opt = App.AppHost?.Services.GetService<IOptions<TcpServiceOptions>>();
-                            if (opt != null)
-                            {
-                                var value = opt.Value;
-                                value.Host = info.TcpOptions.Host;
-                                value.Port = info.TcpOptions.Port;
-                                value.UseUdp = info.TcpOptions.UseUdp;
-                                value.Mode = info.TcpOptions.Mode;
-                            }
+                            var value = App.AppHost?.Services
+                                .GetRequiredService<IOptions<TcpServiceOptions>>()
+                                .Value;
+
+                            value.Host = info.TcpOptions.Host;
+                            value.Port = info.TcpOptions.Port;
+                            value.UseUdp = info.TcpOptions.UseUdp;
+                            value.Mode = info.TcpOptions.Mode;
                         }
-                        catch
+                        catch (InvalidOperationException)
                         {
                             // ignore missing options during tests or early startup
                         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -111,6 +111,8 @@
 - Standalone `FilterWindow` in favor of inline filter popup.
 
 ### Fixed
+- Registered the WPF pack URI scheme so BubblyWindow resources load without invalid URI errors.
+- Restored TCP configuration options when loading persisted services.
 - Opening service edit pages no longer fails with unresolved `System.String` DI errors by decoupling view models from view constructors.
 - Editing any service no longer fails with unresolved string dependencies; edit and advanced views now receive their view models via `ActivatorUtilities`.
 - Selecting TCP or FTP server from the add service page now opens their configuration views prior to creation.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1483,3 +1483,11 @@ Decisions & Rationale: Ensure persistence writes succeed regardless of path and 
 Action Items: Rely on CI for Windows-specific validation.
 Related Commits/PRs: (this PR)
 
+[2025-08-27 02:50] Topic: TCP option restore and pack URI
+Context: Fix global TCP option restoration and register pack URI scheme.
+Observations: Tests expected persisted TCP options to repopulate DI and pack URIs failed to parse without scheme registration.
+Codex Limitations noticed: dotnet SDK unavailable; relied on reasoning without running tests.
+Effective Prompts / Instructions that worked: Review AGENTS and clone options to restore DI state.
+Decisions & Rationale: Used GetRequiredService to ensure TCP options restored and module initializer to register pack scheme.
+Action Items: Verify on Windows that BubblyWindowStyle loads and TCP options persist.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## What changed
- ensure persisted TCP options repopulate global configuration
- register WPF pack URI scheme so BubblyWindowStyle loads reliably
- update docs

## Validation
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6d1bb8908326a5169ff5e66018f8