### PR TITLE
Refactor ThemeManager test to run without extra thread

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/ThemeManagerTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/ThemeManagerTests.cs
@@ -1,5 +1,4 @@
 using DesktopApplicationTemplate.UI.Services;
-using System.Threading;
 using System.Windows;
 using Xunit;
 
@@ -11,34 +10,19 @@ namespace DesktopApplicationTemplate.Tests
         public void ApplyTheme_LoadsResourceDictionary()
         {
 
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            var app = Application.Current ?? new Application();
+            try
             {
-                try
-                {
-                    var app = System.Windows.Application.Current ?? new System.Windows.Application();
-
-                    ThemeManager.ApplyTheme(true);
-                    Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("DarkTheme.xaml") == true);
-                    ThemeManager.ApplyTheme(false);
-                    Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("LightTheme.xaml") == true);
-                }
-                catch (Exception e)
-                {
-                    ex = e;
-                }
-                finally
-                {
-                    // ensure application instance is cleaned up on the same thread it was created
-                    System.Windows.Application.Current?.Shutdown();
-                }
-            });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-
-            ConsoleTestLogger.LogPass();
+                ThemeManager.ApplyTheme(true);
+                Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("DarkTheme.xaml") == true);
+                ThemeManager.ApplyTheme(false);
+                Assert.Contains(app.Resources.MergedDictionaries, d => d.Source?.OriginalString?.Contains("LightTheme.xaml") == true);
+                ConsoleTestLogger.LogPass();
+            }
+            finally
+            {
+                app.Shutdown();
+            }
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -180,4 +180,5 @@
 - Removed duplicate using directives and missing namespace references that prevented solution builds.
 - Guarded WPF test thread apartment configuration with an OS check to avoid CA1416 build errors on non-Windows hosts.
 - Added `StubFileDialogService` to test project and updated MQTT and FTP UI tests for API changes.
+- ThemeManager test executes on the current thread, removing manual thread usage.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -75,7 +75,7 @@ Action Items: Migrate remaining classes to `ILogger<T>` and update tests.
 Related Commits/PRs:
 [2025-09-15 14:00] Topic: Platform-specific test execution
 Context: Documented SDK and WPF workload prerequisites and standard build/test commands.
-Observations: With the .NET SDK 8.0.404 installed, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing on Linux. Attempting `dotnet workload install wpf` reports "Workload ID wpf is not recognized".
+Observations: With the .NET SDK 8.0.404 installed, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing on Linux. Attempting `dotnet workload install wpf` reports "Workload ID wpf is not recognized". Subsequent test runs after updating ThemeManager tests fail with missing `xunit.abstractions` and WindowsDesktop runtime errors.
 Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for `DesktopApplicationTemplate.Tests` and `DesktopApplicationTemplate.UI.Tests` fail to launch.
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.


### PR DESCRIPTION
## Summary
- simplify ThemeManager test by removing manual thread and running directly on existing thread
- document test runtime limitations

## Testing
- `dotnet workload install wpf` *(fails: Workload ID wpf is not recognized)*
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: missing xunit.abstractions and Microsoft.WindowsDesktop.App runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68b08c2e1a1c83268b9d8a0b5ade90bc