### PR TITLE
refactor: use object initializers

### DIFF
--- a/DesktopApplicationTemplate.Tests/CsvServiceEditorViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CsvServiceEditorViewModelTests.cs
@@ -13,9 +13,11 @@ public class CsvServiceEditorViewModelTests
     {
         IServiceRule rule = new ServiceRule();
         IServiceScreen<CsvServiceOptions> screen = new ServiceScreen<CsvServiceOptions>();
-        var vm = new CsvServiceEditorViewModel(rule, screen);
-        vm.ServiceName = "svc";
-        vm.OutputPath = "path";
+        var vm = new CsvServiceEditorViewModel(rule, screen)
+        {
+            ServiceName = "svc",
+            OutputPath = "path"
+        };
         string? name = null;
         CsvServiceOptions? received = null;
         vm.ServiceSaved += (n, o) => { name = n; received = o; };

--- a/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerCreateViewModelTests.cs
@@ -55,8 +55,7 @@ public class FtpServerCreateViewModelTests
     {
         IServiceRule rule = new ServiceRule();
         IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
-        var vm = new FtpServerCreateViewModel(rule, screen);
-        vm.Port = 0;
+        var vm = new FtpServerCreateViewModel(rule, screen) { Port = 0 };
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();
     }
@@ -66,8 +65,7 @@ public class FtpServerCreateViewModelTests
     {
         IServiceRule rule = new ServiceRule();
         IServiceScreen<FtpServerOptions> screen = new ServiceScreen<FtpServerOptions>();
-        var vm = new FtpServerCreateViewModel(rule, screen);
-        vm.ServiceName = string.Empty;
+        var vm = new FtpServerCreateViewModel(rule, screen) { ServiceName = string.Empty };
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();
     }

--- a/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerEditViewModelTests.cs
@@ -66,8 +66,7 @@ public class FtpServerEditViewModelTests
     {
         var options = new FtpServerOptions();
         IServiceRule rule = new ServiceRule();
-        var vm = new FtpServerEditViewModel(rule, "ftp", options);
-        vm.Port = 0;
+        var vm = new FtpServerEditViewModel(rule, "ftp", options) { Port = 0 };
         Assert.True(vm.HasErrors);
         ConsoleTestLogger.LogPass();
     }

--- a/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
+++ b/DesktopApplicationTemplate.Tests/HttpServiceNetworkTests.cs
@@ -63,8 +63,14 @@ public class HttpServiceNetworkTests
             });
 
         var helper = new SaveConfirmationHelper(new Mock<ILoggingService>().Object);
-        var vm = new HttpServiceViewModel(helper) { Url = "http://localhost/", SelectedMethod = "POST", RequestBody = "data", MessageHandler = handlerMock.Object };
-        vm.Headers.Add(new HttpServiceViewModel.HeaderItem { Key = "X-Test", Value = "1" });
+        var vm = new HttpServiceViewModel(helper)
+        {
+            Url = "http://localhost/",
+            SelectedMethod = "POST",
+            RequestBody = "data",
+            MessageHandler = handlerMock.Object,
+            Headers = { new HttpServiceViewModel.HeaderItem { Key = "X-Test", Value = "1" } }
+        };
 
         await vm.SendRequestAsync();
 

--- a/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
@@ -19,11 +19,15 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
-            vm.Services.Add(new ServiceViewModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP", IsActive = true, Order = 0 });
-            vm.Services.Add(new ServiceViewModel { DisplayName = "TCP - TCP1", ServiceType = "TCP", IsActive = true, Order = 1 });
-
-            vm.Filters.NameFilter = "HTTP";
+            var vm = new MainViewModel(csv, networkVm, network.Object)
+            {
+                Services =
+                {
+                    new ServiceViewModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP", IsActive = true, Order = 0 },
+                    new ServiceViewModel { DisplayName = "TCP - TCP1", ServiceType = "TCP", IsActive = true, Order = 1 }
+                },
+                Filters = { NameFilter = "HTTP" }
+            };
 
             var visible = vm.FilteredServices.Cast<ServiceViewModel>().ToList();
             Assert.Single(visible);

--- a/DesktopApplicationTemplate.Tests/MqttAdvancedConfigViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttAdvancedConfigViewModelTests.cs
@@ -15,15 +15,17 @@ public class MqttAdvancedConfigViewModelTests
         var tempCert = Path.GetTempFileName();
         File.WriteAllBytes(tempCert, new byte[] { 1, 2, 3 });
         var options = new MqttServiceOptions();
-        var vm = new MqttAdvancedConfigViewModel(options);
-        vm.ClientCertificatePath = tempCert;
-        vm.WillTopic = "topic";
-        vm.WillPayload = "payload";
-        vm.WillQualityOfService = MqttQualityOfServiceLevel.AtLeastOnce;
-        vm.WillRetain = true;
-        vm.KeepAliveSeconds = 30;
-        vm.CleanSession = false;
-        vm.ReconnectDelaySeconds = 10;
+        var vm = new MqttAdvancedConfigViewModel(options)
+        {
+            ClientCertificatePath = tempCert,
+            WillTopic = "topic",
+            WillPayload = "payload",
+            WillQualityOfService = MqttQualityOfServiceLevel.AtLeastOnce,
+            WillRetain = true,
+            KeepAliveSeconds = 30,
+            CleanSession = false,
+            ReconnectDelaySeconds = 10
+        };
         MqttServiceOptions? received = null;
         vm.Saved += o => received = o;
 

--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -18,8 +18,7 @@ namespace DesktopApplicationTemplate.Tests
             SettingsViewModel.FilePath = Path.Combine(tempDir, "userSettings.json");
             try
             {
-                var vm = new SettingsViewModel();
-                vm.FirstRun = false;
+                var vm = new SettingsViewModel { FirstRun = false };
                 SettingsViewModel.SaveConfirmationSuppressed = true;
                 SettingsViewModel.CloseConfirmationSuppressed = true;
                 vm.Save();

--- a/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
@@ -12,12 +12,13 @@ public class TcpCreateServiceViewModelTests
     public void SaveCommand_Raises_ServiceSaved()
     {
         IServiceRule rule = new ServiceRule();
-        var vm = new TcpCreateServiceViewModel(rule);
-        vm.ServiceName = "svc";
-        vm.Host = "host";
-        vm.Port = 1234;
-        vm.Options.UseUdp = true;
-        vm.Options.Mode = TcpServiceMode.ReceiveAndSend;
+        var vm = new TcpCreateServiceViewModel(rule)
+        {
+            ServiceName = "svc",
+            Host = "host",
+            Port = 1234,
+            Options = { UseUdp = true, Mode = TcpServiceMode.ReceiveAndSend }
+        };
         TcpServiceOptions? received = null;
         string? name = null;
         vm.ServiceSaved += (n, o) => { name = n; received = o; };
@@ -49,11 +50,12 @@ public class TcpCreateServiceViewModelTests
     public void AdvancedConfigCommand_Raises_Event_WithOptions()
     {
         IServiceRule rule = new ServiceRule();
-        var vm = new TcpCreateServiceViewModel(rule);
-        vm.Host = "host";
-        vm.Port = 123;
-        vm.Options.UseUdp = true;
-        vm.Options.Mode = TcpServiceMode.Sending;
+        var vm = new TcpCreateServiceViewModel(rule)
+        {
+            Host = "host",
+            Port = 123,
+            Options = { UseUdp = true, Mode = TcpServiceMode.Sending }
+        };
         TcpServiceOptions? received = null;
         vm.AdvancedConfigRequested += o => received = o;
 
@@ -70,8 +72,7 @@ public class TcpCreateServiceViewModelTests
     public void SettingEmptyServiceName_AddsError()
     {
         IServiceRule rule = new ServiceRule();
-        var vm = new TcpCreateServiceViewModel(rule);
-        vm.ServiceName = string.Empty;
+        var vm = new TcpCreateServiceViewModel(rule) { ServiceName = string.Empty };
         Assert.True(vm.HasErrors);
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -11,9 +11,14 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void DisplayLogs_RespectsLogLevelFilter()
     {
-        var vm = new TcpServiceMessagesViewModel();
-        vm.Logs.Add(new LogEntry { Message = "a", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Debug });
-        vm.Logs.Add(new LogEntry { Message = "b", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Error });
+        var vm = new TcpServiceMessagesViewModel
+        {
+            Logs =
+            {
+                new LogEntry { Message = "a", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Debug },
+                new LogEntry { Message = "b", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Error }
+            }
+        };
 
         vm.LogLevelFilter = DesktopApplicationTemplate.Core.Services.LogLevel.Error;
 
@@ -23,8 +28,10 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ClearLogCommand_RemovesLogs()
     {
-        var vm = new TcpServiceMessagesViewModel();
-        vm.Logs.Add(new LogEntry { Message = "test" });
+        var vm = new TcpServiceMessagesViewModel
+        {
+            Logs = { new LogEntry { Message = "test" } }
+        };
 
         vm.ClearLogCommand.Execute(null);
 
@@ -71,15 +78,20 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void MessageCollections_ExposeGroupedData()
     {
-        var vm = new TcpServiceMessagesViewModel();
-        vm.Messages.Add(new TcpMessageRow
+        var vm = new TcpServiceMessagesViewModel
         {
-            IncomingMessage = "in",
-            IncomingIp = "1.1.1.1",
-            OutgoingMessage = "out",
-            ConnectedService = "svc",
-            Result = "ok"
-        });
+            Messages =
+            {
+                new TcpMessageRow
+                {
+                    IncomingMessage = "in",
+                    IncomingIp = "1.1.1.1",
+                    OutgoingMessage = "out",
+                    ConnectedService = "svc",
+                    Result = "ok"
+                }
+            }
+        };
 
         vm.IncomingData.Should().ContainSingle(d => d.Contains("in"));
         vm.ScriptModifications.Should().ContainSingle("out");

--- a/DesktopApplicationTemplate.Tests/TcpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceViewModelTests.cs
@@ -15,10 +15,7 @@ public class TcpServiceViewModelTests
         var logger = new Mock<ILoggingService>();
         var helper = new SaveConfirmationHelper(logger.Object) { SaveConfirmationSuppressed = true };
         var messages = new TcpServiceMessagesViewModel();
-        var vm = new TcpServiceViewModel(helper, messages);
-
-        vm.ScriptContent = "test";
-
+        var vm = new TcpServiceViewModel(helper, messages) { ScriptContent = "test" };
         messages.ScriptContent.Should().Be("test");
     }
 
@@ -28,14 +25,15 @@ public class TcpServiceViewModelTests
         var logger = new Mock<ILoggingService>();
         var helper = new SaveConfirmationHelper(logger.Object);
         var messages = new TcpServiceMessagesViewModel();
-        var vm = new TcpServiceViewModel(helper, messages);
-
-        vm.ComputerIp = "1.2.3.4";
-        vm.ListeningPort = "1000";
-        vm.ServerIp = "5.6.7.8";
-        vm.ServerGateway = "9.9.9.9";
-        vm.ServerPort = "2000";
-        vm.IsUdp = true;
+        var vm = new TcpServiceViewModel(helper, messages)
+        {
+            ComputerIp = "1.2.3.4",
+            ListeningPort = "1000",
+            ServerIp = "5.6.7.8",
+            ServerGateway = "9.9.9.9",
+            ServerPort = "2000",
+            IsUdp = true
+        };
 
         messages.ComputerIp.Should().Be("1.2.3.4");
         messages.ListeningPort.Should().Be("1000");

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -119,6 +119,7 @@ Another Attempt: After relocating logging abstractions to the core library, the 
 Latest Attempt: After guarding client certificate usage for cross-platform support, the `dotnet` command is still missing; build and tests deferred to CI.
 Another Attempt: After replacing explicit null checks with throw helpers in MqttService, the `dotnet` CLI remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After replacing event-handler casts with property pattern matching, the `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
+Latest Attempt: During object and collection initializer refactor, the `dotnet` command remained unavailable; restore, build, and test commands could not run and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- refactor tests to use object and collection initializers
- log missing .NET SDK in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf0a6588083268bbb9302cc673454