### PR TITLE
Track running service tasks and log lifecycle to file

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -24,7 +25,25 @@ namespace DesktopApplicationTemplate.Service
         private readonly ILogger<ServiceManager> _logger;
         private readonly IConfiguration _config;
         private readonly string _filePath;
-        private readonly Dictionary<string, CancellationTokenSource> _running = new();
+        private readonly Dictionary<string, RunningService> _running = new();
+        private readonly Dictionary<string, ServiceRecord> _records = new();
+        private readonly string _activeServicesFilePath;
+
+        private sealed class RunningService
+        {
+            public CancellationTokenSource CancellationTokenSource { get; init; } = default!;
+            public Task Task { get; init; } = default!;
+            public DateTime StartTime { get; init; }
+            public string ServiceType { get; init; } = string.Empty;
+        }
+
+        private sealed class ServiceRecord
+        {
+            public string Name { get; init; } = string.Empty;
+            public string ServiceType { get; init; } = string.Empty;
+            public DateTime StartTime { get; init; }
+            public string Status { get; set; } = string.Empty;
+        }
 
         public IReadOnlyCollection<string> ActiveServices => _running.Keys.ToList();
 
@@ -33,6 +52,7 @@ namespace DesktopApplicationTemplate.Service
             _logger = logger;
             _config = config;
             _filePath = filePath ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
+            _activeServicesFilePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "activeservices.txt"));
         }
 
         public void Sync()
@@ -72,18 +92,39 @@ namespace DesktopApplicationTemplate.Service
         {
             _logger.LogInformation("Starting {type} service: {name}", info.ServiceType, info.DisplayName);
             var cts = new CancellationTokenSource();
-            _running[info.DisplayName] = cts;
-            _ = Task.Run(() => RunServiceLoop(info, cts.Token));
+            var start = DateTime.UtcNow;
+            var task = Task.Run(() => RunServiceLoop(info, cts.Token));
+            _running[info.DisplayName] = new RunningService
+            {
+                CancellationTokenSource = cts,
+                Task = task,
+                StartTime = start,
+                ServiceType = info.ServiceType
+            };
+
+            _records[info.DisplayName] = new ServiceRecord
+            {
+                Name = info.DisplayName,
+                ServiceType = info.ServiceType,
+                StartTime = start,
+                Status = "Running"
+            };
+
+            WriteActiveServices();
+
             _logger.LogInformation("Started service: {name}", info.DisplayName);
         }
 
         private void StopService(string name)
         {
-            if (_running.TryGetValue(name, out var cts))
+            if (_running.TryGetValue(name, out var service))
             {
                 _logger.LogInformation("Stopping service: {name}", name);
-                cts.Cancel();
+                service.CancellationTokenSource.Cancel();
                 _running.Remove(name);
+                if (_records.TryGetValue(name, out var record))
+                    record.Status = "Stopped";
+                WriteActiveServices();
                 _logger.LogInformation("Stopped service: {name}", name);
             }
         }
@@ -124,9 +165,44 @@ namespace DesktopApplicationTemplate.Service
 
         public void Dispose()
         {
-            foreach (var cts in _running.Values)
-                cts.Cancel();
+            foreach (var running in _running.Values)
+                running.CancellationTokenSource.Cancel();
+
+            foreach (var record in _records.Values)
+            {
+                if (record.Status != "Stopped")
+                    record.Status = "Stopped";
+            }
+
+            WriteActiveServices();
+
             _running.Clear();
+            _records.Clear();
+            if (File.Exists(_activeServicesFilePath))
+            {
+                try
+                {
+                    File.Delete(_activeServicesFilePath);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private void WriteActiveServices()
+        {
+            try
+            {
+                var pid = Process.GetCurrentProcess().Id;
+                var lines = _records.Values
+                    .Select(r => $"{pid}\t{r.Name}\t{r.ServiceType}\t{r.StartTime:o}\t{r.Status}")
+                    .ToArray();
+                File.WriteAllLines(_activeServicesFilePath, lines);
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Added
 - Reusable service rule and screen abstractions with DI registration and view model integration.
 - Generic `ServiceCreateViewModelBase<TOptions>` and `ServiceEditViewModelBase<TOptions>` consolidating save, cancel, and advanced configuration commands.
+- Service manager tracks task start times and writes statuses to `activeservices.txt` for running services.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -87,7 +87,8 @@ Clarification: WPF workload installation is no longer required; related setup ch
 Updated UI tests to remove collection fixtures; each test initializes Application via helper and assembly disables parallel execution.
 Latest Attempt: `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Current Attempt: `dotnet` CLI not found; unable to run restore, build, or tests locally. Rely on CI for verification.
-Related Commits/PRs: 8517691, 4c0dbb5
+Newest Attempt: After ServiceManager updates, `dotnet restore`, `dotnet build`, and `dotnet test --settings tests.runsettings` all reported the `dotnet` command is missing; relying on CI.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- track running service tasks with start timestamps
- record service lifecycle in solution-level activeservices.txt
- document test command limitations in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c168faf083269c05c14d86d4dc62