### PR TITLE
Add parameterless HttpServiceView constructor

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -16,6 +16,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -26,6 +27,12 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         private readonly ViewModels.HttpServiceViewModel _viewModel;
         private readonly ILoggingService _logger;
+
+        public HttpServiceView()
+            : this(App.AppHost.Services.GetRequiredService<ViewModels.HttpServiceViewModel>(),
+                   App.AppHost.Services.GetRequiredService<ILoggingService>())
+        {
+        }
 
         public HttpServiceView(ViewModels.HttpServiceViewModel viewModel, ILoggingService logger)
         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Removed assembly qualifiers from internal namespaces and explicitly referenced shared views so converters, behaviors, and shared controls resolve across XAML views.
 - Qualified shared log control references and removed redundant assembly-qualified namespaces so converters, behaviors, and editors resolve correctly across views.
 - Aligned ServiceLogViewModel with the shared `LogEntry` model and added explicit assembly namespaces so logs and converters compile across service views.
+- Added parameterless constructor resolving dependencies for `HttpServiceView`, enabling the XAML designer to load.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -138,6 +138,7 @@ Another Attempt: After fixing ServiceLogView namespace bindings and command dele
 Newest Attempt: After qualifying XAML namespaces and marking MQTT subscription view model as Windows-only, the `dotnet` CLI is still missing; relying on CI for build and test.
 Latest Attempt: After aligning log view model with shared log entry and adding assembly-qualified namespaces, the `dotnet` command remains unavailable; build and tests will run in CI.
 Latest Attempt: After removing remaining assembly qualifiers from service view namespaces to fix converter errors, the dotnet CLI remains unavailable; build and tests deferred to CI.
+Latest Attempt: After adding a parameterless constructor to HttpServiceView, the dotnet CLI remains unavailable; rebuild and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- provide a parameterless `HttpServiceView` constructor that resolves the view model and logger for XAML designer usage
- document the change and note the missing `dotnet` CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0558e82608326b35830679934cc77