### PR TITLE
feat: add reusable editor button bar for service views

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml
@@ -4,7 +4,10 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
-      mc:Ignorable="d">
+      mc:Ignorable="d"
+      AdvancedAutomationName="Open CSV Advanced Configuration"
+      SaveAutomationName="Save CSV Service"
+      CancelAutomationName="Cancel CSV Edit">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -43,10 +44,13 @@
         </TextBox>
         <Button Grid.Row="1" Grid.Column="2" Content="Browse" Width="75" Margin="5,0,0,0" Command="{Binding BrowseCommand}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="3" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open File Observer Advanced Configuration"/>
-            <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create File Observer Service"/>
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel File Observer Creation"/>
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="3"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding CreateCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               SaveButtonText="Create"
+                               AdvancedAutomationName="Open File Observer Advanced Configuration"
+                               SaveAutomationName="Create File Observer Service"
+                               CancelAutomationName="Cancel File Observer Creation" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -41,10 +42,12 @@
             </TextBox.Style>
         </TextBox>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open File Observer Advanced Configuration"/>
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save File Observer Service"/>
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel File Observer Edit"/>
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding SaveCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               AdvancedAutomationName="Open File Observer Advanced Configuration"
+                               SaveAutomationName="Save File Observer Service"
+                               CancelAutomationName="Cancel File Observer Edit" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -26,11 +27,13 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Root Path" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open FTP Advanced Configuration"/>
-                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save FTP Server"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel FTP Server Creation"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open FTP Advanced Configuration"
+                                   SaveAutomationName="Save FTP Server"
+                                   CancelAutomationName="Cancel FTP Server Creation" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/FtpServerEditView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerEditView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -26,11 +27,13 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Root Path" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open FTP Advanced Configuration"/>
-                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save FTP Server"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel FTP Server Edit"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open FTP Advanced Configuration"
+                                   SaveAutomationName="Save FTP Server"
+                                   CancelAutomationName="Cancel FTP Server Edit" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatCreateServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -22,11 +23,14 @@
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Base Message" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseMessage}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open Heartbeat Advanced Configuration"/>
-                <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create Heartbeat Service"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel Heartbeat Creation"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding CreateCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   SaveButtonText="Create"
+                                   AdvancedAutomationName="Open Heartbeat Advanced Configuration"
+                                   SaveAutomationName="Create Heartbeat Service"
+                                   CancelAutomationName="Cancel Heartbeat Creation" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatEditServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -22,11 +23,13 @@
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Base Message" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseMessage}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open Heartbeat Advanced Configuration"/>
-                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save Heartbeat Service"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel Heartbeat Edit"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open Heartbeat Advanced Configuration"
+                                   SaveAutomationName="Save Heartbeat Service"
+                                   CancelAutomationName="Cancel Heartbeat Edit" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -30,11 +31,14 @@
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Attached Service" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AttachedService}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HID Advanced Configuration"/>
-                <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create HID Service"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HID Creation"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding CreateCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   SaveButtonText="Create"
+                                   AdvancedAutomationName="Open HID Advanced Configuration"
+                                   SaveAutomationName="Create HID Service"
+                                   CancelAutomationName="Cancel HID Creation" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -30,11 +31,13 @@
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Attached Service" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AttachedService}" Style="{StaticResource FormField}"/>
 
-            <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HID Advanced Configuration"/>
-                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HID Service"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HID Edit"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open HID Advanced Configuration"
+                                   SaveAutomationName="Save HID Service"
+                                   CancelAutomationName="Cancel HID Edit" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HttpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpCreateServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -21,10 +22,13 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Base URL" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseUrl}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HTTP Advanced Configuration"/>
-            <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create HTTP Service"/>
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HTTP Creation"/>
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding CreateCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               SaveButtonText="Create"
+                               AdvancedAutomationName="Open HTTP Advanced Configuration"
+                               SaveAutomationName="Create HTTP Service"
+                               CancelAutomationName="Cancel HTTP Creation" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HttpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpEditServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -21,10 +22,12 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Base URL" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseUrl}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open HTTP Advanced Configuration"/>
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HTTP Service"/>
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel HTTP Edit"/>
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding SaveCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               AdvancedAutomationName="Open HTTP Advanced Configuration"
+                               SaveAutomationName="Save HTTP Service"
+                               CancelAutomationName="Cancel HTTP Edit" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
@@ -4,6 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:svc="clr-namespace:DesktopApplicationTemplate.UI.Services"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -88,11 +89,14 @@
                 <ComboBoxItem Content="WebSocket TLS" Tag="{x:Static svc:MqttConnectionType.WebSocketTls}"/>
             </ComboBox>
 
-            <StackPanel Grid.Row="7" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0" >
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open MQTT Advanced Configuration"/>
-                <Button x:Name="CreateButton" Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create MQTT Service"/>
-                <Button x:Name="CancelButton" Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel MQTT Creation"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="7" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding CreateCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   SaveButtonText="Create"
+                                   AdvancedAutomationName="Open MQTT Advanced Configuration"
+                                   SaveAutomationName="Create MQTT Service"
+                                   CancelAutomationName="Cancel MQTT Creation" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -78,11 +79,13 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Password}" Style="{StaticResource FormField}" ToolTip="Password"/>
 
-            <StackPanel Grid.Row="6" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open MQTT Advanced Configuration"/>
-                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save MQTT Service"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel MQTT Edit"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open MQTT Advanced Configuration"
+                                   SaveAutomationName="Save MQTT Service"
+                                   CancelAutomationName="Cancel MQTT Edit" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/ScpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScpCreateServiceView.xaml
@@ -4,6 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -34,10 +35,13 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
         <PasswordBox Grid.Row="4" Grid.Column="1" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open SCP Advanced Configuration"/>
-            <Button Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create SCP Service"/>
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel SCP Creation"/>
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding CreateCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               SaveButtonText="Create"
+                               AdvancedAutomationName="Open SCP Advanced Configuration"
+                               SaveAutomationName="Create SCP Service"
+                               CancelAutomationName="Cancel SCP Creation" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/ScpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScpEditServiceView.xaml
@@ -4,6 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -34,10 +35,12 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
         <PasswordBox Grid.Row="4" Grid.Column="1" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open SCP Advanced Configuration"/>
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save SCP Service"/>
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel SCP Edit"/>
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding SaveCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               AdvancedAutomationName="Open SCP Advanced Configuration"
+                               SaveAutomationName="Save SCP Service"
+                               CancelAutomationName="Cancel SCP Edit" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.EditorButtonBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+        <Button Content="Advanced"
+                Width="100" Margin="5"
+                Command="{Binding AdvancedConfigCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                AutomationProperties.Name="{Binding AdvancedAutomationName, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        <Button Content="{Binding SaveButtonText, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Width="100" Margin="5"
+                Command="{Binding SaveCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                AutomationProperties.Name="{Binding SaveAutomationName, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        <Button Content="Cancel"
+                Width="100" Margin="5"
+                Command="{Binding CancelCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                AutomationProperties.Name="{Binding CancelAutomationName, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+    </StackPanel>
+</UserControl>

--- a/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml.cs
@@ -1,0 +1,76 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class EditorButtonBar : UserControl
+{
+    public EditorButtonBar()
+    {
+        InitializeComponent();
+    }
+
+    public ICommand? AdvancedConfigCommand
+    {
+        get => (ICommand?)GetValue(AdvancedConfigCommandProperty);
+        set => SetValue(AdvancedConfigCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty AdvancedConfigCommandProperty =
+        DependencyProperty.Register(nameof(AdvancedConfigCommand), typeof(ICommand), typeof(EditorButtonBar));
+
+    public ICommand? SaveCommand
+    {
+        get => (ICommand?)GetValue(SaveCommandProperty);
+        set => SetValue(SaveCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveCommandProperty =
+        DependencyProperty.Register(nameof(SaveCommand), typeof(ICommand), typeof(EditorButtonBar));
+
+    public ICommand? CancelCommand
+    {
+        get => (ICommand?)GetValue(CancelCommandProperty);
+        set => SetValue(CancelCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty CancelCommandProperty =
+        DependencyProperty.Register(nameof(CancelCommand), typeof(ICommand), typeof(EditorButtonBar));
+
+    public string SaveButtonText
+    {
+        get => (string)GetValue(SaveButtonTextProperty);
+        set => SetValue(SaveButtonTextProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveButtonTextProperty =
+        DependencyProperty.Register(nameof(SaveButtonText), typeof(string), typeof(EditorButtonBar), new PropertyMetadata("Save"));
+
+    public string AdvancedAutomationName
+    {
+        get => (string)GetValue(AdvancedAutomationNameProperty);
+        set => SetValue(AdvancedAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty AdvancedAutomationNameProperty =
+        DependencyProperty.Register(nameof(AdvancedAutomationName), typeof(string), typeof(EditorButtonBar), new PropertyMetadata("Open Advanced Configuration"));
+
+    public string SaveAutomationName
+    {
+        get => (string)GetValue(SaveAutomationNameProperty);
+        set => SetValue(SaveAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveAutomationNameProperty =
+        DependencyProperty.Register(nameof(SaveAutomationName), typeof(string), typeof(EditorButtonBar), new PropertyMetadata("Save Service"));
+
+    public string CancelAutomationName
+    {
+        get => (string)GetValue(CancelAutomationNameProperty);
+        set => SetValue(CancelAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty CancelAutomationNameProperty =
+        DependencyProperty.Register(nameof(CancelAutomationName), typeof(string), typeof(EditorButtonBar), new PropertyMetadata("Cancel"));
+}

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml
@@ -1,6 +1,7 @@
 <Page x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       x:Name="Root">
     <Grid Margin="20">
         <Grid.RowDefinitions>
@@ -8,10 +9,13 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <ContentPresenter Grid.Row="0" />
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" />
-            <Button Content="{Binding SaveButtonText}" Width="100" Margin="5" Command="{Binding SaveCommand}" />
-            <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" />
-        </StackPanel>
+        <views:EditorButtonBar Grid.Row="1"
+                               AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                               SaveCommand="{Binding SaveCommand}"
+                               CancelCommand="{Binding CancelCommand}"
+                               SaveButtonText="{Binding SaveButtonText}"
+                               AdvancedAutomationName="{Binding AdvancedAutomationName, RelativeSource={RelativeSource AncestorType=Page}}"
+                               SaveAutomationName="{Binding SaveAutomationName, RelativeSource={RelativeSource AncestorType=Page}}"
+                               CancelAutomationName="{Binding CancelAutomationName, RelativeSource={RelativeSource AncestorType=Page}}" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace DesktopApplicationTemplate.UI.Views;
@@ -8,4 +9,31 @@ public partial class ServiceEditorView : Page
     {
         InitializeComponent();
     }
+
+    public string AdvancedAutomationName
+    {
+        get => (string)GetValue(AdvancedAutomationNameProperty);
+        set => SetValue(AdvancedAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty AdvancedAutomationNameProperty =
+        DependencyProperty.Register(nameof(AdvancedAutomationName), typeof(string), typeof(ServiceEditorView), new PropertyMetadata("Open Advanced Configuration"));
+
+    public string SaveAutomationName
+    {
+        get => (string)GetValue(SaveAutomationNameProperty);
+        set => SetValue(SaveAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveAutomationNameProperty =
+        DependencyProperty.Register(nameof(SaveAutomationName), typeof(string), typeof(ServiceEditorView), new PropertyMetadata("Save Service"));
+
+    public string CancelAutomationName
+    {
+        get => (string)GetValue(CancelAutomationNameProperty);
+        set => SetValue(CancelAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty CancelAutomationNameProperty =
+        DependencyProperty.Register(nameof(CancelAutomationName), typeof(string), typeof(ServiceEditorView), new PropertyMetadata("Cancel"));
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
@@ -5,6 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
@@ -70,11 +71,14 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open TCP Advanced Configuration"/>
-                <Button x:Name="CreateButton" Content="Create" Width="100" Margin="5" Command="{Binding CreateCommand}" AutomationProperties.Name="Create TCP Service"/>
-                <Button x:Name="CancelButton" Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel TCP Creation"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding CreateCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   SaveButtonText="Create"
+                                   AdvancedAutomationName="Open TCP Advanced Configuration"
+                                   SaveAutomationName="Create TCP Service"
+                                   CancelAutomationName="Cancel TCP Creation" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
@@ -5,6 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
@@ -70,11 +71,13 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-                <Button Content="Advanced" Width="100" Margin="5" Command="{Binding AdvancedConfigCommand}" AutomationProperties.Name="Open TCP Advanced Configuration"/>
-                <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save TCP Service"/>
-                <Button Content="Cancel" Width="100" Margin="5" Command="{Binding CancelCommand}" AutomationProperties.Name="Cancel TCP Edit"/>
-            </StackPanel>
+            <views:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open TCP Advanced Configuration"
+                                   SaveAutomationName="Save TCP Service"
+                                   CancelAutomationName="Cancel TCP Edit" />
         </Grid>
     </ScrollViewer>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Main window height constrained to the work area to prevent overlapping the taskbar.
 - MQTT create and edit views include tooltips on text fields to clarify expected input.
 - Create and edit service view models inject `IServiceRule` to validate required fields with XAML error tooltips.
+- Service editor views share a reusable `EditorButtonBar` control with consistent automation names.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -106,6 +106,7 @@ Latest Attempt: After registering service screen for FTP options and adding DI r
 Latest Attempt: Installed the .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` failed because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Newest Attempt: After introducing shared ServiceEditorView, the `dotnet` command remains unavailable; relying on CI for verification.
 Another Attempt: After exposing AdvancedConfigCommand directly in HTTP service views, the `dotnet` CLI remains unavailable; relying on CI for build and test.
+Latest Attempt: After consolidating editor buttons into a shared control, the `dotnet` CLI is still missing; relying on CI for verification.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add reusable `EditorButtonBar` user control with configurable commands and automation names
- swap out individual service editor button stacks for shared control
- log missing `dotnet` CLI when attempting restore/build/test

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87e29375883268b3db86b46e593f8