### PR TITLE
Initialize WPF application resources in FTP view tests

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/ApplicationResourceHelper.cs
+++ b/DesktopApplicationTemplate.UI.Tests/ApplicationResourceHelper.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+using System.Windows;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public static class ApplicationResourceHelper
+{
+    private static readonly Uri FormsUri = new("/DesktopApplicationTemplate.UI;component/Themes/Forms.xaml", UriKind.Relative);
+
+    public static void EnsureApplication()
+    {
+        var app = Application.Current ?? new Application();
+
+        if (!app.Resources.MergedDictionaries.Any(d => d.Source == FormsUri))
+        {
+            app.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = FormsUri });
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI.Tests/FtpServerAdvancedConfigViewTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/FtpServerAdvancedConfigViewTests.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Threading;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using FluentAssertions;
 using Moq;
-using Xunit;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -15,45 +13,28 @@ public class FtpServerAdvancedConfigViewTests
     [WpfFact]
     public void Initialize_SetsDataContext_AndLogger()
     {
-        FtpServerAdvancedConfigView? view = null;
-        FtpServerAdvancedConfigViewModel? vm = null;
-        ILoggingService? logger = null;
-        var thread = new Thread(() =>
-        {
-            logger = new Mock<ILoggingService>().Object;
-            vm = new FtpServerAdvancedConfigViewModel(new FtpServerOptions());
-            view = new FtpServerAdvancedConfigView(logger);
-            view.Initialize(vm);
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
+        ApplicationResourceHelper.EnsureApplication();
 
-        view!.DataContext.Should().Be(vm);
-        vm!.Logger.Should().BeSameAs(logger);
+        var logger = new Mock<ILoggingService>().Object;
+        var vm = new FtpServerAdvancedConfigViewModel(new FtpServerOptions());
+        var view = new FtpServerAdvancedConfigView(logger);
+
+        view.Initialize(vm);
+
+        view.DataContext.Should().Be(vm);
+        vm.Logger.Should().BeSameAs(logger);
     }
 
     [WpfFact]
     public void Initialize_Throws_When_ViewModelNull()
     {
-        Exception? ex = null;
-        var thread = new Thread(() =>
-        {
-            var view = new FtpServerAdvancedConfigView(new Mock<ILoggingService>().Object);
-            try
-            {
-                view.Initialize(null!);
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
+        ApplicationResourceHelper.EnsureApplication();
 
-        ex.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("vm");
+        var view = new FtpServerAdvancedConfigView(new Mock<ILoggingService>().Object);
+
+        Action act = () => view.Initialize(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("vm");
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/FtpServerEditViewTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/FtpServerEditViewTests.cs
@@ -1,5 +1,4 @@
-using System.Threading;
-using System.Windows.Controls;
+using System;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using FluentAssertions;
@@ -11,39 +10,22 @@ public class FtpServerEditViewTests
     [WpfFact]
     public void Constructor_SetsDataContext()
     {
-        FtpServerEditView? view = null;
-        var thread = new Thread(() =>
-        {
-            var vm = new FtpServerEditViewModel("ftp", new());
-            view = new FtpServerEditView(vm);
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
+        ApplicationResourceHelper.EnsureApplication();
 
-        view!.DataContext.Should().BeOfType<FtpServerEditViewModel>();
+        var vm = new FtpServerEditViewModel("ftp", new());
+        var view = new FtpServerEditView(vm);
+
+        view.DataContext.Should().BeOfType<FtpServerEditViewModel>();
     }
 
     [WpfFact]
     public void Constructor_Throws_When_ViewModelNull()
     {
-        Exception? ex = null;
-        var thread = new Thread(() =>
-        {
-            try
-            {
-                _ = new FtpServerEditView(null!);
-            }
-            catch (Exception e)
-            {
-                ex = e;
-            }
-        });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
+        ApplicationResourceHelper.EnsureApplication();
 
-        ex.Should().BeOfType<ArgumentNullException>()
-            .Which.ParamName.Should().Be("viewModel");
+        Action act = () => new FtpServerEditView(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .And.ParamName.Should().Be("viewModel");
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -181,4 +181,5 @@
 - Guarded WPF test thread apartment configuration with an OS check to avoid CA1416 build errors on non-Windows hosts.
 - Added `StubFileDialogService` to test project and updated MQTT and FTP UI tests for API changes.
 - ThemeManager test executes on the current thread, removing manual thread usage.
+- FTP view tests use a helper to initialize `Application` resources, eliminating manual thread setup.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -75,7 +75,7 @@ Action Items: Migrate remaining classes to `ILogger<T>` and update tests.
 Related Commits/PRs:
 [2025-09-15 14:00] Topic: Platform-specific test execution
 Context: Documented SDK and WPF workload prerequisites and standard build/test commands.
-Observations: With the .NET SDK 8.0.404 installed, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing on Linux. Attempting `dotnet workload install wpf` reports "Workload ID wpf is not recognized". Subsequent test runs after updating ThemeManager tests fail with missing `xunit.abstractions` and WindowsDesktop runtime errors.
+Observations: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime and `xunit.abstractions` package are missing on Linux. The `dotnet workload install wpf` step was removed since WPF ships with the SDK.
 Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for `DesktopApplicationTemplate.Tests` and `DesktopApplicationTemplate.UI.Tests` fail to launch.
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.


### PR DESCRIPTION
## Summary
- Add `ApplicationResourceHelper` to create an `Application` and merge Forms theme for WPF tests
- Use helper in FTP view tests and drop manual threads
- Document test environment constraints and helper usage in changelog

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings --no-build` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime and xunit.abstractions package missing on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68b08e1706d483268991df938996f612