### PR TITLE
Guard TCP options retrieval during service load

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -145,23 +145,14 @@ namespace DesktopApplicationTemplate.UI.Services
                 {
                     if (info.ServiceType == "TCP" && info.TcpOptions != null)
                     {
-                        if (App.AppHost?.Services is IServiceProvider services)
+                        var opt = App.AppHost?.Services.GetService<IOptions<TcpServiceOptions>>();
+                        if (opt != null)
                         {
-                            try
-                            {
-                                var value = services
-                                    .GetRequiredService<IOptions<TcpServiceOptions>>()
-                                    .Value;
-
-                                value.Host = info.TcpOptions.Host;
-                                value.Port = info.TcpOptions.Port;
-                                value.UseUdp = info.TcpOptions.UseUdp;
-                                value.Mode = info.TcpOptions.Mode;
-                            }
-                            catch (InvalidOperationException)
-                            {
-                                // ignore missing options during tests or early startup
-                            }
+                            var value = opt.Value;
+                            value.Host = info.TcpOptions.Host;
+                            value.Port = info.TcpOptions.Port;
+                            value.UseUdp = info.TcpOptions.UseUdp;
+                            value.Mode = info.TcpOptions.Mode;
                         }
                     }
                     if ((info.ServiceType == "FTP Server" || info.ServiceType == "FTP") && info.FtpOptions != null)

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -169,3 +169,11 @@ Effective Prompts / Instructions that worked: `rg` and `find` searches for Codex
 Decisions & Rationale: No action needed beyond verification.
 Action Items: Rely on CI for test execution.
 Related Commits/PRs:
+[2025-08-27 19:20] Topic: TCP options GetService fix
+Context: Replaced GetRequiredService with null-checked GetService and removed exception suppression in ServicePersistence.
+Observations: TCP options now update only when available via DI.
+Codex Limitations noticed: .NET SDK not installed; unable to run restore, build, or tests locally.
+Effective Prompts / Instructions that worked: User request to handle missing TCP options without throwing.
+Decisions & Rationale: Avoid InvalidOperationException during startup by checking for registered options.
+Action Items: Rely on CI for test coverage.
+Related Commits/PRs: f37e904


### PR DESCRIPTION
## Summary
- avoid InvalidOperationException by using `GetService` to retrieve `TcpServiceOptions`
- document TCP options persistence update in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5a054368832687e7294da860b5ff