### PR TITLE
feat: add Roslyn script editor window

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.25103.5738" />
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
+    <PackageReference Include="RoslynPad.Editor.Windows" Version="4.12.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />

--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Input;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using DesktopApplicationTemplate.UI.Helpers;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+public class ScriptEditorViewModel : ViewModelBase
+{
+    private string _scriptText = "string Process(string message)\n{\n    return message;\n}";
+    private string _testMessage = string.Empty;
+    private string _outputMessage = string.Empty;
+    private Brush _outputBrush = Brushes.Black;
+    private string _lastTestMessage = string.Empty;
+
+    public string ScriptText
+    {
+        get => _scriptText;
+        set
+        {
+            if (_scriptText != value)
+            {
+                _scriptText = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string TestMessage
+    {
+        get => _testMessage;
+        set
+        {
+            if (_testMessage != value)
+            {
+                _testMessage = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string OutputMessage
+    {
+        get => _outputMessage;
+        set
+        {
+            if (_outputMessage != value)
+            {
+                _outputMessage = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public Brush OutputBrush
+    {
+        get => _outputBrush;
+        set
+        {
+            if (_outputBrush != value)
+            {
+                _outputBrush = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public ICommand RunCommand { get; }
+    public ICommand SaveCommand { get; }
+
+    public event EventHandler<ScriptSavedEventArgs>? RequestClose;
+    public event Action<IEnumerable<Diagnostic>>? ErrorsChanged;
+
+    public ScriptEditorViewModel()
+    {
+        RunCommand = new AsyncRelayCommand(RunAsync);
+        SaveCommand = new RelayCommand(Save);
+    }
+
+    private async Task RunAsync()
+    {
+        var globals = new Globals { message = TestMessage };
+        var code = ScriptText + "\nProcess(message);";
+        var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(Globals));
+        var diagnostics = script.Compile();
+        ErrorsChanged?.Invoke(diagnostics);
+
+        if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+        {
+            OutputMessage = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+            OutputBrush = Brushes.Red;
+            return;
+        }
+
+        try
+        {
+            var result = await script.RunAsync(globals);
+            OutputMessage = result.ReturnValue;
+            OutputBrush = Brushes.Black;
+            _lastTestMessage = TestMessage;
+        }
+        catch (Exception ex)
+        {
+            OutputMessage = ex.ToString();
+            OutputBrush = Brushes.Red;
+        }
+    }
+
+    private void Save() => RequestClose?.Invoke(this, new ScriptSavedEventArgs(ScriptText, _lastTestMessage));
+
+    private class Globals
+    {
+        public string message = string.Empty;
+    }
+}
+
+public class ScriptSavedEventArgs : EventArgs
+{
+    public ScriptSavedEventArgs(string script, string testMessage)
+    {
+        Script = script;
+        TestMessage = testMessage;
+    }
+
+    public string Script { get; }
+    public string TestMessage { get; }
+}

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
@@ -1,28 +1,24 @@
 <Window x:Class="DesktopApplicationTemplate.UI.Views.ScriptEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
-        Title="Script Editor" SizeToContent="WidthAndHeight"
-        AllowsTransparency="True"
-        Style="{DynamicResource BubblyWindowStyle}">
-    <Window.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
-    </Window.Resources>
+        xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
+        Title="Script Editor" Height="450" Width="800">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TextBox x:Name="ScriptBox" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"
-                 behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="OK" Width="80" Margin="0,0,5,0" Click="Ok_Click"/>
-            <Button Content="Cancel" Width="80" Click="Cancel_Click"/>
-            <Button Content="Help" Width="80" Margin="5,0,0,0" Click="Help_Click"/>
+        <avalonEdit:TextEditor x:Name="Editor"
+                               Text="{Binding ScriptText, UpdateSourceTrigger=PropertyChanged}"
+                               SyntaxHighlighting="C#"
+                               ShowLineNumbers="True" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,5,0,5">
+            <TextBlock Text="Test message:" VerticalAlignment="Center"/>
+            <TextBox Width="200" Margin="5,0,0,0" Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" />
+            <Button Content="Run" Width="80" Margin="10,0,0,0" Command="{Binding RunCommand}" />
+            <Button Content="Save" Width="80" Margin="5,0,0,0" Command="{Binding SaveCommand}" />
         </StackPanel>
+        <TextBlock Grid.Row="2" Text="{Binding OutputMessage}" Foreground="{Binding OutputBrush}"/>
     </Grid>
 </Window>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
@@ -1,34 +1,46 @@
+using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Media;
+using ICSharpCode.AvalonEdit.Document;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.CodeAnalysis;
 
-namespace DesktopApplicationTemplate.UI.Views
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class ScriptEditorWindow : Window
 {
-    public partial class ScriptEditorWindow : Window
+    public string ScriptText { get; private set; } = string.Empty;
+    public string LastTestMessage { get; private set; } = string.Empty;
+
+    public ScriptEditorWindow()
     {
-        public string ScriptText { get; private set; } = string.Empty;
+        InitializeComponent();
+        var vm = new ScriptEditorViewModel();
+        DataContext = vm;
+        vm.RequestClose += OnRequestClose;
+        vm.ErrorsChanged += HighlightErrors;
+    }
 
-        public ScriptEditorWindow(string initial)
+    private void OnRequestClose(object? sender, ScriptSavedEventArgs e)
+    {
+        ScriptText = e.Script;
+        LastTestMessage = e.TestMessage;
+        DialogResult = true;
+        Close();
+    }
+
+    private void HighlightErrors(IEnumerable<Diagnostic> diagnostics)
+    {
+        foreach (DocumentLine line in Editor.Document.Lines)
         {
-            InitializeComponent();
-            ScriptBox.Text = initial;
+            line.BackgroundColor = null;
         }
 
-        private void Ok_Click(object sender, RoutedEventArgs e)
+        foreach (var diag in diagnostics)
         {
-            ScriptText = ScriptBox.Text;
-            DialogResult = true;
-            Close();
-        }
-
-        private void Cancel_Click(object sender, RoutedEventArgs e)
-        {
-            DialogResult = false;
-            Close();
-        }
-
-        private void Help_Click(object sender, RoutedEventArgs e)
-        {
-            var help = new AsciiHelpWindow();
-            help.ShowDialog();
+            var span = diag.Location.GetLineSpan();
+            var line = Editor.Document.GetLineByNumber(span.StartLinePosition.Line + 1);
+            line.BackgroundColor = Colors.MistyRose;
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Reusable `AdvancedConfigViewModelBase<TOptions>` and `AdvancedConfigButtonBar` unify Save/Back logic across advanced configuration views.
 - Reusable `ServiceLogView` control and `ServiceLogViewModel` provide consistent log panels for the main window and services.
 - Reusable `ServiceMessageTableView` and `ServiceMessageTableViewModel` display recent service messages with default columns, integrated into the TCP service view.
+- Script editor window with Roslyn-based syntax highlighting and run/save commands.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -146,6 +146,7 @@ Latest Attempt: After adding a parameterless constructor to HttpServiceView, the
 Latest Attempt: Installed the .NET SDK 8.0.404 and removed assembly qualifiers from HTTP and MQTT views; `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings --no-build` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Latest Attempt: After updating ServiceLogView build metadata and reverting HttpServiceView to the project-local shared namespace, `dotnet build DesktopApplicationTemplate.sln` succeeded but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing.
 Latest Attempt: After removing TCP script controls and adding a test message property, the `dotnet` command is still missing; build and tests will run in CI.
+Latest Attempt: After adding the script editor window, the `dotnet` command remains unavailable; build and tests will run in CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add script editor window with AvalonEdit and Roslyn run/save commands
- expose ScriptEditorViewModel with run and save
- document new feature in changelog and collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c0872d65dc83269dc915ada0fae3a2