### PR TITLE
Multi-target core and use cross-platform log colors

### DIFF
--- a/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
+++ b/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -56,13 +56,13 @@ namespace DesktopApplicationTemplate.UI.Services
             _ = WriteToFileAsync(entry.Message + Environment.NewLine);
         }
 
-        private static System.Windows.Media.Brush LevelToColor(LogLevel level) => level switch
+        private static string LevelToColor(LogLevel level) => level switch
         {
-            LogLevel.Debug => System.Windows.Media.Brushes.Black,
-            LogLevel.Warning => System.Windows.Media.Brushes.Orange,
-            LogLevel.Error => System.Windows.Media.Brushes.Red,
-            LogLevel.Critical => System.Windows.Media.Brushes.DarkRed,
-            _ => System.Windows.Media.Brushes.Black
+            LogLevel.Debug => "#000000",
+            LogLevel.Warning => "#FFA500",
+            LogLevel.Error => "#FF0000",
+            LogLevel.Critical => "#8B0000",
+            _ => "#000000"
         };
 
         public void Reload()

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -149,7 +149,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug, bool checkReference = true)
         {
             var ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
-            var entry = new LogEntry { Message = $"{ts} {message}", Color = color ?? WpfBrushes.Black, Level = level };
+            var entry = new LogEntry { Message = $"{ts} {message}", Color = (color ?? WpfBrushes.Black).ToString(), Level = level };
             Logs.Insert(0, entry);
             LogAdded?.Invoke(this, entry);
             if (checkReference)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -101,7 +101,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     if (vm.Logger != null)
                     {
-                        logger.LogAdded += entry => svc.AddLog(entry.Message, entry.Color, entry.Level);
+                        logger.LogAdded += entry =>
+                        {
+                            var brush = (Brush?)new BrushConverter().ConvertFromString(entry.Color);
+                            svc.AddLog(entry.Message, brush, entry.Level);
+                        };
                     }
                 }
 

--- a/DesktopApplicationTemplate.Windows/Models/LogEntry.cs
+++ b/DesktopApplicationTemplate.Windows/Models/LogEntry.cs
@@ -20,8 +20,8 @@ namespace DesktopApplicationTemplate.Models
         public string Message { get; set; } = string.Empty;
 
         /// <summary>
-        /// Display color for the entry.
+        /// Display color for the entry in a cross-platform format (e.g., "#FF0000").
         /// </summary>
-        public System.Windows.Media.Brush Color { get; set; } = System.Windows.Media.Brushes.Black;
+        public string Color { get; set; } = "#000000";
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Renamed root `CollaborationAndDebugTips.txt` to `CollaborationGuidelines.txt` and clarified distinction from `docs/CollaborationAndDebugTips.txt`.
 - Updated `global.json` to require the .NET 8 SDK version `8.0.404`.
 - Disabled default `AutoStart` and set environment configuration files to `"AutoStart": false`.
+- Core library now multi-targets `net8.0` and `net8.0-windows`.
 
 ### Navigation & UI
 #### Added
@@ -148,6 +149,7 @@
 #### Changed
 - Removed custom `ILoggingService` and service registrations in favor of `Microsoft.Extensions.Logging` with console and debug providers.
 - Relocated `LogEntry`, `LogLevel`, and `ILoggingService` to a new `DesktopApplicationTemplate.Windows` library to remove WPF dependencies from the core project.
+- `LogEntry` now stores colors as hex strings instead of `System.Windows.Media.Brush`.
 
 ### Documentation & CI
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -262,3 +262,12 @@ Effective Prompts / Instructions that worked: User request to isolate WPF-specif
 Decisions & Rationale: Introduced a dedicated Windows project while preserving existing namespaces to minimize code changes.
 Action Items: Rely on CI for verification.
 Related Commits/PRs:
+
+[2025-09-10 17:00] Topic: Cross-platform log colors
+Context: Replaced `System.Windows.Media.Brush` usage with hex color strings in `LogEntry` and related services.
+Observations: Logging now avoids WPF types; UI converts hex strings back to brushes for display.
+Codex Limitations noticed: `dotnet` CLI missing; restore/build/test cannot run in container.
+Effective Prompts / Instructions that worked: User request to remove WPF dependencies and multi-target core project.
+Decisions & Rationale: Use hex strings to represent colors for platform neutrality.
+Action Items: Rely on CI for full test execution.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- Multi-target DesktopApplicationTemplate.Core for net8.0 and net8.0-windows
- Represent log entry colors as hex strings and map log levels to hex codes
- Convert log color strings back to brushes when displaying logs

## Testing
- `dotnet workload install wpf` *(fails: A compatible .NET SDK 8.0.404 was not found)*
- `dotnet restore` *(fails: Requested SDK version 8.0.404 not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Requested SDK version 8.0.404 not found)*
- `dotnet test --settings tests.runsettings` *(fails: Requested SDK version 8.0.404 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b066adaa8c8326b68429f1951767f2