### PR TITLE
Qualify behaviors namespace in HttpServiceView

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -6,7 +6,7 @@
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
+      xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
 
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
 

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml
@@ -6,7 +6,7 @@
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
+      xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
 
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,7 +66,7 @@
 - Included `Forms.xaml` in theme resources with Page build action.
 - Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
 - `TextBoxHintBehavior` now uses `DependencyObject` parameters so the installer recognizes `AutoToolTip`.
-- Assembly-qualified behaviors namespace in `HttpServiceView` so the designer can instantiate `TextBoxHintBehavior`.
+- Removed assembly qualifier from `HttpServiceView` behaviors namespace to restore build.
 - Added missing helper namespace in `App.xaml.cs`, restoring `SaveConfirmationHelper`, `CloseConfirmationHelper`, and `DependencyChecker` registrations.
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Included `Forms.xaml` in theme resources with Page build action.
 - Installer window references `TextBoxHintBehavior.AutoToolTip` without design-time warnings.
 - `TextBoxHintBehavior` now uses `DependencyObject` parameters so the installer recognizes `AutoToolTip`.
+- Assembly-qualified behaviors namespace in `HttpServiceView` so the designer can instantiate `TextBoxHintBehavior`.
 - Added missing helper namespace in `App.xaml.cs`, restoring `SaveConfirmationHelper`, `CloseConfirmationHelper`, and `DependencyChecker` registrations.
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -409,8 +409,8 @@ Action Items: Rely on CI for WPF validation.
 Related Commits/PRs:
 [2025-09-22 10:00] Topic: TextBox hint behavior namespace
 Context: Verified TextBoxHintBehavior is public and ensured Forms.xaml references the behaviors namespace with assembly qualification.
-Observations: Verified Forms.xaml already contained the assembly-qualified behaviors namespace, added TextBox-specific attached property accessors with [AttachedPropertyBrowsableForType] to expose AutoToolTip to the installer project, and attempted dotnet restore/build/test, but the dotnet CLI is unavailable in this container.
-Codex Limitations noticed: .NET SDK and WindowsDesktop runtime missing; build and tests cannot run.
+Observations: Verified Forms.xaml already contained the assembly-qualified behaviors namespace, added TextBox-specific attached property accessors with [AttachedPropertyBrowsableForType] to expose AutoToolTip to the installer project, and attempted dotnet restore/build/test, but the dotnet CLI is unavailable in this container. Updated `HttpServiceView.xaml` to use the assembly-qualified behaviors namespace; `dotnet build` reports `TextBoxHintBehavior.AutoToolTip` missing in the specified XML namespace.
+Codex Limitations noticed: .NET SDK and WindowsDesktop runtime missing previously; after installing the SDK, build now fails with a XAML property error.
 Effective Prompts / Instructions that worked: User request to confirm UI build references and behavior visibility.
 Decisions & Rationale: Added assembly-qualified namespace to avoid XAML parse errors and will rely on CI for verification.
 Action Items: Rely on CI.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -409,10 +409,10 @@ Action Items: Rely on CI for WPF validation.
 Related Commits/PRs:
 [2025-09-22 10:00] Topic: TextBox hint behavior namespace
 Context: Verified TextBoxHintBehavior is public and ensured Forms.xaml references the behaviors namespace with assembly qualification.
-Observations: Verified Forms.xaml already contained the assembly-qualified behaviors namespace, added TextBox-specific attached property accessors with [AttachedPropertyBrowsableForType] to expose AutoToolTip to the installer project, and attempted dotnet restore/build/test, but the dotnet CLI is unavailable in this container. Updated `HttpServiceView.xaml` to use the assembly-qualified behaviors namespace; `dotnet build` reports `TextBoxHintBehavior.AutoToolTip` missing in the specified XML namespace.
-Codex Limitations noticed: .NET SDK and WindowsDesktop runtime missing previously; after installing the SDK, build now fails with a XAML property error.
+Observations: Verified Forms.xaml already contained the assembly-qualified behaviors namespace, added TextBox-specific attached property accessors with [AttachedPropertyBrowsableForType] to expose AutoToolTip to the installer project, and attempted dotnet restore/build/test, but the dotnet CLI is unavailable in this container. Updated `HttpServiceView.xaml` to use the assembly-qualified behaviors namespace; `dotnet build` reports `TextBoxHintBehavior.AutoToolTip` missing in the specified XML namespace. Removing the assembly qualifier restores the build.
+Codex Limitations noticed: .NET SDK and WindowsDesktop runtime missing previously; after installing the SDK, build succeeded but tests require the WindowsDesktop runtime.
 Effective Prompts / Instructions that worked: User request to confirm UI build references and behavior visibility.
-Decisions & Rationale: Added assembly-qualified namespace to avoid XAML parse errors and will rely on CI for verification.
+Decisions & Rationale: Added assembly-qualified namespace to avoid XAML parse errors but reverted to the project-local namespace to resolve the build error and rely on CI for verification.
 Action Items: Rely on CI.
 Related Commits/PRs:
 


### PR DESCRIPTION
## Summary
- qualify behaviors namespace in HttpServiceView so designers can locate TextBoxHintBehavior
- log build outcome for assembly-qualified TextBoxHintBehavior

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: TextBoxHintBehavior.AutoToolTip not found)*
- `dotnet test --settings tests.runsettings --no-build` *(partial: core tests pass, UI tests cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_68c05dfbfb5883269195e6f634a88c32