### PR TITLE
Refactor service rule usage in view-model tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceEditorViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceEditorViewModelTests.cs
@@ -11,7 +11,9 @@ public class CsvServiceEditorViewModelTests
     [Fact]
     public void SaveCommand_Raises_ServiceSaved()
     {
-        var vm = new CsvServiceEditorViewModel(new ServiceRule(), new ServiceScreen<CsvServiceOptions>());
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<CsvServiceOptions> screen = new ServiceScreen<CsvServiceOptions>();
+        var vm = new CsvServiceEditorViewModel(rule, screen);
         vm.ServiceName = "svc";
         vm.OutputPath = "path";
         string? name = null;
@@ -28,7 +30,9 @@ public class CsvServiceEditorViewModelTests
     [Fact]
     public void Load_Sets_Existing_Values_ForEdit()
     {
-        var vm = new CsvServiceEditorViewModel(new ServiceRule(), new ServiceScreen<CsvServiceOptions>());
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<CsvServiceOptions> screen = new ServiceScreen<CsvServiceOptions>();
+        var vm = new CsvServiceEditorViewModel(rule, screen);
         var options = new CsvServiceOptions { OutputPath = "p" };
 
         vm.Load("svc", options);

--- a/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
@@ -14,7 +14,9 @@ public class FtpServerCreateViewModelTests
     public void SaveCommand_RaisesServerSaved()
     {
         var logger = new Mock<ILoggingService>();
-        var vm = new FtpServerCreateViewModel(new ServiceRule(), new ServiceScreen<FtpServerOptions>(logger.Object), logger.Object)
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>(logger.Object);
+        var vm = new FtpServerCreateViewModel(rule, screen, logger.Object)
         {
             ServiceName = "ftp",
             Port = 21,
@@ -36,7 +38,9 @@ public class FtpServerCreateViewModelTests
     [Fact]
     public void CancelCommand_RaisesEditCancelled()
     {
-        var vm = new FtpServerCreateViewModel(new ServiceRule(), new ServiceScreen<FtpServerOptions>());
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
+        var vm = new FtpServerCreateViewModel(rule, screen);
         var cancelled = false;
         vm.EditCancelled += () => cancelled = true;
 
@@ -49,7 +53,9 @@ public class FtpServerCreateViewModelTests
     [Fact]
     public void SettingInvalidPort_AddsError()
     {
-        var vm = new FtpServerCreateViewModel(new ServiceRule(), new ServiceScreen<FtpServerOptions>());
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
+        var vm = new FtpServerCreateViewModel(rule, screen);
         vm.Port = 0;
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();
@@ -58,7 +64,9 @@ public class FtpServerCreateViewModelTests
     [Fact]
     public void SettingEmptyServiceName_AddsError()
     {
-        var vm = new FtpServerCreateViewModel(new ServiceRule(), new ServiceScreen<FtpServerOptions>());
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
+        var vm = new FtpServerCreateViewModel(rule, screen);
         vm.ServiceName = string.Empty;
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();
@@ -67,7 +75,9 @@ public class FtpServerCreateViewModelTests
     [Fact]
     public void SaveCommand_DoesNotRaise_WhenInvalid()
     {
-        var vm = new FtpServerCreateViewModel(new ServiceRule(), new ServiceScreen<FtpServerOptions>())
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
+        var vm = new FtpServerCreateViewModel(rule, screen)
         {
             ServiceName = string.Empty,
             Port = 21,
@@ -85,7 +95,9 @@ public class FtpServerCreateViewModelTests
     [Fact]
     public void AdvancedCommand_RaisesRequested()
     {
-        var vm = new FtpServerCreateViewModel(new ServiceRule(), new ServiceScreen<FtpServerOptions>());
+        IServiceRule rule = new ServiceRule();
+        IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
+        var vm = new FtpServerCreateViewModel(rule, screen);
         var raised = false;
         vm.AdvancedConfigRequested += _ => raised = true;
 
@@ -101,6 +113,7 @@ public class FtpServerCreateViewModelTests
         var services = new ServiceCollection();
         services.AddSingleton<IServiceRule, ServiceRule>();
         services.AddSingleton(typeof(IServiceScreen<>), typeof(ServiceScreen<>));
+        services.AddSingleton<ILoggingService>(_ => new Mock<ILoggingService>().Object);
         services.AddTransient<FtpServerCreateViewModel>();
 
         using var provider = services.BuildServiceProvider();

--- a/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
@@ -13,7 +13,8 @@ public class FtpServerEditViewModelTests
     public void Constructor_LoadsExistingSettings()
     {
         var options = new FtpServerOptions { Port = 22, RootPath = "/srv" };
-        var vm = new FtpServerEditViewModel(new ServiceRule(), "ftp", options);
+        IServiceRule rule = new ServiceRule();
+        var vm = new FtpServerEditViewModel(rule, "ftp", options);
         Assert.Equal("ftp", vm.ServiceName);
         Assert.Equal(22, vm.Port);
         Assert.Equal("/srv", vm.RootPath);
@@ -25,7 +26,8 @@ public class FtpServerEditViewModelTests
     {
         var logger = new Mock<ILoggingService>();
         var options = new FtpServerOptions { Port = 21, RootPath = "/tmp" };
-        var vm = new FtpServerEditViewModel(new ServiceRule(), "ftp", options, logger.Object)
+        IServiceRule rule = new ServiceRule();
+        var vm = new FtpServerEditViewModel(rule, "ftp", options, logger.Object)
         {
             Port = 2121,
             RootPath = "/var",
@@ -48,7 +50,8 @@ public class FtpServerEditViewModelTests
     public void CancelCommand_RaisesEditCancelled()
     {
         var options = new FtpServerOptions();
-        var vm = new FtpServerEditViewModel(new ServiceRule(), "ftp", options);
+        IServiceRule rule = new ServiceRule();
+        var vm = new FtpServerEditViewModel(rule, "ftp", options);
         var cancelled = false;
         vm.EditCancelled += () => cancelled = true;
 
@@ -62,7 +65,8 @@ public class FtpServerEditViewModelTests
     public void SettingInvalidPort_AddsError()
     {
         var options = new FtpServerOptions();
-        var vm = new FtpServerEditViewModel(new ServiceRule(), "ftp", options);
+        IServiceRule rule = new ServiceRule();
+        var vm = new FtpServerEditViewModel(rule, "ftp", options);
         vm.Port = 0;
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();
@@ -72,7 +76,8 @@ public class FtpServerEditViewModelTests
     public void SaveCommand_DoesNotRaise_WhenInvalid()
     {
         var options = new FtpServerOptions();
-        var vm = new FtpServerEditViewModel(new ServiceRule(), "ftp", options)
+        IServiceRule rule = new ServiceRule();
+        var vm = new FtpServerEditViewModel(rule, "ftp", options)
         {
             Port = 0,
             RootPath = "/tmp"

--- a/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttCreateServiceViewModelTests.cs
@@ -15,7 +15,8 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void SaveCommand_Raises_ServiceSaved()
     {
-        var vm = new MqttCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new MqttCreateServiceViewModel(rule);
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1234;
@@ -38,7 +39,8 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void CancelCommand_Raises_EditCancelled()
     {
-        var vm = new MqttCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new MqttCreateServiceViewModel(rule);
         var cancelled = false;
         vm.EditCancelled += () => cancelled = true;
 
@@ -52,7 +54,8 @@ public class MqttCreateServiceViewModelTests
     {
         var tempCert = Path.GetTempFileName();
         File.WriteAllBytes(tempCert, new byte[] { 1, 2, 3 });
-        var vm = new MqttCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new MqttCreateServiceViewModel(rule);
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1234;
@@ -95,7 +98,8 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void SaveCommand_ConvertsBlankFieldsToNull()
     {
-        var vm = new MqttCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new MqttCreateServiceViewModel(rule);
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1883;
@@ -121,7 +125,8 @@ public class MqttCreateServiceViewModelTests
     [Fact]
     public void SettingEmptyServiceName_AddsError()
     {
-        var vm = new MqttCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new MqttCreateServiceViewModel(rule);
         vm.ServiceName = string.Empty;
         Assert.True(vm.HasErrors);
     }

--- a/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
@@ -11,7 +11,8 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void SaveCommand_Raises_ServiceSaved()
     {
-        var vm = new TcpCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpCreateServiceViewModel(rule);
         vm.ServiceName = "svc";
         vm.Host = "host";
         vm.Port = 1234;
@@ -34,7 +35,8 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void CancelCommand_Raises_EditCancelled()
     {
-        var vm = new TcpCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpCreateServiceViewModel(rule);
         var cancelled = false;
         vm.EditCancelled += () => cancelled = true;
 
@@ -46,7 +48,8 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void AdvancedConfigCommand_Raises_Event_WithOptions()
     {
-        var vm = new TcpCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpCreateServiceViewModel(rule);
         vm.Host = "host";
         vm.Port = 123;
         vm.Options.UseUdp = true;
@@ -66,7 +69,8 @@ public class TcpCreateServiceViewModelTests
     [Fact]
     public void SettingEmptyServiceName_AddsError()
     {
-        var vm = new TcpCreateServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpCreateServiceViewModel(rule);
         vm.ServiceName = string.Empty;
         Assert.True(vm.HasErrors);
     }

--- a/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
@@ -12,7 +12,8 @@ public class TcpEditServiceViewModelTests
     public void SaveCommand_Raises_ServiceSaved()
     {
         var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening };
-        var vm = new TcpEditServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpEditServiceViewModel(rule);
         vm.Load("svc", options);
         vm.Host = "new";
         vm.Port = 2;
@@ -36,7 +37,8 @@ public class TcpEditServiceViewModelTests
     public void AdvancedConfigCommand_Raises_Event_WithUpdatedOptions()
     {
         var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening };
-        var vm = new TcpEditServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpEditServiceViewModel(rule);
         vm.Load("svc", options);
         vm.Host = "new";
         vm.Port = 2;
@@ -57,7 +59,8 @@ public class TcpEditServiceViewModelTests
     [Fact]
     public void SettingEmptyServiceName_AddsError()
     {
-        var vm = new TcpEditServiceViewModel(new ServiceRule());
+        IServiceRule rule = new ServiceRule();
+        var vm = new TcpEditServiceViewModel(rule);
         vm.Load("svc", new TcpServiceOptions());
         vm.ServiceName = string.Empty;
         Assert.True(vm.HasErrors);

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -114,6 +114,7 @@ Another Attempt: After adding Service.Services using to FtpServerEditViewModelTe
 Newest Attempt: Installed .NET SDK 8.0.404 and ran `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj`; build failed with CS0108/CS0067 errors in generated WPF code and ServiceEditorViewModelBase, so CI will handle verification.
 Another Attempt: After adding a missing `DesktopApplicationTemplate.UI.Services` using to CsvServiceEditorViewModelTests, `dotnet build DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj` still fails with CS0108 errors in generated `CsvServiceEditorView.g.cs`; will rely on CI.
 Another Attempt: After safeguarding `CsvServiceOptions` access with null-conditionals, the `dotnet` command remains unavailable; build and tests deferred to CI.
+Another Attempt: After typing view-model dependencies as interfaces, the `dotnet` command is still missing; build and test rely on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- ensure view-model tests use IServiceRule and IServiceScreen interfaces before constructing view models
- register ILoggingService for FtpServerCreateViewModel DI resolution
- document missing dotnet CLI when attempting to run tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b899a2a9488326b7a1fee83410b766