### PR TITLE
Fix XAML namespace resolution for HTTP and MQTT views

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MqttEditConnectionView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditConnectionView.xaml
@@ -1,7 +1,7 @@
 <Page x:Class="DesktopApplicationTemplate.UI.Views.MqttEditConnectionView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:svc="clr-namespace:DesktopApplicationTemplate.UI.Services;assembly=DesktopApplicationTemplate.UI"
+      xmlns:svc="clr-namespace:DesktopApplicationTemplate.UI.Services"
       mc:Ignorable="d"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Qualified shared log control references and removed redundant assembly-qualified namespaces so converters, behaviors, and editors resolve correctly across views.
 - Aligned ServiceLogViewModel with the shared `LogEntry` model and added explicit assembly namespaces so logs and converters compile across service views.
 - Added parameterless constructor resolving dependencies for `HttpServiceView`, enabling the XAML designer to load.
+- Removed assembly-qualified namespaces from HTTP and MQTT views so converters and enums resolve during build.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -118,6 +118,7 @@ Another Attempt: After safeguarding `CsvServiceOptions` access with null-conditi
 Another Attempt: After typing view-model dependencies as interfaces, the `dotnet` command is still missing; build and test rely on CI.
 Another Attempt: After relocating logging abstractions to the core library, the `dotnet` CLI remains unavailable; relying on CI for build and tests.
 Latest Attempt: After guarding client certificate usage for cross-platform support, the `dotnet` command is still missing; build and tests deferred to CI.
+Newest Attempt: After qualifying HttpServiceView helper namespace and installing the .NET SDK 8.0.404, `dotnet build DesktopApplicationTemplate.sln` failed with missing `MqttConnectionType`, and `dotnet test --settings tests.runsettings --no-build` ran only core tests due to the absent WindowsDesktop runtime.
 Another Attempt: After replacing explicit null checks with throw helpers in MqttService, the `dotnet` CLI remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Another Attempt: After adding a reusable ServiceLogView component, the `dotnet` command is still missing; relying on CI for build and test.
 Latest Attempt: After replacing event-handler casts with property pattern matching, the `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
@@ -139,7 +140,8 @@ Newest Attempt: After qualifying XAML namespaces and marking MQTT subscription v
 Latest Attempt: After aligning log view model with shared log entry and adding assembly-qualified namespaces, the `dotnet` command remains unavailable; build and tests will run in CI.
 Latest Attempt: After removing remaining assembly qualifiers from service view namespaces to fix converter errors, the dotnet CLI remains unavailable; build and tests deferred to CI.
 Latest Attempt: After adding a parameterless constructor to HttpServiceView, the dotnet CLI remains unavailable; rebuild and tests deferred to CI.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a
+Latest Attempt: Installed the .NET SDK 8.0.404 and removed assembly qualifiers from HTTP and MQTT views; `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings --no-build` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- remove assembly qualifiers from helper and service namespaces so XAML converters and enums resolve
- log build/test attempt and WindowsDesktop runtime limitation

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings --no-build` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0579be4208326b7334637112fcb31