### PR TITLE
Add placeholder hints for TCP service fields

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
@@ -3,7 +3,12 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
             <Grid.ColumnDefinitions>
@@ -18,13 +23,22 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+            <Grid Grid.Row="0" Grid.Column="1">
+                <TextBox x:Name="ServiceNameBox" Text="{Binding ServiceName}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host}" Style="{StaticResource FormField}"/>
+            <Grid Grid.Row="1" Grid.Column="1">
+                <TextBox x:Name="HostBox" Text="{Binding Host}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}"/>
+            <Grid Grid.Row="2" Grid.Column="1">
+                <TextBox x:Name="PortBox" Text="{Binding Port}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open TCP Advanced Configuration"/>

--- a/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
@@ -3,7 +3,12 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
             <Grid.ColumnDefinitions>
@@ -18,13 +23,22 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+            <Grid Grid.Row="0" Grid.Column="1">
+                <TextBox x:Name="ServiceNameBox" Text="{Binding ServiceName}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host}" Style="{StaticResource FormField}"/>
+            <Grid Grid.Row="1" Grid.Column="1">
+                <TextBox x:Name="HostBox" Text="{Binding Host}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}"/>
+            <Grid Grid.Row="2" Grid.Column="1">
+                <TextBox x:Name="PortBox" Text="{Binding Port}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
             <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
                 <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open TCP Advanced Configuration"/>

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -98,7 +98,8 @@ Recent Attempt: `dotnet` command still missing; unable to run restore, build, or
 Newest Attempt: After adding MQTT log view, `dotnet` CLI remains missing; relying on CI for build and test.
 Another Attempt: After embedding a collapsible MQTT log panel and wiring global log handling, the `dotnet` CLI remains unavailable; relying on CI for build and test.
 Another Attempt: After updating TcpEditServiceViewModel advanced config and installing the .NET SDK 8.0.404, `dotnet restore` succeeded but `dotnet build` failed with MqttService.cs missing `ConnectingFailedAsync`; relying on CI for validation.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210
+Another Attempt: After adding TCP view placeholders, the `dotnet` command is still missing; restore, build, and tests cannot run locally, so CI will verify.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- add automatic tooltips and placeholder examples to TCP create/edit service fields
- document missing dotnet CLI while verifying TCP placeholder update

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83b29de6083268126d0d1bece6271