### PR TITLE
Replace keybd_event with SendInput and add keyboard helper tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/KeyboardHelperTests.cs
+++ b/DesktopApplicationTemplate.Tests/KeyboardHelperTests.cs
@@ -1,0 +1,19 @@
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Helpers;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class KeyboardHelperTests
+{
+    [WindowsFact]
+    public void PressAndRelease_RestoresState()
+    {
+        KeyboardHelper.PressKey(Key.A);
+        Assert.True(KeyboardHelper.IsPressed(Key.A));
+
+        KeyboardHelper.ReleaseKey(Key.A);
+        Assert.False(KeyboardHelper.IsPressed(Key.A));
+        ConsoleTestLogger.LogPass();
+    }
+}

--- a/DesktopApplicationTemplate.UI/Helpers/KeyboardHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/KeyboardHelper.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.UI.Helpers
@@ -7,26 +9,113 @@ namespace DesktopApplicationTemplate.UI.Helpers
     /// <summary>
     /// Provides utilities for interacting with the keyboard.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public static class KeyboardHelper
     {
+        private const int INPUT_KEYBOARD = 1;
         private const uint KEYEVENTF_KEYUP = 0x0002;
 
-        [DllImport("user32.dll")]
-        private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
+        private static readonly HashSet<Key> _pressedKeys = new();
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INPUT
+        {
+            public uint type;
+            public InputUnion U;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct InputUnion
+        {
+            [FieldOffset(0)]
+            public KEYBDINPUT ki;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct KEYBDINPUT
+        {
+            public ushort wVk;
+            public ushort wScan;
+            public uint dwFlags;
+            public uint time;
+            public UIntPtr dwExtraInfo;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
         /// <summary>
-        /// Releases the specified keys to prevent them from remaining in a pressed state.
+        /// Programmatically presses the specified keys.
         /// </summary>
-        /// <param name="keys">Keys to release.</param>
-        public static void ReleaseKeys(params Key[] keys)
+        /// <param name="keys">Keys to press.</param>
+        public static void PressKey(params Key[] keys)
         {
             if (keys == null) throw new ArgumentNullException(nameof(keys));
 
             foreach (var key in keys)
             {
-                var virtualKey = (byte)KeyInterop.VirtualKeyFromKey(key);
-                keybd_event(virtualKey, 0, KEYEVENTF_KEYUP, UIntPtr.Zero);
+                lock (_pressedKeys)
+                {
+                    if (_pressedKeys.Add(key))
+                    {
+                        Send(key, false);
+                    }
+                }
             }
+        }
+
+        /// <summary>
+        /// Releases the specified keys that were programmatically pressed.
+        /// </summary>
+        /// <param name="keys">Keys to release.</param>
+        public static void ReleaseKey(params Key[] keys)
+        {
+            if (keys == null) throw new ArgumentNullException(nameof(keys));
+
+            foreach (var key in keys)
+            {
+                lock (_pressedKeys)
+                {
+                    if (_pressedKeys.Remove(key))
+                    {
+                        Send(key, true);
+                    }
+                }
+            }
+        }
+
+        internal static bool IsPressed(Key key)
+        {
+            lock (_pressedKeys)
+            {
+                return _pressedKeys.Contains(key);
+            }
+        }
+
+        private static void Send(Key key, bool keyUp)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            var input = new INPUT
+            {
+                type = INPUT_KEYBOARD,
+                U = new InputUnion
+                {
+                    ki = new KEYBDINPUT
+                    {
+                        wVk = (ushort)KeyInterop.VirtualKeyFromKey(key),
+                        wScan = 0,
+                        dwFlags = keyUp ? KEYEVENTF_KEYUP : 0,
+                        time = 0,
+                        dwExtraInfo = UIntPtr.Zero
+                    }
+                }
+            };
+
+            SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Consolidated save and close dialogs into a configurable `ConfirmationWindow` with optional suppression.
 - Event handlers use C# property pattern matching instead of casting `sender` and accessing `DataContext`.
 - Replaced `as` cast and null check with pattern matching in `SettingsPage.NavigateBack`.
+- Keyboard helper now uses `SendInput` with `PressKey`/`ReleaseKey` APIs that track pressed keys.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -121,6 +121,7 @@ Another Attempt: After replacing explicit null checks with throw helpers in Mqtt
 Latest Attempt: After replacing event-handler casts with property pattern matching, the `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
 Latest Attempt: During object and collection initializer refactor, the `dotnet` command remained unavailable; restore, build, and test commands could not run and CI will verify.
 Another Attempt: After removing the keyboard release call, the `dotnet` command remains unavailable; build and tests deferred to CI.
+Latest Attempt: After implementing the SendInput-based keyboard helper, the `dotnet` CLI is still missing; build and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- replace keybd_event P/Invoke with SendInput implementation
- add PressKey/ReleaseKey API that tracks pressed keys
- cover KeyboardHelper with Windows-only unit test

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb25fd34fc8326adb9579ccf6551d6