### PR TITLE
Display MQTT log entries and log connection state changes

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -22,6 +22,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <!-- Connection bar -->
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
@@ -85,5 +86,14 @@
                     Width="60"
                     Margin="5,0,0,0"/>
         </StackPanel>
+
+        <!-- Log entries -->
+        <ListBox Grid.Row="3" Margin="0,10,0,0" ItemsSource="{Binding LogEntries}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
     </Grid>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -97,6 +97,7 @@
 - Tag subscriptions support per-topic endpoints, QoS selection, subscribe/unsubscribe commands, and visual feedback.
 - Dedicated window for editing MQTT connection settings with update, cancel, and unsubscribe commands.
 - Tag subscriptions view displays a connection status indicator.
+- Tag subscriptions view shows log entries for connection events and errors.
 
 #### Changed
 - `MqttService` refactored with options-based constructor, clean reconnect logic, and consolidated publish methods.
@@ -108,6 +109,7 @@
 - Removed obsolete MQTT options model and duplicate subscribe implementations.
 - MQTT service creation now occurs within the main window frame and returns after completion.
 - Expanded connection types to include MQTT/WebSocket variants with optional TLS and updated connection views.
+- `MqttService` logs connection state changes and errors through the injected logging service.
 
 #### Fixed
 - MQTT service disconnects before reconnecting when settings change and converts blank will-topic/payload fields to `null`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -95,6 +95,7 @@ Newest Attempt: After handling missing MainViewModel on exit, the `dotnet` CLI r
 Another Attempt: After expanding MQTT connection types, the `dotnet` CLI is still missing; restore, build, and test commands cannot execute.
 Latest Attempt: After updating MQTT topic subscription handling, the `dotnet` command remains unavailable; restore, build, and test cannot run and CI is required.
 Recent Attempt: `dotnet` command still missing; unable to run restore, build, or tests locally and will rely on CI.
+Newest Attempt: After adding MQTT log view, `dotnet` CLI remains missing; relying on CI for build and test.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- capture logger output in `MqttTagSubscriptionsViewModel` and surface in MQTT subscriptions view
- log MQTT connection changes and failures via `MqttService`
- note missing `dotnet` CLI when attempting restore/build/test

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74bc695f48326b30c8dbe66b78e79