### PR TITLE
Propagate TCP edit values before advanced config

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
@@ -29,4 +29,26 @@ public class TcpEditServiceViewModelTests
         Assert.True(received.UseUdp);
         Assert.Equal(TcpServiceMode.Sending, received.Mode);
     }
+
+    [Fact]
+    public void AdvancedConfigCommand_Raises_Event_WithUpdatedOptions()
+    {
+        var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening };
+        var vm = new TcpEditServiceViewModel();
+        vm.Load("svc", options);
+        vm.Host = "new";
+        vm.Port = 2;
+        options.UseUdp = true;
+        options.Mode = TcpServiceMode.Sending;
+        TcpServiceOptions? received = null;
+        vm.AdvancedConfigRequested += o => received = o;
+
+        vm.AdvancedConfigCommand.Execute(null);
+
+        Assert.NotNull(received);
+        Assert.Equal("new", received!.Host);
+        Assert.Equal(2, received.Port);
+        Assert.True(received.UseUdp);
+        Assert.Equal(TcpServiceMode.Sending, received.Mode);
+    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpEditServiceViewModel.cs
@@ -87,6 +87,11 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     protected override void OnCancel() => Cancelled?.Invoke();
 
     /// <inheritdoc />
-    protected override void OnAdvancedConfig() => AdvancedConfigRequested?.Invoke(_options);
+    protected override void OnAdvancedConfig()
+    {
+        _options.Host = Host;
+        _options.Port = Port;
+        AdvancedConfigRequested?.Invoke(_options);
+    }
 }
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -97,6 +97,7 @@ Latest Attempt: After updating MQTT topic subscription handling, the `dotnet` co
 Recent Attempt: `dotnet` command still missing; unable to run restore, build, or tests locally and will rely on CI.
 Newest Attempt: After adding MQTT log view, `dotnet` CLI remains missing; relying on CI for build and test.
 Another Attempt: After embedding a collapsible MQTT log panel and wiring global log handling, the `dotnet` CLI remains unavailable; relying on CI for build and test.
+Another Attempt: After updating TcpEditServiceViewModel advanced config and installing the .NET SDK 8.0.404, `dotnet restore` succeeded but `dotnet build` failed with MqttService.cs missing `ConnectingFailedAsync`; relying on CI for validation.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- ensure `TcpEditServiceViewModel` syncs host and port before raising advanced config event
- test that advanced configuration receives current TCP edit values
- document build limitation in collaboration tips

## Testing
- `~/.dotnet/dotnet restore`
- `~/.dotnet/dotnet build DesktopApplicationTemplate.sln` *(fails: IMqttClient lacks `ConnectingFailedAsync`)*
- `~/.dotnet/dotnet test --settings tests.runsettings` *(core tests pass, UI project build fails: IMqttClient lacks `ConnectingFailedAsync`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8387a46d88326abd2edee75965ed8