### PR TITLE
Expose AdvancedConfigCommand in HTTP service views

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/HttpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpCreateServiceViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -35,11 +34,6 @@ public class HttpCreateServiceViewModel : ServiceCreateViewModelBase<HttpService
     /// Raised when advanced configuration is requested.
     /// </summary>
     public event Action<HttpServiceOptions>? AdvancedConfigRequested;
-
-    /// <summary>
-    /// Command to open advanced configuration.
-    /// </summary>
-    public ICommand OpenAdvancedConfigCommand => AdvancedConfigCommand;
 
     /// <summary>
     /// Name of the service.

--- a/DesktopApplicationTemplate.UI/Views/HttpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpCreateServiceView.xaml
@@ -22,7 +22,7 @@
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseUrl}" Style="{StaticResource FormField}"/>
 
         <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding OpenAdvancedConfigCommand}" AutomationProperties.Name="Open HTTP Advanced Configuration"/>
+            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HTTP Advanced Configuration"/>
             <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create HTTP Service"/>
             <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HTTP Creation"/>
         </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/HttpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpEditServiceView.xaml
@@ -22,7 +22,7 @@
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseUrl}" Style="{StaticResource FormField}"/>
 
         <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding OpenAdvancedConfigCommand}" AutomationProperties.Name="Open HTTP Advanced Configuration"/>
+            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HTTP Advanced Configuration"/>
             <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HTTP Service"/>
             <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HTTP Edit"/>
         </StackPanel>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -149,6 +149,9 @@
 #### Added
 - HTTP service creation and edit views with advanced configuration for authentication and TLS certificate paths.
 
+#### Changed
+- Exposed `AdvancedConfigCommand` directly in HTTP service creation and edit views, removing the redundant wrapper command.
+
 ### File Observer
 #### Added
 - File search service with async caching and DI integration for File Observer.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -105,6 +105,7 @@ Another Attempt: After injecting IServiceRule into create/edit view models and u
 Latest Attempt: After registering service screen for FTP options and adding DI resolution test, the `dotnet` command is still missing; relying on CI.
 Latest Attempt: Installed the .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` failed because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Newest Attempt: After introducing shared ServiceEditorView, the `dotnet` command remains unavailable; relying on CI for verification.
+Another Attempt: After exposing AdvancedConfigCommand directly in HTTP service views, the `dotnet` CLI remains unavailable; relying on CI for build and test.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- remove redundant `OpenAdvancedConfigCommand` property from `HttpCreateServiceViewModel`
- bind HTTP create/edit views directly to `AdvancedConfigCommand`
- log dotnet CLI absence in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87ca49d288326ab98cce49ac07c13