### PR TITLE
Fix FTP advanced configuration view DI

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServerAdvancedConfigViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerAdvancedConfigViewTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class FtpServerAdvancedConfigViewTests
+{
+    [Fact]
+    public void Initialize_SetsDataContext_AndLogger()
+    {
+        FtpServerAdvancedConfigView? view = null;
+        FtpServerAdvancedConfigViewModel? vm = null;
+        ILoggingService? logger = null;
+        var thread = new Thread(() =>
+        {
+            logger = new Mock<ILoggingService>().Object;
+            vm = new FtpServerAdvancedConfigViewModel(new FtpServerOptions());
+            view = new FtpServerAdvancedConfigView(logger);
+            view.Initialize(vm);
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        view!.DataContext.Should().Be(vm);
+        vm!.Logger.Should().BeSameAs(logger);
+    }
+
+    [Fact]
+    public void Initialize_Throws_When_ViewModelNull()
+    {
+        Exception? ex = null;
+        var thread = new Thread(() =>
+        {
+            var view = new FtpServerAdvancedConfigView(new Mock<ILoggingService>().Object);
+            try
+            {
+                view.Initialize(null!);
+            }
+            catch (Exception e)
+            {
+                ex = e;
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        ex.Should().BeOfType<ArgumentNullException>()
+            .Which.ParamName.Should().Be("vm");
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/FtpServerAdvancedConfigView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerAdvancedConfigView.xaml.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class FtpServerAdvancedConfigView : Page
+{
+    private readonly ILoggingService _logger;
+
+    public FtpServerAdvancedConfigView(ILoggingService logger)
+    {
+        InitializeComponent();
+        _logger = logger;
+    }
+
+    public void Initialize(FtpServerAdvancedConfigViewModel vm)
+    {
+        if (vm is null)
+            throw new ArgumentNullException(nameof(vm));
+
+        DataContext = vm;
+        vm.Logger = _logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -503,7 +503,8 @@ namespace DesktopApplicationTemplate.UI.Views
             vm.AdvancedConfigRequested += opts2 =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<FtpServerAdvancedConfigViewModel>(App.AppHost.Services, opts2);
-                var advView = ActivatorUtilities.CreateInstance<FtpServerAdvancedConfigView>(App.AppHost.Services, advVm);
+                var advView = App.AppHost.Services.GetRequiredService<FtpServerAdvancedConfigView>();
+                advView.Initialize(advVm);
                 advVm.Saved += _ => ShowPage(view);
                 advVm.BackRequested += () => ShowPage(view);
                 ShowPage(advView);
@@ -924,7 +925,8 @@ namespace DesktopApplicationTemplate.UI.Views
                 vm.AdvancedConfigRequested += opts =>
                 {
                     var advVm = ActivatorUtilities.CreateInstance<FtpServerAdvancedConfigViewModel>(App.AppHost.Services, opts);
-                    var advView = ActivatorUtilities.CreateInstance<FtpServerAdvancedConfigView>(App.AppHost.Services, advVm);
+                    var advView = App.AppHost.Services.GetRequiredService<FtpServerAdvancedConfigView>();
+                    advView.Initialize(advVm);
                     advVm.Saved += _ => ShowPage(editView);
                     advVm.BackRequested += () => ShowPage(editView);
                     ShowPage(advView);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - FTP server edit view checks for a `null` view model before initializing XAML, preventing parse exceptions.
 - Variable naming conflicts resolved in main window edit workflow to prevent build errors.
 - FTP server creation no longer freezes when selecting the service type and closes the selection window after saving.
+- Advanced configuration view injects logging via DI and initializes with a view model, resolving constructor instantiation errors.
 
 ### TCP Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -113,3 +113,11 @@ Effective Prompts / Instructions that worked: Error log in issue description hig
 Decisions & Rationale: Set binding to one-way to align with read-only property and avoid startup crash.
 Action Items: Verify behavior on Windows CI.
 Related Commits/PRs:
+[2025-08-27 05:00] Topic: FTP advanced config DI
+Context: FtpServerAdvancedConfigView failed to construct due to mismatched constructor arguments.
+Observations: Added code-behind with logger injection and Initialize pattern; MainWindow now resolves view from DI and sets DataContext.
+Codex Limitations noticed: Linux environment lacks WPF runtime so tests cannot execute.
+Effective Prompts / Instructions that worked: Align view initialization with existing advanced config patterns and DI guidelines.
+Decisions & Rationale: Use logger-injected constructor and separate Initialize method to match other services and avoid extraneous constructor arguments.
+Action Items: Rely on CI for full test execution.
+Related Commits/PRs:


### PR DESCRIPTION
## What changed
- resolve constructor error by injecting logger and initializing FTP advanced config view through DI
- ensure advanced FTP config navigation uses initialized view model
- test FTP advanced config view initialization
- document FTP advanced config DI fix

## Validation
- [ ] All tests pass
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [ ] Removed stale code


------
https://chatgpt.com/codex/tasks/task_e_68ae9056f9ec8326be0806890e4fbd70