### PR TITLE
Target TextBox in AutoToolTip behavior to resolve installer warning

### DIFF
--- a/DesktopApplicationTemplate.UI/Behaviors/TextBoxHintBehavior.cs
+++ b/DesktopApplicationTemplate.UI/Behaviors/TextBoxHintBehavior.cs
@@ -23,33 +23,35 @@ public static class TextBoxHintBehavior
             new PropertyMetadata(false, OnAutoToolTipChanged));
 
     /// <summary>
-    /// Gets the value of the <see cref="AutoToolTipProperty"/> for the specified object.
+    /// Gets the value of the <see cref="AutoToolTipProperty"/> for the specified text box.
     /// </summary>
-    /// <param name="obj">The dependency object.</param>
+    /// <param name="textBox">The text box.</param>
     /// <returns>The current value.</returns>
-    public static bool GetAutoToolTip(DependencyObject obj)
+    [AttachedPropertyBrowsableForType(typeof(TextBox))]
+    public static bool GetAutoToolTip(TextBox textBox)
     {
-        if (obj is null)
+        if (textBox is null)
         {
-            throw new ArgumentNullException(nameof(obj));
+            throw new ArgumentNullException(nameof(textBox));
         }
 
-        return (bool)obj.GetValue(AutoToolTipProperty);
+        return (bool)textBox.GetValue(AutoToolTipProperty);
     }
 
     /// <summary>
-    /// Sets the value of the <see cref="AutoToolTipProperty"/> for the specified object.
+    /// Sets the value of the <see cref="AutoToolTipProperty"/> for the specified text box.
     /// </summary>
-    /// <param name="obj">The dependency object.</param>
+    /// <param name="textBox">The text box.</param>
     /// <param name="value">The value to set.</param>
-    public static void SetAutoToolTip(DependencyObject obj, bool value)
+    [AttachedPropertyBrowsableForType(typeof(TextBox))]
+    public static void SetAutoToolTip(TextBox textBox, bool value)
     {
-        if (obj is null)
+        if (textBox is null)
         {
-            throw new ArgumentNullException(nameof(obj));
+            throw new ArgumentNullException(nameof(textBox));
         }
 
-        obj.SetValue(AutoToolTipProperty, value);
+        textBox.SetValue(AutoToolTipProperty, value);
     }
 
     private static void OnAutoToolTipChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@
 - System namespace references and form style resources compiled to eliminate XAML parse failures.
 - Marked main window `ContentFrame` public so UI tests can inspect navigation.
 - Included `Forms.xaml` in theme resources with Page build action.
+- Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -353,7 +353,7 @@ Action Items: Rely on CI for WPF validation.
 Related Commits/PRs:
 [2025-09-22 10:00] Topic: TextBox hint behavior namespace
 Context: Verified TextBoxHintBehavior is public and ensured Forms.xaml references the behaviors namespace with assembly qualification.
-Observations: Verified Forms.xaml already contained the assembly-qualified behaviors namespace and attempted dotnet restore/build/test, but the dotnet CLI is unavailable in this container.
+Observations: Verified Forms.xaml already contained the assembly-qualified behaviors namespace, added TextBox-specific attached property accessors with [AttachedPropertyBrowsableForType] to expose AutoToolTip to the installer project, and attempted dotnet restore/build/test, but the dotnet CLI is unavailable in this container.
 Codex Limitations noticed: .NET SDK and WindowsDesktop runtime missing; build and tests cannot run.
 Effective Prompts / Instructions that worked: User request to confirm UI build references and behavior visibility.
 Decisions & Rationale: Added assembly-qualified namespace to avoid XAML parse errors and will rely on CI for verification.


### PR DESCRIPTION
## Summary
- Restrict AutoToolTip attached property to `TextBox` and annotate with `AttachedPropertyBrowsableForType`
- Log AutoToolTip fix and environment limitations
- Note installer window now references `TextBoxHintBehavior.AutoToolTip` without warnings

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6d12eb083268ca07c4fc6ae6731