### PR TITLE
Use plain text console test logger

### DIFF
--- a/TestCommon/ConsoleTestLogger.cs
+++ b/TestCommon/ConsoleTestLogger.cs
@@ -9,7 +9,7 @@ public static class ConsoleTestLogger
     {
         var prevColor = Console.ForegroundColor;
         Console.ForegroundColor = ConsoleColor.Green;
-        Console.WriteLine("\u001b[1m[Tests] " + testName + " PASSED\u001b[0m");
+        Console.WriteLine($"[Tests] {testName} PASSED");
         Console.ForegroundColor = prevColor;
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -188,4 +188,5 @@
 - Added `StubFileDialogService` to test project and updated MQTT and FTP UI tests for API changes.
 - ThemeManager test executes on the current thread, removing manual thread usage.
 - FTP view tests use a helper to initialize `Application` resources, eliminating manual thread setup.
+- Console test logger writes plain text messages to avoid Visual Studio RPC errors when expanding test results.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -337,8 +337,8 @@ Related Commits/PRs:
 
 [2025-09-20 10:00] Topic: Console test logger usings
 Context: Added global using statements for ConsoleTestLogger across test projects.
-Observations: dotnet SDK 8.0.404 required by global.json is unavailable; commands fall back to 8.0.119 and fail.
-Codex Limitations noticed: Missing .NET 8.0.404 SDK and WindowsDesktop runtime prevent building or running tests.
+Observations: Installed .NET SDK 8.0.404 and replaced escape sequences with plain text; `dotnet restore` and `dotnet build` succeeded, but `dotnet test` aborted because the Microsoft.WindowsDesktop.App runtime is missing.
+Codex Limitations noticed: WindowsDesktop runtime absent on Linux so tests cannot run after building.
 Effective Prompts / Instructions that worked: Repository guidance on logging limitations and updating shared test utilities.
 Decisions & Rationale: Consolidate logger access with global usings while documenting environment constraints.
 Action Items: Rely on CI for verification.


### PR DESCRIPTION
## Summary
- remove escape sequences from ConsoleTestLogger and rely on foreground color
- document Visual Studio test log fix in changelog and collaboration tips

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: You must install or update .NET to run this application. Framework: 'Microsoft.WindowsDesktop.App', version '8.0.0')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b978390483268a1b8901f803d64b