### PR TITLE
Specify service name for Windows service host

### DIFF
--- a/DesktopApplication.Installer/Services/UninstallService.cs
+++ b/DesktopApplication.Installer/Services/UninstallService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service;
 
 namespace DesktopApplication.Installer.Services
 {
@@ -15,7 +16,7 @@ namespace DesktopApplication.Installer.Services
     {
         private readonly IProcessManager _processManager;
         private readonly ILoggingService? _logger;
-        private const string ServiceProcessName = "DesktopApplicationTemplate.Service";
+        private const string ServiceProcessName = WindowsServiceInfo.ServiceName;
 
         public UninstallService(IProcessManager processManager, ILoggingService? logger = null)
         {

--- a/DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
+++ b/DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<UseWindowsService>true</UseWindowsService>
+        <UseWindowsService>true</UseWindowsService>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>DesktopApplicationTemplateService</AssemblyName>
+    <RootNamespace>DesktopApplicationTemplate.Service</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -24,7 +24,11 @@ namespace DesktopApplicationTemplate.Service
                 .ConfigureLogging(logging => logging.AddConsole().AddDebug());
             if (runAsService && OperatingSystem.IsWindows())
             {
-                builder = builder.UseWindowsService(); // Enables Windows Service behavior
+                builder = builder.UseWindowsService(options =>
+                {
+                    options.ServiceName = WindowsServiceInfo.ServiceName;
+                    options.DisplayName = WindowsServiceInfo.DisplayName;
+                }); // Enables Windows Service behavior
             }
 
             return builder.ConfigureServices((hostContext, services) =>

--- a/DesktopApplicationTemplate.Service/WindowsServiceInfo.cs
+++ b/DesktopApplicationTemplate.Service/WindowsServiceInfo.cs
@@ -1,0 +1,8 @@
+namespace DesktopApplicationTemplate.Service;
+
+public static class WindowsServiceInfo
+{
+    public const string ServiceName = "DesktopApplicationTemplateService";
+    public const string DisplayName = "DesktopApplicationTemplate Service";
+}
+

--- a/DesktopApplicationTemplate.Tests/UninstallServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/UninstallServiceTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Threading.Tasks;
 using DesktopApplication.Installer.Services;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service;
 using Moq;
 using Xunit;
 
@@ -22,7 +23,7 @@ public class UninstallServiceTests
 
         await service.UninstallAsync(temp);
 
-        processManager.Verify(p => p.GetProcessIdsByName("DesktopApplicationTemplate.Service"), Times.Once);
+        processManager.Verify(p => p.GetProcessIdsByName(WindowsServiceInfo.ServiceName), Times.Once);
         processManager.Verify(p => p.KillProcess(1), Times.Once);
         processManager.Verify(p => p.KillProcess(2), Times.Once);
         Assert.False(Directory.Exists(temp));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Core library targets `net8.0` to avoid Windows targeting pack restore errors.
 - Adjusted solution and project references so cross-platform assemblies depend only on the core while Windows projects also reference `DesktopApplicationTemplate.Windows`.
 - Replaced `ServiceCreated`/`ServiceUpdated` with unified `ServiceSaved` events and centralized `ServiceName` validation in `ServiceEditorViewModelBase`.
+- Windows service host sets explicit `ServiceName` and `DisplayName` values with the application name and installer uses the same constant.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -126,6 +126,7 @@ Current Attempt: After adding keyboard release hooks for process exit and unhand
 Latest Attempt: After removing `KeyboardHelper` and its tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After removing the MainView key handler, the `dotnet` command is still missing; build and tests deferred to CI.
 Another Attempt: After confirming `KeyboardHelperTests.cs` is absent, the `dotnet` CLI remains unavailable; build and tests deferred to CI.
+Another Attempt: After adding explicit Windows service name options, the `dotnet` command is still missing; build and tests rely on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- set explicit Windows service name and display name that start with the application name
- share Windows service name constants and align uninstaller and tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0194881688326a3226f7263e70356