### PR TITLE
doc: log installer build attempt

### DIFF
--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -425,3 +425,12 @@ Effective Prompts / Instructions that worked: User request to eliminate unstable
 Decisions & Rationale: Drop UI tests to avoid infinite loops and rely on CI or manual verification for UI behavior.
 Action Items: Rely on CI for any UI validation.
 Related Commits/PRs:
+
+[2025-09-28 10:00] Topic: Installer build verification
+Context: Attempted to rebuild installer after verifying TextBoxHintBehavior.AutoToolTip.
+Observations: Property is public and installer references UI, but build failed with CS0108 in CsvServiceEditorView.g.cs hiding InitializeComponent.
+Codex Limitations noticed: none
+Effective Prompts / Instructions that worked: User request to confirm behavior and rebuild.
+Decisions & Rationale: Document build failure and rely on CI.
+Action Items: Resolve CsvServiceEditorView code generation conflicts.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- log attempt to rebuild installer and note CSV editor generated code errors

## Testing
- `dotnet restore`
- `dotnet build DesktopApplication.Installer/DesktopApplication.Installer.csproj` *(fails: CsvServiceEditorView InitializeComponent hides inherited member)*
- `dotnet test --settings tests.runsettings` *(fails: CsvServiceEditorView InitializeComponent hides inherited member)*

------
https://chatgpt.com/codex/tasks/task_e_68b89d7a365c8326a99866484857df63