### PR TITLE
fix: add missing WPF and logging references

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
+++ b/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
+++ b/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
@@ -1,9 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+  </ItemGroup>
 
 </Project>

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="SSH.NET" Version="2025.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.25103.5738" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -142,6 +142,7 @@
 - Moved `LogEntry` to core and restored logging event subscriptions, resolving missing reference build errors.
 - Registered `LoggingService` with the DI container to satisfy `SaveConfirmationHelper` and prevent runtime errors.
 - Marked log models and levels as Windows-specific to silence cross-platform analyzer warnings.
+- Added missing WPF framework and logging abstraction references to core and UI projects, resolving `System.Windows.Media` and `ILogger` build errors.
 
 #### Changed
 - Removed custom `ILoggingService` and service registrations in favor of `Microsoft.Extensions.Logging` with console and debug providers.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -202,3 +202,13 @@ Effective Prompts / Instructions that worked: `apt-get install dotnet-sdk-8.0` t
 Decisions & Rationale: Rely on CI for full test execution.
 Action Items: none
 Related Commits/PRs:
+
+[2025-09-07 10:30] Topic: Logging package references
+Context: Build errors for System.Windows.Media and ILogger due to missing WPF and logging assemblies.
+Observations: Core targeted net8.0 without WPF; UI lacked logging abstractions reference.
+Codex Limitations noticed: dotnet CLI not installed; unable to restore, build, or run tests.
+Effective Prompts / Instructions that worked: Compiler errors highlighted missing references.
+Decisions & Rationale: Target net8.0-windows with UseWPF and add Microsoft.Extensions.Logging.Abstractions to resolve errors.
+Action Items: Rely on CI for verification.
+Related Commits/PRs:
+


### PR DESCRIPTION
## Summary
- target `net8.0-windows` and enable WPF in core and test projects
- add `Microsoft.Extensions.Logging.Abstractions` to core and UI
- document logging package fix in changelog and collaboration log

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7965cc20832682d9cd6cf4ccd3c6