### PR TITLE
Use WPF test attributes for logging service tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.Tests
 {
     public class LoggingServiceTests
     {
-        [Theory]
+        [WpfTheory]
         [InlineData(LogLevel.Debug)]
         [InlineData(LogLevel.Warning)]
         [InlineData(LogLevel.Error)]
@@ -42,7 +42,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public async Task Log_WritesMessageToFile()
         {
             var uiLogger = new Mock<IRichTextLogger>();
@@ -75,7 +75,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public void MinimumLevel_Change_FiltersExistingLogs()
         {
             var uiLogger = new Mock<IRichTextLogger>();
@@ -97,7 +97,7 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
+        [WpfFact]
         public async Task Reload_ReplaysEntriesFromExistingFile()
         {
             var path = Path.GetTempFileName();


### PR DESCRIPTION
## Summary
- replace xUnit Fact/Theory with WpfFact/WpfTheory in logging service tests

## Testing
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b056cbb8f48326a19070fe56a7b64a