### PR TITLE
Fix recursive event raisers in ServiceEditorViewModelBase

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceEditorViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceEditorViewModelBase.cs
@@ -90,18 +90,21 @@ public abstract class ServiceEditorViewModelBase<TOptions> : ValidatableViewMode
     /// Raises the <see cref="ServiceSaved"/> event with the provided options.
     /// </summary>
     /// <param name="options">Options to include with the event.</param>
-    protected void RaiseServiceSaved(TOptions options) => RaiseServiceSaved(options);
+    protected void RaiseServiceSaved(TOptions options) =>
+        ServiceSaved?.Invoke(ServiceName, options);
 
     /// <summary>
     /// Raises the <see cref="EditCancelled"/> event.
     /// </summary>
-    protected void RaiseEditCancelled() => RaiseEditCancelled();
+    protected void RaiseEditCancelled() =>
+        EditCancelled?.Invoke();
 
     /// <summary>
     /// Raises the <see cref="AdvancedConfigRequested"/> event with the provided options.
     /// </summary>
     /// <param name="options">Options to include with the event.</param>
-    protected void RaiseAdvancedConfigRequested(TOptions options) => RaiseAdvancedConfigRequested(options);
+    protected void RaiseAdvancedConfigRequested(TOptions options) =>
+        AdvancedConfigRequested?.Invoke(options);
 
     /// <summary>
     /// Handles save operations for the service.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Adjusted solution and project references so cross-platform assemblies depend only on the core while Windows projects also reference `DesktopApplicationTemplate.Windows`.
 - Replaced `ServiceCreated`/`ServiceUpdated` with unified `ServiceSaved` events and centralized `ServiceName` validation in `ServiceEditorViewModelBase`.
 
+#### Fixed
+- Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.
+
 ### Navigation & UI
 #### Added
 - Navigation helpers for HTTP, HID, File Observer, Heartbeat, CSV Creator, and SCP services with tests ensuring double-click opens edit views.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -347,7 +347,7 @@ Action Items: Rely on CI for Windows build and test.
 Related Commits/PRs: e91c00d
 [2025-08-28 15:44] Topic: UI project build on Linux
 Context: Attempted to build DesktopApplicationTemplate.UI project alone as requested.
-Observations: `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` and `dotnet test --settings tests.runsettings` failed because the `dotnet` CLI is not installed.
+Observations: `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` and `dotnet test --settings tests.runsettings` failed because the `dotnet` CLI is not installed. Latest attempt after event invocation refactor still reports `command not found: dotnet`.
 Codex Limitations noticed: .NET SDK and WindowsDesktop runtime are missing, so build and tests cannot run in the container.
 Effective Prompts / Instructions that worked: Build command supplied by user instructions.
 Decisions & Rationale: Log the missing tooling and rely on CI for Windows-specific build and test.


### PR DESCRIPTION
## Summary
- replace recursive helper methods in `ServiceEditorViewModelBase` with direct event invocations
- document missing `dotnet` CLI on Linux build environment
- note fix in changelog

## Testing
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(fails: command not found: dotnet)*
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ec7eb908326a32cecd497159043