### PR TITLE
Use throw helpers for MQTT null checks

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/MqttService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttService.cs
@@ -86,7 +86,7 @@ public class MqttService
     /// <param name="subscription">The subscription to upsert.</param>
     public void UpdateTagSubscription(TagSubscription subscription)
     {
-        if (subscription is null) throw new ArgumentNullException(nameof(subscription));
+        ArgumentNullException.ThrowIfNull(subscription);
         _tagSubscriptions[subscription.Topic] = subscription;
         TagSubscriptionChanged?.Invoke(this, subscription);
     }
@@ -271,8 +271,8 @@ public class MqttService
     /// </summary>
     public async Task PublishAsync(string topic, string message, CancellationToken token = default)
     {
-        if (topic is null) throw new ArgumentNullException(nameof(topic));
-        if (message is null) throw new ArgumentNullException(nameof(message));
+        ArgumentNullException.ThrowIfNull(topic);
+        ArgumentNullException.ThrowIfNull(message);
 
         _logger.Log("MQTT publish start", LogLevel.Debug);
         var payload = _routingService.ResolveTokens(message);
@@ -289,7 +289,7 @@ public class MqttService
     /// </summary>
     public async Task PublishAsync(IDictionary<string, IEnumerable<string>> endpointMessages, CancellationToken token = default)
     {
-        if (endpointMessages is null) throw new ArgumentNullException(nameof(endpointMessages));
+        ArgumentNullException.ThrowIfNull(endpointMessages);
         foreach (var pair in endpointMessages)
         {
             foreach (var msg in pair.Value)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -126,6 +126,7 @@
 - Expanded connection types to include MQTT/WebSocket variants with optional TLS and updated connection views.
 - `MqttService` logs connection state changes and errors through the injected logging service.
 - Guarded client certificate loading with Windows checks and platform exceptions.
+- Replaced explicit null checks with `ArgumentNullException.ThrowIfNull` in `MqttService`.
 
 #### Fixed
 - MQTT service disconnects before reconnecting when settings change and converts blank will-topic/payload fields to `null`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -117,6 +117,7 @@ Another Attempt: After safeguarding `CsvServiceOptions` access with null-conditi
 Another Attempt: After typing view-model dependencies as interfaces, the `dotnet` command is still missing; build and test rely on CI.
 Another Attempt: After relocating logging abstractions to the core library, the `dotnet` CLI remains unavailable; relying on CI for build and tests.
 Latest Attempt: After guarding client certificate usage for cross-platform support, the `dotnet` command is still missing; build and tests deferred to CI.
+Another Attempt: After replacing explicit null checks with throw helpers in MqttService, the `dotnet` CLI remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- replace explicit null checks in `MqttService` with `ArgumentNullException.ThrowIfNull`
- document MQTT null-check simplification in changelog
- log missing `dotnet` CLI after attempting tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad9bc788c83268d17d7f349bec429