### PR TITLE
Remove Windows runtime guard from tests

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
+++ b/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />

--- a/DesktopApplicationTemplate.Tests/BubblyWindowStyleTests.cs
+++ b/DesktopApplicationTemplate.Tests/BubblyWindowStyleTests.cs
@@ -11,7 +11,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void BubblyWindowStyle_LoadsWithRoundedCorners()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? capturedException = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceTests.cs
@@ -195,7 +195,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void CsvServiceView_LoadsInto_ContentFrame()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
+++ b/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
@@ -22,7 +22,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />

--- a/DesktopApplicationTemplate.Tests/KeyboardHelperTests.cs
+++ b/DesktopApplicationTemplate.Tests/KeyboardHelperTests.cs
@@ -6,10 +6,9 @@ namespace DesktopApplicationTemplate.Tests;
 
 public class KeyboardHelperTests
 {
-    [SkippableFact]
+    [WpfFact]
     public void ReleaseKeys_DoesNotThrow()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         FluentActions.Invoking(() => KeyboardHelper.ReleaseKeys(Key.A))
             .Should().NotThrow();

--- a/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
+++ b/DesktopApplicationTemplate.Tests/LogLevelSelectionTests.cs
@@ -18,7 +18,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void HttpServiceView_LogLevelSelection_UpdatesLogger()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -22,7 +22,6 @@ public class MainViewCreateNavigationTests
     [WpfFact]
     public void NavigateToTcp_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -66,7 +65,6 @@ public class MainViewCreateNavigationTests
     [WpfFact]
     public void NavigateToFtpServer_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -112,7 +110,6 @@ public class MainViewCreateNavigationTests
     [WpfFact]
     public void NavigateToHid_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -160,7 +157,6 @@ public class MainViewCreateNavigationTests
     [WpfFact]
     public void NavigateToFileObserver_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -209,7 +205,6 @@ public class MainViewCreateNavigationTests
     [WpfFact]
     public void NavigateToScp_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCsvNavigationTests.cs
@@ -23,7 +23,6 @@ public class MainViewCsvNavigationTests
     [WpfFact]
     public void NavigateToCsvCreator_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -69,7 +68,6 @@ public class MainViewCsvNavigationTests
     [WpfFact]
     public void DoubleClickCsvService_OpensEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewFileObserverNavigationTests.cs
@@ -23,7 +23,6 @@ public class MainViewFileObserverNavigationTests
     [WpfFact]
     public void EditFileObserverService_ShowsEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -79,7 +78,6 @@ public class MainViewFileObserverNavigationTests
     [WpfFact]
     public void DoubleClickFileObserverService_OpensEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHeartbeatNavigationTests.cs
@@ -23,7 +23,6 @@ public class MainViewHeartbeatNavigationTests
     [WpfFact]
     public void NavigateToHeartbeat_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -68,7 +67,6 @@ public class MainViewHeartbeatNavigationTests
     [WpfFact]
     public void EditHeartbeatService_ShowsEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -122,7 +120,6 @@ public class MainViewHeartbeatNavigationTests
     [WpfFact]
     public void DoubleClickHeartbeatService_OpensEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHidNavigationTests.cs
@@ -23,7 +23,6 @@ public class MainViewHidNavigationTests
     [WpfFact]
     public void EditHidService_ShowsEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -78,7 +77,6 @@ public class MainViewHidNavigationTests
     [WpfFact]
     public void DoubleClickHidService_OpensEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewHttpNavigationTests.cs
@@ -22,7 +22,6 @@ public class MainViewHttpNavigationTests
     [WpfFact]
     public void NavigateToHttp_ShowsCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -67,7 +66,6 @@ public class MainViewHttpNavigationTests
     [WpfFact]
     public void EditHttpService_ShowsEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -121,7 +119,6 @@ public class MainViewHttpNavigationTests
     [WpfFact]
     public void DoubleClickHttpService_OpensEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewMqttNavigationTests.cs
@@ -20,7 +20,6 @@ public class MainViewMqttNavigationTests
     [WpfFact]
     public void CreateMqttService_Advanced_Back_ReturnsToCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -75,7 +74,6 @@ public class MainViewMqttNavigationTests
     [WpfFact]
     public void EditMqttService_ShowsEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewScpNavigationTests.cs
@@ -22,7 +22,6 @@ public class MainViewScpNavigationTests
     [WpfFact]
     public void EditScpService_ShowsEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {
@@ -77,7 +76,6 @@ public class MainViewScpNavigationTests
     [WpfFact]
     public void DoubleClickScpService_OpensEditView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewTcpNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTcpNavigationTests.cs
@@ -20,7 +20,6 @@ public class MainViewTcpNavigationTests
     [WpfFact]
     public void CreateTcpService_Advanced_Back_ReturnsToCreateView()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
         var thread = new Thread(() =>
         {

--- a/DesktopApplicationTemplate.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewTests.cs
@@ -20,7 +20,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MainView_ServiceList_HasMaxHeight()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -56,7 +55,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MainView_HasCloseCommandBinding()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -92,7 +90,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MainView_HasMinimizeCommandBinding()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -128,7 +125,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void OpenServiceEditor_NonCsv_SetsContentFrame()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -166,7 +162,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void OpenServiceEditor_CsvCreator_ShowsWindow()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -207,7 +202,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MainView_KeyDown_IgnoresNonEscape()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -252,7 +246,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void HeaderBar_DoubleClick_TogglesWindowState()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
@@ -27,10 +27,9 @@ public class MqttEditConnectionViewModelTests
         return new MqttEditConnectionViewModel(service, options, Mock.Of<ILoggingService>());
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateAsync_ReconnectsWithUpdatedOptions()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
@@ -46,10 +45,9 @@ public class MqttEditConnectionViewModelTests
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ToggleSubscriptionAsync_Disconnects()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
@@ -63,10 +61,9 @@ public class MqttEditConnectionViewModelTests
         Assert.True(closed);
     }
 
-    [SkippableFact]
+    [Fact]
     public void Cancel_DoesNotModifyOptions()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
@@ -81,10 +78,9 @@ public class MqttEditConnectionViewModelTests
         Assert.True(closed);
     }
 
-    [SkippableFact]
+    [Fact]
     public void Host_Invalid_AddsError()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         var original = vm.Host;
         vm.Host = "bad host";
@@ -93,10 +89,9 @@ public class MqttEditConnectionViewModelTests
         Assert.Contains("Invalid host", vm.GetErrors(nameof(vm.Host)).Cast<string>());
     }
 
-    [SkippableFact]
+    [Fact]
     public void Port_Invalid_AddsError()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         var original = vm.Port;
         vm.Port = 70000;
@@ -105,10 +100,9 @@ public class MqttEditConnectionViewModelTests
         Assert.Contains("Port must be 1-65535", vm.GetErrors(nameof(vm.Port)).Cast<string>());
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task UpdateAsync_UpdatesAllOptionsAndRaisesRequestClose()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
@@ -135,20 +129,18 @@ public class MqttEditConnectionViewModelTests
         Assert.True(closed);
     }
 
-    [SkippableFact]
+    [Fact]
     public void ConnectionType_WebSocket_DisablesTls()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.ConnectionType = MqttConnectionType.WebSocket;
         Assert.False(vm.IsTlsEnabled);
         Assert.False(vm.UseTls);
     }
 
-    [SkippableFact]
+    [Fact]
     public void SubscriptionButtonText_ReflectsConnectionState()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         Assert.Equal("Subscribe", vm.SubscriptionButtonText);
         vm.GetType().GetProperty("IsConnected")!.SetValue(vm, true);

--- a/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceViewModelTests.cs
@@ -38,20 +38,18 @@ public class MqttServiceViewModelTests
         return new MqttServiceViewModel(service, routing.Object, helper, options, logger);
     }
 
-    [SkippableFact]
+    [Fact]
     public void AddTopicCommand_AddsTopic()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.NewTopic = "test/topic";
         vm.AddTopicCommand.Execute(null);
         Assert.Contains("test/topic", vm.Topics);
     }
 
-    [SkippableFact]
+    [Fact]
     public void AddMessageCommand_AddsPair()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.NewEndpoint = "endpoint";
         vm.NewMessage = "payload";
@@ -59,10 +57,9 @@ public class MqttServiceViewModelTests
         Assert.Single(vm.Messages);
     }
 
-    [SkippableFact]
+    [Fact]
     public void RemoveMessageCommand_RemovesSelectedPair()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.Messages.Add(new MqttEndpointMessage { Endpoint = "t", Message = "m" });
         vm.SelectedMessage = vm.Messages.First();
@@ -70,10 +67,9 @@ public class MqttServiceViewModelTests
         Assert.Empty(vm.Messages);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ConnectAsync_SetsIsConnected()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MqttClientConnectResult());
@@ -83,10 +79,9 @@ public class MqttServiceViewModelTests
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ConnectAsync_InvalidOptions_RaisesEditRequested()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ArgumentException("Host cannot be null"));
@@ -97,10 +92,9 @@ public class MqttServiceViewModelTests
         Assert.True(raised);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task PublishSelectedAsync_ResolvesTokens()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var routing = new Mock<IMessageRoutingService>();
         routing.Setup(r => r.ResolveTokens("endpoint")).Returns("resolvedEndpoint");
         routing.Setup(r => r.ResolveTokens("payload")).Returns("resolvedPayload");
@@ -116,46 +110,41 @@ public class MqttServiceViewModelTests
         client.Verify(c => c.PublishAsync(It.Is<MqttApplicationMessage>(m => m.Topic == "resolvedEndpoint" && m.ConvertPayloadToString() == "resolvedPayload"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [SkippableFact]
+    [Fact]
     public void PortSetter_RejectsOutOfRange()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.Port = 70000;
         Assert.Contains("Port must be 1-65535", vm.GetErrors(nameof(vm.Port)).Cast<string>());
     }
 
-    [SkippableFact]
+    [Fact]
     public void HostSetter_InvalidAddsError()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.Host = "invalid_host";
         Assert.Contains("Invalid host", vm.GetErrors(nameof(vm.Host)).Cast<string>());
     }
 
-    [SkippableFact]
+    [Fact]
     public void KeepAliveSecondsSetter_RejectsOutOfRange()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.KeepAliveSeconds = -1;
         Assert.Contains("Keep alive must be 0-65535", vm.GetErrors(nameof(vm.KeepAliveSeconds)).Cast<string>());
     }
 
-    [SkippableFact]
+    [Fact]
     public void ReconnectDelaySetter_RejectsNegative()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.ReconnectDelay = -5;
         Assert.Contains("Reconnect delay must be >= 0", vm.GetErrors(nameof(vm.ReconnectDelay)).Cast<string>());
     }
 
-    [SkippableFact]
+    [Fact]
     public void WillQualityOfServiceSetter_InvalidAddsError()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var vm = CreateViewModel();
         vm.WillQualityOfService = (MqttQualityOfServiceLevel)99;
         Assert.Contains("Invalid QoS", vm.GetErrors(nameof(vm.WillQualityOfService)).Cast<string>());

--- a/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
@@ -38,19 +38,17 @@ public class MqttTagSubscriptionsViewModelTests
         return (vm, client, service);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ConnectAsync_InvokesClient()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var (vm, client, _) = CreateViewModel();
         await vm.ConnectAsync();
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task ConnectAsync_RaisesEditRequested_OnInvalidOptions()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var client = new Mock<IMqttClient>();
         client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ArgumentException("Host cannot be null or whitespace."));
@@ -63,10 +61,9 @@ public class MqttTagSubscriptionsViewModelTests
         Assert.True(raised);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task AddTopicAsync_SubscribesAndAdds()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var (vm, client, _) = CreateViewModel();
         vm.NewTopic = "t";
         vm.NewQoS = MqttQualityOfServiceLevel.AtLeastOnce;
@@ -78,10 +75,9 @@ public class MqttTagSubscriptionsViewModelTests
         Assert.Contains(vm.SubscriptionResults, r => r.Topic == "t" && r.IsSuccess);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task RemoveTopicAsync_UnsubscribesAndRemoves()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var (vm, client, service) = CreateViewModel();
         var sub = new TagSubscription("t");
         service.UpdateTagSubscription(sub);
@@ -93,10 +89,9 @@ public class MqttTagSubscriptionsViewModelTests
         Assert.Null(vm.SelectedSubscription);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task PublishTestMessageAsync_Publishes_WhenValid()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var (vm, client, _) = CreateViewModel();
         var sub = new TagSubscription("t") { OutgoingMessage = "m" };
         vm.Subscriptions.Add(sub);
@@ -105,10 +100,9 @@ public class MqttTagSubscriptionsViewModelTests
         client.Verify(c => c.PublishAsync(It.Is<MQTTnet.MqttApplicationMessage>(m => m.Topic == "t"), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task TestTagEndpointCommand_Publishes_WhenValid()
     {
-        Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
         var (vm, client, _) = CreateViewModel();
         var sub = new TagSubscription("tag") { Endpoint = "e", OutgoingMessage = "m" };
         await ((AsyncRelayCommand<TagSubscription>)vm.TestTagEndpointCommand).ExecuteAsync(sub);

--- a/DesktopApplicationTemplate.Tests/MqttViewsAccessibilityTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttViewsAccessibilityTests.cs
@@ -19,7 +19,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MqttCreateServiceView_ExposesNamedButtons()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -45,7 +44,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MqttEditConnectionView_ExposesUpdateButton()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>
@@ -74,7 +72,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void MqttTagSubscriptionsView_ExposesSendButton()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/ScrollBarStyleTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScrollBarStyleTests.cs
@@ -13,7 +13,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void LightTheme_ScrollBarStyle_HasReducedWidth()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsPageNavigationTests.cs
@@ -18,7 +18,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void NavigateBack_ReturnsToHomePage()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ThemeManagerTests.cs
@@ -10,7 +10,6 @@ namespace DesktopApplicationTemplate.Tests
         [WpfFact]
         public void ApplyTheme_LoadsResourceDictionary()
         {
-            Skip.IfNot(OperatingSystem.IsWindows(), "Requires Windows desktop runtime");
 
             Exception? ex = null;
             var thread = new Thread(() =>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -162,6 +162,7 @@
 - Reorganized collaboration log into topic-based blocks and added logging guidelines.
 - Removed Codex-specific tests and categories, eliminating the `CodexSafe` trait and custom `TestCategoryAttribute`.
 - Setup script now runs only the primary test suite after removing the Codex test project.
+- Removed Windows desktop runtime checks from tests so they run when Visual Studio provides the runtime.
 
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -220,3 +220,12 @@ Effective Prompts / Instructions that worked: Compiler errors highlighting missi
 Decisions & Rationale: Clean up using statements and import model namespaces to restore compilation.
 Action Items: Rely on CI for Windows-specific test execution.
 Related Commits/PRs:
+
+[2025-09-09 00:00] Topic: Windows runtime test skips removal
+Context: Removed Windows desktop runtime checks and SkippableFact attributes so tests run when Visual Studio provides the runtime.
+Observations: Tests still cannot execute in the container because the Microsoft.WindowsDesktop runtime is absent.
+Codex Limitations noticed: Missing WindowsDesktop runtime prevents local test execution.
+Effective Prompts / Instructions that worked: User request to remove environment check.
+Decisions & Rationale: Allow tests to run on capable machines and rely on CI for verification.
+Action Items: Rely on CI for full test run.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- Allow tests to run without Windows desktop runtime checks
- Drop SkippableFact dependency from test projects
- Document removal of runtime guard

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b04fb90d248326ab6368aa7b80f0e3