### PR TITLE
feat(mqtt): expose connection state and pass options

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttTagSubscriptionsViewModelTests.cs
@@ -34,7 +34,7 @@ public class MqttTagSubscriptionsViewModelTests
         var options = Options.Create(new MqttServiceOptions { Host = "localhost", Port = 1883, ClientId = "client" });
         var routing = Mock.Of<IMessageRoutingService>();
         var service = new MqttService(client.Object, options, routing, logger);
-        var vm = new MqttTagSubscriptionsViewModel(service);
+        var vm = new MqttTagSubscriptionsViewModel(service, options);
         return (vm, client, service);
     }
 
@@ -43,6 +43,7 @@ public class MqttTagSubscriptionsViewModelTests
     {
         var (vm, client, _) = CreateViewModel();
         await vm.ConnectAsync();
+        Assert.True(vm.IsConnected);
         client.Verify(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -54,11 +55,12 @@ public class MqttTagSubscriptionsViewModelTests
             .ThrowsAsync(new ArgumentException("Host cannot be null or whitespace."));
         var options = Options.Create(new MqttServiceOptions());
         var service = new MqttService(client.Object, options, Mock.Of<IMessageRoutingService>(), Mock.Of<ILoggingService>());
-        var vm = new MqttTagSubscriptionsViewModel(service);
+        var vm = new MqttTagSubscriptionsViewModel(service, options);
         bool raised = false;
         vm.EditConnectionRequested += (_, _) => raised = true;
         await vm.ConnectAsync();
         Assert.True(raised);
+        Assert.False(vm.IsConnected);
     }
 
     [Fact]

--- a/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MqttServiceViewModel.cs
@@ -456,7 +456,7 @@ public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel,
         Logger?.Log("MQTT connect start", LogLevel.Debug);
         try
         {
-            await _service.ConnectAsync(options).ConfigureAwait(false);
+            await _service.ConnectAsync(options ?? _options).ConfigureAwait(false);
             IsConnected = true;
             Logger?.Log("MQTT connect finished", LogLevel.Debug);
         }

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -7,6 +7,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:sys="clr-namespace:System;assembly=System.Runtime"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       mc:Ignorable="d">
     <Page.Resources>
         <ObjectDataProvider x:Key="QoSValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
@@ -14,6 +15,7 @@
                 <x:Type TypeName="mqtt:MqttQualityOfServiceLevel" />
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
+        <helpers:BooleanToBrushConverter x:Key="BoolToBrush" TrueBrush="Green" FalseBrush="Red" />
     </Page.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
@@ -24,6 +26,7 @@
         <!-- Connection bar -->
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
             <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80" AutomationProperties.Name="Connect MQTT"/>
+            <Ellipse Width="10" Height="10" Margin="5,0,0,0" Fill="{Binding IsConnected, Converter={StaticResource BoolToBrush}}"/>
             <TextBox Text="{Binding NewTopic}" Width="200" Margin="10,0,0,0" x:Name="NewTopicBox" ToolTip="Topic to subscribe"
                      behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
             <ComboBox Width="100" Margin="5,0,0,0"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -96,12 +96,14 @@
 - UI for configuring MQTT endpoint–message pairs with placeholders, tooltips, per-tag outgoing test messages, and will-message support.
 - Tag subscriptions support per-topic endpoints, QoS selection, subscribe/unsubscribe commands, and visual feedback.
 - Dedicated window for editing MQTT connection settings with update, cancel, and unsubscribe commands.
+- Tag subscriptions view displays a connection status indicator.
 
 #### Changed
 - `MqttService` refactored with options-based constructor, clean reconnect logic, and consolidated publish methods.
 - `MqttServiceViewModel` uses `MqttServiceOptions` for settings and delegates token resolution to `MessageRoutingService`.
 - `MessageRoutingService` tracks latest messages per service and resolves `{ServiceName.Message}` tokens before publishing.
 - `MqttTagSubscriptionsViewModel` consolidated to a single subscription collection with unified properties.
+- `MqttTagSubscriptionsViewModel` passes updated options to `MqttService.ConnectAsync` and logs connection success or failure.
 - Topics now appear in the subscription list before broker subscribe and log errors when the call fails; the Add button disables when no topic is provided.
 - Removed obsolete MQTT options model and duplicate subscribe implementations.
 - MQTT service creation now occurs within the main window frame and returns after completion.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -94,6 +94,7 @@ Latest Attempt: After adjusting App startup to tolerate missing MainView registr
 Newest Attempt: After handling missing MainViewModel on exit, the `dotnet` CLI remains unavailable and tests could not run.
 Another Attempt: After expanding MQTT connection types, the `dotnet` CLI is still missing; restore, build, and test commands cannot execute.
 Latest Attempt: After updating MQTT topic subscription handling, the `dotnet` command remains unavailable; restore, build, and test cannot run and CI is required.
+Recent Attempt: `dotnet` command still missing; unable to run restore, build, or tests locally and will rely on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- ensure MqttService.ConnectAsync uses current options from view model
- show connection state in MQTT tag subscriptions view
- test MQTT tag subscription connection state handling

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a0073fc8326bd88544110315127