### PR TITLE
Fix CsvServiceEditorView build conflict

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml
@@ -1,20 +1,18 @@
-<views:ServiceEditorView x:Class="DesktopApplicationTemplate.UI.Views.CsvServiceEditorView"
+<Page x:Class="DesktopApplicationTemplate.UI.Views.CsvServiceEditorView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
-      mc:Ignorable="d"
-      AdvancedAutomationName="Open CSV Advanced Configuration"
-      SaveAutomationName="Save CSV Service"
-      CancelAutomationName="Cancel CSV Edit">
+      mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Grid>
+        <Grid Margin="20">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -24,6 +22,14 @@
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Output Path" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding OutputPath}" Style="{StaticResource FormField}"/>
+
+            <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
+                                   SaveCommand="{Binding SaveCommand}"
+                                   CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open CSV Advanced Configuration"
+                                   SaveAutomationName="Save CSV Service"
+                                   CancelAutomationName="Cancel CSV Edit" />
         </Grid>
     </ScrollViewer>
-</views:ServiceEditorView>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml.cs
@@ -1,9 +1,10 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using System.Windows.Controls;
 
 namespace DesktopApplicationTemplate.UI.Views;
 
-public partial class CsvServiceEditorView : ServiceEditorView
+public partial class CsvServiceEditorView : Page
 {
     private readonly ILoggingService _logger;
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -155,6 +155,7 @@
 - Guarded CSV viewer configuration serialization to prevent stack overflow on empty data.
 - Eliminated recursive logging and added guards that capture configuration snapshots on save failures.
 - Guarded `CsvServiceOptions` property access against null references during service persistence.
+- Csv service editor view now compiles on all platforms by using a `Page` root instead of inheriting from `ServiceEditorView`.
 
 ### HTTP Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -431,9 +431,9 @@ Related Commits/PRs:
 
 [2025-09-28 10:00] Topic: Installer build verification
 Context: Attempted to rebuild installer after verifying TextBoxHintBehavior.AutoToolTip.
-Observations: Property is public and installer references UI, but build failed with CS0108 in CsvServiceEditorView.g.cs hiding InitializeComponent.
-Codex Limitations noticed: none
+Observations: Replaced inheritance from ServiceEditorView with a Page and EditorButtonBar composition to remove CS0108 warnings; UI and installer projects now build.
+Codex Limitations noticed: Microsoft.WindowsDesktop runtime missing so tests abort after building.
 Effective Prompts / Instructions that worked: User request to confirm behavior and rebuild.
-Decisions & Rationale: Document build failure and rely on CI.
-Action Items: Resolve CsvServiceEditorView code generation conflicts.
+Decisions & Rationale: Avoid InitializeComponent name conflicts by composing EditorButtonBar directly; rely on CI for Windows-specific tests.
+Action Items: none
 Related Commits/PRs:


### PR DESCRIPTION
## Summary
- replace CsvServiceEditorView base class with Page to stop InitializeComponent name collisions
- document build fix and note test runtime limitation

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj`
- `dotnet build DesktopApplication.Installer/DesktopApplication.Installer.csproj`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bade9d366c83269be6b1354aea6030