### PR TITLE
Add reusable service message table and integrate into TCP view

### DIFF
--- a/DesktopApplicationTemplate.Tests/DiContainerTests.cs
+++ b/DesktopApplicationTemplate.Tests/DiContainerTests.cs
@@ -21,6 +21,7 @@ public class DiContainerTests
         services.AddSingleton<IServiceRule, ServiceRule>();
         services.AddSingleton<MqttService>();
         services.AddSingleton<MqttTagSubscriptionsViewModel>();
+        services.AddSingleton<ServiceMessageTableViewModel>();
         services.AddTransient<TcpCreateServiceViewModel>();
         services.AddTransient<TcpEditServiceViewModel>();
         services.AddTransient<TcpAdvancedConfigViewModel>();
@@ -45,6 +46,7 @@ public class DiContainerTests
         Assert.NotNull(provider.GetRequiredService<TcpEditServiceViewModel>());
         Assert.NotNull(provider.GetRequiredService<TcpAdvancedConfigViewModel>());
         Assert.NotNull(provider.GetRequiredService<TcpServiceMessagesViewModel>());
+        Assert.NotNull(provider.GetRequiredService<ServiceMessageTableViewModel>());
         Assert.NotNull(provider.GetRequiredService<TcpServiceViewModel>());
     }
 }

--- a/DesktopApplicationTemplate.Tests/ServiceMessageTableViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceMessageTableViewModelTests.cs
@@ -1,0 +1,19 @@
+using System;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class ServiceMessageTableViewModelTests
+{
+    [Fact]
+    public void AddMessage_InsertsAtTopWithTimestamp()
+    {
+        var vm = new ServiceMessageTableViewModel();
+        vm.AddMessage("in1", "out1", "dest1");
+        vm.AddMessage("in2", "out2", "dest2");
+
+        Assert.Equal("in2", vm.Messages[0].IncomingMessage);
+        Assert.True((DateTime.Now - vm.Messages[0].Timestamp).TotalSeconds < 5);
+    }
+}

--- a/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpHttpViewModelLoggingTests.cs
@@ -17,7 +17,7 @@ namespace DesktopApplicationTemplate.Tests
         {
             var logger = new Mock<ILoggingService>();
             var helper = new SaveConfirmationHelper(logger.Object);
-            var vm = new TcpServiceViewModel(helper, new TcpServiceMessagesViewModel()) { Logger = logger.Object };
+            var vm = new TcpServiceViewModel(helper, new TcpServiceMessagesViewModel(), new ServiceMessageTableViewModel()) { Logger = logger.Object };
             vm.ComputerIp = "127.0.0.1";
             vm.ListeningPort = "5000";
 

--- a/DesktopApplicationTemplate.Tests/TcpServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceViewModelTests.cs
@@ -15,7 +15,8 @@ public class TcpServiceViewModelTests
         var logger = new Mock<ILoggingService>();
         var helper = new SaveConfirmationHelper(logger.Object) { SaveConfirmationSuppressed = true };
         var messages = new TcpServiceMessagesViewModel();
-        var vm = new TcpServiceViewModel(helper, messages) { ScriptContent = "test" };
+        var table = new ServiceMessageTableViewModel();
+        var vm = new TcpServiceViewModel(helper, messages, table) { ScriptContent = "test" };
         messages.ScriptContent.Should().Be("test");
     }
 
@@ -25,7 +26,8 @@ public class TcpServiceViewModelTests
         var logger = new Mock<ILoggingService>();
         var helper = new SaveConfirmationHelper(logger.Object);
         var messages = new TcpServiceMessagesViewModel();
-        var vm = new TcpServiceViewModel(helper, messages)
+        var table = new ServiceMessageTableViewModel();
+        var vm = new TcpServiceViewModel(helper, messages, table)
         {
             ComputerIp = "1.2.3.4",
             ListeningPort = "1000",
@@ -49,7 +51,8 @@ public class TcpServiceViewModelTests
         var logger = new Mock<ILoggingService>();
         var helper = new SaveConfirmationHelper(logger.Object);
         var messages = new TcpServiceMessagesViewModel();
-        var vm = new TcpServiceViewModel(helper, messages);
+        var table = new ServiceMessageTableViewModel();
+        var vm = new TcpServiceViewModel(helper, messages, table);
         var raised = false;
         vm.Saved += (_, _) => raised = true;
 
@@ -64,7 +67,8 @@ public class TcpServiceViewModelTests
         var logger = new Mock<ILoggingService>();
         var helper = new SaveConfirmationHelper(logger.Object);
         var messages = new TcpServiceMessagesViewModel();
-        var vm = new TcpServiceViewModel(helper, messages);
+        var table = new ServiceMessageTableViewModel();
+        var vm = new TcpServiceViewModel(helper, messages, table);
         var raised = false;
         vm.BackRequested += (_, _) => raised = true;
 

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -61,6 +61,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<TcpServiceView>();
             services.AddSingleton<TcpServiceViewModel>();
+            services.AddSingleton<ServiceMessageTableViewModel>();
             services.AddSingleton<TcpServiceMessagesView>();
             services.AddTransient<TcpServiceMessagesViewModel>();
             services.AddSingleton<DependencyChecker>();

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -49,6 +49,13 @@
     <Compile Update="Views/Shared/ServiceLogView.xaml.cs">
       <DependentUpon>ServiceLogView.xaml</DependentUpon>
     </Compile>
+    <Page Update="Views/Shared/ServiceMessageTableView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Update="Views/Shared/ServiceMessageTableView.xaml.cs">
+      <DependentUpon>ServiceMessageTableView.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   </Project>

--- a/DesktopApplicationTemplate.UI/Models/ServiceMessageRow.cs
+++ b/DesktopApplicationTemplate.UI/Models/ServiceMessageRow.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.Models
+{
+    /// <summary>
+    /// Represents a single service message exchange.
+    /// </summary>
+    public class ServiceMessageRow
+    {
+        /// <summary>Incoming message content.</summary>
+        public string IncomingMessage { get; set; } = string.Empty;
+
+        /// <summary>Outgoing message content.</summary>
+        public string OutgoingMessage { get; set; } = string.Empty;
+
+        /// <summary>Destination service endpoint or route.</summary>
+        public string Destination { get; set; } = string.Empty;
+
+        /// <summary>Timestamp of the message exchange.</summary>
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.ObjectModel;
+using DesktopApplicationTemplate.UI.Models;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    /// <summary>
+    /// View model providing a tabular collection of service messages.
+    /// </summary>
+    public class ServiceMessageTableViewModel : ViewModelBase
+    {
+        /// <summary>Collection of service message rows.</summary>
+        public ObservableCollection<ServiceMessageRow> Messages { get; } = new();
+
+        /// <summary>
+        /// Adds a new message row and inserts it at the top to maintain
+        /// descending timestamp order.
+        /// </summary>
+        public void AddMessage(string incoming, string outgoing, string destination)
+        {
+            Messages.Insert(0, new ServiceMessageRow
+            {
+                IncomingMessage = incoming ?? string.Empty,
+                OutgoingMessage = outgoing ?? string.Empty,
+                Destination = destination ?? string.Empty,
+                Timestamp = DateTime.Now
+            });
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceViewModel.cs
@@ -15,6 +15,9 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
     {
         private readonly TcpServiceMessagesViewModel _messagesViewModel;
 
+        /// <summary>Table view model for displaying message history.</summary>
+        public ServiceMessageTableViewModel MessageTable { get; }
+
         private string _statusMessage = string.Empty;
         private bool _isServerRunning;
 
@@ -235,10 +238,14 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
         /// </summary>
         public ICommand BackCommand { get; }
 
-        public TcpServiceViewModel(SaveConfirmationHelper saveHelper, TcpServiceMessagesViewModel messagesViewModel)
+        public TcpServiceViewModel(
+            SaveConfirmationHelper saveHelper,
+            TcpServiceMessagesViewModel messagesViewModel,
+            ServiceMessageTableViewModel messageTable)
         {
             _saveHelper = saveHelper;
             _messagesViewModel = messagesViewModel ?? throw new ArgumentNullException(nameof(messagesViewModel));
+            MessageTable = messageTable;
             StatusMessage = "Chappie is initializing...";
             IsServerRunning = false;
             SaveCommand = new RelayCommand(Save);
@@ -307,6 +314,7 @@ public class TcpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, 
                     if (SettingsViewModel.TcpLoggingEnabled)
                         Logger?.Log($"Script output: {result}", LogLevel.Debug);
                     OutputMessage = result;
+                    MessageTable.AddMessage(InputMessage, result, $"{ServerIp}:{ServerPort}");
                     MessageBox.Show(result, "Test Result");
                 }
                 else if (SettingsViewModel.TcpLoggingEnabled)

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceMessageTableView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <DataGrid ItemsSource="{Binding Messages}"
+              CanUserAddRows="False"
+              CanUserDeleteRows="False"
+              CanUserResizeColumns="True"
+              IsReadOnly="True"
+              HeadersVisibility="Column"
+              RowHeaderWidth="0"
+              Height="360"
+              ScrollViewer.VerticalScrollBarVisibility="Auto">
+        <DataGrid.Columns>
+            <DataGridTextColumn Header="Incoming" Binding="{Binding IncomingMessage}" Width="*"/>
+            <DataGridTextColumn Header="Outgoing" Binding="{Binding OutgoingMessage}" Width="*"/>
+            <DataGridTextColumn Header="Destination" Binding="{Binding Destination}" Width="*"/>
+            <DataGridTextColumn Header="Timestamp" Binding="{Binding Timestamp}" Width="Auto"/>
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace DesktopApplicationTemplate.UI.Views.Shared
+{
+    /// <summary>
+    /// Interaction logic for ServiceMessageTableView.xaml
+    /// </summary>
+    public partial class ServiceMessageTableView : UserControl
+    {
+        public ServiceMessageTableView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceView.xaml
@@ -5,6 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
         mc:Ignorable="d"
       Title="Chappie Desktop Application" d:DesignWidth="682.857">
     <Page.Resources>
@@ -97,6 +98,7 @@
 
             <!-- RIGHT SIDE -->
             <StackPanel Grid.Column="1" Margin="10">
+                <shared:ServiceMessageTableView DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
                 <TextBlock Text="Chappie Log" FontWeight="Bold" FontSize="14"/>
                 <DockPanel Margin="0,5,0,5">
                     <ComboBox x:Name="LogLevelBox" Width="150" Margin="0,0,10,0" SelectedIndex="0" SelectionChanged="LogLevelBox_SelectionChanged">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Text inputs now automatically display tooltips derived from bound property names, guiding expected user input.
 - Reusable `AdvancedConfigViewModelBase<TOptions>` and `AdvancedConfigButtonBar` unify Save/Back logic across advanced configuration views.
 - Reusable `ServiceLogView` control and `ServiceLogViewModel` provide consistent log panels for the main window and services.
+- Reusable `ServiceMessageTableView` and `ServiceMessageTableViewModel` display recent service messages with default columns, integrated into the TCP service view.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -108,6 +108,7 @@ Latest Attempt: Installed the .NET SDK 8.0.404; `dotnet restore` and `dotnet bui
 Newest Attempt: After introducing shared ServiceEditorView, the `dotnet` command remains unavailable; relying on CI for verification.
 Another Attempt: After exposing AdvancedConfigCommand directly in HTTP service views, the `dotnet` CLI remains unavailable; relying on CI for build and test.
 Latest Attempt: After consolidating editor buttons into a shared control, the `dotnet` CLI is still missing; relying on CI for verification.
+Latest Attempt: After adding ServiceMessageTableView, `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Current Attempt: After centralizing advanced config view models and button bars, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Latest Attempt: Installed SDK 8.0 via apt and dotnet-install to satisfy global.json; restore succeeded, but build and tests fail with missing `ILoggingService` and WPF-generated code errors. Rely on CI for verification.
 Newest Attempt: After unifying service editor events, the `dotnet` command remains unavailable; build and tests deferred to CI.


### PR DESCRIPTION
## Summary
- add ServiceMessageTableViewModel and view to show incoming/outgoing messages with destination and timestamp
- wire table into TcpServiceView and log script test results
- record build limitation note for missing WindowsDesktop runtime

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c06d2710f48326ba081417a02e56b4