### PR TITLE
Fix MQTT and TCP service build errors

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttEditConnectionViewModelTests.cs
@@ -130,7 +130,6 @@ public class MqttEditConnectionViewModelTests
     }
 
     [Fact]
-    [Fact]
     public void SubscriptionButtonText_ReflectsConnectionState()
     {
         var vm = CreateViewModel();

--- a/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
@@ -32,7 +32,7 @@ public class MqttServiceTests
         service.ConnectionStateChanged += (_, c) => state = c;
 
         await service.ConnectAsync();
-        client.Raise(c => c.ConnectedAsync += null!, (MqttClientConnectedEventArgs?)null);
+        client.Raise(c => c.ConnectedAsync += null!, new MqttClientConnectedEventArgs(new MqttClientConnectResult()));
 
         Assert.True(state);
         ConsoleTestLogger.LogPass();
@@ -203,7 +203,15 @@ public class MqttServiceTests
         bool? state = null;
         service.ConnectionStateChanged += (_, c) => state = c;
 
-        client.Raise(c => c.DisconnectedAsync += null!, (MqttClientDisconnectedEventArgs?)null);
+        client.Raise(
+            c => c.DisconnectedAsync += null!,
+            new MqttClientDisconnectedEventArgs(
+                false,
+                new MqttClientConnectResult(),
+                MqttClientDisconnectReason.NormalDisconnection,
+                null,
+                new List<MqttUserProperty>(),
+                null));
 
         Assert.False(state);
         logger.Verify(l => l.Log(It.Is<string>(s => s.Contains("MQTT disconnected")), LogLevel.Warning), Times.Once);

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -48,16 +48,12 @@ public class MqttService
 
         _client.DisconnectedAsync += e =>
         {
-            var message = e?.Exception != null ? $"MQTT disconnected: {e.Exception.Message}" : "MQTT disconnected";
-            _logger.Log(message, LogLevel.Warning);
+            var wasConnected = e?.ClientWasConnected == true;
+            var prefix = wasConnected ? "MQTT disconnected" : "MQTT connection failed";
+            var message = e?.Exception != null ? $"{prefix}: {e.Exception.Message}" : prefix;
+            var level = wasConnected ? LogLevel.Warning : LogLevel.Error;
+            _logger.Log(message, level);
             OnConnectionStateChanged(false);
-            return Task.CompletedTask;
-        };
-
-        _client.ConnectingFailedAsync += e =>
-        {
-            var message = e?.Exception != null ? $"MQTT connection failed: {e.Exception.Message}" : "MQTT connection failed";
-            _logger.Log(message, LogLevel.Error);
             return Task.CompletedTask;
         };
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -252,13 +252,13 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
         public void Load(TcpServiceOptions options)
         {
             _options = options ?? new TcpServiceOptions();
-            ComputerIp = options.Host;
-            ListeningPort = options.Port.ToString();
-            IsUdp = options.UseUdp;
-            SelectedMode = options.Mode.ToString();
-            ScriptContent = options.Script;
-            InputMessage = options.InputMessage;
-            OutputMessage = options.OutputMessage;
+            ComputerIp = _options.Host;
+            ListeningPort = _options.Port.ToString();
+            IsUdp = _options.UseUdp;
+            SelectedMode = _options.Mode.ToString();
+            ScriptContent = _options.Script;
+            InputMessage = _options.InputMessage;
+            OutputMessage = _options.OutputMessage;
             _messagesViewModel.UpdateScript(ScriptContent);
         }
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -15,12 +15,14 @@ using DesktopApplicationTemplate.Models;
 using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 using DesktopApplicationTemplate.UI;
+using System.Runtime.Versioning;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public partial class MainView : Window
     {
         private readonly MainViewModel _viewModel;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.
 - SCP service creation validates required fields and disables the Create command when inputs are invalid.
+- Marked main window as Windows-only to silence cross-platform analyzer warnings.
 
 ### HID Service
 #### Added
@@ -92,6 +93,7 @@
 #### Fixed
 - Replaced `UriParser.GetSyntax` usage with `IsKnownScheme` and guarded TCP option restoration to avoid null references.
 - Registered the WPF pack URI scheme so BubblyWindow resources load without invalid URI errors.
+- Loading TCP options no longer dereferences a null reference.
 
 ### MQTT Service
 #### Added
@@ -124,6 +126,7 @@
 - Added missing `MQTTnet.Protocol` using to restore `MqttQualityOfServiceLevel` references.
 - Host validation now accepts domain names and rejects underscores.
 - Restored `MqttEndpointMessage` namespace in MQTT service view model to fix build errors.
+- Logged connection failures through the disconnected handler and removed obsolete `ConnectingFailedAsync` usage.
 
 ### CSV Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -103,6 +103,7 @@ Another Attempt: After extending TCP advanced configuration with script fields, 
 Another Attempt: After adding SCP service validation, the `dotnet` command is still missing; will rely on CI.
 Another Attempt: After injecting IServiceRule into create/edit view models and updating XAML validation, the `dotnet` CLI remains unavailable; relying on CI.
 Latest Attempt: After registering service screen for FTP options and adding DI resolution test, the `dotnet` command is still missing; relying on CI.
+Latest Attempt: Installed the .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` failed because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- log MQTT connection failures via the disconnected handler and drop obsolete ConnectingFailedAsync event
- guard TcpService option loading against null values
- mark MainView as Windows-only and tidy duplicated test attributes

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b85109f9e4832685aabe43594b45b4