### PR TITLE
Register service screen and rule for FTP creation

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
@@ -2,6 +2,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -91,6 +92,21 @@ public class FtpServerCreateViewModelTests
         vm.AdvancedConfigCommand.Execute(null);
 
         Assert.True(raised);
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Fact]
+    public void ServiceProvider_ResolvesFtpServerCreateViewModel()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IServiceRule, ServiceRule>();
+        services.AddSingleton(typeof(IServiceScreen<>), typeof(ServiceScreen<>));
+        services.AddTransient<FtpServerCreateViewModel>();
+
+        using var provider = services.BuildServiceProvider();
+        var vm = provider.GetService<FtpServerCreateViewModel>();
+
+        Assert.NotNull(vm);
         ConsoleTestLogger.LogPass();
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -56,6 +56,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<IFileSearchService, DesktopApplicationTemplate.Service.Services.FileSearchService>();
             services.AddSingleton<SaveConfirmationHelper>();
             services.AddSingleton<IServiceRule, DesktopApplicationTemplate.Service.Services.ServiceRule>();
+            services.AddSingleton(typeof(IServiceScreen<>), typeof(DesktopApplicationTemplate.Service.Services.ServiceScreen<>));
             services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<TcpServiceView>();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Variable naming conflicts resolved in main window edit workflow to prevent build errors.
 - FTP server creation no longer freezes when selecting the service type and closes the selection window after saving.
 - Advanced configuration view injects logging via DI and initializes with a view model, resolving constructor instantiation errors.
+- Registered generic service screen in App startup so FTP create view model resolves via DI.
 
 ### TCP Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -102,6 +102,7 @@ Another Attempt: After adding TCP view placeholders, the `dotnet` command is sti
 Another Attempt: After extending TCP advanced configuration with script fields, the `dotnet` CLI remains unavailable; relying on CI.
 Another Attempt: After adding SCP service validation, the `dotnet` command is still missing; will rely on CI.
 Another Attempt: After injecting IServiceRule into create/edit view models and updating XAML validation, the `dotnet` CLI remains unavailable; relying on CI.
+Latest Attempt: After registering service screen for FTP options and adding DI resolution test, the `dotnet` command is still missing; relying on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- Register generic `IServiceScreen<>` so FTP view models resolve via DI
- Add DI resolution test for `FtpServerCreateViewModel`
- Note missing dotnet CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84e196e34832687cd3752b16eb301