### PR TITLE
Isolate WPF behavior tests and document runtime limits

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/TextBoxHintBehaviorTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/TextBoxHintBehaviorTests.cs
@@ -3,9 +3,11 @@ using DesktopApplicationTemplate.UI.Behaviors;
 using FluentAssertions;
 using Xunit;
 
+namespace DesktopApplicationTemplate.Tests;
+
 public class TextBoxHintBehaviorTests
 {
-    [Theory]
+    [WindowsTheory]
     [InlineData("ServiceName", "Service Name")]
     [InlineData("TcpIp", "Tcp Ip")]
     public void GetFriendlyName_Splits_CamelCase(string input, string expected)
@@ -13,7 +15,7 @@ public class TextBoxHintBehaviorTests
         TextBoxHintBehavior.GetFriendlyName(input).Should().Be(expected);
     }
 
-    [Fact]
+    [WindowsFact]
     public void GetFriendlyName_Throws_When_Null()
     {
         Action act = () => TextBoxHintBehavior.GetFriendlyName(null!);

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -75,8 +75,8 @@ Action Items: Migrate remaining classes to `ILogger<T>` and update tests.
 Related Commits/PRs:
 [2025-09-15 14:00] Topic: Platform-specific test execution
 Context: Documented SDK and WPF workload prerequisites and standard build/test commands.
-Observations: `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` fail because the .NET SDK and WindowsDesktop runtime are missing on Linux.
-Codex Limitations noticed: `dotnet` CLI and WindowsDesktop runtime unavailable, so tests cannot run locally.
+Observations: With the .NET SDK 8.0.404 installed, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing on Linux. Attempting `dotnet workload install wpf` reports "Workload ID wpf is not recognized".
+Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for `DesktopApplicationTemplate.Tests` and `DesktopApplicationTemplate.UI.Tests` fail to launch.
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
 Action Items: Rely on CI for Windows-specific build and test.


### PR DESCRIPTION
## Summary
- move `TextBoxHintBehaviorTests` into the WPF-focused `DesktopApplicationTemplate.UI.Tests` and guard it with Windows-specific test attributes
- note that WindowsDesktop runtime and WPF workload are unavailable on Linux, causing Windows-targeted tests to abort

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings --no-build` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b085f88a0083268699cc27794615b5