### PR TITLE
Document topic-based note style

### DIFF
--- a/CollaborationGuidelines.txt
+++ b/CollaborationGuidelines.txt
@@ -31,6 +31,11 @@ GitHub Workflow Notes
 - After all code updates, run `dotnet test` and include the output in the pull request.
 - Only committed code is evaluated, so ensure the working tree is clean before calling `make_pr`.
 
+Documentation Style
+-------------------
+- When updating `docs/CHANGELOG.md` or `docs/CollaborationAndDebugTips.txt`, find the existing topic and insert new notes within that block.
+- Add a timestamp only when starting a new topic to prevent redundant entries.
+
 Draw.io Integration
 -------------------
 - Store architecture diagrams as `.drawio` files in the `design` directory.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -168,6 +168,7 @@
 - CI workflow runs on pushes to `feature/**` and `bugfix/**` branches, supports manual triggers, and skips checks for pull requests targeting `dev`.
 - Updated GitHub workflows to install the WPF workload instead of the deprecated `windowsdesktop` workload.
 - Reorganized collaboration log into topic-based blocks and added logging guidelines.
+- Clarified that new notes should extend existing topic blocks without repeating timestamps.
 - Removed Codex-specific tests and categories, eliminating the `CodexSafe` trait and custom `TestCategoryAttribute`.
 - Setup script now runs only the primary test suite after removing the Codex test project.
 - Removed Windows desktop runtime checks from tests so they run when Visual Studio provides the runtime.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -80,6 +80,7 @@ Codex Limitations noticed: `dotnet` CLI and WindowsDesktop runtime unavailable, 
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
 Action Items: Rely on CI for Windows-specific build and test.
+Notes: Documented convention to append updates within existing topic blocks and omit redundant timestamps.
 Related Commits/PRs:
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
@@ -320,14 +321,6 @@ Decisions & Rationale: Reduce duplication and simplify maintenance by sharing fi
 Action Items: Rely on CI for test execution.
 Related Commits/PRs:
 
-[2025-09-15 14:00] Topic: Platform-specific test execution
-Context: Documented SDK and WPF workload prerequisites and standard build/test commands.
-Observations: `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` fail because the .NET SDK and WindowsDesktop runtime are missing on Linux.
-Codex Limitations noticed: `dotnet` CLI and WindowsDesktop runtime unavailable, so tests cannot run locally.
-Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
-Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
-Action Items: Rely on CI for Windows-specific build and test.
-Related Commits/PRs:
 [2025-08-28 15:35] Topic: dotnet restore/build on Linux
 Context: Installed .NET SDK 8.0.404 via script to run restore and build commands.
 Observations: `dotnet restore DesktopApplicationTemplate.Core` succeeded; `dotnet workload install wpf` reported "Workload ID wpf is not recognized"; `dotnet build DesktopApplicationTemplate.sln` failed with CA1416 for `Thread.SetApartmentState` in `WpfFactAttribute`.


### PR DESCRIPTION
## Summary
- Describe documentation style so notes extend existing topics without repeating timestamps
- Clarify changelog instructions to append notes within topic blocks
- Clean up duplicate platform-specific test log entry and record the new convention

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b084d928848326959aa2b50635c6cf