### PR TITLE
Guard CSV options access

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -65,9 +65,9 @@ namespace DesktopApplicationTemplate.UI.Services
                 {
                     csv = new CsvServiceOptions
                     {
-                        OutputPath = s.CsvOptions.OutputPath,
-                        Delimiter = s.CsvOptions.Delimiter,
-                        IncludeHeaders = s.CsvOptions.IncludeHeaders
+                        OutputPath = s.CsvOptions?.OutputPath ?? string.Empty,
+                        Delimiter = s.CsvOptions?.Delimiter ?? ",",
+                        IncludeHeaders = s.CsvOptions?.IncludeHeaders ?? true
                     };
                 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -151,6 +151,7 @@
 - CSV service increments file index only when `FileNamePattern` contains `{index}`.
 - Guarded CSV viewer configuration serialization to prevent stack overflow on empty data.
 - Eliminated recursive logging and added guards that capture configuration snapshots on save failures.
+- Guarded `CsvServiceOptions` property access against null references during service persistence.
 
 ### HTTP Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -113,6 +113,7 @@ Newest Attempt: After unifying service editor events, the `dotnet` command remai
 Another Attempt: After adding Service.Services using to FtpServerEditViewModelTests, `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed because the `dotnet` command is missing; relying on CI.
 Newest Attempt: Installed .NET SDK 8.0.404 and ran `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj`; build failed with CS0108/CS0067 errors in generated WPF code and ServiceEditorViewModelBase, so CI will handle verification.
 Another Attempt: After adding a missing `DesktopApplicationTemplate.UI.Services` using to CsvServiceEditorViewModelTests, `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` still fails with CS0108 errors in generated `CsvServiceEditorView.g.cs`; will rely on CI.
+Another Attempt: After safeguarding `CsvServiceOptions` access with null-conditionals, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- guard `CsvServiceOptions` property access in `ServicePersistence` to tolerate null
- document CSV service persistence fix
- log build limitation in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8961afcf083269d3d411da712157a