### PR TITLE
Detect OS before installing WPF workload

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -163,6 +163,7 @@
 - Removed Codex-specific tests and categories, eliminating the `CodexSafe` trait and custom `TestCategoryAttribute`.
 - Setup script now runs only the primary test suite after removing the Codex test project.
 - Removed Windows desktop runtime checks from tests so they run when Visual Studio provides the runtime.
+- Setup script detects the host OS and installs the WPF workload only on Windows, logging when skipped and honoring `SKIP_WORKLOAD`.
 
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -245,3 +245,12 @@ Effective Prompts / Instructions that worked: User request to clarify prerequisi
 Decisions & Rationale: Add README guidance for installing WPF workload and running `dotnet restore`, `dotnet build`, and `dotnet test`.
 Action Items: Rely on CI or Windows host for successful build and test.
 Related Commits/PRs:
+
+[2025-09-10 08:00] Topic: Setup script OS detection
+Context: Added OS detection so the setup script installs the WPF workload only on Windows.
+Observations: Running on Linux skipped the workload; restore/build/test still fail due to missing Microsoft.WindowsDesktop runtime.
+Codex Limitations noticed: Linux container lacks WindowsDesktop runtime so tests cannot execute.
+Effective Prompts / Instructions that worked: User request to conditionally install the WPF workload while honoring `SKIP_WORKLOAD`.
+Decisions & Rationale: Use `$OSTYPE`/`dotnet --info` to determine OS and log when skipping; rely on CI for Windows validation.
+Action Items: Rely on CI for Windows-specific build and test.
+Related Commits/PRs:

--- a/setup.sh
+++ b/setup.sh
@@ -8,14 +8,30 @@ git config core.hooksPath .githooks
 git lfs install
 
 dotnet restore
+# Determine the host operating system
+OS_FAMILY=""
+if [ -n "$OSTYPE" ]; then
+    case "$OSTYPE" in
+        msys*|cygwin*|win32*) OS_FAMILY="Windows" ;;
+        *) OS_FAMILY="" ;;
+    esac
+fi
+
+if [ -z "$OS_FAMILY" ]; then
+    OS_FAMILY=$(dotnet --info | grep -m 1 '^OS Name:' | cut -d: -f2 | xargs)
+fi
 
 if [ -z "$SKIP_WORKLOAD" ]; then
-    echo "Checking for wpf workload..."
-    if ! dotnet workload list | grep -q wpf; then
-        echo "Installing wpf workload..."
-        dotnet workload install wpf
+    if [[ "$OS_FAMILY" == "Windows" ]]; then
+        echo "Checking for wpf workload on Windows..."
+        if ! dotnet workload list | grep -q wpf; then
+            echo "Installing wpf workload..."
+            dotnet workload install wpf
+        else
+            echo "wpf workload already installed."
+        fi
     else
-        echo "wpf workload already installed."
+        echo "Non-Windows OS ($OS_FAMILY) detected; skipping wpf workload installation."
     fi
 else
     echo "SKIP_WORKLOAD set - skipping wpf workload installation."


### PR DESCRIPTION
## Summary
- Detect host OS in setup script using `$OSTYPE`/`dotnet --info`
- Install WPF workload only on Windows with skip message for other platforms
- Log setup behavior and environment notes in collaboration docs and changelog

## Testing
- `dotnet restore` *(fails: DesktopApplicationTemplate.Core not compatible with net8.0)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: DesktopApplicationTemplate.Core not compatible with net8.0)*
- `dotnet test --settings tests.runsettings` *(fails: DesktopApplicationTemplate.Core not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b06093e1388326b1ccda2c2af5bb60