### PR TITLE
Ensure Forms theme uses assembly-qualified behaviors namespace

### DIFF
--- a/DesktopApplicationTemplate.UI/Themes/Forms.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/Forms.xaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors">
+                    xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI">
     <!-- Reusable styles for form labels and input controls -->
     <Style x:Key="FormLabel" TargetType="TextBlock">
         <Setter Property="Margin" Value="0,0,10,5" />

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -378,3 +378,11 @@ Effective Prompts / Instructions that worked: User provided error list highlight
 Decisions & Rationale: Target only net8.0 because Windows-specific code lives in the Windows library.
 Action Items: Rely on CI for WPF validation.
 Related Commits/PRs:
+[2025-09-22 10:00] Topic: TextBox hint behavior namespace
+Context: Verified TextBoxHintBehavior is public and ensured Forms.xaml references the behaviors namespace with assembly qualification.
+Observations: Attempted dotnet restore/build/test but dotnet CLI is unavailable in container.
+Codex Limitations noticed: .NET SDK and WindowsDesktop runtime missing; build and tests cannot run.
+Effective Prompts / Instructions that worked: User request to confirm UI build references and behavior visibility.
+Decisions & Rationale: Added assembly-qualified namespace to avoid XAML parse errors and will rely on CI for verification.
+Action Items: Rely on CI.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- qualify behaviors namespace in `Forms.xaml` so `TextBoxHintBehavior` resolves from the UI assembly
- log environment limitation when verifying behavior visibility

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09aa2380483269925dc527e24ba4c