### PR TITLE
chore: remove Codex test from setup script

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -159,6 +159,7 @@
 - Updated GitHub workflows to install the WPF workload instead of the deprecated `windowsdesktop` workload.
 - Reorganized collaboration log into topic-based blocks and added logging guidelines.
 - Removed obsolete `CodexSafe` test category trait and `TestCategoryAttribute` helper.
+- Setup script no longer runs the Codex test project.
 
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -146,6 +146,14 @@ Effective Prompts / Instructions that worked: Use AGENTS guidelines for XAML and
 Decisions & Rationale: Explicitly declare namespaces and OS support to ensure build stability.
 Action Items: Monitor CI for Windows-specific issues.
 Related Commits/PRs:
+[2025-08-27 18:11] Topic: Setup script cleanup
+Context: Removed Codex test project invocation from setup script.
+Observations: Script now restores, builds, and runs primary tests only.
+Codex Limitations noticed: Linux container lacks WindowsDesktop runtime; tests cannot run locally.
+Effective Prompts / Instructions that worked: User request to simplify setup.
+Decisions & Rationale: Streamline setup by excluding Codex-specific tests.
+Action Items: Rely on CI for Windows-specific test coverage.
+Related Commits/PRs:
 [2025-08-28 15:00] Topic: TextBox hint behavior parse error
 Context: Application startup failed with a XAML parse exception for TextBoxHintBehavior in Forms.xaml.
 Observations: Adding an explicit assembly reference in Forms.xaml's behaviors namespace resolved the missing type error.
@@ -169,4 +177,13 @@ Codex Limitations noticed: dotnet CLI unavailable; tests cannot run locally.
 Effective Prompts / Instructions that worked: User request to clean up obsolete test categories.
 Decisions & Rationale: Simplify test suite and remove unused trait infrastructure.
 Action Items: Monitor CI for Windows-specific issues.
+Related Commits/PRs:
+
+[2025-08-27 18:11] Topic: Setup script cleanup
+Context: Removed Codex test project invocation from setup script.
+Observations: Script now restores, builds, and runs primary tests only.
+Codex Limitations noticed: Linux container lacks WindowsDesktop runtime; tests cannot run locally.
+Effective Prompts / Instructions that worked: User request to simplify setup.
+Decisions & Rationale: Streamline setup by excluding Codex-specific tests.
+Action Items: Rely on CI for Windows-specific test coverage.
 Related Commits/PRs:

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,5 @@ else
 fi
 dotnet build DesktopApplicationTemplate.sln
 dotnet test DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
-dotnet test DesktopApplicationTemplate.Tests.Codex/DesktopApplicationTemplate.Tests.Codex.csproj
 
 echo "Setup complete."


### PR DESCRIPTION
## What changed
- [x] Code
- [ ] UI/XAML
- [ ] Tests
- [ ] DI registrations
- [x] Docs updated

## Validation
- [ ] CI green
- [ ] No deadlocks; async only
- [ ] No unsafe collection access
- [x] Removed stale code


------
https://chatgpt.com/codex/tasks/task_e_68af4a167fa88326a99673b596158e6d