### PR TITLE
docs: log Windows runtime limitation

### DIFF
--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -80,7 +80,7 @@ Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
 Action Items: Rely on CI for Windows-specific build and test.
-Notes: Documented convention to append updates within existing topic blocks and omit redundant timestamps. After adding `Forms.xaml`, `dotnet test --settings tests.runsettings` still aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing and `dotnet workload install wpf` remains unrecognized on Linux. WPF projects require Windows or the WindowsDesktop runtime; without it, builds produce `InitializeComponent` and `NETSDK1100` errors.
+Notes: Documented convention to append updates within existing topic blocks and omit redundant timestamps. After adding `Forms.xaml`, `dotnet test --settings tests.runsettings` still aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing and `dotnet workload install wpf` remains unrecognized on Linux. WPF projects require Windows or the WindowsDesktop runtime; without it, builds produce `InitializeComponent` and `NETSDK1100` errors. Current run: installed .NET SDK 8.0.404 via dotnet-install; `dotnet workload install wpf` still unrecognized, and `dotnet test --settings tests.runsettings` aborts due to missing Microsoft.WindowsDesktop.App 8.0.0 runtime.
 Related Commits/PRs:
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- document that dotnet wpf workload fails to install and tests abort without WindowsDesktop runtime

## Testing
- `dotnet workload install wpf`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0996a4ff48326b25349f6ab0f5bee