### PR TITLE
Exclude TestCommon from test discovery

### DIFF
--- a/TestCommon/TestCommon.csproj
+++ b/TestCommon/TestCommon.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>DesktopApplicationTemplate.Tests</RootNamespace>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -168,6 +168,7 @@
 - CI workflow runs on pushes to `feature/**` and `bugfix/**` branches, supports manual triggers, and skips checks for pull requests targeting `dev`.
 - Updated GitHub workflows to install the WPF workload instead of the deprecated `windowsdesktop` workload.
 - Reorganized collaboration log into topic-based blocks and added logging guidelines.
+- Marked `TestCommon` as a non-test project to prevent `dotnet test` from discovering it.
 - Clarified that new notes should extend existing topic blocks without repeating timestamps.
 - Removed Codex-specific tests and categories, eliminating the `CodexSafe` trait and custom `TestCategoryAttribute`.
 - Setup script now runs only the primary test suite after removing the Codex test project.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -314,12 +314,12 @@ Action Items: Rely on CI for verification.
 Related Commits/PRs:
 [2025-09-15 10:00] Topic: Shared test utilities
 Context: Introduced TestCommon library for reusable fixtures and consolidated ConsoleTestLogger and Windows/Wpf test attributes.
-Observations: All test projects reference TestCommon to remove duplicated code; unable to run tests locally due to missing .NET SDK and WindowsDesktop runtime.
-Codex Limitations noticed: `dotnet` CLI and Windows desktop runtime unavailable in the container.
+Observations: All test projects reference TestCommon to remove duplicated code and now skip it as a test project; tests still cannot run due to missing WindowsDesktop runtime.
+Codex Limitations noticed: Windows desktop runtime unavailable in the container.
 Effective Prompts / Instructions that worked: User request to centralize shared test helpers.
 Decisions & Rationale: Reduce duplication and simplify maintenance by sharing fixtures.
 Action Items: Rely on CI for test execution.
-Related Commits/PRs:
+Related Commits/PRs: e6a90a3, ed1d219
 
 [2025-08-28 15:35] Topic: dotnet restore/build on Linux
 Context: Installed .NET SDK 8.0.404 via script to run restore and build commands.


### PR DESCRIPTION
## Summary
- mark TestCommon library as not being a test project
- document the change in changelog and collaboration tips

## Testing
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b08f653d908326b6287e0aad293850