### PR TITLE
Fix Forms.xaml namespace and duplicate inclusion

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -36,7 +36,6 @@
     <Resource Include="Themes/ToggleSwitch.xaml" />
     <Resource Include="Themes/MqttTagSubscriptionsView.xaml" />
     <Resource Include="Themes/DataFlowDiagram.xaml" />
-      <Page Include="Themes/Forms.xaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopApplicationTemplate.UI/Themes/Forms.xaml
+++ b/DesktopApplicationTemplate.UI/Themes/Forms.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI">
+    xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors">
     <!-- Reusable styles for form labels and input controls -->
     <Style x:Key="FormLabel" TargetType="TextBlock">
         <Setter Property="Margin" Value="0,0,10,5" />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,7 @@
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.
 - Service list averages use one-way bindings to avoid runtime parse exceptions.
 - Main window declares behaviors namespace to prevent XAML parse errors.
-- Forms theme explicitly references the UI assembly for `TextBoxHintBehavior` to avoid missing type errors.
+- Forms theme uses project namespaces without assembly qualifiers and relies on SDK implicit page inclusion to load the `FormField` style without duplicate XAML item errors.
 - System namespace references and form style resources compiled to eliminate XAML parse failures.
 - Marked main window `ContentFrame` public so UI tests can inspect navigation.
 - Included `Forms.xaml` in theme resources with Page build action.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -154,6 +154,7 @@ Related Commits/PRs:
 [2025-08-27 17:47] Topic: System namespace and FormField style
 Context: XAML errors for missing System.Object and FormField style.
 Observations: Removed explicit assembly qualifier in Forms.xaml and compiled it as a Page to ensure FormField style loads.
+Additional Notes: Later removed the manual Page include since the SDK already includes XAML files implicitly, avoiding duplicate item errors.
 Effective Prompts / Instructions that worked: User request to resolve assembly and resource errors.
 Decisions & Rationale: Use project namespaces and compile resources to avoid runtime parse failures.
 Action Items: Validate changes on Windows CI.


### PR DESCRIPTION
## Summary
- use project namespace in Forms.xaml so TextBoxHintBehavior resolves
- rely on SDK implicit page inclusion and remove explicit Forms.xaml entry
- document XAML build fix in changelog and collaboration tips

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aa2ae0748326a61292aaf0b44a8d