### PR TITLE
test: share WPF Application across UI tests

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/ApplicationFixture.cs
+++ b/DesktopApplicationTemplate.UI.Tests/ApplicationFixture.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Windows;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public sealed class ApplicationFixture : IDisposable
+{
+    public ApplicationFixture()
+    {
+        if (Application.Current is null)
+        {
+            _ = new Application();
+        }
+
+        ApplicationResourceHelper.EnsureApplication();
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+[CollectionDefinition("Application", DisableParallelization = true)]
+public sealed class ApplicationCollection : ICollectionFixture<ApplicationFixture>
+{
+}

--- a/DesktopApplicationTemplate.UI.Tests/ApplicationResourceHelper.cs
+++ b/DesktopApplicationTemplate.UI.Tests/ApplicationResourceHelper.cs
@@ -10,7 +10,12 @@ public static class ApplicationResourceHelper
 
     public static void EnsureApplication()
     {
-        var app = Application.Current ?? new Application();
+        var app = Application.Current;
+
+        if (app is null)
+        {
+            return;
+        }
 
         if (!app.Resources.MergedDictionaries.Any(d => d.Source == FormsUri))
         {

--- a/DesktopApplicationTemplate.UI.Tests/FtpServerAdvancedConfigViewTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/FtpServerAdvancedConfigViewTests.cs
@@ -8,13 +8,12 @@ using Moq;
 
 namespace DesktopApplicationTemplate.Tests;
 
+[Collection("Application")]
 public class FtpServerAdvancedConfigViewTests
 {
     [WpfFact]
     public void Initialize_SetsDataContext_AndLogger()
     {
-        ApplicationResourceHelper.EnsureApplication();
-
         var logger = new Mock<ILoggingService>().Object;
         var vm = new FtpServerAdvancedConfigViewModel(new FtpServerOptions());
         var view = new FtpServerAdvancedConfigView(logger);
@@ -28,8 +27,6 @@ public class FtpServerAdvancedConfigViewTests
     [WpfFact]
     public void Initialize_Throws_When_ViewModelNull()
     {
-        ApplicationResourceHelper.EnsureApplication();
-
         var view = new FtpServerAdvancedConfigView(new Mock<ILoggingService>().Object);
 
         Action act = () => view.Initialize(null!);

--- a/DesktopApplicationTemplate.UI.Tests/FtpServerEditViewTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/FtpServerEditViewTests.cs
@@ -5,13 +5,12 @@ using FluentAssertions;
 
 namespace DesktopApplicationTemplate.Tests;
 
+[Collection("Application")]
 public class FtpServerEditViewTests
 {
     [WpfFact]
     public void Constructor_SetsDataContext()
     {
-        ApplicationResourceHelper.EnsureApplication();
-
         var vm = new FtpServerEditViewModel("ftp", new());
         var view = new FtpServerEditView(vm);
 
@@ -21,8 +20,6 @@ public class FtpServerEditViewTests
     [WpfFact]
     public void Constructor_Throws_When_ViewModelNull()
     {
-        ApplicationResourceHelper.EnsureApplication();
-
         Action act = () => new FtpServerEditView(null!);
 
         act.Should().Throw<ArgumentNullException>()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -185,4 +185,5 @@
 - Added `StubFileDialogService` to test project and updated MQTT and FTP UI tests for API changes.
 - ThemeManager test executes on the current thread, removing manual thread usage.
 - FTP view tests use a helper to initialize `Application` resources, eliminating manual thread setup.
+- WPF UI tests share a single `Application` via collection fixture and disable parallelization to prevent multiple initializations.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -75,13 +75,13 @@ Action Items: Migrate remaining classes to `ILogger<T>` and update tests.
 Related Commits/PRs:
 [2025-09-15 14:00] Topic: Platform-specific test execution
 Context: Documented SDK and WPF workload prerequisites and standard build/test commands.
-Observations: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime and `xunit.abstractions` package are missing on Linux. The `dotnet workload install wpf` step was removed since WPF ships with the SDK.
-Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for `DesktopApplicationTemplate.Tests` and `DesktopApplicationTemplate.UI.Tests` fail to launch.
+Observations: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings --no-build` aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime and `xunit.abstractions` package are missing on Linux. The `dotnet workload install wpf` step was removed since WPF ships with the SDK. In the current container, the `dotnet` CLI itself is not available, so restore, build, and test commands cannot run.
+Codex Limitations noticed: WindowsDesktop runtime unavailable, so test hosts for `DesktopApplicationTemplate.Tests` and `DesktopApplicationTemplate.UI.Tests` fail to launch. The .NET SDK is also missing, preventing `dotnet` commands from executing.
 Effective Prompts / Instructions that worked: Repository guidelines to log environment constraints and rely on CI for verification.
 Decisions & Rationale: Highlight prerequisites and note that CI or a Windows host is required for full test execution.
 Action Items: Rely on CI for Windows-specific build and test.
 Notes: Documented convention to append updates within existing topic blocks and omit redundant timestamps. After adding `Forms.xaml`, `dotnet test --settings tests.runsettings` still aborts because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing and `dotnet workload install wpf` remains unrecognized on Linux. WPF projects require Windows or the WindowsDesktop runtime; without it, builds produce `InitializeComponent` and `NETSDK1100` errors.
-Related Commits/PRs:
+Related Commits/PRs: 8517691, 4c0dbb5
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- initialize WPF Application once per collection with a fixture
- reuse Application.Current in resource helper
- document missing .NET SDK and disable parallel UI tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09b7211c483268c8d6f4e5fb5b0cd