### PR TITLE
Persist last TCP test message

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -111,7 +111,8 @@ namespace DesktopApplicationTemplate.Tests
                             Mode = TcpServiceMode.Sending,
                             InputMessage = "in",
                             Script = "return message;",
-                            OutputMessage = "out"
+                            OutputMessage = "out",
+                            LastTestMessage = "last"
                         }
                     }
                 };
@@ -126,6 +127,7 @@ namespace DesktopApplicationTemplate.Tests
                 opt.InputMessage = "changed";
                 opt.Script = "changed";
                 opt.OutputMessage = "changed";
+                opt.LastTestMessage = "changed";
 
                 var loaded = ServicePersistence.Load();
                 var info = Assert.Single(loaded);
@@ -137,6 +139,7 @@ namespace DesktopApplicationTemplate.Tests
                 Assert.Equal("in", info.TcpOptions.InputMessage);
                 Assert.Equal("return message;", info.TcpOptions.Script);
                 Assert.Equal("out", info.TcpOptions.OutputMessage);
+                Assert.Equal("last", info.TcpOptions.LastTestMessage);
 
                 // global options restored
                 var restored = host.Services.GetRequiredService<IOptions<TcpServiceOptions>>().Value;
@@ -147,6 +150,7 @@ namespace DesktopApplicationTemplate.Tests
                 Assert.Equal("in", restored.InputMessage);
                 Assert.Equal("return message;", restored.Script);
                 Assert.Equal("out", restored.OutputMessage);
+                Assert.Equal("last", restored.LastTestMessage);
             }
             finally
             {

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -91,11 +91,14 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ServiceName_NoPriorMessage_UsesDefault()
     {
-        var routing = new MessageRoutingService();
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing)
+        var service = new ServiceViewModel
         {
-            ServiceName = "svc"
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = new TcpServiceOptions()
         };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
 
         vm.TestMessage.Should().Be("svc-PEAK-123456789");
     }
@@ -103,13 +106,34 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ServiceName_WithPriorMessage_UsesStored()
     {
-        var routing = new MessageRoutingService();
-        routing.UpdateMessage("svc", "hello");
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing)
+        var service = new ServiceViewModel
         {
-            ServiceName = "svc"
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = new TcpServiceOptions { LastTestMessage = "hello" }
         };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
 
         vm.TestMessage.Should().Be("hello");
+    }
+
+    [Fact]
+    public void Save_UpdatesLastTestMessage()
+    {
+        var options = new TcpServiceOptions();
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
+        vm.TestMessage = "test";
+
+        vm.Save();
+
+        options.LastTestMessage.Should().Be("test");
     }
 }

--- a/DesktopApplicationTemplate.Tests/TcpServiceOptionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceOptionsTests.cs
@@ -21,6 +21,7 @@ public class TcpServiceOptionsTests
         Assert.Equal(string.Empty, options.InputMessage);
         Assert.Equal(string.Empty, options.Script);
         Assert.Equal(string.Empty, options.OutputMessage);
+        Assert.Equal(string.Empty, options.LastTestMessage);
     }
 
     [Fact]
@@ -34,7 +35,8 @@ public class TcpServiceOptionsTests
             ["TcpService:Mode"] = "Sending",
             ["TcpService:InputMessage"] = "hi",
             ["TcpService:Script"] = "return message;",
-            ["TcpService:OutputMessage"] = "hi"
+            ["TcpService:OutputMessage"] = "hi",
+            ["TcpService:LastTestMessage"] = "last"
         };
 
         var configuration = new ConfigurationBuilder()
@@ -55,5 +57,6 @@ public class TcpServiceOptionsTests
         Assert.Equal("hi", options.InputMessage);
         Assert.Equal("return message;", options.Script);
         Assert.Equal("hi", options.OutputMessage);
+        Assert.Equal("last", options.LastTestMessage);
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -35,7 +35,8 @@ namespace DesktopApplicationTemplate.UI.Services
                         Mode = s.TcpOptions.Mode,
                         InputMessage = s.TcpOptions.InputMessage,
                         Script = s.TcpOptions.Script,
-                        OutputMessage = s.TcpOptions.OutputMessage
+                        OutputMessage = s.TcpOptions.OutputMessage,
+                        LastTestMessage = s.TcpOptions.LastTestMessage
                     };
                 }
 
@@ -159,6 +160,7 @@ namespace DesktopApplicationTemplate.UI.Services
                             value.InputMessage = info.TcpOptions.InputMessage;
                             value.Script = info.TcpOptions.Script;
                             value.OutputMessage = info.TcpOptions.OutputMessage;
+                            value.LastTestMessage = info.TcpOptions.LastTestMessage;
                         }
                     }
                     if ((info.ServiceType == "FTP Server" || info.ServiceType == "FTP") && info.FtpOptions != null)

--- a/DesktopApplicationTemplate.UI/Services/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Services/TcpServiceOptions.cs
@@ -51,5 +51,10 @@ namespace DesktopApplicationTemplate.UI.Services
         /// Resulting message after executing <see cref="Script"/>.
         /// </summary>
         public string OutputMessage { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Most recent test message entered in the TCP messages view.
+        /// </summary>
+        public string LastTestMessage { get; set; } = string.Empty;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -381,6 +381,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 Services[i].Order = i;
             }
+            foreach (var svc in Services)
+            {
+                if (svc.ServicePage?.DataContext is TcpServiceMessagesViewModel tcpVm)
+                {
+                    tcpVm.Save();
+                }
+            }
             ServicePersistence.Save(Services);
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -82,6 +82,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public event EventHandler? AdvancedSettingsRequested;
 
         private readonly IMessageRoutingService _routing;
+        private TcpServiceOptions _options = new();
 
         private string _serviceName = string.Empty;
 
@@ -147,6 +148,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
         }
 
+        /// <summary>Associates the view model with a service and its TCP options.</summary>
+        /// <param name="service">The service context.</param>
+        public void SetService(ServiceViewModel service)
+        {
+            if (service == null) throw new ArgumentNullException(nameof(service));
+            _options = service.TcpOptions ?? new TcpServiceOptions();
+            ServiceName = service.DisplayName.Split(" - ").Last();
+        }
+
         /// <summary>Updates network and scripting settings.</summary>
         public void UpdateNetworkSettings(string computerIp, string listeningPort, string serverIp, string serverGateway, string serverPort, bool isUdp)
         {
@@ -180,15 +190,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);
 
+        /// <summary>Saves the current test message to options and routing.</summary>
+        public void Save()
+        {
+            _options.LastTestMessage = TestMessage;
+            _routing.UpdateMessage(ServiceName, TestMessage);
+        }
+
         private void InitializeTestMessage()
         {
             if (string.IsNullOrWhiteSpace(ServiceName))
                 return;
 
-            if (!_routing.TryGetMessage(ServiceName, out var msg) || string.IsNullOrEmpty(msg))
-                TestMessage = $"{ServiceName}-PEAK-123456789";
-            else
-                TestMessage = msg;
+            TestMessage = string.IsNullOrWhiteSpace(_options.LastTestMessage)
+                ? $"{ServiceName}-PEAK-123456789"
+                : _options.LastTestMessage;
+            _routing.UpdateMessage(ServiceName, TestMessage);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
             if (DataContext is TcpServiceMessagesViewModel vm)
-                vm.ServiceName = service.DisplayName.Split(" - ").Last();
+                vm.SetService(service);
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Removed unused `HomePage` view and `PackUriSchemeInitializer`.
 - TCP create and edit views inline UDP and mode options, removing the separate advanced configuration view.
 - TCP service messages view removes script editors and adds a test message input bound to view model.
+- TCP options persist the last test message and preload it when reopening the service.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -375,6 +375,8 @@ Another Attempt: After inlining TCP advanced options into create/edit views, the
 
 Latest Attempt: After removing TcpServiceView and updating navigation, the `dotnet` command remains unavailable; relying on CI for tests.
 
+Another Attempt: After persisting the TCP last test message, the `dotnet` command is still missing; will rely on CI for build and test.
+
 [2025-09-16 10:00] Topic: WindowsFact CA1416 guard
 Context: Build failed due to Windows-only `Thread.SetApartmentState` usage in a WindowsFact test case.
 Observations: Wrapped `SetApartmentState` call in `OperatingSystem.IsWindows` check; CA1416 no longer triggers but UI tests still fail to compile because the WPF workload isn't available on Linux.


### PR DESCRIPTION
## Summary
- store the last test string in `TcpServiceOptions`
- update `TcpServiceMessagesViewModel` to save and reload the last test message
- document TCP test message persistence

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08461c0808326bb2ddf4196d21bd8