### PR TITLE
feat: enable script editing for TCP messages

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -136,4 +136,39 @@ public class TcpServiceMessagesViewModelTests
 
         options.LastTestMessage.Should().Be("test");
     }
+
+    [Fact]
+    public void Save_UpdatesScript()
+    {
+        var options = new TcpServiceOptions();
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
+        vm.Script = "return message;";
+
+        vm.Save();
+
+        options.Script.Should().Be("return message;");
+    }
+
+    [Fact]
+    public void SetService_LoadsScript()
+    {
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = new TcpServiceOptions { Script = "return message;" }
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+
+        vm.SetService(service);
+
+        vm.Script.Should().Be("return message;");
+    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -101,6 +101,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private string _testMessage = string.Empty;
 
+        private string _script = string.Empty;
+
         /// <summary>Message used for testing communication.</summary>
         public string TestMessage
         {
@@ -109,6 +111,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 if (_testMessage == value) return;
                 _testMessage = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>Script applied to incoming messages before routing.</summary>
+        public string Script
+        {
+            get => _script;
+            set
+            {
+                if (_script == value) return;
+                _script = value ?? string.Empty;
                 OnPropertyChanged();
             }
         }
@@ -155,6 +169,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (service == null) throw new ArgumentNullException(nameof(service));
             _options = service.TcpOptions ?? new TcpServiceOptions();
             ServiceName = service.DisplayName.Split(" - ").Last();
+            Script = _options.Script;
         }
 
         /// <summary>Updates network and scripting settings.</summary>
@@ -194,6 +209,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void Save()
         {
             _options.LastTestMessage = TestMessage;
+            _options.Script = Script;
             _routing.UpdateMessage(ServiceName, TestMessage);
         }
 

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -39,6 +39,7 @@
             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
                 <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
+                <Button Content="Edit Script" Margin="10,0,0,0" Click="EditScript_Click"/>
             </StackPanel>
             <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
             <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 
@@ -20,6 +21,26 @@ namespace DesktopApplicationTemplate.UI.Views
             LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
             if (DataContext is TcpServiceMessagesViewModel vm)
                 vm.SetService(service);
+        }
+
+        private void EditScript_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not TcpServiceMessagesViewModel vm)
+                return;
+
+            var editor = new ScriptEditorWindow();
+            if (editor.DataContext is ScriptEditorViewModel svm)
+            {
+                svm.ScriptText = vm.Script;
+                svm.TestMessage = vm.TestMessage;
+            }
+
+            if (editor.ShowDialog() == true)
+            {
+                vm.Script = editor.ScriptText;
+                vm.TestMessage = editor.LastTestMessage;
+                vm.Save();
+            }
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Reusable `ServiceLogView` control and `ServiceLogViewModel` provide consistent log panels for the main window and services.
 - Reusable `ServiceMessageTableView` and `ServiceMessageTableViewModel` display recent service messages with default columns, integrated into the TCP service view.
 - Script editor window with Roslyn-based syntax highlighting and run/save commands.
+- TCP service messages view adds an Edit Script button for modifying scripts and test messages.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -479,3 +479,11 @@ Effective Prompts / Instructions that worked: User request to adopt modern patte
 Decisions & Rationale: Use 'is not' pattern with early return.
 Action Items: Rely on CI for validation.
 Related Commits/PRs:
+[2025-09-30 10:00] Topic: Script editor dependency conflict
+Context: Tried restoring, building, and testing after adding TCP script editing.
+Observations: dotnet restore/build/test failed with Microsoft.CodeAnalysis.Common version conflicts.
+Codex Limitations noticed: Dependency mismatch blocks local validation; will depend on CI.
+Effective Prompts / Instructions that worked: Repository instructions to log limitations.
+Decisions & Rationale: Note conflict and proceed with code changes relying on CI verification.
+Action Items: Resolve package versions in future work.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- add Edit Script button to TCP message view
- open ScriptEditorWindow to modify script and test message
- persist script edits in TcpServiceMessagesViewModel and tests

## Testing
- `~/.dotnet/dotnet restore` *(fails: Version conflict detected for Microsoft.CodeAnalysis.Common)*
- `~/.dotnet/dotnet build DesktopApplicationTemplate.sln` *(fails: Version conflict detected for Microsoft.CodeAnalysis.Common)*
- `~/.dotnet/dotnet test --settings tests.runsettings` *(fails: Version conflict detected for Microsoft.CodeAnalysis.Common)*

------
https://chatgpt.com/codex/tasks/task_e_68c08a6573e48326b60d9bba2681e05a