### PR TITLE
refactor: simplify tcp messages view

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using FluentAssertions;
 using Xunit;
@@ -11,7 +12,7 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void DisplayLogs_RespectsLogLevelFilter()
     {
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel)
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService())
         {
             Logs =
             {
@@ -28,7 +29,7 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ClearLogCommand_RemovesLogs()
     {
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel)
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService())
         {
             Logs = { new LogEntry { Message = "test" } }
         };
@@ -41,7 +42,7 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void OpenAdvancedSettingsCommand_RaisesEvent()
     {
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel());
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         var raised = false;
         vm.AdvancedSettingsRequested += (_, _) => raised = true;
 
@@ -51,19 +52,9 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
-    public void UpdateScript_SetsScriptContent()
-    {
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel());
-
-        vm.UpdateScript("print('hi')");
-
-        vm.ScriptContent.Should().Be("print('hi')");
-    }
-
-    [Fact]
     public void UpdateNetworkSettings_SetsProperties()
     {
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel());
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
 
         vm.UpdateNetworkSettings("1.1.1.1", "1000", "2.2.2.2", "3.3.3.3", "2000", true);
 
@@ -78,7 +69,7 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void MessageCollections_ExposeGroupedData()
     {
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel)
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService())
         {
             Messages =
             {
@@ -94,7 +85,31 @@ public class TcpServiceMessagesViewModelTests
         };
 
         vm.IncomingData.Should().ContainSingle(d => d.Contains("in"));
-        vm.ScriptModifications.Should().ContainSingle("out");
         vm.OutgoingResults.Should().ContainSingle(r => r.Contains("svc") && r.Contains("ok"));
+    }
+
+    [Fact]
+    public void ServiceName_NoPriorMessage_UsesDefault()
+    {
+        var routing = new MessageRoutingService();
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing)
+        {
+            ServiceName = "svc"
+        };
+
+        vm.TestMessage.Should().Be("svc-PEAK-123456789");
+    }
+
+    [Fact]
+    public void ServiceName_WithPriorMessage_UsesStored()
+    {
+        var routing = new MessageRoutingService();
+        routing.UpdateMessage("svc", "hello");
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing)
+        {
+            ServiceName = "svc"
+        };
+
+        vm.TestMessage.Should().Be("hello");
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -8,6 +8,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -26,9 +27,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         /// <summary>Incoming data extracted from <see cref="Messages"/>.</summary>
         public IEnumerable<string> IncomingData => Messages.Select(m => $"{m.IncomingIp}: {m.IncomingMessage}");
-
-        /// <summary>Script modifications extracted from <see cref="Messages"/>.</summary>
-        public IEnumerable<string> ScriptModifications => Messages.Select(m => m.OutgoingMessage);
 
         /// <summary>Outgoing results extracted from <see cref="Messages"/>.</summary>
         public IEnumerable<string> OutgoingResults => Messages.Select(m => $"{m.ConnectedService}: {m.Result}");
@@ -83,8 +81,36 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <summary>Raised when the advanced settings view should open.</summary>
         public event EventHandler? AdvancedSettingsRequested;
 
-        /// <summary>Current script content.</summary>
-        public string ScriptContent { get; private set; } = string.Empty;
+        private readonly IMessageRoutingService _routing;
+
+        private string _serviceName = string.Empty;
+
+        /// <summary>Name of the service associated with these messages.</summary>
+        public string ServiceName
+        {
+            get => _serviceName;
+            set
+            {
+                if (_serviceName == value) return;
+                _serviceName = value ?? string.Empty;
+                OnPropertyChanged();
+                InitializeTestMessage();
+            }
+        }
+
+        private string _testMessage = string.Empty;
+
+        /// <summary>Message used for testing communication.</summary>
+        public string TestMessage
+        {
+            get => _testMessage;
+            set
+            {
+                if (_testMessage == value) return;
+                _testMessage = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
 
         /// <summary>Computer IP for incoming connections.</summary>
         public string ComputerIp { get; private set; } = string.Empty;
@@ -104,14 +130,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <summary>Whether UDP mode is enabled.</summary>
         public bool IsUdp { get; private set; }
 
-        public TcpServiceMessagesViewModel(ServiceMessageTableViewModel messageTable)
+        public TcpServiceMessagesViewModel(ServiceMessageTableViewModel messageTable, IMessageRoutingService routing)
         {
             MessageTable = messageTable ?? throw new ArgumentNullException(nameof(messageTable));
+            _routing = routing ?? throw new ArgumentNullException(nameof(routing));
 
             Messages.CollectionChanged += (_, _) =>
             {
                 OnPropertyChanged(nameof(IncomingData));
-                OnPropertyChanged(nameof(ScriptModifications));
                 OnPropertyChanged(nameof(OutgoingResults));
             };
 
@@ -119,14 +145,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             ExportLogCommand = new RelayCommand(ExportLogs);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
             OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
-        }
-
-        /// <summary>Updates the stored script content.</summary>
-        /// <param name="script">New script text.</param>
-        public void UpdateScript(string script)
-        {
-            ScriptContent = script ?? string.Empty;
-            OnPropertyChanged(nameof(ScriptContent));
         }
 
         /// <summary>Updates network and scripting settings.</summary>
@@ -161,5 +179,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);
+
+        private void InitializeTestMessage()
+        {
+            if (string.IsNullOrWhiteSpace(ServiceName))
+                return;
+
+            if (!_routing.TryGetMessage(ServiceName, out var msg) || string.IsNullOrEmpty(msg))
+                TestMessage = $"{ServiceName}-PEAK-123456789";
+            else
+                TestMessage = msg;
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -16,7 +16,6 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <StackPanel Grid.Column="0">
@@ -24,12 +23,7 @@
                 <ListBox ItemsSource="{Binding IncomingData}"/>
             </StackPanel>
 
-            <StackPanel Grid.Column="1" Margin="10,0">
-                <TextBlock Text="Script Modifications" FontWeight="Bold" Margin="0,0,0,5"/>
-                <ListBox ItemsSource="{Binding ScriptModifications}"/>
-            </StackPanel>
-
-            <StackPanel Grid.Column="2">
+            <StackPanel Grid.Column="1">
                 <TextBlock Text="Outgoing Results" FontWeight="Bold" Margin="0,0,0,5"/>
                 <ListBox ItemsSource="{Binding OutgoingResults}"/>
             </StackPanel>
@@ -39,11 +33,16 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <Button Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
-            <shared:ServiceMessageTableView Grid.Row="1" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
-            <shared:ServiceLogView Grid.Row="2" x:Name="LogView" />
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
+            </StackPanel>
+            <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
+            <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
+            <shared:ServiceLogView Grid.Row="3" x:Name="LogView" />
         </Grid>
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 
@@ -17,6 +18,8 @@ namespace DesktopApplicationTemplate.UI.Views
         public void SetServiceContext(ServiceViewModel service)
         {
             LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
+            if (DataContext is TcpServiceMessagesViewModel vm)
+                vm.ServiceName = service.DisplayName.Split(" - ").Last();
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Removed `MainView` KeyDown handler; pressing Escape no longer returns to the home page.
 - Removed unused `HomePage` view and `PackUriSchemeInitializer`.
 - TCP create and edit views inline UDP and mode options, removing the separate advanced configuration view.
+- TCP service messages view removes script editors and adds a test message input bound to view model.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -145,6 +145,7 @@ Latest Attempt: After removing remaining assembly qualifiers from service view n
 Latest Attempt: After adding a parameterless constructor to HttpServiceView, the dotnet CLI remains unavailable; rebuild and tests deferred to CI.
 Latest Attempt: Installed the .NET SDK 8.0.404 and removed assembly qualifiers from HTTP and MQTT views; `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings --no-build` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Latest Attempt: After updating ServiceLogView build metadata and reverting HttpServiceView to the project-local shared namespace, `dotnet build DesktopApplicationTemplate.sln` succeeded but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing.
+Latest Attempt: After removing TCP script controls and adding a test message property, the `dotnet` command is still missing; build and tests will run in CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- remove script columns from TCP messages view and add test message textbox
- drop unused script properties from TcpServiceMessagesViewModel and add TestMessage with default fallback
- log environment constraints and update docs

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c081f3d740832697c300ce76ee699d