### PR TITLE
test: add WPF STA fact attribute

### DIFF
--- a/DesktopApplicationTemplate.Tests/BubblyWindowStyleTests.cs
+++ b/DesktopApplicationTemplate.Tests/BubblyWindowStyleTests.cs
@@ -8,7 +8,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class BubblyWindowStyleTests
     {
-        [Fact]
+        [WpfFact]
         public void BubblyWindowStyle_LoadsWithRoundedCorners()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/CreateServicePageTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServicePageTests.cs
@@ -12,7 +12,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class CreateServicePageTests
 {
-    [Fact]
+    [WpfFact]
     public void ServiceType_Click_RaisesTcpSelected()
     {
         string? receivedName = null;
@@ -31,7 +31,7 @@ public class CreateServicePageTests
         receivedName.Should().Be("TCP1");
     }
 
-    [Fact]
+    [WpfFact]
     public void ServiceType_Click_RaisesFtpServerSelected()
     {
         string? receivedName = null;
@@ -50,7 +50,7 @@ public class CreateServicePageTests
         receivedName.Should().Be("FTP Server1");
     }
 
-    [Fact]
+    [WpfFact]
     public void ServiceType_Click_RaisesHeartbeatSelected()
     {
         string? receivedName = null;
@@ -69,7 +69,7 @@ public class CreateServicePageTests
         receivedName.Should().Be("Heartbeat1");
     }
 
-    [Fact]
+    [WpfFact]
     public void ServiceType_Click_RaisesHidSelected()
     {
         string? receivedName = null;
@@ -88,7 +88,7 @@ public class CreateServicePageTests
         receivedName.Should().Be("HID1");
     }
 
-    [Fact]
+    [WpfFact]
     public void ServiceType_Click_RaisesCsvSelected()
     {
         string? receivedName = null;
@@ -107,7 +107,7 @@ public class CreateServicePageTests
         receivedName.Should().Be("CSV Creator1");
     }
 
-    [Fact]
+    [WpfFact]
     public void ServiceType_Click_RaisesHttpSelected()
     {
         string? receivedName = null;
@@ -126,7 +126,7 @@ public class CreateServicePageTests
         receivedName.Should().Be("HTTP1");
     }
 
-    [Fact]
+    [WpfFact]
     public void Cancel_Click_RaisesCancelled()
     {
         bool cancelled = false;

--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -15,7 +15,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class CsvServiceTests
     {
-        [Fact]
+        [WpfFact]
         public void EnsureColumnsForService_AddsColumns()
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
@@ -29,7 +29,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void EnsureColumnsForService_SkipsCsvServices()
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
@@ -42,7 +42,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void RemoveColumnsForService_RemovesColumns()
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
@@ -58,7 +58,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void RemoveColumnsForService_StartsNewFile()
         {
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -87,7 +87,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void RecordLog_WritesCsvRow()
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()+".json");
@@ -104,7 +104,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void AppendRow_CreatesIncrementingFiles()
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -135,7 +135,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void AppendRow_CreatesNestedDirectory()
         {
             var baseDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -163,7 +163,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void AppendRow_WithoutIndexPlaceholder_UsesSingleFile()
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -192,7 +192,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void CsvServiceView_LoadsInto_ContentFrame()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/FtpServerAdvancedConfigViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerAdvancedConfigViewTests.cs
@@ -12,7 +12,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class FtpServerAdvancedConfigViewTests
 {
-    [Fact]
+    [WpfFact]
     public void Initialize_SetsDataContext_AndLogger()
     {
         FtpServerAdvancedConfigView? view = null;
@@ -33,7 +33,7 @@ public class FtpServerAdvancedConfigViewTests
         vm!.Logger.Should().BeSameAs(logger);
     }
 
-    [Fact]
+    [WpfFact]
     public void Initialize_Throws_When_ViewModelNull()
     {
         Exception? ex = null;

--- a/DesktopApplicationTemplate.Tests/FtpServerEditViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerEditViewTests.cs
@@ -8,7 +8,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class FtpServerEditViewTests
 {
-    [Fact]
+    [WpfFact]
     public void Constructor_SetsDataContext()
     {
         FtpServerEditView? view = null;
@@ -24,7 +24,7 @@ public class FtpServerEditViewTests
         view!.DataContext.Should().BeOfType<FtpServerEditViewModel>();
     }
 
-    [Fact]
+    [WpfFact]
     public void Constructor_Throws_When_ViewModelNull()
     {
         Exception? ex = null;

--- a/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
+++ b/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
@@ -15,7 +15,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class LogLevelSelectionTests
     {
-        [Fact]
+        [WpfFact]
         public void HttpServiceView_LogLevelSelection_UpdatesLogger()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewCreateNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void NavigateToTcp_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -64,7 +64,7 @@ public class MainViewCreateNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void NavigateToFtpServer_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -111,7 +111,7 @@ public class MainViewCreateNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void NavigateToHid_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -160,7 +160,7 @@ public class MainViewCreateNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void NavigateToFileObserver_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -210,7 +210,7 @@ public class MainViewCreateNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void NavigateToScp_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
@@ -20,7 +20,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewCsvNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void NavigateToCsvCreator_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -67,7 +67,7 @@ public class MainViewCsvNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void DoubleClickCsvService_OpensEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
@@ -20,7 +20,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewFileObserverNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void EditFileObserverService_ShowsEditView()
     {
         if (!OperatingSystem.IsWindows())
@@ -77,7 +77,7 @@ public class MainViewFileObserverNavigationTests
        thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void DoubleClickFileObserverService_OpensEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewFtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFtpServiceTests.cs
@@ -18,7 +18,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewFtpServiceTests
 {
-    [Fact]
+    [WpfFact]
     public void AddFtpService_SetsOptionsAndAddsService()
     {
         var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
@@ -20,7 +20,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewHeartbeatNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void NavigateToHeartbeat_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -66,7 +66,7 @@ public class MainViewHeartbeatNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void EditHeartbeatService_ShowsEditView()
     {
         if (!OperatingSystem.IsWindows())
@@ -121,7 +121,7 @@ public class MainViewHeartbeatNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void DoubleClickHeartbeatService_OpensEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
@@ -20,7 +20,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewHidNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void EditHidService_ShowsEditView()
     {
         if (!OperatingSystem.IsWindows())
@@ -76,7 +76,7 @@ public class MainViewHidNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void DoubleClickHidService_OpensEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewHttpNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void NavigateToHttp_ShowsCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -65,7 +65,7 @@ public class MainViewHttpNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void EditHttpService_ShowsEditView()
     {
         if (!OperatingSystem.IsWindows())
@@ -120,7 +120,7 @@ public class MainViewHttpNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void DoubleClickHttpService_OpensEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
@@ -17,7 +17,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewMqttNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void CreateMqttService_Advanced_Back_ReturnsToCreateView()
     {
         if (!OperatingSystem.IsWindows())
@@ -73,7 +73,7 @@ public class MainViewMqttNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void EditMqttService_ShowsEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewScpNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void EditScpService_ShowsEditView()
     {
         if (!OperatingSystem.IsWindows())
@@ -75,7 +75,7 @@ public class MainViewScpNavigationTests
         thread.Join();
     }
 
-    [Fact]
+    [WpfFact]
     public void DoubleClickScpService_OpensEditView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewTcpEditTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTcpEditTests.cs
@@ -20,7 +20,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewTcpEditTests
 {
-    [Fact]
+    [WpfFact]
     public void EditTcpService_SavesUpdatedOptions()
     {
         var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/MainViewTcpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTcpNavigationTests.cs
@@ -17,7 +17,7 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class MainViewTcpNavigationTests
 {
-    [Fact]
+    [WpfFact]
     public void CreateTcpService_Advanced_Back_ReturnsToCreateView()
     {
         if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -16,7 +16,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class MainViewTests
     {
-        [Fact]
+        [WpfFact]
         public void MainView_ServiceList_HasMaxHeight()
         {
             if (!OperatingSystem.IsWindows())
@@ -53,7 +53,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void MainView_HasCloseCommandBinding()
         {
             if (!OperatingSystem.IsWindows())
@@ -90,7 +90,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void MainView_HasMinimizeCommandBinding()
         {
             if (!OperatingSystem.IsWindows())
@@ -127,7 +127,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void OpenServiceEditor_NonCsv_SetsContentFrame()
         {
             if (!OperatingSystem.IsWindows())
@@ -166,7 +166,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void OpenServiceEditor_CsvCreator_ShowsWindow()
         {
             if (!OperatingSystem.IsWindows())
@@ -208,7 +208,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void MainView_KeyDown_IgnoresNonEscape()
         {
             if (!OperatingSystem.IsWindows())
@@ -254,7 +254,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void HeaderBar_DoubleClick_TogglesWindowState()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/MqttViewsAccessibilityTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttViewsAccessibilityTests.cs
@@ -16,7 +16,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class MqttViewsAccessibilityTests
     {
-        [Fact]
+        [WpfFact]
         public void MqttCreateServiceView_ExposesNamedButtons()
         {
             if (!OperatingSystem.IsWindows())
@@ -43,7 +43,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void MqttEditConnectionView_ExposesUpdateButton()
         {
             if (!OperatingSystem.IsWindows())
@@ -73,7 +73,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void MqttTagSubscriptionsView_ExposesSendButton()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/ScrollBarStyleTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScrollBarStyleTests.cs
@@ -10,7 +10,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class ScrollBarStyleTests
     {
-        [Fact]
+        [WpfFact]
         public void LightTheme_ScrollBarStyle_HasReducedWidth()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
@@ -14,7 +14,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class SettingsPageNavigationTests
     {
-        [Fact]
+        [WpfFact]
         public void NavigateBack_ReturnsToHomePage()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
@@ -7,7 +7,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class ThemeManagerTests
     {
-        [Fact]
+        [WpfFact]
         public void ApplyTheme_LoadsResourceDictionary()
         {
             if (!OperatingSystem.IsWindows())

--- a/DesktopApplicationTemplate.Tests/WpfFactAttribute.cs
+++ b/DesktopApplicationTemplate.Tests/WpfFactAttribute.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace DesktopApplicationTemplate.Tests;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("DesktopApplicationTemplate.Tests.WpfFactDiscoverer", "DesktopApplicationTemplate.Tests")]
+public sealed class WpfFactAttribute : FactAttribute { }
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("DesktopApplicationTemplate.Tests.WpfTheoryDiscoverer", "DesktopApplicationTemplate.Tests")]
+public sealed class WpfTheoryAttribute : TheoryAttribute { }
+
+internal sealed class WpfFactDiscoverer : IXunitTestCaseDiscoverer
+{
+    private readonly IMessageSink _diagnosticMessageSink;
+
+    public WpfFactDiscoverer(IMessageSink diagnosticMessageSink) => _diagnosticMessageSink = diagnosticMessageSink;
+
+    public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+    {
+        yield return new WpfTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
+    }
+}
+
+internal sealed class WpfTheoryDiscoverer : IXunitTestCaseDiscoverer
+{
+    private readonly IMessageSink _diagnosticMessageSink;
+
+    public WpfTheoryDiscoverer(IMessageSink diagnosticMessageSink) => _diagnosticMessageSink = diagnosticMessageSink;
+
+    public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+    {
+        yield return new WpfTheoryTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod);
+    }
+}
+
+internal class WpfTestCase : XunitTestCase
+{
+    [Obsolete("Called by the test runner", true)]
+    public WpfTestCase() { }
+
+    public WpfTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
+
+    public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+    {
+        var tcs = new TaskCompletionSource<RunSummary>();
+        var thread = new Thread(() =>
+        {
+            var result = base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource)
+                .GetAwaiter().GetResult();
+            tcs.SetResult(result);
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        return tcs.Task;
+    }
+}
+
+internal class WpfTheoryTestCase : XunitTheoryTestCase
+{
+    [Obsolete("Called by the test runner", true)]
+    public WpfTheoryTestCase() { }
+
+    public WpfTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
+
+    public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+    {
+        var tcs = new TaskCompletionSource<RunSummary>();
+        var thread = new Thread(() =>
+        {
+            var result = base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource)
+                .GetAwaiter().GetResult();
+            tcs.SetResult(result);
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+        return tcs.Task;
+    }
+}

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -186,3 +186,11 @@ Decisions & Rationale: Use CollectionBehavior attribute to enforce sequential ex
 Action Items: Rely on CI for Windows execution.
 Related Commits/PRs:
 
+[2025-08-27 21:16] Topic: WPF test attributes
+Context: Added custom WpfFact/WpfTheory to run UI tests on STA threads and updated existing WPF tests to use them.
+Observations: .NET SDK 8.0.404 installed successfully, but Microsoft.WindowsDesktop runtime is unavailable so tests abort.
+Codex Limitations noticed: Missing WindowsDesktop runtime prevents executing WPF tests on Linux.
+Effective Prompts / Instructions that worked: User request to replace Fact with WpfFact in UI tests.
+Decisions & Rationale: Provide reusable attributes so UI tests no longer manage threads manually.
+Action Items: Rely on CI for Windows-specific test execution.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- add WpfFact/WpfTheory attributes to execute tests on STA threads
- use WpfFact in UI tests touching WPF objects
- document Linux test limitations in collaboration tips

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7476eb848326b8ec30b2533eb280