### PR TITLE
Remove remaining Wpf test markers

### DIFF
--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -89,6 +89,7 @@ Latest Attempt: `dotnet restore` and `dotnet build` succeeded, but `dotnet test 
 Current Attempt: `dotnet` CLI not found; unable to run restore, build, or tests locally. Rely on CI for verification.
 Newest Attempt: After ServiceManager updates, `dotnet restore`, `dotnet build`, and `dotnet test --settings tests.runsettings` all reported the `dotnet` command is missing; relying on CI.
 Another Attempt: After removing legacy WPF test fixtures, `dotnet` commands remain unavailable; continue relying on CI.
+Most Recent Attempt: `dotnet --version` still reports command not found; tests skipped and CI used for validation.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- confirm UI tests already use WindowsFact and have no Wpf test collection
- log missing `dotnet` CLI preventing local test execution

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c394404c832697151d9a0f87a711