### PR TITLE
refactor: use property patterns for event handlers

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -29,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void ServiceType_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button button && button.DataContext is CreateServiceViewModel.ServiceTypeMetadata meta)
+            if (sender is Button { DataContext: CreateServiceViewModel.ServiceTypeMetadata meta } button)
             {
                 var name = _viewModel.GenerateDefaultName(meta.Type);
                 if (meta.Type == "MQTT")

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -32,8 +32,10 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             InitializeComponent();
             _viewModel = viewModel;
-            var factory = App.AppHost.Services.GetService(typeof(ILoggerFactory)) as ILoggerFactory;
-            _logger = factory?.CreateLogger<MainView>();
+            if (App.AppHost.Services.GetService(typeof(ILoggerFactory)) is ILoggerFactory factory)
+            {
+                _logger = factory.CreateLogger<MainView>();
+            }
             DataContext = _viewModel;
             _viewModel.EditRequested += OnEditRequested;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
@@ -994,7 +996,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void DeleteServiceMenu_Click(object sender, RoutedEventArgs e)
         {
-            if ((sender as MenuItem)?.DataContext is ServiceViewModel svc)
+            if (sender is MenuItem { DataContext: ServiceViewModel svc })
             {
                 var index = _viewModel.Services.IndexOf(svc);
                 svc.LogAdded -= _viewModel.OnServiceLogAdded;
@@ -1014,7 +1016,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void RenameServiceMenu_Click(object sender, RoutedEventArgs e)
         {
-            if ((sender as MenuItem)?.DataContext is ServiceViewModel svc)
+            if (sender is MenuItem { DataContext: ServiceViewModel svc })
             {
                 string input = Interaction.InputBox("Enter new service name:", "Rename Service", svc.DisplayName);
                 if (!string.IsNullOrWhiteSpace(input))
@@ -1032,7 +1034,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void ChangeColorMenu_Click(object sender, RoutedEventArgs e)
         {
-            if ((sender as MenuItem)?.DataContext is ServiceViewModel svc)
+            if (sender is MenuItem { DataContext: ServiceViewModel svc })
             {
                 var dlg = new ColorPickerWindow { Owner = this };
                 if (dlg.ShowDialog() == true)
@@ -1067,8 +1069,8 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            var element = e.OriginalSource as DependencyObject;
-            if (Helpers.VisualTreeHelperExtensions.FindParent<ButtonBase>(element) == null)
+            if (e.OriginalSource is not DependencyObject element ||
+                Helpers.VisualTreeHelperExtensions.FindParent<ButtonBase>(element) == null)
             {
                 try
                 {
@@ -1084,8 +1086,8 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void HeaderBar_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            var element = e.OriginalSource as DependencyObject;
-            if (Helpers.VisualTreeHelperExtensions.FindParent<ButtonBase>(element) != null)
+            if (e.OriginalSource is DependencyObject element &&
+                Helpers.VisualTreeHelperExtensions.FindParent<ButtonBase>(element) != null)
                 return;
 
             WindowState = WindowState == WindowState.Maximized
@@ -1098,7 +1100,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void MainView_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
-            var element = e.OriginalSource as DependencyObject;
+            if (e.OriginalSource is not DependencyObject element)
+                return;
+
             bool clickedListItem = Helpers.VisualTreeHelperExtensions.FindParent<ListBoxItem>(element) != null;
             bool clickedFrame = Helpers.VisualTreeHelperExtensions.FindParent<Frame>(element) != null;
             bool clickedButton = Helpers.VisualTreeHelperExtensions.FindParent<ButtonBase>(element) != null;
@@ -1127,7 +1131,7 @@ namespace DesktopApplicationTemplate.UI.Views
             if (e.ClickCount < 2)
                 return;
 
-            if ((sender as Border)?.DataContext is ServiceViewModel svc)
+            if (sender is Border { DataContext: ServiceViewModel svc })
             {
                 _logger?.LogDebug("Service {Name} double-clicked", svc.DisplayName);
                 if (_viewModel.EditServiceCommand.CanExecute(svc))
@@ -1158,7 +1162,7 @@ namespace DesktopApplicationTemplate.UI.Views
             if (Math.Abs(position.X - _dragStart.X) > SystemParameters.MinimumHorizontalDragDistance ||
                 Math.Abs(position.Y - _dragStart.Y) > SystemParameters.MinimumVerticalDragDistance)
             {
-                if (sender is Border border && border.DataContext is ServiceViewModel svc)
+                if (sender is Border { DataContext: ServiceViewModel svc } border)
                 {
                     DragDrop.DoDragDrop(border, svc, System.Windows.DragDropEffects.Move);
                 }
@@ -1171,8 +1175,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
 
             var source = (ServiceViewModel)e.Data.GetData(typeof(ServiceViewModel))!;
-            var target = (sender as Border)?.DataContext as ServiceViewModel;
-            if (source == null || target == null || source == target)
+            if (sender is not Border { DataContext: ServiceViewModel target } || source == target)
                 return;
 
             int oldIndex = _viewModel.Services.IndexOf(source);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Create and edit service view models inject `IServiceRule` to validate required fields with XAML error tooltips.
 - Service editor views share a reusable `EditorButtonBar` control with consistent automation names.
 - Consolidated save and close dialogs into a configurable `ConfirmationWindow` with optional suppression.
+- Event handlers use C# property pattern matching instead of casting `sender` and accessing `DataContext`.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -118,6 +118,7 @@ Another Attempt: After typing view-model dependencies as interfaces, the `dotnet
 Another Attempt: After relocating logging abstractions to the core library, the `dotnet` CLI remains unavailable; relying on CI for build and tests.
 Latest Attempt: After guarding client certificate usage for cross-platform support, the `dotnet` command is still missing; build and tests deferred to CI.
 Another Attempt: After replacing explicit null checks with throw helpers in MqttService, the `dotnet` CLI remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
+Latest Attempt: After replacing event-handler casts with property pattern matching, the `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- streamline event handlers by matching sender and DataContext with C# property patterns
- document property pattern refactor in changelog
- log missing dotnet CLI when attempting restore/build/test

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badb68e3908326a9bfa276c7faec44