### PR TITLE
Fix Windows service options and installer tooltip behavior

### DIFF
--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -27,7 +27,6 @@ namespace DesktopApplicationTemplate.Service
                 builder = builder.UseWindowsService(options =>
                 {
                     options.ServiceName = WindowsServiceInfo.ServiceName;
-                    options.DisplayName = WindowsServiceInfo.DisplayName;
                 }); // Enables Windows Service behavior
             }
 

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -4,6 +4,7 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Helpers;
 // Qualify service-layer types explicitly to avoid name clashes with UI services
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/DesktopApplicationTemplate.UI/Behaviors/TextBoxHintBehavior.cs
+++ b/DesktopApplicationTemplate.UI/Behaviors/TextBoxHintBehavior.cs
@@ -25,33 +25,25 @@ public static class TextBoxHintBehavior
     /// <summary>
     /// Gets the value of the <see cref="AutoToolTipProperty"/> for the specified text box.
     /// </summary>
-    /// <param name="textBox">The text box.</param>
+    /// <param name="obj">The text box.</param>
     /// <returns>The current value.</returns>
     [AttachedPropertyBrowsableForType(typeof(TextBox))]
-    public static bool GetAutoToolTip(TextBox textBox)
+    public static bool GetAutoToolTip(DependencyObject obj)
     {
-        if (textBox is null)
-        {
-            throw new ArgumentNullException(nameof(textBox));
-        }
-
-        return (bool)textBox.GetValue(AutoToolTipProperty);
+        ArgumentNullException.ThrowIfNull(obj);
+        return (bool)obj.GetValue(AutoToolTipProperty);
     }
 
     /// <summary>
     /// Sets the value of the <see cref="AutoToolTipProperty"/> for the specified text box.
     /// </summary>
-    /// <param name="textBox">The text box.</param>
+    /// <param name="obj">The text box.</param>
     /// <param name="value">The value to set.</param>
     [AttachedPropertyBrowsableForType(typeof(TextBox))]
-    public static void SetAutoToolTip(TextBox textBox, bool value)
+    public static void SetAutoToolTip(DependencyObject obj, bool value)
     {
-        if (textBox is null)
-        {
-            throw new ArgumentNullException(nameof(textBox));
-        }
-
-        textBox.SetValue(AutoToolTipProperty, value);
+        ArgumentNullException.ThrowIfNull(obj);
+        obj.SetValue(AutoToolTipProperty, value);
     }
 
     private static void OnAutoToolTipChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.
+- Removed unsupported `DisplayName` assignment from Windows service options to restore service build.
 
 ### Navigation & UI
 #### Added
@@ -62,6 +63,7 @@
 - Marked main window `ContentFrame` public to allow navigation inspection.
 - Included `Forms.xaml` in theme resources with Page build action.
 - Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
+- `TextBoxHintBehavior` now uses `DependencyObject` parameters so the installer recognizes `AutoToolTip`.
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.
 - SCP service creation validates required fields and disables the Create command when inputs are invalid.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Included `Forms.xaml` in theme resources with Page build action.
 - Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
 - `TextBoxHintBehavior` now uses `DependencyObject` parameters so the installer recognizes `AutoToolTip`.
+- Added missing helper namespace in `App.xaml.cs`, restoring `SaveConfirmationHelper`, `CloseConfirmationHelper`, and `DependencyChecker` registrations.
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.
 - SCP service creation validates required fields and disables the Create command when inputs are invalid.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -127,6 +127,7 @@ Latest Attempt: After removing `KeyboardHelper` and its tests, the `dotnet` comm
 Latest Attempt: After removing the MainView key handler, the `dotnet` command is still missing; build and tests deferred to CI.
 Another Attempt: After confirming `KeyboardHelperTests.cs` is absent, the `dotnet` CLI remains unavailable; build and tests deferred to CI.
 Another Attempt: After adding explicit Windows service name options, the `dotnet` command is still missing; build and tests rely on CI.
+Latest Attempt: After removing the unsupported DisplayName option and correcting TextBoxHintBehavior signatures, the `dotnet` command remains unavailable; relying on CI for verification.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -128,6 +128,7 @@ Latest Attempt: After removing the MainView key handler, the `dotnet` command is
 Another Attempt: After confirming `KeyboardHelperTests.cs` is absent, the `dotnet` CLI remains unavailable; build and tests deferred to CI.
 Another Attempt: After adding explicit Windows service name options, the `dotnet` command is still missing; build and tests rely on CI.
 Latest Attempt: After removing the unsupported DisplayName option and correcting TextBoxHintBehavior signatures, the `dotnet` command remains unavailable; relying on CI for verification.
+Latest Attempt: After importing the Helpers namespace into App startup to resolve missing helper types, the `dotnet` CLI is still missing; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- remove unsupported DisplayName option from UseWindowsService to restore service build
- expose TextBoxHintBehavior.AutoToolTip across assemblies with DependencyObject signatures
- document build notes and changelog

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01bb464788326b4f2199bfc1f1fc1