### PR TITLE
refactor: remove unused MainView key handler

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -39,7 +39,6 @@ namespace DesktopApplicationTemplate.UI.Views
             DataContext = _viewModel;
             _viewModel.EditRequested += OnEditRequested;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
-            KeyDown += MainView_KeyDown;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
             CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
@@ -1048,15 +1047,6 @@ namespace DesktopApplicationTemplate.UI.Views
                     }
                     _viewModel.SaveServices();
                 }
-            }
-        }
-
-        private void MainView_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (e.Key == System.Windows.Input.Key.Escape)
-            {
-                _viewModel.SelectedService = null;
-                ShowHome();
             }
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Event handlers use C# property pattern matching instead of casting `sender` and accessing `DataContext`.
 - Replaced `as` cast and null check with pattern matching in `SettingsPage.NavigateBack`.
 - Removed `KeyboardHelper` and exit hooks; simulated key presses manage their own cleanup.
+- Removed `MainView` KeyDown handler; pressing Escape no longer returns to the home page.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -124,6 +124,7 @@ Another Attempt: After removing the keyboard release call, the `dotnet` command 
 Latest Attempt: After implementing the SendInput-based keyboard helper, the `dotnet` CLI is still missing; build and tests deferred to CI.
 Current Attempt: After adding keyboard release hooks for process exit and unhandled exceptions, installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeed but `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
 Latest Attempt: After removing `KeyboardHelper` and its tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After removing the MainView key handler, the `dotnet` command is still missing; build and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- remove MainView KeyDown subscription and handler
- note removal in changelog
- log missing `dotnet` CLI for build/test

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e45ab748326a4875ead04ce0c90