### PR TITLE
Fix build errors in MQTT view model and tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -5,7 +5,6 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
@@ -14,6 +14,7 @@ using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using System.Windows.Controls;
 using System.Windows.Input;
+using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate.Tests;
 

--- a/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewFtpServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFtpServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
+using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate.Tests;
 

--- a/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.Tests/MainViewTcpEditTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTcpEditTests.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
 using System.Reflection;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.Tests;
 

--- a/DesktopApplicationTemplate.Tests/MainViewTcpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTcpNavigationTests.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -4,7 +4,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Models;
 // Qualify service-layer types explicitly to avoid name clashes with UI services
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.Core.Models;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.Options;
 using MQTTnet.Protocol;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,6 +104,7 @@
 - `MqttCreateServiceView` no longer hosts duplicate `StackPanel` elements, resolving build errors.
 - Added missing `MQTTnet.Protocol` using to restore `MqttQualityOfServiceLevel` references.
 - Host validation now accepts domain names and rejects underscores.
+- Restored `MqttEndpointMessage` namespace in MQTT service view model to fix build errors.
 
 ### CSV Service
 #### Added
@@ -164,4 +165,5 @@
 
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.
+- Removed duplicate using directives and missing namespace references that prevented solution builds.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -212,3 +212,11 @@ Decisions & Rationale: Target net8.0-windows with UseWPF and add Microsoft.Exten
 Action Items: Rely on CI for verification.
 Related Commits/PRs:
 
+[2025-09-08 12:00] Topic: Build error fixes
+Context: Removed duplicate using directives and added missing namespaces to resolve build failures.
+Observations: Solution now builds, but tests abort due to missing Microsoft.WindowsDesktop runtime.
+Codex Limitations noticed: WindowsDesktop runtime unavailable in container.
+Effective Prompts / Instructions that worked: Compiler errors highlighting missing types and namespace conflicts.
+Decisions & Rationale: Clean up using statements and import model namespaces to restore compilation.
+Action Items: Rely on CI for Windows-specific test execution.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- remove duplicate using directives and import missing namespaces in app startup and MQTT service view model
- clean up test files by deduplicating service usings and importing UI view models
- document build fixes and environment limitations

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7b44907c8326bc6c057df0db7840