### PR TITLE
Expand MQTT connection types

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttAdvancedConfigViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttAdvancedConfigViewModelTests.cs
@@ -16,7 +16,6 @@ public class MqttAdvancedConfigViewModelTests
         File.WriteAllBytes(tempCert, new byte[] { 1, 2, 3 });
         var options = new MqttServiceOptions();
         var vm = new MqttAdvancedConfigViewModel(options);
-        vm.UseTls = true;
         vm.ClientCertificatePath = tempCert;
         vm.WillTopic = "topic";
         vm.WillPayload = "payload";
@@ -32,7 +31,6 @@ public class MqttAdvancedConfigViewModelTests
 
         File.Delete(tempCert);
         Assert.NotNull(received);
-        Assert.True(received!.UseTls);
         Assert.Equal("topic", received.WillTopic);
         Assert.Equal("payload", received.WillPayload);
         Assert.Equal(MqttQualityOfServiceLevel.AtLeastOnce, received.WillQualityOfService);

--- a/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
@@ -58,7 +58,7 @@ public class MqttCreateServiceViewModelTests
         vm.ClientId = "client";
         vm.Username = "user";
         vm.Password = "pass";
-        vm.Options.UseTls = true;
+        vm.Options.ConnectionType = MqttConnectionType.MqttTls;
         vm.Options.WillTopic = "wt";
         vm.Options.WillPayload = "wp";
         vm.Options.WillQualityOfService = MqttQualityOfServiceLevel.AtLeastOnce;
@@ -79,7 +79,7 @@ public class MqttCreateServiceViewModelTests
         Assert.Equal("client", received.ClientId);
         Assert.Equal("user", received.Username);
         Assert.Equal("pass", received.Password);
-        Assert.True(received.UseTls);
+        Assert.Equal(MqttConnectionType.MqttTls, received.ConnectionType);
         Assert.Equal("wt", received.WillTopic);
         Assert.Equal("wp", received.WillPayload);
         Assert.Equal(MqttQualityOfServiceLevel.AtLeastOnce, received.WillQualityOfService);

--- a/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
@@ -130,14 +130,6 @@ public class MqttEditConnectionViewModelTests
     }
 
     [Fact]
-    public void ConnectionType_WebSocket_DisablesTls()
-    {
-        var vm = CreateViewModel();
-        vm.ConnectionType = MqttConnectionType.WebSocket;
-        Assert.False(vm.IsTlsEnabled);
-        Assert.False(vm.UseTls);
-    }
-
     [Fact]
     public void SubscriptionButtonText_ReflectsConnectionState()
     {

--- a/DesktopApplicationTemplate.Tests/MqttServiceOptionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceOptionsTests.cs
@@ -13,7 +13,7 @@ public class MqttServiceOptionsTests
         Assert.Equal(string.Empty, options.Host);
         Assert.Equal(1883, options.Port);
         Assert.Equal(string.Empty, options.ClientId);
-        Assert.False(options.UseTls);
+        Assert.Equal(MqttConnectionType.Mqtt, options.ConnectionType);
         Assert.Equal(60, options.KeepAliveSeconds);
         Assert.True(options.CleanSession);
     }

--- a/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
@@ -120,7 +120,7 @@ public class MqttServiceTests
             ClientId = "id",
             Username = "u",
             Password = "p",
-            UseTls = true,
+            ConnectionType = MqttConnectionType.MqttTls,
             ClientCertificate = cert
         });
         var service = new MqttService(client.Object, options, Mock.Of<IMessageRoutingService>(), Mock.Of<ILoggingService>());

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -111,12 +111,13 @@ public class MqttService
                 .WithWillRetain(opts.WillRetain);
         }
 
-        if (opts.ConnectionType == MqttConnectionType.WebSocket)
+        if (opts.ConnectionType == MqttConnectionType.WebSocket || opts.ConnectionType == MqttConnectionType.WebSocketTls)
         {
             var path = string.IsNullOrWhiteSpace(opts.WebSocketPath) ? string.Empty : opts.WebSocketPath;
+            var scheme = opts.ConnectionType == MqttConnectionType.WebSocketTls ? "wss" : "ws";
             builder = builder.WithWebSocketServer(o =>
             {
-                o.WithUri($"ws://{opts.Host}:{opts.Port}{path}");
+                o.WithUri($"{scheme}://{opts.Host}:{opts.Port}{path}");
             });
         }
         else
@@ -129,7 +130,7 @@ public class MqttService
             builder = builder.WithCredentials(opts.Username, opts.Password);
         }
 
-        if (opts.UseTls && opts.ConnectionType != MqttConnectionType.WebSocket)
+        if (opts.ConnectionType == MqttConnectionType.MqttTls || opts.ConnectionType == MqttConnectionType.WebSocketTls)
         {
             builder = builder.WithTlsOptions(o =>
             {

--- a/DesktopApplicationTemplate.UI/Services/MqttServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttServiceOptions.cs
@@ -5,8 +5,10 @@ namespace DesktopApplicationTemplate.UI.Services
 {
     public enum MqttConnectionType
     {
-        Tcp,
-        WebSocket
+        Mqtt,
+        MqttTls,
+        WebSocket,
+        WebSocketTls
     }
 
     public class MqttServiceOptions
@@ -16,9 +18,8 @@ namespace DesktopApplicationTemplate.UI.Services
         public string ClientId { get; set; } = string.Empty;
         public string? Username { get; set; }
         public string? Password { get; set; }
-        public MqttConnectionType ConnectionType { get; set; } = MqttConnectionType.Tcp;
+        public MqttConnectionType ConnectionType { get; set; } = MqttConnectionType.Mqtt;
         public string? WebSocketPath { get; set; }
-        public bool UseTls { get; set; }
         public byte[]? ClientCertificate { get; set; }
         public string? WillTopic { get; set; }
         public string? WillPayload { get; set; }

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttAdvancedConfigViewModel.cs
@@ -16,7 +16,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 public class MqttAdvancedConfigViewModel : ViewModelBase
 {
     private readonly MqttServiceOptions _options;
-    private bool _useTls;
     private string? _clientCertificatePath;
     private string? _willTopic;
     private string? _willPayload;
@@ -32,7 +31,6 @@ public class MqttAdvancedConfigViewModel : ViewModelBase
     public MqttAdvancedConfigViewModel(MqttServiceOptions options, ILoggingService? logger = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
-        _useTls = options.UseTls;
         _willTopic = options.WillTopic;
         _willPayload = options.WillPayload;
         _willQualityOfService = options.WillQualityOfService;
@@ -73,15 +71,6 @@ public class MqttAdvancedConfigViewModel : ViewModelBase
     /// Raised when navigation back is requested.
     /// </summary>
     public event Action? BackRequested;
-
-    /// <summary>
-    /// Whether TLS should be used for the connection.
-    /// </summary>
-    public bool UseTls
-    {
-        get => _useTls;
-        set { _useTls = value; OnPropertyChanged(); }
-    }
 
     /// <summary>
     /// Path to the client certificate used for TLS authentication.
@@ -158,7 +147,6 @@ public class MqttAdvancedConfigViewModel : ViewModelBase
     private void Save()
     {
         Logger?.Log("MQTT advanced options start", LogLevel.Debug);
-        _options.UseTls = UseTls;
         _options.WillTopic = string.IsNullOrWhiteSpace(WillTopic) ? null : WillTopic;
         _options.WillPayload = string.IsNullOrWhiteSpace(WillPayload) ? null : WillPayload;
         _options.WillQualityOfService = WillQualityOfService;

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttEditConnectionViewModel.cs
@@ -22,7 +22,6 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
     private string? _username;
     private string? _password;
     private MqttConnectionType _connectionType;
-    private bool _useTls;
     private string? _webSocketPath;
     private bool _isConnected;
 
@@ -130,21 +129,12 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
     }
 
     /// <summary>
-    /// Connection type (TCP or WebSocket).
+    /// Connection type.
     /// </summary>
     public MqttConnectionType ConnectionType
     {
         get => _connectionType;
-        set { _connectionType = value; OnPropertyChanged(); UpdateTlsState(); }
-    }
-
-    /// <summary>
-    /// Whether TLS is used for the connection.
-    /// </summary>
-    public bool UseTls
-    {
-        get => _useTls;
-        set { _useTls = value; OnPropertyChanged(); }
+        set { _connectionType = value; OnPropertyChanged(); }
     }
 
     /// <summary>
@@ -155,11 +145,6 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         get => _webSocketPath;
         set { _webSocketPath = value; OnPropertyChanged(); }
     }
-
-    /// <summary>
-    /// Gets a value indicating whether TLS options are enabled.
-    /// </summary>
-    public bool IsTlsEnabled => ConnectionType == MqttConnectionType.Tcp;
 
     /// <summary>
     /// Gets or sets a value indicating whether the service is connected.
@@ -200,7 +185,6 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         _password = _options.Password;
         _connectionType = _options.ConnectionType;
         _webSocketPath = _options.WebSocketPath;
-        _useTls = _options.UseTls;
         OnPropertyChanged(nameof(Host));
         OnPropertyChanged(nameof(Port));
         OnPropertyChanged(nameof(ClientId));
@@ -208,8 +192,6 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         OnPropertyChanged(nameof(Password));
         OnPropertyChanged(nameof(ConnectionType));
         OnPropertyChanged(nameof(WebSocketPath));
-        OnPropertyChanged(nameof(UseTls));
-        UpdateTlsState();
     }
 
     /// <summary>
@@ -225,7 +207,6 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         _options.Password = _password;
         _options.ConnectionType = _connectionType;
         _options.WebSocketPath = _webSocketPath;
-        _options.UseTls = _useTls;
         await _service.ConnectAsync(_options).ConfigureAwait(false);
         Logger?.Log("MQTT connection update finished", LogLevel.Debug);
         RequestClose?.Invoke(this, EventArgs.Empty);
@@ -271,12 +252,4 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
             AddError(nameof(ClientId), "Client Id required");
     }
 
-    private void UpdateTlsState()
-    {
-        if (_connectionType == MqttConnectionType.WebSocket)
-        {
-            UseTls = false;
-        }
-        OnPropertyChanged(nameof(IsTlsEnabled));
-    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -173,22 +173,6 @@ public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel,
     }
 
     /// <summary>
-    /// When true, TLS is used for the connection.
-    /// </summary>
-    public bool UseTls
-    {
-        get => _options.UseTls;
-        set
-        {
-            if (_options.UseTls == value)
-                return;
-            DisconnectIfConnected();
-            _options.UseTls = value;
-            OnPropertyChanged();
-        }
-    }
-
-    /// <summary>
     /// Topic published by the broker when the client disconnects unexpectedly.
     /// </summary>
     public string? WillTopic

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -538,7 +538,7 @@ namespace DesktopApplicationTemplate.UI.Views
             opt.ClientId = options.ClientId;
             opt.Username = options.Username;
             opt.Password = options.Password;
-            opt.UseTls = options.UseTls;
+            opt.ConnectionType = options.ConnectionType;
             opt.WillTopic = options.WillTopic;
             opt.WillPayload = options.WillPayload;
             opt.WillQualityOfService = options.WillQualityOfService;

--- a/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml
@@ -19,37 +19,33 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="Use TLS" Style="{StaticResource FormLabel}"/>
-        <CheckBox Grid.Row="0" Grid.Column="1" IsChecked="{Binding UseTls}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Client Certificate" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ClientCertificatePath}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Text="Client Certificate" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ClientCertificatePath}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Will Topic" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding WillTopic}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="2" Grid.Column="0" Text="Will Topic" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding WillTopic}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Will Payload" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding WillPayload}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Text="Will Payload" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding WillPayload}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Will QoS" Style="{StaticResource FormLabel}"/>
+        <ComboBox Grid.Row="3" Grid.Column="1" ItemsSource="{Binding QoSLevels}" SelectedItem="{Binding WillQualityOfService}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="4" Grid.Column="0" Text="Will QoS" Style="{StaticResource FormLabel}"/>
-        <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding QoSLevels}" SelectedItem="{Binding WillQualityOfService}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Will Retain" Style="{StaticResource FormLabel}"/>
+        <CheckBox Grid.Row="4" Grid.Column="1" IsChecked="{Binding WillRetain}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="5" Grid.Column="0" Text="Will Retain" Style="{StaticResource FormLabel}"/>
-        <CheckBox Grid.Row="5" Grid.Column="1" IsChecked="{Binding WillRetain}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="5" Grid.Column="0" Text="Keep Alive" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding KeepAliveSeconds}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="6" Grid.Column="0" Text="Keep Alive" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding KeepAliveSeconds}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="6" Grid.Column="0" Text="Clean Session" Style="{StaticResource FormLabel}"/>
+        <CheckBox Grid.Row="6" Grid.Column="1" IsChecked="{Binding CleanSession}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="7" Grid.Column="0" Text="Clean Session" Style="{StaticResource FormLabel}"/>
-        <CheckBox Grid.Row="7" Grid.Column="1" IsChecked="{Binding CleanSession}" Style="{StaticResource FormField}"/>
+        <TextBlock Grid.Row="7" Grid.Column="0" Text="Reconnect Delay" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding ReconnectDelaySeconds}" Style="{StaticResource FormField}"/>
 
-        <TextBlock Grid.Row="8" Grid.Column="0" Text="Reconnect Delay" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding ReconnectDelaySeconds}" Style="{StaticResource FormField}"/>
-
-        <StackPanel Grid.Row="9" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+        <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
             <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save MQTT Advanced Configuration"/>
             <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to MQTT Configuration"/>
         </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:svc="clr-namespace:DesktopApplicationTemplate.UI.Services"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -17,6 +18,7 @@
                 <RowDefinition Height="Auto" /> <!-- ClientId -->
                 <RowDefinition Height="Auto" /> <!-- Username -->
                 <RowDefinition Height="Auto" /> <!-- Password -->
+                <RowDefinition Height="Auto" /> <!-- Connection Type -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
 
@@ -38,7 +40,15 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Password}" Style="{StaticResource FormField}" ToolTip="Password"/>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0" >
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Connection Type" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="6" Grid.Column="1" SelectedValue="{Binding Options.ConnectionType}" SelectedValuePath="Tag" Style="{StaticResource FormField}">
+                <ComboBoxItem Content="MQTT" Tag="{x:Static svc:MqttConnectionType.Mqtt}"/>
+                <ComboBoxItem Content="MQTT TLS" Tag="{x:Static svc:MqttConnectionType.MqttTls}"/>
+                <ComboBoxItem Content="WebSocket" Tag="{x:Static svc:MqttConnectionType.WebSocket}"/>
+                <ComboBoxItem Content="WebSocket TLS" Tag="{x:Static svc:MqttConnectionType.WebSocketTls}"/>
+            </ComboBox>
+
+            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0" >
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open MQTT Advanced Configuration"/>
                 <Button x:Name="CreateButton" Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create MQTT Service"/>
                 <Button x:Name="CancelButton" Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel MQTT Creation"/>

--- a/DesktopApplicationTemplate.UI/Views/MqttEditConnectionView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditConnectionView.xaml
@@ -19,7 +19,6 @@
                 <RowDefinition Height="Auto" /> <!-- Password -->
                 <RowDefinition Height="Auto" /> <!-- Connection Type -->
                 <RowDefinition Height="Auto" /> <!-- WebSocket Path -->
-                <RowDefinition Height="Auto" /> <!-- UseTls -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
 
@@ -40,8 +39,10 @@
 
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Connection Type" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="5" Grid.Column="1" SelectedValue="{Binding ConnectionType}" SelectedValuePath="Tag" Style="{StaticResource FormField}">
-                <ComboBoxItem Content="TCP" Tag="{x:Static svc:MqttConnectionType.Tcp}"/>
+                <ComboBoxItem Content="MQTT" Tag="{x:Static svc:MqttConnectionType.Mqtt}"/>
+                <ComboBoxItem Content="MQTT TLS" Tag="{x:Static svc:MqttConnectionType.MqttTls}"/>
                 <ComboBoxItem Content="WebSocket" Tag="{x:Static svc:MqttConnectionType.WebSocket}"/>
+                <ComboBoxItem Content="WebSocket TLS" Tag="{x:Static svc:MqttConnectionType.WebSocketTls}"/>
             </ComboBox>
 
             <TextBlock Grid.Row="6" Grid.Column="0" Text="WS Path">
@@ -50,6 +51,9 @@
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding ConnectionType}" Value="WebSocket">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding ConnectionType}" Value="WebSocketTls">
                                 <Setter Property="Visibility" Value="Visible" />
                             </DataTrigger>
                         </Style.Triggers>
@@ -64,14 +68,15 @@
                             <DataTrigger Binding="{Binding ConnectionType}" Value="WebSocket">
                                 <Setter Property="Visibility" Value="Visible" />
                             </DataTrigger>
+                            <DataTrigger Binding="{Binding ConnectionType}" Value="WebSocketTls">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
                         </Style.Triggers>
                     </Style>
                 </TextBox.Style>
             </TextBox>
-
-            <CheckBox Grid.Row="7" Grid.Column="1" Content="Use TLS" IsChecked="{Binding UseTls}" IsEnabled="{Binding IsTlsEnabled}" Style="{StaticResource FormField}"/>
-
-            <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+            
+            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button x:Name="SubscriptionButton" Content="{Binding SubscriptionButtonText}" Width="110" Margin="5" Command="{Binding ToggleSubscriptionCommand}" AutomationProperties.Name="{Binding SubscriptionButtonText}">
                     <Button.Style>
                         <Style TargetType="Button">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,6 +104,7 @@
 - `MqttTagSubscriptionsViewModel` consolidated to a single subscription collection with unified properties.
 - Removed obsolete MQTT options model and duplicate subscribe implementations.
 - MQTT service creation now occurs within the main window frame and returns after completion.
+- Expanded connection types to include MQTT/WebSocket variants with optional TLS and updated connection views.
 
 #### Fixed
 - MQTT service disconnects before reconnecting when settings change and converts blank will-topic/payload fields to `null`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -92,6 +92,7 @@ Another Attempt: After removing legacy WPF test fixtures, `dotnet` commands rema
 Most Recent Attempt: `dotnet --version` still reports command not found; tests skipped and CI used for validation.
 Latest Attempt: After adjusting App startup to tolerate missing MainView registration, the `dotnet` CLI remains unavailable and tests could not run.
 Newest Attempt: After handling missing MainViewModel on exit, the `dotnet` CLI remains unavailable and tests could not run.
+Another Attempt: After expanding MQTT connection types, the `dotnet` CLI is still missing; restore, build, and test commands cannot execute.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- support MQTT, MQTT TLS, WebSocket, and WebSocket TLS connection types
- construct proper URI and TLS options during MQTT connections
- allow selecting connection type in MQTT create and edit views

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b746a041588326899273bc3f8e219a