### PR TITLE
Limit create service selections to core network types

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
@@ -6,11 +6,8 @@ namespace DesktopApplicationTemplate.Tests
     public class CreateServiceViewModelTests
     {
         [Theory]
-        [InlineData("HID")]
         [InlineData("TCP")]
         [InlineData("HTTP")]
-        [InlineData("File Observer")]
-        [InlineData("Heartbeat")]
         [InlineData("CSV Creator")]
         [InlineData("SCP")]
         [InlineData("MQTT")]

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -9,11 +9,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public ObservableCollection<ServiceTypeMetadata> ServiceTypes { get; } = new()
         {
-            new("HID", "HID", "🔌"),
             new("TCP", "TCP", "🔗"),
             new("HTTP", "HTTP", "🌐"),
-            new("File Observer", "File Observer", "📂"),
-            new("Heartbeat", "Heartbeat", "❤️"),
             new("CSV Creator", "CSV Creator", "📄"),
             new("SCP", "SCP", "📦"),
             new("MQTT", "MQTT", "📡"),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - CSV create and edit views consolidated into a shared editor with dynamic save button text.
 - MQTT create, edit, and subscription views follow design spacing with shared form styles and accessibility names.
 - Service creation flows now display within the main view, removing the separate Create Service window and placeholder navigation text.
+- Create service page limits options to TCP, MQTT, HTTP, FTP, SCP, and CSV services.
 - Main window height constrained to the work area to prevent overlapping the taskbar.
 - MQTT create and edit views include tooltips on text fields to clarify expected input.
 - Create and edit service view models inject `IServiceRule` to validate required fields with XAML error tooltips.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -368,6 +368,7 @@ Effective Prompts / Instructions that worked: User request to centralize shared 
 Decisions & Rationale: Reduce duplication and simplify maintenance by sharing fixtures.
 Action Items: Rely on CI for test execution.
 Related Commits/PRs: e6a90a3, ed1d219
+Latest Attempt: After limiting service creation options, the `dotnet` command remains unavailable; tests could not run locally and CI will verify.
 
 [2025-09-16 10:00] Topic: WindowsFact CA1416 guard
 Context: Build failed due to Windows-only `Thread.SetApartmentState` usage in a WindowsFact test case.


### PR DESCRIPTION
## Summary
- hide non-network services in create service page
- update service name generation tests
- log missing dotnet CLI when running tests

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c066ebd1108326b232e1709e9608ac