### PR TITLE
Capture dispatcher exceptions in UI tests

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/BubblyWindowStyleTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/BubblyWindowStyleTests.cs
@@ -1,6 +1,5 @@
 using DesktopApplicationTemplate.UI;
 using System;
-using System.Threading;
 using System.Windows;
 using Xunit;
 
@@ -11,34 +10,18 @@ namespace DesktopApplicationTemplate.Tests
         [WindowsFact]
         public void BubblyWindowStyle_LoadsWithRoundedCorners()
         {
-
-            Exception? capturedException = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-                try
+                var resourceDictionary = new ResourceDictionary
                 {
-                    var resourceDictionary = new ResourceDictionary
-                    {
-                        Source = new Uri("pack://application:,,,/DesktopApplicationTemplate.UI;component/Themes/BubblyWindow.xaml")
-                    };
+                    Source = new Uri("pack://application:,,,/DesktopApplicationTemplate.UI;component/Themes/BubblyWindow.xaml")
+                };
 
-                    Assert.True(resourceDictionary.Contains("BubblyWindowStyle"));
-                    _ = (Style)resourceDictionary["BubblyWindowStyle"];
-                }
-                catch (Exception ex)
-                {
-                    capturedException = ex;
-                }
+                Assert.True(resourceDictionary.Contains("BubblyWindowStyle"));
+                _ = (Style)resourceDictionary["BubblyWindowStyle"];
+
+                ConsoleTestLogger.LogPass();
             });
-
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-
-            if (capturedException != null)
-                throw capturedException;
-
-            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/CreateServicePageTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/CreateServicePageTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -16,7 +15,7 @@ public class CreateServicePageTests
     public void ServiceType_Click_RaisesTcpSelected()
     {
         string? receivedName = null;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -25,9 +24,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { button, new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         receivedName.Should().Be("TCP1");
     }
 
@@ -35,7 +31,7 @@ public class CreateServicePageTests
     public void ServiceType_Click_RaisesFtpServerSelected()
     {
         string? receivedName = null;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -44,9 +40,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { button, new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         receivedName.Should().Be("FTP Server1");
     }
 
@@ -54,7 +47,7 @@ public class CreateServicePageTests
     public void ServiceType_Click_RaisesHeartbeatSelected()
     {
         string? receivedName = null;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -63,9 +56,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { button, new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         receivedName.Should().Be("Heartbeat1");
     }
 
@@ -73,7 +63,7 @@ public class CreateServicePageTests
     public void ServiceType_Click_RaisesHidSelected()
     {
         string? receivedName = null;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -82,9 +72,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { button, new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         receivedName.Should().Be("HID1");
     }
 
@@ -92,7 +79,7 @@ public class CreateServicePageTests
     public void ServiceType_Click_RaisesCsvSelected()
     {
         string? receivedName = null;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -101,9 +88,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { button, new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         receivedName.Should().Be("CSV Creator1");
     }
 
@@ -111,7 +95,7 @@ public class CreateServicePageTests
     public void ServiceType_Click_RaisesHttpSelected()
     {
         string? receivedName = null;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -120,9 +104,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("ServiceType_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { button, new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         receivedName.Should().Be("HTTP1");
     }
 
@@ -130,7 +111,7 @@ public class CreateServicePageTests
     public void Cancel_Click_RaisesCancelled()
     {
         bool cancelled = false;
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var vm = new CreateServiceViewModel();
             var page = new CreateServicePage(vm);
@@ -138,9 +119,6 @@ public class CreateServicePageTests
             var method = typeof(CreateServicePage).GetMethod("Cancel_Click", BindingFlags.Instance | BindingFlags.NonPublic)!;
             method.Invoke(page, new object[] { new Button(), new RoutedEventArgs() });
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
         cancelled.Should().BeTrue();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewCreateNavigationTests.cs
@@ -22,8 +22,7 @@ public class MainViewCreateNavigationTests
     [WindowsFact]
     public void NavigateToTcp_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -57,16 +56,12 @@ public class MainViewCreateNavigationTests
             view.ContentFrame.Content.Should().BeOfType<TcpCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void NavigateToFtpServer_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -102,16 +97,12 @@ public class MainViewCreateNavigationTests
             view.ContentFrame.Content.Should().BeOfType<FtpServerCreateView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void NavigateToHid_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -149,16 +140,12 @@ public class MainViewCreateNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HidCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void NavigateToFileObserver_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -197,16 +184,12 @@ public class MainViewCreateNavigationTests
             view.ContentFrame.Content.Should().BeOfType<FileObserverCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void NavigateToScp_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -242,8 +225,5 @@ public class MainViewCreateNavigationTests
             view.ContentFrame.Content.Should().BeOfType<ScpCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewCsvNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewCsvNavigationTests.cs
@@ -23,8 +23,7 @@ public class MainViewCsvNavigationTests
     [WindowsFact]
     public void NavigateToCsvCreator_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -60,16 +59,12 @@ public class MainViewCsvNavigationTests
             view.ContentFrame.Content.Should().BeOfType<CsvCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void DoubleClickCsvService_OpensEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -118,8 +113,5 @@ public class MainViewCsvNavigationTests
             view.ContentFrame.Content.Should().BeOfType<CsvEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewFileObserverNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewFileObserverNavigationTests.cs
@@ -23,8 +23,7 @@ public class MainViewFileObserverNavigationTests
     [WindowsFact]
     public void EditFileObserverService_ShowsEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -70,16 +69,12 @@ public class MainViewFileObserverNavigationTests
             view.ContentFrame.Content.Should().BeOfType<FileObserverEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-       thread.Join();
     }
 
     [WindowsFact]
     public void DoubleClickFileObserverService_OpensEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -128,8 +123,5 @@ public class MainViewFileObserverNavigationTests
             view.ContentFrame.Content.Should().BeOfType<FileObserverEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewHeartbeatNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewHeartbeatNavigationTests.cs
@@ -23,8 +23,7 @@ public class MainViewHeartbeatNavigationTests
     [WindowsFact]
     public void NavigateToHeartbeat_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -59,16 +58,12 @@ public class MainViewHeartbeatNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HeartbeatCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void EditHeartbeatService_ShowsEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -112,16 +107,12 @@ public class MainViewHeartbeatNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HeartbeatEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void DoubleClickHeartbeatService_OpensEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -168,8 +159,5 @@ public class MainViewHeartbeatNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HeartbeatEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewHidNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewHidNavigationTests.cs
@@ -23,8 +23,7 @@ public class MainViewHidNavigationTests
     [WindowsFact]
     public void EditHidService_ShowsEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -69,16 +68,12 @@ public class MainViewHidNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HidEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void DoubleClickHidService_OpensEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -126,8 +121,5 @@ public class MainViewHidNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HidEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewHttpNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewHttpNavigationTests.cs
@@ -22,8 +22,7 @@ public class MainViewHttpNavigationTests
     [WindowsFact]
     public void NavigateToHttp_ShowsCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -58,16 +57,12 @@ public class MainViewHttpNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HttpCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void EditHttpService_ShowsEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -111,16 +106,12 @@ public class MainViewHttpNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HttpEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void DoubleClickHttpService_OpensEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -167,8 +158,5 @@ public class MainViewHttpNavigationTests
             view.ContentFrame.Content.Should().BeOfType<HttpEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewMqttNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewMqttNavigationTests.cs
@@ -20,8 +20,7 @@ public class MainViewMqttNavigationTests
     [WindowsFact]
     public void CreateMqttService_Advanced_Back_ReturnsToCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -66,16 +65,12 @@ public class MainViewMqttNavigationTests
             view.ContentFrame.Content.Should().BeOfType<MqttCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void EditMqttService_ShowsEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -124,8 +119,5 @@ public class MainViewMqttNavigationTests
             view.ContentFrame.Content.Should().BeOfType<MqttEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewScpNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewScpNavigationTests.cs
@@ -22,8 +22,7 @@ public class MainViewScpNavigationTests
     [WindowsFact]
     public void EditScpService_ShowsEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -68,16 +67,12 @@ public class MainViewScpNavigationTests
             view.ContentFrame.Content.Should().BeOfType<ScpEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 
     [WindowsFact]
     public void DoubleClickScpService_OpensEditView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -125,8 +120,5 @@ public class MainViewScpNavigationTests
             view.ContentFrame.Content.Should().BeOfType<ScpEditServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewTcpEditTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewTcpEditTests.cs
@@ -24,7 +24,7 @@ public class MainViewTcpEditTests
     [WindowsFact]
     public void EditTcpService_SavesUpdatedOptions()
     {
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var startup = new Mock<IStartupService>();
@@ -97,8 +97,5 @@ public class MainViewTcpEditTests
             File.ReadAllText(tempFile).Should().Contain("127.0.0.1");
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewTcpNavigationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewTcpNavigationTests.cs
@@ -20,8 +20,7 @@ public class MainViewTcpNavigationTests
     [WindowsFact]
     public void CreateTcpService_Advanced_Back_ReturnsToCreateView()
     {
-
-        var thread = new Thread(() =>
+        ApplicationResourceHelper.RunOnDispatcher(() =>
         {
             var logger = new LoggingService(new NullRichTextLogger());
             var fileDialog = new Mock<IFileDialogService>();
@@ -66,8 +65,5 @@ public class MainViewTcpNavigationTests
             view.ContentFrame.Content.Should().BeOfType<TcpCreateServiceView>();
             ConsoleTestLogger.LogPass();
         });
-        thread.SetApartmentState(ApartmentState.STA);
-        thread.Start();
-        thread.Join();
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/MainViewTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewTests.cs
@@ -20,260 +20,154 @@ namespace DesktopApplicationTemplate.Tests
         [WindowsFact]
         public void MainView_ServiceList_HasMaxHeight()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
+                var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
 
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
-                    var view = new MainView(vm);
-                    var list = view.FindName("ServiceList") as System.Windows.Controls.ListBox;
-                    Assert.Equal(350, list?.MaxHeight);
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
+                var view = new MainView(vm);
+                var list = view.FindName("ServiceList") as System.Windows.Controls.ListBox;
+                Assert.Equal(350, list?.MaxHeight);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void MainView_HasCloseCommandBinding()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
-                    var view = new MainView(vm);
-                    bool bound = view.CommandBindings.OfType<CommandBinding>()
-                                        .Any(b => b.Command == SystemCommands.CloseWindowCommand);
-                    Assert.True(bound);
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
+                var view = new MainView(vm);
+                bool bound = view.CommandBindings.OfType<CommandBinding>()
+                                    .Any(b => b.Command == SystemCommands.CloseWindowCommand);
+                Assert.True(bound);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void MainView_HasMinimizeCommandBinding()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
-                    var view = new MainView(vm);
-                    bool bound = view.CommandBindings.OfType<CommandBinding>()
-                                        .Any(b => b.Command == SystemCommands.MinimizeWindowCommand);
-                    Assert.True(bound);
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                var configPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString() + ".json");
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
+                var view = new MainView(vm);
+                bool bound = view.CommandBindings.OfType<CommandBinding>()
+                                    .Any(b => b.Command == SystemCommands.MinimizeWindowCommand);
+                Assert.True(bound);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void OpenServiceEditor_NonCsv_SetsContentFrame()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
-                    var view = new MainView(vm);
-                    var svc = new ServiceViewModel { DisplayName = "TCP - Test", ServiceType = "TCP" };
-                    svc.SetColorsByType();
-                    var method = typeof(MainView).GetMethod("OpenServiceEditor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    method?.Invoke(view, new object[] { svc });
-                    Assert.NotNull(view.ContentFrame.Content);
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
+                var view = new MainView(vm);
+                var svc = new ServiceViewModel { DisplayName = "TCP - Test", ServiceType = "TCP" };
+                svc.SetColorsByType();
+                var method = typeof(MainView).GetMethod("OpenServiceEditor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                method?.Invoke(view, new object[] { svc });
+                Assert.NotNull(view.ContentFrame.Content);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void OpenServiceEditor_CsvCreator_ShowsWindow()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var csvVm = new CsvViewerViewModel(new StubFileDialogService(), configPath);
-                    var vm = new MainViewModel(new CsvService(csvVm), networkVm, network.Object, null, servicesPath);
-                    var view = new MainView(vm);
-                    var svc = new ServiceViewModel { DisplayName = "CSV - Test", ServiceType = "CSV Creator" };
-                    svc.SetColorsByType();
-                    // Ensure window closes immediately to avoid blocking
-                    System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() => csvVm.CloseCommand.Execute(null)));
-                    var method = typeof(MainView).GetMethod("OpenServiceEditor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    method?.Invoke(view, new object[] { svc });
-                    Assert.NotNull(view); // method executed without exception
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var csvVm = new CsvViewerViewModel(new StubFileDialogService(), configPath);
+                var vm = new MainViewModel(new CsvService(csvVm), networkVm, network.Object, null, servicesPath);
+                var view = new MainView(vm);
+                var svc = new ServiceViewModel { DisplayName = "CSV - Test", ServiceType = "CSV Creator" };
+                svc.SetColorsByType();
+                System.Windows.Threading.Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() => csvVm.CloseCommand.Execute(null)));
+                var method = typeof(MainView).GetMethod("OpenServiceEditor", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                method?.Invoke(view, new object[] { svc });
+                Assert.NotNull(view);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void MainView_KeyDown_IgnoresNonEscape()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
-                    vm.SelectedService = new ServiceViewModel { DisplayName = "Svc", ServiceType = "TCP" };
-                    var view = new MainView(vm);
+                var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
+                vm.SelectedService = new ServiceViewModel { DisplayName = "Svc", ServiceType = "TCP" };
+                var view = new MainView(vm);
 
-                    var method = typeof(MainView).GetMethod("MainView_KeyDown", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    var src = new TestPresentationSource();
+                var method = typeof(MainView).GetMethod("MainView_KeyDown", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var src = new TestPresentationSource();
 
-                    var dArgs = new KeyEventArgs(Keyboard.PrimaryDevice, src, 0, Key.D) { RoutedEvent = Keyboard.KeyDownEvent };
-                    method?.Invoke(view, new object[] { view, dArgs });
-                    Assert.NotNull(vm.SelectedService);
+                var dArgs = new KeyEventArgs(Keyboard.PrimaryDevice, src, 0, Key.D) { RoutedEvent = Keyboard.KeyDownEvent };
+                method?.Invoke(view, new object[] { view, dArgs });
+                Assert.NotNull(vm.SelectedService);
 
-                    var escArgs = new KeyEventArgs(Keyboard.PrimaryDevice, src, 0, Key.Escape) { RoutedEvent = Keyboard.KeyDownEvent };
-                    method?.Invoke(view, new object[] { view, escArgs });
-                    Assert.Null(vm.SelectedService);
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                var escArgs = new KeyEventArgs(Keyboard.PrimaryDevice, src, 0, Key.Escape) { RoutedEvent = Keyboard.KeyDownEvent };
+                method?.Invoke(view, new object[] { view, escArgs });
+                Assert.Null(vm.SelectedService);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void HeaderBar_DoubleClick_TogglesWindowState()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-            try
-            {
-                ApplicationResourceHelper.EnsureApplication();
-                    var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
-                    var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
-                    Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
-                    var network = new Mock<INetworkConfigurationService>();
-                    var networkVm = new NetworkConfigurationViewModel(network.Object);
-                    var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
-                    var view = new MainView(vm) { WindowState = WindowState.Normal };
-                    var method = typeof(MainView).GetMethod("HeaderBar_MouseDoubleClick", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left) { RoutedEvent = Control.MouseDoubleClickEvent };
+                var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+                var servicesPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "services.json");
+                Directory.CreateDirectory(Path.GetDirectoryName(servicesPath)!);
+                var network = new Mock<INetworkConfigurationService>();
+                var networkVm = new NetworkConfigurationViewModel(network.Object);
+                var vm = new MainViewModel(new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath)), networkVm, network.Object, null, servicesPath);
+                var view = new MainView(vm) { WindowState = WindowState.Normal };
+                var method = typeof(MainView).GetMethod("HeaderBar_MouseDoubleClick", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var args = new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, MouseButton.Left) { RoutedEvent = Control.MouseDoubleClickEvent };
 
-                    method?.Invoke(view, new object[] { view, args });
-                    Assert.Equal(WindowState.Maximized, view.WindowState);
+                method?.Invoke(view, new object[] { view, args });
+                Assert.Equal(WindowState.Maximized, view.WindowState);
 
-                    method?.Invoke(view, new object[] { view, args });
-                    Assert.Equal(WindowState.Normal, view.WindowState);
-                }
-                catch (Exception e) { ex = e; }
-                finally
-                {
-                    System.Windows.Application.Current?.Shutdown();
-                }
+                method?.Invoke(view, new object[] { view, args });
+                Assert.Equal(WindowState.Normal, view.WindowState);
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         private class TestPresentationSource : PresentationSource

--- a/DesktopApplicationTemplate.UI.Tests/MqttViewsAccessibilityTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MqttViewsAccessibilityTests.cs
@@ -19,79 +19,43 @@ namespace DesktopApplicationTemplate.Tests
         [WindowsFact]
         public void MqttCreateServiceView_ExposesNamedButtons()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-                try
-                {
-                    ApplicationResourceHelper.EnsureApplication();
-                    var view = new MqttCreateServiceView(new MqttCreateServiceViewModel(), new Mock<ILoggingService>().Object);
-                    var create = (Button)view.FindName("CreateButton");
-                    Assert.Equal("Create MQTT Service", AutomationProperties.GetName(create));
-                }
-                catch (Exception e) { ex = e; }
-                finally { Application.Current?.Shutdown(); }
+                var view = new MqttCreateServiceView(new MqttCreateServiceViewModel(), new Mock<ILoggingService>().Object);
+                var create = (Button)view.FindName("CreateButton");
+                Assert.Equal("Create MQTT Service", AutomationProperties.GetName(create));
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void MqttEditConnectionView_ExposesUpdateButton()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-                try
-                {
-                    ApplicationResourceHelper.EnsureApplication();
-                    var options = Options.Create(new MqttServiceOptions { Host = "h", Port = 1, ClientId = "c" });
-                    var service = new MqttService(options, new Mock<IMessageRoutingService>().Object, new Mock<ILoggingService>().Object);
-                    var vm = new MqttEditConnectionViewModel(service, options, new Mock<ILoggingService>().Object);
-                    var view = new MqttEditConnectionView(vm);
-                    var update = (Button)view.FindName("UpdateButton");
-                    Assert.Equal("Update Connection", AutomationProperties.GetName(update));
-                }
-                catch (Exception e) { ex = e; }
-                finally { Application.Current?.Shutdown(); }
+                var options = Options.Create(new MqttServiceOptions { Host = "h", Port = 1, ClientId = "c" });
+                var service = new MqttService(options, new Mock<IMessageRoutingService>().Object, new Mock<ILoggingService>().Object);
+                var vm = new MqttEditConnectionViewModel(service, options, new Mock<ILoggingService>().Object);
+                var view = new MqttEditConnectionView(vm);
+                var update = (Button)view.FindName("UpdateButton");
+                Assert.Equal("Update Connection", AutomationProperties.GetName(update));
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
 
         [WindowsFact]
         public void MqttTagSubscriptionsView_ExposesSendButton()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-                try
-                {
-                    ApplicationResourceHelper.EnsureApplication();
-                    var options = Options.Create(new MqttServiceOptions { Host = "h", Port = 1, ClientId = "c" });
-                    var service = new MqttService(options, new Mock<IMessageRoutingService>().Object, new Mock<ILoggingService>().Object);
-                    var vm = new MqttTagSubscriptionsViewModel(service) { Logger = new Mock<ILoggingService>().Object };
-                    var view = new MqttTagSubscriptionsView(vm, new Mock<ILoggingService>().Object);
-                    var send = (Button)view.FindName("SendButton");
-                    Assert.Equal("Send Test Message", AutomationProperties.GetName(send));
-                }
-                catch (Exception e) { ex = e; }
-                finally { Application.Current?.Shutdown(); }
+                var options = Options.Create(new MqttServiceOptions { Host = "h", Port = 1, ClientId = "c" });
+                var service = new MqttService(options, new Mock<IMessageRoutingService>().Object, new Mock<ILoggingService>().Object);
+                var vm = new MqttTagSubscriptionsViewModel(service) { Logger = new Mock<ILoggingService>().Object };
+                var view = new MqttTagSubscriptionsView(vm, new Mock<ILoggingService>().Object);
+                var send = (Button)view.FindName("SendButton");
+                Assert.Equal("Send Test Message", AutomationProperties.GetName(send));
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI.Tests/ScrollBarStyleTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/ScrollBarStyleTests.cs
@@ -1,7 +1,6 @@
 using DesktopApplicationTemplate.UI;
 using System;
 using System.Linq;
-using System.Threading;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using Xunit;
@@ -13,27 +12,17 @@ namespace DesktopApplicationTemplate.Tests
         [WindowsFact]
         public void LightTheme_ScrollBarStyle_HasReducedWidth()
         {
-
-            Exception? ex = null;
-            var thread = new Thread(() =>
+            ApplicationResourceHelper.RunOnDispatcher(() =>
             {
-                try
-                {
-                    var dict = new ResourceDictionary { Source = new Uri("pack://application:,,,/DesktopApplicationTemplate.UI;component/Themes/LightTheme.xaml") };
-                    Assert.True(dict.Contains(typeof(System.Windows.Controls.Primitives.ScrollBar)));
-                    var style = (Style)dict[typeof(System.Windows.Controls.Primitives.ScrollBar)];
-                    var width = style.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == System.Windows.Controls.Primitives.ScrollBar.WidthProperty)?.Value;
-                    var height = style.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == System.Windows.Controls.Primitives.ScrollBar.HeightProperty)?.Value;
-                    Assert.Equal(8.0, (double)(width ?? 0));
-                    Assert.Equal(8.0, (double)(height ?? 0));
-                }
-                catch (Exception e) { ex = e; }
+                var dict = new ResourceDictionary { Source = new Uri("pack://application:,,,/DesktopApplicationTemplate.UI;component/Themes/LightTheme.xaml") };
+                Assert.True(dict.Contains(typeof(ScrollBar)));
+                var style = (Style)dict[typeof(ScrollBar)];
+                var width = style.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == ScrollBar.WidthProperty)?.Value;
+                var height = style.Setters.OfType<Setter>().FirstOrDefault(s => s.Property == ScrollBar.HeightProperty)?.Value;
+                Assert.Equal(8.0, (double)(width ?? 0));
+                Assert.Equal(8.0, (double)(height ?? 0));
+                ConsoleTestLogger.LogPass();
             });
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
-            if (ex != null) throw ex;
-            ConsoleTestLogger.LogPass();
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -178,6 +178,7 @@
 - Removed Windows desktop runtime checks from tests so they run when Visual Studio provides the runtime.
 - Core unit test project targets cross-platform `net8.0` for broader compatibility.
 - Removed WPF workload installation steps; WPF ships with the Windows .NET SDK.
+- UI tests run on a dispatcher helper that captures unhandled dispatcher exceptions.
 - Temporarily removed ThemeManager UI test that triggered dispatcher access errors.
 - Migrated tests from `WpfFact`/`WpfTheory` to `WindowsFact`/`WindowsTheory` and dropped the WPF test collection fixture.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -85,6 +85,7 @@ Additional Notes: Installed .NET SDK 8.0.404 via dotnet-install; `dotnet restore
 Clarification: WPF workload installation is no longer required; related setup checks have been removed.
 Updated UI tests to remove collection fixtures; each test initializes Application via helper and assembly disables parallel execution.
 Latest Attempt: `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
+Current Attempt: `dotnet` CLI not found; unable to run restore, build, or tests locally. Rely on CI for verification.
 Related Commits/PRs: 8517691, 4c0dbb5
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- capture DispatcherUnhandledException in RunOnDispatcher and rethrow after shutdown
- migrate UI tests to use dispatcher helper instead of manual threads
- document dispatcher helper usage

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ba6a5a688326b22a741b1050fa2f