### PR TITLE
refactor: use pattern matching in settings navigation

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml.cs
@@ -50,11 +50,12 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
             }
 
-            var mainWindow = Window.GetWindow(this) as MainView;
-            if (mainWindow != null)
+            if (Window.GetWindow(this) is not MainView mainWindow)
             {
-                mainWindow.ShowHome();
+                return;
             }
+
+            mainWindow.ShowHome();
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Service editor views share a reusable `EditorButtonBar` control with consistent automation names.
 - Consolidated save and close dialogs into a configurable `ConfirmationWindow` with optional suppression.
 - Event handlers use C# property pattern matching instead of casting `sender` and accessing `DataContext`.
+- Replaced `as` cast and null check with pattern matching in `SettingsPage.NavigateBack`.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -438,3 +438,11 @@ Effective Prompts / Instructions that worked: User request to confirm behavior a
 Decisions & Rationale: Avoid InitializeComponent name conflicts by composing EditorButtonBar directly; rely on CI for Windows-specific tests.
 Action Items: none
 Related Commits/PRs:
+[2025-09-05 14:24] Topic: Pattern matching conversions
+Context: Updated SettingsPage.NavigateBack to use pattern matching.
+Observations: Replaced 'as' cast null check with 'is not' pattern, improving readability.
+Codex Limitations noticed: dotnet CLI not installed; restore/build/test cannot run.
+Effective Prompts / Instructions that worked: User request to adopt modern pattern matching.
+Decisions & Rationale: Use 'is not' pattern with early return.
+Action Items: Rely on CI for validation.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- use pattern matching instead of as-cast null check when returning to home from settings
- note pattern matching change in docs
- log environment limitation about missing dotnet CLI

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baf21cb594832682427bfabb677ece