### PR TITLE
Inject service rule validation into service view models

### DIFF
--- a/DesktopApplicationTemplate.Tests/DiContainerTests.cs
+++ b/DesktopApplicationTemplate.Tests/DiContainerTests.cs
@@ -2,6 +2,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Service.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -17,6 +18,7 @@ public class DiContainerTests
         services.AddSingleton<ILoggingService, LoggingService>();
         services.AddSingleton<IMessageRoutingService, MessageRoutingService>();
         services.AddSingleton<SaveConfirmationHelper>();
+        services.AddSingleton<IServiceRule, ServiceRule>();
         services.AddSingleton<MqttService>();
         services.AddSingleton<MqttTagSubscriptionsViewModel>();
         services.AddTransient<TcpCreateServiceViewModel>();

--- a/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using MQTTnet.Protocol;
@@ -14,7 +15,7 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void SaveCommand_Raises_ServiceCreated()
     {
-        var vm = new MqttCreateServiceViewModel();
+        var vm = new MqttCreateServiceViewModel(new ServiceRule());
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1234;
@@ -37,7 +38,7 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void CancelCommand_Raises_Cancelled()
     {
-        var vm = new MqttCreateServiceViewModel();
+        var vm = new MqttCreateServiceViewModel(new ServiceRule());
         var cancelled = false;
         vm.Cancelled += () => cancelled = true;
 
@@ -51,7 +52,7 @@ public class MqttCreateServiceViewModelTests
     {
         var tempCert = Path.GetTempFileName();
         File.WriteAllBytes(tempCert, new byte[] { 1, 2, 3 });
-        var vm = new MqttCreateServiceViewModel();
+        var vm = new MqttCreateServiceViewModel(new ServiceRule());
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1234;
@@ -94,7 +95,7 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void SaveCommand_ConvertsBlankFieldsToNull()
     {
-        var vm = new MqttCreateServiceViewModel();
+        var vm = new MqttCreateServiceViewModel(new ServiceRule());
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1883;
@@ -115,5 +116,13 @@ public class MqttCreateServiceViewModelTests
         Assert.Null(received.WillTopic);
         Assert.Null(received.WillPayload);
         Assert.Null(received.ReconnectDelay);
+    }
+
+    [Fact]
+    public void SettingEmptyServiceName_AddsError()
+    {
+        var vm = new MqttCreateServiceViewModel(new ServiceRule());
+        vm.ServiceName = string.Empty;
+        Assert.True(vm.HasErrors);
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
@@ -1,3 +1,5 @@
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Xunit;
@@ -9,7 +11,7 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void SaveCommand_Raises_ServiceCreated()
     {
-        var vm = new TcpCreateServiceViewModel();
+        var vm = new TcpCreateServiceViewModel(new ServiceRule());
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1234;
@@ -32,7 +34,7 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void CancelCommand_Raises_Cancelled()
     {
-        var vm = new TcpCreateServiceViewModel();
+        var vm = new TcpCreateServiceViewModel(new ServiceRule());
         var cancelled = false;
         vm.Cancelled += () => cancelled = true;
 
@@ -44,7 +46,7 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void AdvancedConfigCommand_Raises_Event_WithOptions()
     {
-        var vm = new TcpCreateServiceViewModel();
+        var vm = new TcpCreateServiceViewModel(new ServiceRule());
         vm.Host = "host";
         vm.Port = 123;
         vm.Options.UseUdp = true;
@@ -59,5 +61,13 @@ public class TcpCreateServiceViewModelTests
         Assert.Equal(123, received.Port);
         Assert.True(received.UseUdp);
         Assert.Equal(TcpServiceMode.Sending, received.Mode);
+    }
+
+    [Fact]
+    public void SettingEmptyServiceName_AddsError()
+    {
+        var vm = new TcpCreateServiceViewModel(new ServiceRule());
+        vm.ServiceName = string.Empty;
+        Assert.True(vm.HasErrors);
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
@@ -1,3 +1,5 @@
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Xunit;
@@ -10,7 +12,7 @@ public class TcpEditServiceViewModelTests
     public void SaveCommand_Raises_ServiceUpdated()
     {
         var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening };
-        var vm = new TcpEditServiceViewModel();
+        var vm = new TcpEditServiceViewModel(new ServiceRule());
         vm.Load("svc", options);
         vm.Host = "new";
         vm.Port = 2;
@@ -34,7 +36,7 @@ public class TcpEditServiceViewModelTests
     public void AdvancedConfigCommand_Raises_Event_WithUpdatedOptions()
     {
         var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening };
-        var vm = new TcpEditServiceViewModel();
+        var vm = new TcpEditServiceViewModel(new ServiceRule());
         vm.Load("svc", options);
         vm.Host = "new";
         vm.Port = 2;
@@ -50,5 +52,14 @@ public class TcpEditServiceViewModelTests
         Assert.Equal(2, received.Port);
         Assert.True(received.UseUdp);
         Assert.Equal(TcpServiceMode.Sending, received.Mode);
+    }
+
+    [Fact]
+    public void SettingEmptyServiceName_AddsError()
+    {
+        var vm = new TcpEditServiceViewModel(new ServiceRule());
+        vm.Load("svc", new TcpServiceOptions());
+        vm.ServiceName = string.Empty;
+        Assert.True(vm.HasErrors);
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -55,6 +55,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<IFileDialogService, FileDialogService>();
             services.AddSingleton<IFileSearchService, DesktopApplicationTemplate.Service.Services.FileSearchService>();
             services.AddSingleton<SaveConfirmationHelper>();
+            services.AddSingleton<IServiceRule, DesktopApplicationTemplate.Service.Services.ServiceRule>();
             services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<TcpServiceView>();

--- a/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
@@ -17,10 +17,30 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                    <Style.Triggers>
+                        <Trigger Property="Validation.HasError" Value="True">
+                            <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="File Path" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                    <Style.Triggers>
+                        <Trigger Property="Validation.HasError" Value="True">
+                            <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
         <Button Grid.Row="1" Grid.Column="2" Content="Browse" Width="75" Margin="5,0,0,0" Command="{Binding BrowseCommand}"/>
 
         <StackPanel Grid.Row="2" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">

--- a/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
@@ -16,10 +16,30 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                    <Style.Triggers>
+                        <Trigger Property="Validation.HasError" Value="True">
+                            <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="File Path" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath}" Style="{StaticResource FormField}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding FilePath, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox.Style>
+                <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                    <Style.Triggers>
+                        <Trigger Property="Validation.HasError" Value="True">
+                            <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBox.Style>
+        </TextBox>
 
         <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
             <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open File Observer Advanced Configuration"/>

--- a/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
@@ -23,16 +23,56 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}" ToolTip="Service Name"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host}" Style="{StaticResource FormField}" ToolTip="Host"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}" ToolTip="Port"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Client Id" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ClientId}" Style="{StaticResource FormField}" ToolTip="Client Id"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ClientId, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Username" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Username}" Style="{StaticResource FormField}" ToolTip="Username"/>

--- a/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
@@ -21,16 +21,56 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName}" Style="{StaticResource FormField}" ToolTip="Service Name"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host}" Style="{StaticResource FormField}" ToolTip="Host"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port}" Style="{StaticResource FormField}" ToolTip="Port"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Client Id" Style="{StaticResource FormLabel}"/>
-            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ClientId}" Style="{StaticResource FormField}" ToolTip="Client Id"/>
+            <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ClientId, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <TextBox.Style>
+                    <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                        <Style.Triggers>
+                            <Trigger Property="Validation.HasError" Value="True">
+                                <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBox.Style>
+            </TextBox>
 
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Username" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Username}" Style="{StaticResource FormField}" ToolTip="Username"/>

--- a/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
@@ -24,19 +24,49 @@
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="0" Grid.Column="1">
-                <TextBox x:Name="ServiceNameBox" Text="{Binding ServiceName}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBox x:Name="ServiceNameBox" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="1" Grid.Column="1">
-                <TextBox x:Name="HostBox" Text="{Binding Host}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="2" Grid.Column="1">
-                <TextBox x:Name="PortBox" Text="{Binding Port}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 

--- a/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
@@ -24,19 +24,49 @@
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Service Name" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="0" Grid.Column="1">
-                <TextBox x:Name="ServiceNameBox" Text="{Binding ServiceName}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBox x:Name="ServiceNameBox" Text="{Binding ServiceName, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="1" Grid.Column="1">
-                <TextBox x:Name="HostBox" Text="{Binding Host}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="2" Grid.Column="1">
-                <TextBox x:Name="PortBox" Text="{Binding Port}" Style="{StaticResource FormField}" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
+                <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Service creation flows now display within the main view, removing the separate Create Service window and placeholder navigation text.
 - Main window height constrained to the work area to prevent overlapping the taskbar.
 - MQTT create and edit views include tooltips on text fields to clarify expected input.
+- Create and edit service view models inject `IServiceRule` to validate required fields with XAML error tooltips.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -101,6 +101,7 @@ Another Attempt: After updating TcpEditServiceViewModel advanced config and inst
 Another Attempt: After adding TCP view placeholders, the `dotnet` command is still missing; restore, build, and tests cannot run locally, so CI will verify.
 Another Attempt: After extending TCP advanced configuration with script fields, the `dotnet` CLI remains unavailable; relying on CI.
 Another Attempt: After adding SCP service validation, the `dotnet` command is still missing; will rely on CI.
+Another Attempt: After injecting IServiceRule into create/edit view models and updating XAML validation, the `dotnet` CLI remains unavailable; relying on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- validate service names, hosts, ports, and file paths by injecting `IServiceRule` into create/edit view models
- show validation errors in tooltips for service configuration fields
- register shared `ServiceRule` with the DI container and extend unit tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b848cd93448326aae90e6264a385e7