### PR TITLE
Include Forms theme resource

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -36,6 +36,8 @@
     <Resource Include="Themes/ToggleSwitch.xaml" />
     <Resource Include="Themes/MqttTagSubscriptionsView.xaml" />
     <Resource Include="Themes/DataFlowDiagram.xaml" />
+    <Resource Include="Themes/Forms.xaml" />
+    <Page Include="Themes/Forms.xaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Forms theme explicitly references the UI assembly for `TextBoxHintBehavior` to avoid missing type errors.
 - System namespace references and form style resources compiled to eliminate XAML parse failures.
 - Marked main window `ContentFrame` public so UI tests can inspect navigation.
+- Included `Forms.xaml` in theme resources with Page build action.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -80,7 +80,7 @@ Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
 Action Items: Rely on CI for Windows-specific build and test.
-Notes: Documented convention to append updates within existing topic blocks and omit redundant timestamps.
+Notes: Documented convention to append updates within existing topic blocks and omit redundant timestamps. After adding `Forms.xaml`, `dotnet test --settings tests.runsettings` still aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing and `dotnet workload install wpf` remains unrecognized on Linux.
 Related Commits/PRs:
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- include Forms.xaml in UI theme resources and compile as a Page
- log missing WindowsDesktop runtime when running tests

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b090c50f008326adb671d34b4b2053