### PR TITLE
Handle missing MainView registration during startup

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -203,8 +203,16 @@ namespace DesktopApplicationTemplate.UI
                 settings.Save();
             }
 
-            var mainWindow = AppHost.Services.GetRequiredService<MainView>();
-            mainWindow.Show();
+            var mainWindow = AppHost.Services.GetService<MainView>();
+            if (mainWindow is null)
+            {
+                var logger = AppHost.Services.GetService<ILogger<App>>();
+                logger?.LogWarning("MainView service missing; skipping window creation.");
+            }
+            else
+            {
+                mainWindow.Show();
+            }
 
             base.OnStartup(e);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Marked main window `ContentFrame` public so UI tests can inspect navigation.
 - Included `Forms.xaml` in theme resources with Page build action.
 - Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
+- Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -90,7 +90,8 @@ Current Attempt: `dotnet` CLI not found; unable to run restore, build, or tests 
 Newest Attempt: After ServiceManager updates, `dotnet restore`, `dotnet build`, and `dotnet test --settings tests.runsettings` all reported the `dotnet` command is missing; relying on CI.
 Another Attempt: After removing legacy WPF test fixtures, `dotnet` commands remain unavailable; continue relying on CI.
 Most Recent Attempt: `dotnet --version` still reports command not found; tests skipped and CI used for validation.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec
+Latest Attempt: After adjusting App startup to tolerate missing MainView registration, the `dotnet` CLI remains unavailable and tests could not run.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- avoid crash when `MainView` isn't registered by skipping window creation and logging a warning
- document startup behavior in changelog
- record test limitations after startup fix

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5144a8c8326b141cb44a5671b21