### PR TITLE
Guard X509 certificate usage for cross-platform

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
@@ -107,7 +107,7 @@ public class MqttServiceTests
         ConsoleTestLogger.LogPass();
     }
 
-    [Fact]
+    [WindowsFact]
     public async Task ConnectAsync_AppliesTlsAndCredentials()
     {
         var client = new Mock<IMqttClient>();
@@ -135,6 +135,29 @@ public class MqttServiceTests
             o.ChannelOptions != null &&
             o.ChannelOptions.TlsOptions != null
         ), It.IsAny<CancellationToken>()), Times.Once);
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ThrowsOnNonWindows_WhenClientCertificateProvided()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var client = new Mock<IMqttClient>();
+        var options = Options.Create(new MqttServiceOptions
+        {
+            Host = "h",
+            Port = 1,
+            ClientId = "id",
+            ConnectionType = MqttConnectionType.MqttTls,
+            ClientCertificate = new byte[] { 1 }
+        });
+        var service = new MqttService(client.Object, options, Mock.Of<IMessageRoutingService>(), Mock.Of<ILoggingService>());
+
+        await Assert.ThrowsAsync<PlatformNotSupportedException>(() => service.ConnectAsync());
         ConsoleTestLogger.LogPass();
     }
 

--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -154,13 +154,20 @@ public class MqttService
                 o.UseTls();
                 if (opts.ClientCertificate is not null)
                 {
-                    try
+                    if (OperatingSystem.IsWindows())
                     {
-                        o.WithClientCertificates(new[] { new X509Certificate2(opts.ClientCertificate) });
+                        try
+                        {
+                            o.WithClientCertificates(new[] { new X509Certificate2(opts.ClientCertificate) });
+                        }
+                        catch (CryptographicException ex)
+                        {
+                            _logger.Log($"Invalid client certificate: {ex.Message}", LogLevel.Warning);
+                        }
                     }
-                    catch (CryptographicException ex)
+                    else
                     {
-                        _logger.Log($"Invalid client certificate: {ex.Message}", LogLevel.Warning);
+                        throw new PlatformNotSupportedException("Client certificates are only supported on Windows.");
                     }
                 }
             });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -125,6 +125,7 @@
 - MQTT service creation now occurs within the main window frame and returns after completion.
 - Expanded connection types to include MQTT/WebSocket variants with optional TLS and updated connection views.
 - `MqttService` logs connection state changes and errors through the injected logging service.
+- Guarded client certificate loading with Windows checks and platform exceptions.
 
 #### Fixed
 - MQTT service disconnects before reconnecting when settings change and converts blank will-topic/payload fields to `null`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -116,6 +116,7 @@ Another Attempt: After adding a missing `DesktopApplicationTemplate.UI.Services`
 Another Attempt: After safeguarding `CsvServiceOptions` access with null-conditionals, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Another Attempt: After typing view-model dependencies as interfaces, the `dotnet` command is still missing; build and test rely on CI.
 Another Attempt: After relocating logging abstractions to the core library, the `dotnet` CLI remains unavailable; relying on CI for build and tests.
+Latest Attempt: After guarding client certificate usage for cross-platform support, the `dotnet` command is still missing; build and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- guard MQTT client certificate loading with an OS check and exception for non-Windows
- run client-certificate TLS test only on Windows and add non-Windows guard test
- document cross-platform certificate guard in changelog and collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a66c50b88326b68dd6b7a13a363d