### PR TITLE
fix: compile forms style and correct XAML references

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -32,7 +32,6 @@
     <Resource Include="Themes/LightTheme.xaml" />
     <Resource Include="Themes/DarkTheme.xaml" />
     <Resource Include="Themes/ToggleSwitch.xaml" />
-    <Resource Include="Themes/Forms.xaml" />
     <Resource Include="Themes/MqttTagSubscriptionsView.xaml" />
     <Resource Include="Themes/DataFlowDiagram.xaml" />
   </ItemGroup>

--- a/DesktopApplicationTemplate.UI/Themes/Forms.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/Forms.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI">
+                    xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors">
     <!-- Reusable styles for form labels and input controls -->
     <Style x:Key="FormLabel" TargetType="TextBlock">
         <Setter Property="Margin" Value="0,0,10,5" />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Service list averages use one-way bindings to avoid runtime parse exceptions.
 - Main window declares behaviors namespace to prevent XAML parse errors.
 - Forms theme explicitly references the UI assembly for `TextBoxHintBehavior` to avoid missing type errors.
+- System namespace references and form style resources compiled to eliminate XAML parse failures.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -154,3 +154,11 @@ Effective Prompts / Instructions that worked: Exception message highlighted the 
 Decisions & Rationale: Specify the UI assembly to ensure the XAML parser locates the behavior regardless of load context.
 Action Items: Monitor CI for any remaining XAML parse issues.
 Related Commits/PRs:
+[2025-08-27 17:47] Topic: System namespace and FormField style
+Context: XAML errors for missing System.Object and FormField style.
+Observations: Removed explicit assembly qualifier in Forms.xaml and compiled it as a Page to ensure FormField style loads.
+Codex Limitations noticed: WPF tests require WindowsDesktop runtime; dotnet test aborted.
+Effective Prompts / Instructions that worked: User request to resolve assembly and resource errors.
+Decisions & Rationale: Use project namespaces and compile resources to avoid runtime parse failures.
+Action Items: Validate changes on Windows CI.
+Related Commits/PRs:


### PR DESCRIPTION
## What changed
- compile Forms.xaml so `FormField` style is available at runtime
- trim unnecessary assembly qualifiers in forms resource dictionary
- document XAML namespace and style fix

## Validation
- `dotnet build DesktopApplicationTemplate.sln -v minimal`
- `dotnet test --no-build --settings tests.runsettings -v minimal` *(fails: missing Microsoft.WindowsDesktop runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68af434a34508326b57f2e19a8dd9e45