### PR TITLE
Inject service rule into FTP edit tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
@@ -62,7 +62,7 @@ public class FtpServerEditViewModelTests
     public void SettingInvalidPort_AddsError()
     {
         var options = new FtpServerOptions();
-        var vm = new FtpServerEditViewModel("ftp", options);
+        var vm = new FtpServerEditViewModel(new ServiceRule(), "ftp", options);
         vm.Port = 0;
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -111,6 +111,7 @@ Current Attempt: After centralizing advanced config view models and button bars,
 Latest Attempt: Installed SDK 8.0 via apt and dotnet-install to satisfy global.json; restore succeeded, but build and tests fail with missing `ILoggingService` and WPF-generated code errors. Rely on CI for verification.
 Newest Attempt: After unifying service editor events, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Another Attempt: After adding Service.Services using to FtpServerEditViewModelTests, `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed because the `dotnet` command is missing; relying on CI.
+Newest Attempt: Installed .NET SDK 8.0.404 and ran `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj`; build failed with CS0108/CS0067 errors in generated WPF code and ServiceEditorViewModelBase, so CI will handle verification.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- ensure FtpServerEditViewModel tests construct with ServiceRule and logger
- log build failure while attempting to run tests

## Testing
- `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` *(fails: CS0108/CS0067 in WPF-generated code)*

------
https://chatgpt.com/codex/tasks/task_e_68b88e02cda48326829289b91419a15a