### PR TITLE
docs: document WPF workload requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ See `CollaborationGuidelines.txt` for tips on working with the repository. A run
 - [.NET 8 SDK](https://dotnet.microsoft.com/download) (8.0.404)
 - [Git LFS](https://git-lfs.com) for large binary assets
 - Windows OS is required to run the WPF UI and service projects.
+- WPF workload for the .NET SDK:
+
+  ```bash
+  dotnet workload install wpf
+  ```
 
 Ensure the 8.0.404 SDK is installed so the pinned `global.json` version resolves correctly.
 
@@ -32,13 +37,22 @@ repository root will automatically respect this setting.
 
 ## Initial setup
 
-After cloning the repository, run the setup script to configure the Git
-hooks and [Git LFS](https://git-lfs.com/). The script also restores
-dependencies, builds the solution, and executes the unit tests:
+After cloning the repository:
 
-```bash
-./setup.sh
-```
+- Install the WPF workload and run a full build and test cycle:
+
+  ```bash
+  dotnet workload install wpf
+  dotnet restore
+  dotnet build DesktopApplicationTemplate.sln
+  dotnet test --settings tests.runsettings
+  ```
+
+- Run the setup script to configure the Git hooks and [Git LFS](https://git-lfs.com/):
+
+  ```bash
+  ./setup.sh
+  ```
 
 Run the script any time the project dependencies or hooks need to be refreshed.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -237,3 +237,11 @@ Effective Prompts / Instructions that worked: User request to drop Windows-speci
 Decisions & Rationale: Update tests to target net8.0; rely on CI or future core refactor for full cross-platform support.
 Action Items: none
 Related Commits/PRs:
+[2025-09-10 00:00] Topic: WPF workload requirement
+Context: Documented need for WPF workload and full build/test cycle after installation.
+Observations: `dotnet workload install wpf` is not recognized on Linux; restore/build/test fail due to Windows-only dependencies.
+Codex Limitations noticed: Linux container lacks WPF workload and WindowsDesktop runtime.
+Effective Prompts / Instructions that worked: User request to clarify prerequisites and setup steps.
+Decisions & Rationale: Add README guidance for installing WPF workload and running `dotnet restore`, `dotnet build`, and `dotnet test`.
+Action Items: Rely on CI or Windows host for successful build and test.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- clarify that the WPF workload must be installed with `dotnet workload install wpf`
- outline restore, build, and test steps after installing the workload
- log the requirement and Linux limitation in collaboration tips

## Testing
- `dotnet workload install wpf` *(fails: Workload ID wpf is not recognized)*
- `dotnet restore` *(fails: Project DesktopApplicationTemplate.Core is not compatible with net8.0)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Project DesktopApplicationTemplate.Core is not compatible with net8.0)*
- `dotnet test --settings tests.runsettings` *(fails: Project DesktopApplicationTemplate.Core is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b058daa2888326af6b053fca1fb2cc