### PR TITLE
Add validation to SCP service creation

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpCreateServiceViewModel.cs
@@ -9,6 +9,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// </summary>
 public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOptions>
 {
+    private readonly IServiceRule _rule;
     private string _serviceName = string.Empty;
     private string _host = string.Empty;
     private string _port = "22";
@@ -18,9 +19,10 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     /// <summary>
     /// Initializes a new instance of the <see cref="ScpCreateServiceViewModel"/> class.
     /// </summary>
-    public ScpCreateServiceViewModel(ILoggingService? logger = null)
+    public ScpCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
         : base(logger)
     {
+        _rule = rule ?? throw new ArgumentNullException(nameof(rule));
     }
 
     /// <summary>
@@ -44,7 +46,21 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     public string ServiceName
     {
         get => _serviceName;
-        set { _serviceName = value; OnPropertyChanged(); }
+        set
+        {
+            _serviceName = value;
+            var error = _rule.ValidateRequired(value, "Service name");
+            if (error is not null)
+            {
+                AddError(nameof(ServiceName), error);
+                Logger?.Log(error, LogLevel.Warning);
+            }
+            else
+            {
+                ClearErrors(nameof(ServiceName));
+            }
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>
@@ -53,7 +69,21 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     public string Host
     {
         get => _host;
-        set { _host = value; OnPropertyChanged(); }
+        set
+        {
+            _host = value;
+            var error = _rule.ValidateRequired(value, "Host");
+            if (error is not null)
+            {
+                AddError(nameof(Host), error);
+                Logger?.Log(error, LogLevel.Warning);
+            }
+            else
+            {
+                ClearErrors(nameof(Host));
+            }
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>
@@ -62,7 +92,30 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     public string Port
     {
         get => _port;
-        set { _port = value; OnPropertyChanged(); }
+        set
+        {
+            _port = value;
+            if (int.TryParse(value, out var port))
+            {
+                var error = _rule.ValidatePort(port);
+                if (error is not null)
+                {
+                    AddError(nameof(Port), error);
+                    Logger?.Log(error, LogLevel.Warning);
+                }
+                else
+                {
+                    ClearErrors(nameof(Port));
+                }
+            }
+            else
+            {
+                var error = "Port must be a number";
+                AddError(nameof(Port), error);
+                Logger?.Log(error, LogLevel.Warning);
+            }
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>
@@ -71,7 +124,21 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     public string Username
     {
         get => _username;
-        set { _username = value; OnPropertyChanged(); }
+        set
+        {
+            _username = value;
+            var error = _rule.ValidateRequired(value, "Username");
+            if (error is not null)
+            {
+                AddError(nameof(Username), error);
+                Logger?.Log(error, LogLevel.Warning);
+            }
+            else
+            {
+                ClearErrors(nameof(Username));
+            }
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>
@@ -80,7 +147,21 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     public string Password
     {
         get => _password;
-        set { _password = value; OnPropertyChanged(); }
+        set
+        {
+            _password = value;
+            var error = _rule.ValidateRequired(value, "Password");
+            if (error is not null)
+            {
+                AddError(nameof(Password), error);
+                Logger?.Log(error, LogLevel.Warning);
+            }
+            else
+            {
+                ClearErrors(nameof(Password));
+            }
+            OnPropertyChanged();
+        }
     }
 
     /// <summary>
@@ -91,6 +172,11 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     /// <inheritdoc />
     protected override void OnSave()
     {
+        if (HasErrors)
+        {
+            Logger?.Log("SCP create validation failed", LogLevel.Warning);
+            return;
+        }
         Logger?.Log("SCP create options start", LogLevel.Debug);
         Options.Host = Host;
         if (int.TryParse(Port, out var port))

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceCreateViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceCreateViewModelBase.cs
@@ -17,9 +17,11 @@ public abstract class ServiceCreateViewModelBase<TOptions> : ValidatableViewMode
     protected ServiceCreateViewModelBase(ILoggingService? logger = null)
     {
         Logger = logger;
-        SaveCommand = new RelayCommand(OnSave);
+        var saveCommand = new RelayCommand(OnSave, () => !HasErrors);
+        SaveCommand = saveCommand;
         CancelCommand = new RelayCommand(OnCancel);
         AdvancedConfigCommand = new RelayCommand(OnAdvancedConfig);
+        ErrorsChanged += (_, _) => saveCommand.RaiseCanExecuteChanged();
     }
 
     /// <inheritdoc />
@@ -29,6 +31,11 @@ public abstract class ServiceCreateViewModelBase<TOptions> : ValidatableViewMode
     /// Command executed to save the service.
     /// </summary>
     public ICommand SaveCommand { get; }
+
+    /// <summary>
+    /// Alias for <see cref="SaveCommand"/> used by XAML bindings.
+    /// </summary>
+    public ICommand CreateCommand => SaveCommand;
 
     /// <summary>
     /// Command executed to cancel creation.

--- a/DesktopApplicationTemplate.UI/Views/ScpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScpCreateServiceView.xaml
@@ -20,19 +20,19 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <TextBlock Grid.Row="3" Grid.Column="0" Text="Username" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Username}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Username, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
-        <PasswordBox Grid.Row="4" Grid.Column="1" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Style="{StaticResource FormField}"/>
+        <PasswordBox Grid.Row="4" Grid.Column="1" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
         <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
             <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open SCP Advanced Configuration"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.
+- SCP service creation validates required fields and disables the Create command when inputs are invalid.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -100,6 +100,7 @@ Another Attempt: After embedding a collapsible MQTT log panel and wiring global 
 Another Attempt: After updating TcpEditServiceViewModel advanced config and installing the .NET SDK 8.0.404, `dotnet restore` succeeded but `dotnet build` failed with MqttService.cs missing `ConnectingFailedAsync`; relying on CI for validation.
 Another Attempt: After adding TCP view placeholders, the `dotnet` command is still missing; restore, build, and tests cannot run locally, so CI will verify.
 Another Attempt: After extending TCP advanced configuration with script fields, the `dotnet` CLI remains unavailable; relying on CI.
+Another Attempt: After adding SCP service validation, the `dotnet` command is still missing; will rely on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- validate SCP service creation inputs using `IServiceRule` and log failures
- surface validation errors in SCP create view and disable Create when invalid
- document SCP create validation in changelog and note test environment limits

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84174d5b88326bbce37c89a9138ed