### PR TITLE
feat: add MQTT log panel and wire main log

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -99,7 +99,11 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 if (svc.ServicePage.DataContext is ILoggingViewModel vm && vm.Logger is LoggingService logger)
                 {
-                    if (vm.Logger != null)
+                    if (svc.ServiceType == "MQTT")
+                    {
+                        logger.LogAdded += entry => _viewModel.OnServiceLogAdded(svc, entry);
+                    }
+                    else
                     {
                         logger.LogAdded += entry =>
                         {

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml
@@ -88,12 +88,14 @@
         </StackPanel>
 
         <!-- Log entries -->
-        <ListBox Grid.Row="3" Margin="0,10,0,0" ItemsSource="{Binding LogEntries}">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
+        <Expander Grid.Row="3" Margin="0,10,0,0" Header="Logs" IsExpanded="False">
+            <ListBox ItemsSource="{Binding LogEntries}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Message}" Foreground="{Binding Color}"/>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Expander>
     </Grid>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Dedicated window for editing MQTT connection settings with update, cancel, and unsubscribe commands.
 - Tag subscriptions view displays a connection status indicator.
 - Tag subscriptions view shows log entries for connection events and errors.
+- Tag subscriptions view hosts a collapsible log panel and forwards entries to the main log view.
 
 #### Changed
 - `MqttService` refactored with options-based constructor, clean reconnect logic, and consolidated publish methods.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -96,6 +96,7 @@ Another Attempt: After expanding MQTT connection types, the `dotnet` CLI is stil
 Latest Attempt: After updating MQTT topic subscription handling, the `dotnet` command remains unavailable; restore, build, and test cannot run and CI is required.
 Recent Attempt: `dotnet` command still missing; unable to run restore, build, or tests locally and will rely on CI.
 Newest Attempt: After adding MQTT log view, `dotnet` CLI remains missing; relying on CI for build and test.
+Another Attempt: After embedding a collapsible MQTT log panel and wiring global log handling, the `dotnet` CLI remains unavailable; relying on CI for build and test.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add collapsible log panel to MQTT tag subscriptions view
- forward MQTT logs to main log handler for global visibility
- document environment limitation of missing `dotnet` CLI

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74d4507b48326a19a8fcfcdbdbd54