### PR TITLE
feat(ui): centralize advanced config commands

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/AdvancedConfigViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/AdvancedConfigViewModelBase.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// Base view model providing Save and Back commands for advanced configuration screens.
+/// </summary>
+/// <typeparam name="TOptions">Type of options managed by the screen.</typeparam>
+public abstract class AdvancedConfigViewModelBase<TOptions> : ValidatableViewModelBase, ILoggingViewModel
+    where TOptions : class
+{
+    protected AdvancedConfigViewModelBase(ILoggingService? logger = null)
+    {
+        Logger = logger;
+        SaveCommand = new RelayCommand(Save);
+        BackCommand = new RelayCommand(Back);
+    }
+
+    /// <inheritdoc />
+    public ILoggingService? Logger { get; set; }
+
+    /// <summary>
+    /// Command executed to save the configuration.
+    /// </summary>
+    public ICommand SaveCommand { get; }
+
+    /// <summary>
+    /// Command executed to navigate back without saving.
+    /// </summary>
+    public ICommand BackCommand { get; }
+
+    /// <summary>
+    /// Raised when the configuration is saved.
+    /// </summary>
+    public event Action<TOptions>? Saved;
+
+    /// <summary>
+    /// Raised when navigation back is requested.
+    /// </summary>
+    public event Action? BackRequested;
+
+    private void Save()
+    {
+        var options = OnSave();
+        if (options is not null)
+            Saved?.Invoke(options);
+    }
+
+    private void Back()
+    {
+        OnBack();
+        BackRequested?.Invoke();
+    }
+
+    /// <summary>
+    /// Handles saving the configuration and returns updated options or <c>null</c> to cancel.
+    /// </summary>
+    protected abstract TOptions? OnSave();
+
+    /// <summary>
+    /// Handles back navigation.
+    /// </summary>
+    protected virtual void OnBack()
+    {
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/CsvAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CsvAdvancedConfigViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -8,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced CSV creator configuration.
 /// </summary>
-public class CsvAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
+public class CsvAdvancedConfigViewModel : AdvancedConfigViewModelBase<CsvServiceOptions>
 {
     private readonly CsvServiceOptions _options;
     private string _delimiter;
@@ -18,37 +17,12 @@ public class CsvAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
     /// Initializes a new instance of the <see cref="CsvAdvancedConfigViewModel"/> class.
     /// </summary>
     public CsvAdvancedConfigViewModel(CsvServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _delimiter = options.Delimiter;
         _includeHeaders = options.IncludeHeaders;
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the configuration.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<CsvServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Delimiter used between values.
@@ -68,18 +42,17 @@ public class CsvAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
         set { _includeHeaders = value; OnPropertyChanged(); }
     }
 
-    private void Save()
+    protected override CsvServiceOptions OnSave()
     {
         Logger?.Log("CSV advanced options start", LogLevel.Debug);
         _options.Delimiter = Delimiter;
         _options.IncludeHeaders = IncludeHeaders;
         Logger?.Log("CSV advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("CSV advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserverAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserverAdvancedConfigViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -8,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced File Observer configuration.
 /// </summary>
-public class FileObserverAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class FileObserverAdvancedConfigViewModel : AdvancedConfigViewModelBase<FileObserverServiceOptions>
 {
     private readonly FileObserverServiceOptions _options;
     private string _imageNames;
@@ -22,6 +21,7 @@ public class FileObserverAdvancedConfigViewModel : ValidatableViewModelBase, ILo
     /// Initializes a new instance of the <see cref="FileObserverAdvancedConfigViewModel"/> class.
     /// </summary>
     public FileObserverAdvancedConfigViewModel(FileObserverServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _imageNames = options.ImageNames;
@@ -30,33 +30,7 @@ public class FileObserverAdvancedConfigViewModel : ValidatableViewModelBase, ILo
         _xCount = options.XCount;
         _sendTcp = options.SendTcpCommand;
         _tcpCommand = options.TcpCommand;
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the configuration.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<FileObserverServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Comma-separated list of image names.
@@ -112,7 +86,7 @@ public class FileObserverAdvancedConfigViewModel : ValidatableViewModelBase, ILo
         set { _tcpCommand = value; OnPropertyChanged(); }
     }
 
-    private void Save()
+    protected override FileObserverServiceOptions OnSave()
     {
         Logger?.Log("FileObserver advanced options start", LogLevel.Debug);
         _options.ImageNames = ImageNames;
@@ -122,12 +96,11 @@ public class FileObserverAdvancedConfigViewModel : ValidatableViewModelBase, ILo
         _options.SendTcpCommand = SendTcpCommand;
         _options.TcpCommand = TcpCommand;
         Logger?.Log("FileObserver advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("FileObserver advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FtpServerAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FtpServerAdvancedConfigViewModel.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
@@ -9,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced FTP server options.
 /// </summary>
-public class FtpServerAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class FtpServerAdvancedConfigViewModel : AdvancedConfigViewModelBase<FtpServerOptions>
 {
     private readonly FtpServerOptions _options;
     private bool _allowAnonymous;
@@ -20,38 +18,13 @@ public class FtpServerAdvancedConfigViewModel : ValidatableViewModelBase, ILoggi
     /// Initializes a new instance of the <see cref="FtpServerAdvancedConfigViewModel"/> class.
     /// </summary>
     public FtpServerAdvancedConfigViewModel(FtpServerOptions options, ILoggingService? logger = null)
+        : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _allowAnonymous = options.AllowAnonymous;
         _username = options.Username;
         _password = options.Password;
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the advanced options.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<FtpServerOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested without saving.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Allow anonymous connections.
@@ -109,23 +82,22 @@ public class FtpServerAdvancedConfigViewModel : ValidatableViewModelBase, ILoggi
         }
     }
 
-    private void Save()
+    protected override FtpServerOptions? OnSave()
     {
         ValidateCredentials();
         if (HasErrors)
-            return;
+            return null;
         Logger?.Log("FTP advanced options start", LogLevel.Debug);
         _options.AllowAnonymous = AllowAnonymous;
         _options.Username = string.IsNullOrWhiteSpace(Username) ? null : Username;
         _options.Password = string.IsNullOrWhiteSpace(Password) ? null : Password;
         Logger?.Log("FTP advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("FTP advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 
     private void ValidateCredentials()

--- a/DesktopApplicationTemplate.UI/ViewModels/HeartbeatAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HeartbeatAdvancedConfigViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -8,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced Heartbeat configuration.
 /// </summary>
-public class HeartbeatAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class HeartbeatAdvancedConfigViewModel : AdvancedConfigViewModelBase<HeartbeatServiceOptions>
 {
     private readonly HeartbeatServiceOptions _options;
     private bool _includePing;
@@ -18,37 +17,12 @@ public class HeartbeatAdvancedConfigViewModel : ValidatableViewModelBase, ILoggi
     /// Initializes a new instance of the <see cref="HeartbeatAdvancedConfigViewModel"/> class.
     /// </summary>
     public HeartbeatAdvancedConfigViewModel(HeartbeatServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _includePing = options.IncludePing;
         _includeStatus = options.IncludeStatus;
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the configuration.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<HeartbeatServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Whether to include a ping indicator in the heartbeat.
@@ -68,18 +42,17 @@ public class HeartbeatAdvancedConfigViewModel : ValidatableViewModelBase, ILoggi
         set { _includeStatus = value; OnPropertyChanged(); }
     }
 
-    private void Save()
+    protected override HeartbeatServiceOptions OnSave()
     {
         Logger?.Log("Heartbeat advanced options start", LogLevel.Debug);
         _options.IncludePing = IncludePing;
         _options.IncludeStatus = IncludeStatus;
         Logger?.Log("Heartbeat advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("Heartbeat advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HidAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidAdvancedConfigViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -8,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced HID configuration.
 /// </summary>
-public class HidAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class HidAdvancedConfigViewModel : AdvancedConfigViewModelBase<HidServiceOptions>
 {
     private readonly HidServiceOptions _options;
     private int _debounceTime;
@@ -18,37 +17,12 @@ public class HidAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingView
     /// Initializes a new instance of the <see cref="HidAdvancedConfigViewModel"/> class.
     /// </summary>
     public HidAdvancedConfigViewModel(HidServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _debounceTime = options.DebounceTimeMs;
         _keyDownTime = options.KeyDownTimeMs;
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the configuration.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<HidServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Debounce time in milliseconds.
@@ -68,18 +42,17 @@ public class HidAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingView
         set { _keyDownTime = value; OnPropertyChanged(); }
     }
 
-    private void Save()
+    protected override HidServiceOptions OnSave()
     {
         Logger?.Log("HID advanced options start", LogLevel.Debug);
         _options.DebounceTimeMs = DebounceTimeMs;
         _options.KeyDownTimeMs = KeyDownTimeMs;
         Logger?.Log("HID advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("HID advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/HttpAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HttpAdvancedConfigViewModel.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
@@ -9,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced HTTP options.
 /// </summary>
-public class HttpAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingViewModel
+public class HttpAdvancedConfigViewModel : AdvancedConfigViewModelBase<HttpServiceOptions>
 {
     private readonly HttpServiceOptions _options;
     private string? _username;
@@ -20,38 +18,13 @@ public class HttpAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingVie
     /// Initializes a new instance of the <see cref="HttpAdvancedConfigViewModel"/> class.
     /// </summary>
     public HttpAdvancedConfigViewModel(HttpServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _username = options.Username;
         _password = options.Password;
         _certificatePath = options.ClientCertificatePath;
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the advanced options.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when options are saved.
-    /// </summary>
-    public event Action<HttpServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Username for basic authentication.
@@ -80,19 +53,18 @@ public class HttpAdvancedConfigViewModel : ValidatableViewModelBase, ILoggingVie
         set { _certificatePath = value; OnPropertyChanged(); }
     }
 
-    private void Save()
+    protected override HttpServiceOptions OnSave()
     {
         Logger?.Log("HTTP advanced options start", LogLevel.Debug);
         _options.Username = string.IsNullOrWhiteSpace(Username) ? null : Username;
         _options.Password = string.IsNullOrWhiteSpace(Password) ? null : Password;
         _options.ClientCertificatePath = string.IsNullOrWhiteSpace(ClientCertificatePath) ? null : ClientCertificatePath;
         Logger?.Log("HTTP advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("HTTP advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ScpAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScpAdvancedConfigViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -8,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced SCP configuration.
 /// </summary>
-public class ScpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
+public class ScpAdvancedConfigViewModel : AdvancedConfigViewModelBase<ScpServiceOptions>
 {
     private ScpServiceOptions? _options;
     private string _localPath = string.Empty;
@@ -18,10 +17,8 @@ public class ScpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
     /// Initializes a new instance of the <see cref="ScpAdvancedConfigViewModel"/> class.
     /// </summary>
     public ScpAdvancedConfigViewModel(ILoggingService? logger = null)
+        : base(logger)
     {
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
 
     /// <summary>
@@ -36,29 +33,6 @@ public class ScpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
         OnPropertyChanged(nameof(LocalPath));
         OnPropertyChanged(nameof(RemotePath));
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the configuration.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<ScpServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Local file path to upload.
@@ -78,19 +52,18 @@ public class ScpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
         set { _remotePath = value; OnPropertyChanged(); }
     }
 
-    private void Save()
+    protected override ScpServiceOptions? OnSave()
     {
         Logger?.Log("SCP advanced options start", LogLevel.Debug);
         if (_options is null) throw new InvalidOperationException("Options not loaded");
         _options.LocalPath = LocalPath;
         _options.RemotePath = RemotePath;
         Logger?.Log("SCP advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("SCP advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpAdvancedConfigViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
@@ -10,7 +9,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <summary>
 /// View model for editing advanced TCP configuration.
 /// </summary>
-public class TcpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
+public class TcpAdvancedConfigViewModel : AdvancedConfigViewModelBase<TcpServiceOptions>
 {
     private TcpServiceOptions? _options;
     private bool _useUdp;
@@ -23,10 +22,8 @@ public class TcpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
     /// Initializes a new instance of the <see cref="TcpAdvancedConfigViewModel"/> class.
     /// </summary>
     public TcpAdvancedConfigViewModel(ILoggingService? logger = null)
+        : base(logger)
     {
-        Logger = logger;
-        SaveCommand = new RelayCommand(Save);
-        BackCommand = new RelayCommand(Back);
     }
 
     /// <summary>
@@ -47,29 +44,6 @@ public class TcpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
         OnPropertyChanged(nameof(OutputMessage));
         _ = EvaluateOutputAsync();
     }
-
-    /// <inheritdoc />
-    public ILoggingService? Logger { get; set; }
-
-    /// <summary>
-    /// Command to save the configuration.
-    /// </summary>
-    public ICommand SaveCommand { get; }
-
-    /// <summary>
-    /// Command to navigate back without saving.
-    /// </summary>
-    public ICommand BackCommand { get; }
-
-    /// <summary>
-    /// Raised when the configuration is saved.
-    /// </summary>
-    public event Action<TcpServiceOptions>? Saved;
-
-    /// <summary>
-    /// Raised when navigation back is requested.
-    /// </summary>
-    public event Action? BackRequested;
 
     /// <summary>
     /// Indicates whether UDP should be used instead of TCP.
@@ -131,7 +105,7 @@ public class TcpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
-    private void Save()
+    protected override TcpServiceOptions? OnSave()
     {
         Logger?.Log("TCP advanced options start", LogLevel.Debug);
         if (_options is null) throw new InvalidOperationException("Options not loaded");
@@ -141,13 +115,12 @@ public class TcpAdvancedConfigViewModel : ViewModelBase, ILoggingViewModel
         _options.Script = Script;
         _options.OutputMessage = OutputMessage;
         Logger?.Log("TCP advanced options finished", LogLevel.Debug);
-        Saved?.Invoke(_options);
+        return _options;
     }
 
-    private void Back()
+    protected override void OnBack()
     {
         Logger?.Log("TCP advanced options back", LogLevel.Debug);
-        BackRequested?.Invoke();
     }
 
     private async Task EvaluateOutputAsync()

--- a/DesktopApplicationTemplate.UI/Views/CsvAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -21,9 +22,10 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Include Headers" Style="{StaticResource FormLabel}"/>
         <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding IncludeHeaders}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save CSV Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to CSV Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save CSV Advanced Configuration"
+                                       BackAutomationName="Back to CSV Configuration"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -34,9 +35,10 @@
             <TextBox Text="{Binding TcpCommand}" Width="150" Margin="10,0,0,0" Style="{StaticResource FormField}"/>
         </StackPanel>
 
-        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save File Observer Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to File Observer Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save File Observer Advanced Configuration"
+                                       BackAutomationName="Back to File Observer Configuration"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/FtpServerAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -24,9 +25,11 @@
         <TextBlock Grid.Row="2" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save Configuration" Width="130" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save FTP Advanced Options"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back from FTP Advanced Options"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveButtonText="Save Configuration"
+                                       SaveAutomationName="Save FTP Advanced Options"
+                                       BackAutomationName="Back from FTP Advanced Options"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -21,9 +22,10 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Include Status" Style="{StaticResource FormLabel}"/>
         <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding IncludeStatus}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save Heartbeat Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to Heartbeat Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save Heartbeat Advanced Configuration"
+                                       BackAutomationName="Back to Heartbeat Configuration"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HidAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -21,9 +22,10 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Key Down (ms)" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding KeyDownTimeMs}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HID Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to HID Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save HID Advanced Configuration"
+                                       BackAutomationName="Back to HID Configuration"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/HttpAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -25,9 +26,11 @@
         <TextBlock Grid.Row="2" Grid.Column="0" Text="Certificate Path" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ClientCertificatePath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save Configuration" Width="130" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save HTTP Advanced Options"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back from HTTP Advanced Options"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveButtonText="Save Configuration"
+                                       SaveAutomationName="Save HTTP Advanced Options"
+                                       BackAutomationName="Back from HTTP Advanced Options"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -45,9 +46,10 @@
         <TextBlock Grid.Row="7" Grid.Column="0" Text="Reconnect Delay" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding ReconnectDelaySeconds}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="8" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save MQTT Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to MQTT Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="8" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save MQTT Advanced Configuration"
+                                       BackAutomationName="Back to MQTT Configuration"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/ScpAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScpAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -21,9 +22,10 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Remote Path" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding RemotePath}" Style="{StaticResource FormField}"/>
 
-        <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save SCP Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to SCP Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save SCP Advanced Configuration"
+                                       BackAutomationName="Back to SCP Configuration"/>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.AdvancedConfigButtonBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+        <Button Content="{Binding SaveButtonText, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                Width="130" Margin="5"
+                Command="{Binding SaveCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                AutomationProperties.Name="{Binding SaveAutomationName, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        <Button Content="Back"
+                Width="100" Margin="5"
+                Command="{Binding BackCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                AutomationProperties.Name="{Binding BackAutomationName, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+    </StackPanel>
+</UserControl>

--- a/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml.cs
@@ -1,0 +1,58 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class AdvancedConfigButtonBar : UserControl
+{
+    public AdvancedConfigButtonBar()
+    {
+        InitializeComponent();
+    }
+
+    public ICommand? SaveCommand
+    {
+        get => (ICommand?)GetValue(SaveCommandProperty);
+        set => SetValue(SaveCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveCommandProperty =
+        DependencyProperty.Register(nameof(SaveCommand), typeof(ICommand), typeof(AdvancedConfigButtonBar));
+
+    public ICommand? BackCommand
+    {
+        get => (ICommand?)GetValue(BackCommandProperty);
+        set => SetValue(BackCommandProperty, value);
+    }
+
+    public static readonly DependencyProperty BackCommandProperty =
+        DependencyProperty.Register(nameof(BackCommand), typeof(ICommand), typeof(AdvancedConfigButtonBar));
+
+    public string SaveButtonText
+    {
+        get => (string)GetValue(SaveButtonTextProperty);
+        set => SetValue(SaveButtonTextProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveButtonTextProperty =
+        DependencyProperty.Register(nameof(SaveButtonText), typeof(string), typeof(AdvancedConfigButtonBar), new PropertyMetadata("Save"));
+
+    public string SaveAutomationName
+    {
+        get => (string)GetValue(SaveAutomationNameProperty);
+        set => SetValue(SaveAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty SaveAutomationNameProperty =
+        DependencyProperty.Register(nameof(SaveAutomationName), typeof(string), typeof(AdvancedConfigButtonBar), new PropertyMetadata("Save Advanced Options"));
+
+    public string BackAutomationName
+    {
+        get => (string)GetValue(BackAutomationNameProperty);
+        set => SetValue(BackAutomationNameProperty, value);
+    }
+
+    public static readonly DependencyProperty BackAutomationNameProperty =
+        DependencyProperty.Register(nameof(BackAutomationName), typeof(string), typeof(AdvancedConfigButtonBar), new PropertyMetadata("Back"));
+}

--- a/DesktopApplicationTemplate.UI/Views/TcpAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpAdvancedConfigView.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -33,9 +34,10 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Output Message" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding OutputMessage}" Style="{StaticResource FormField}" IsReadOnly="True"/>
 
-        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
-            <Button Content="Save" Width="100" Margin="5" Command="{Binding SaveCommand}" AutomationProperties.Name="Save TCP Advanced Configuration"/>
-            <Button Content="Back" Width="100" Margin="5" Command="{Binding BackCommand}" AutomationProperties.Name="Back to TCP Configuration"/>
-        </StackPanel>
+        <views:AdvancedConfigButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveAutomationName="Save TCP Advanced Configuration"
+                                       BackAutomationName="Back to TCP Configuration"/>
     </Grid>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Help window includes a close button.
 - Average execution time displayed next to each service name in the service list.
 - Text inputs now automatically display tooltips derived from bound property names, guiding expected user input.
+- Reusable `AdvancedConfigViewModelBase<TOptions>` and `AdvancedConfigButtonBar` unify Save/Back logic across advanced configuration views.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -107,6 +107,7 @@ Latest Attempt: Installed the .NET SDK 8.0.404; `dotnet restore` and `dotnet bui
 Newest Attempt: After introducing shared ServiceEditorView, the `dotnet` command remains unavailable; relying on CI for verification.
 Another Attempt: After exposing AdvancedConfigCommand directly in HTTP service views, the `dotnet` CLI remains unavailable; relying on CI for build and test.
 Latest Attempt: After consolidating editor buttons into a shared control, the `dotnet` CLI is still missing; relying on CI for verification.
+Current Attempt: After centralizing advanced config view models and button bars, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add `AdvancedConfigViewModelBase<TOptions>` with shared Save/Back commands and events
- use new base across advanced config view models
- replace repeated button panels with `AdvancedConfigButtonBar`

## Testing
- `dotnet test --settings tests.runsettings --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b88018e27083269dc8756d1badf9e0