### PR TITLE
Guard WPF test apartment state for non-Windows

### DIFF
--- a/TestCommon/WpfFactAttribute.cs
+++ b/TestCommon/WpfFactAttribute.cs
@@ -40,7 +40,10 @@ internal class WpfTestCase : XunitTestCase
                 .GetAwaiter().GetResult();
             tcs.SetResult(result);
         });
-        thread.SetApartmentState(ApartmentState.STA);
+        if (OperatingSystem.IsWindows())
+        {
+            thread.SetApartmentState(ApartmentState.STA);
+        }
         thread.Start();
         thread.Join();
         return tcs.Task;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -176,4 +176,5 @@
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.
 - Removed duplicate using directives and missing namespace references that prevented solution builds.
+- Guarded WPF test thread apartment configuration with an OS check to avoid CA1416 build errors on non-Windows hosts.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -336,3 +336,11 @@ Effective Prompts / Instructions that worked: Followed setup guidance to install
 Decisions & Rationale: Document limitations and rely on CI for Windows-specific build and test.
 Action Items: Rely on CI for successful build and test.
 Related Commits/PRs:
+[2025-09-16 10:00] Topic: WpfFact CA1416 guard
+Context: Build failed due to Windows-only `Thread.SetApartmentState` usage in WPF test case.
+Observations: Wrapped `SetApartmentState` call in `OperatingSystem.IsWindows` check; CA1416 no longer triggers but UI tests still fail to compile. `dotnet workload install wpf` remains unrecognized on Linux.
+Codex Limitations noticed: WPF workload and WindowsDesktop runtime unavailable; test builds fail with missing WPF members and packages.
+Effective Prompts / Instructions that worked: User request to guard Windows-specific API.
+Decisions & Rationale: Guard thread setup to silence analyzer while WindowsFact skips tests on non-Windows hosts.
+Action Items: Rely on CI for Windows build and test.
+Related Commits/PRs: e91c00d


### PR DESCRIPTION
## Summary
- guard `Thread.SetApartmentState` in WpfFact test case with `OperatingSystem.IsWindows` to prevent CA1416 cross-platform errors
- document CA1416 guard in changelog and collaboration tips

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: missing WPF members in UI tests after building core projects)*
- `dotnet test --settings tests.runsettings` *(fails: missing WPF members and xunit.abstractions package; WPF workload not available on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68b077c52bc48326a393d048815693e9