### PR TITLE
Add missing Service.Services import to FTP edit tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
@@ -1,6 +1,7 @@
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
-using DesktopApplicationTemplate.Core.Services;
 using Moq;
 using Xunit;
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -110,6 +110,7 @@ Latest Attempt: After consolidating editor buttons into a shared control, the `d
 Current Attempt: After centralizing advanced config view models and button bars, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Latest Attempt: Installed SDK 8.0 via apt and dotnet-install to satisfy global.json; restore succeeded, but build and tests fail with missing `ILoggingService` and WPF-generated code errors. Rely on CI for verification.
 Newest Attempt: After unifying service editor events, the `dotnet` command remains unavailable; build and tests deferred to CI.
+Another Attempt: After adding Service.Services using to FtpServerEditViewModelTests, `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed because the `dotnet` command is missing; relying on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add DesktopApplicationTemplate.Service.Services using to FtpServerEditViewModelTests
- log missing dotnet CLI in collaboration tips

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b88cbb62c083269eac0b60e34e2f31