### PR TITLE
docs: log build limitations on Linux

### DIFF
--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -328,3 +328,11 @@ Effective Prompts / Instructions that worked: Repository guidelines to log envir
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
 Action Items: Rely on CI for Windows-specific build and test.
 Related Commits/PRs:
+[2025-08-28 15:35] Topic: dotnet restore/build on Linux
+Context: Installed .NET SDK 8.0.404 via script to run restore and build commands.
+Observations: `dotnet restore DesktopApplicationTemplate.Core` succeeded; `dotnet workload install wpf` reported "Workload ID wpf is not recognized"; `dotnet build DesktopApplicationTemplate.sln` failed with CA1416 for `Thread.SetApartmentState` in `WpfFactAttribute`.
+Codex Limitations noticed: WPF workload unavailable on Linux and build fails due to Windows-only APIs.
+Effective Prompts / Instructions that worked: Followed setup guidance to install SDK and run restore/build.
+Decisions & Rationale: Document limitations and rely on CI for Windows-specific build and test.
+Action Items: Rely on CI for successful build and test.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- Documented Linux environment limitations after installing .NET SDK 8.0.404 and attempting restore/build commands.

## Testing
- `dotnet restore DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: CA1416 – Thread.SetApartmentState is Windows-only)*
- `dotnet test --settings tests.runsettings` *(fails: CA1416 – Thread.SetApartmentState is Windows-only)*

------
https://chatgpt.com/codex/tasks/task_e_68b076c11aa883268612c3bd6c63c283