### PR TITLE
Fix URI scheme and guard TCP option restoration

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -14,11 +14,9 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
-    <PackageReference Include="SSH.NET" Version="2025.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="FluentFTP" Version="53.0.1" />
+    <PackageReference Include="SSH.NET" Version="2025.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.25103.5738" />

--- a/DesktopApplicationTemplate.UI/PackUriSchemeInitializer.cs
+++ b/DesktopApplicationTemplate.UI/PackUriSchemeInitializer.cs
@@ -12,7 +12,7 @@ namespace DesktopApplicationTemplate.UI
         [ModuleInitializer]
         internal static void Initialize()
         {
-            if (UriParser.GetSyntax("pack") is null)
+            if (!UriParser.IsKnownScheme("pack"))
             {
                 UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "pack", -1);
             }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -143,20 +143,23 @@ namespace DesktopApplicationTemplate.UI.Services
                 {
                     if (info.ServiceType == "TCP" && info.TcpOptions != null)
                     {
-                        try
+                        if (App.AppHost?.Services is IServiceProvider services)
                         {
-                            var value = App.AppHost?.Services
-                                .GetRequiredService<IOptions<TcpServiceOptions>>()
-                                .Value;
+                            try
+                            {
+                                var value = services
+                                    .GetRequiredService<IOptions<TcpServiceOptions>>()
+                                    .Value;
 
-                            value.Host = info.TcpOptions.Host;
-                            value.Port = info.TcpOptions.Port;
-                            value.UseUdp = info.TcpOptions.UseUdp;
-                            value.Mode = info.TcpOptions.Mode;
-                        }
-                        catch (InvalidOperationException)
-                        {
-                            // ignore missing options during tests or early startup
+                                value.Host = info.TcpOptions.Host;
+                                value.Port = info.TcpOptions.Port;
+                                value.UseUdp = info.TcpOptions.UseUdp;
+                                value.Mode = info.TcpOptions.Mode;
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                // ignore missing options during tests or early startup
+                            }
                         }
                     }
                     if ((info.ServiceType == "FTP Server" || info.ServiceType == "FTP") && info.FtpOptions != null)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -109,10 +109,12 @@
 - Unused `RichTextLogger` service and installer `CustomControl1` control.
 - `PublishTopic` and `PublishMessage` fields from `MqttServiceViewModel`.
 - Standalone `FilterWindow` in favor of inline filter popup.
+- Removed Windows service and EventLog package references from the UI project.
 
 ### Fixed
 - Registered the WPF pack URI scheme so BubblyWindow resources load without invalid URI errors.
 - Restored TCP configuration options when loading persisted services.
+- Replaced `UriParser.GetSyntax` usage with `IsKnownScheme` and guarded TCP option restoration to avoid null references.
 - Opening service edit pages no longer fails with unresolved `System.String` DI errors by decoupling view models from view constructors.
 - Editing any service no longer fails with unresolved string dependencies; edit and advanced views now receive their view models via `ActivatorUtilities`.
 - Selecting TCP or FTP server from the add service page now opens their configuration views prior to creation.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -1491,3 +1491,11 @@ Effective Prompts / Instructions that worked: Review AGENTS and clone options to
 Decisions & Rationale: Used GetRequiredService to ensure TCP options restored and module initializer to register pack scheme.
 Action Items: Verify on Windows that BubblyWindowStyle loads and TCP options persist.
 Related Commits/PRs: (this PR)
+[2025-08-27 02:41] Topic: UriParser and ServicePersistence fixes
+Context: Build failed due to unsupported UriParser.GetSyntax call and nullable TCP options.
+Observations: Switched to IsKnownScheme, guarded DI resolution for TCP options, and removed Windows service packages from UI.
+Codex Limitations noticed: Linux container lacks Microsoft.WindowsDesktop runtime; tests could not execute.
+Effective Prompts / Instructions that worked: User request to fix build errors and clean references.
+Decisions & Rationale: Use supported URI APIs and null checks to prevent runtime issues; drop unused Windows service packages.
+Action Items: Validate on Windows CI.
+Related Commits/PRs: (this PR)


### PR DESCRIPTION
## Summary
- Use `UriParser.IsKnownScheme` to register WPF pack URI scheme
- Guard `ServicePersistence` TCP option restoration against null `AppHost`
- Drop unused Windows service packages from the UI project

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test DesktopApplicationTemplate.sln --settings tests.runsettings` *(fails: You must install or update .NET to run this application: Microsoft.WindowsDesktop.App 8.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f521fc08326a029365a2380c36e