### PR TITLE
Handle nested binding names in TextBox hints

### DIFF
--- a/DesktopApplicationTemplate.UI/Behaviors/TextBoxHintBehavior.cs
+++ b/DesktopApplicationTemplate.UI/Behaviors/TextBoxHintBehavior.cs
@@ -99,6 +99,9 @@ public static class TextBoxHintBehavior
             throw new ArgumentNullException(nameof(propertyPath));
         }
 
-        return Regex.Replace(propertyPath, "(\\B[A-Z])", " $1");
+        var lastSegmentIndex = propertyPath.LastIndexOf('.');
+        var propertyName = lastSegmentIndex >= 0 ? propertyPath[(lastSegmentIndex + 1)..] : propertyPath;
+
+        return Regex.Replace(propertyName, "(\\B[A-Z])", " $1");
     }
 }

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -352,3 +352,11 @@ Effective Prompts / Instructions that worked: Build command supplied by user ins
 Decisions & Rationale: Log the missing tooling and rely on CI for Windows-specific build and test.
 Action Items: Rely on CI for verification.
 Related Commits/PRs:
+[2025-08-28 15:48] Topic: WPF workload not recognized
+Context: Installed .NET SDK 8.0.404 and attempted to install WPF workload.
+Observations: `dotnet workload install wpf` reported "Workload ID wpf is not recognized"; solution build and tests failed with missing WPF-specific types.
+Codex Limitations noticed: Linux container lacks WPF workload and WindowsDesktop runtime.
+Effective Prompts / Instructions that worked: Repository instruction to log environment constraints.
+Decisions & Rationale: Document limitation and rely on CI for Windows build and tests.
+Action Items: none
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- Handle nested binding paths in `TextBoxHintBehavior` so tooltips show only the final property segment
- Log environment limitation that WPF workloads aren't available in the Linux container

## Testing
- `dotnet restore DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: 'StubFileDialogService' type not found and WPF control names missing)*
- `dotnet test --settings tests.runsettings` *(fails: WPF tests missing UI control definitions; 'StubFileDialogService' type not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b07985f0ec8326b202a27427c3013b