### PR TITLE
Add folder browse option to File Observer creation

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverCreateServiceViewModel.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
@@ -9,15 +11,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// </summary>
 public class FileObserverCreateServiceViewModel : ServiceCreateViewModelBase<FileObserverServiceOptions>
 {
+    private readonly IFileDialogService _fileDialog;
     private string _serviceName = string.Empty;
     private string _filePath = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileObserverCreateServiceViewModel"/> class.
     /// </summary>
-    public FileObserverCreateServiceViewModel(ILoggingService? logger = null)
+    public FileObserverCreateServiceViewModel(IFileDialogService fileDialog, ILoggingService? logger = null)
         : base(logger)
     {
+        _fileDialog = fileDialog ?? throw new ArgumentNullException(nameof(fileDialog));
+        BrowseCommand = new RelayCommand(BrowseFolder);
     }
 
     /// <summary>
@@ -54,6 +59,11 @@ public class FileObserverCreateServiceViewModel : ServiceCreateViewModelBase<Fil
     }
 
     /// <summary>
+    /// Command to browse for a folder.
+    /// </summary>
+    public ICommand BrowseCommand { get; }
+
+    /// <summary>
     /// Current configuration options.
     /// </summary>
     public FileObserverServiceOptions Options { get; } = new();
@@ -80,5 +90,14 @@ public class FileObserverCreateServiceViewModel : ServiceCreateViewModelBase<Fil
         Logger?.Log("Opening FileObserver advanced config", LogLevel.Debug);
         Options.FilePath = FilePath;
         AdvancedConfigRequested?.Invoke(Options);
+    }
+
+    private void BrowseFolder()
+    {
+        var path = _fileDialog.SelectFolder();
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            FilePath = path;
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
@@ -8,6 +8,7 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -20,8 +21,9 @@
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="File Path" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath}" Style="{StaticResource FormField}"/>
+        <Button Grid.Row="1" Grid.Column="2" Content="Browse" Width="75" Margin="5,0,0,0" Command="{Binding BrowseCommand}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+        <StackPanel Grid.Row="2" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
             <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open File Observer Advanced Configuration"/>
             <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create File Observer Service"/>
             <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel File Observer Creation"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,6 +138,7 @@
 #### Added
 - File search service with async caching and DI integration for File Observer.
 - File Observer create, edit, and advanced configuration views with navigation and DI registration.
+- Browse button in File Observer create view to select folders via dialog.
 
 ### Logging
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -384,6 +384,15 @@ Decisions & Rationale: Pump dispatcher and shut down after action to avoid deadl
 Action Items: Rely on CI for verification.
 Related Commits/PRs:
 
+[2025-09-27 13:00] Topic: File Observer browse command
+Context: Added folder selection support to File Observer service creation.
+Observations: Injected IFileDialogService and Browse command to update the path.
+Codex Limitations noticed: dotnet CLI missing; restore, build, and test commands could not run.
+Effective Prompts / Instructions that worked: User request to add Browse button.
+Decisions & Rationale: Enable users to pick directories when configuring the service.
+Action Items: Rely on CI for verification.
+Related Commits/PRs:
+
 [2025-08-29 16:00] Topic: UI test removal
 Context: Removed DesktopApplicationTemplate.UI.Tests project and WPF UI tests that hung due to initialization issues.
 Observations: Deleting UI tests leaves only data-focused tests; solution no longer references the UI test project.


### PR DESCRIPTION
## Summary
- add `BrowseCommand` and `IFileDialogService` dependency to `FileObserverCreateServiceViewModel`
- show Browse button in FileObserver create view
- log File Observer browse command in collaboration tips and changelog

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74579bb58832691faa14da2595320