### PR TITLE
Document consolidated TCP scripting workflow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Removed unused `HomePage` view and `PackUriSchemeInitializer`.
 - TCP create and edit views inline UDP and mode options, removing the separate advanced configuration view.
 - TCP service messages view removes script editors and adds a test message input bound to view model.
+- TCP scripting workflow consolidated into the messages view, enabling inline script editing and execution.
 - TCP options persist the last test message and preload it when reopening the service.
 
 #### Fixed

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -482,7 +482,7 @@ Action Items: Rely on CI for validation.
 Related Commits/PRs:
 [2025-09-30 10:00] Topic: Script editor dependency conflict
 Context: Tried restoring, building, and testing after adding TCP script editing.
-Observations: dotnet restore/build/test failed with Microsoft.CodeAnalysis.Common version conflicts.
+Observations: dotnet restore/build/test failed with Microsoft.CodeAnalysis.Common version conflicts; `dotnet workload install wpf` reports Workload ID not recognized.
 Codex Limitations noticed: Dependency mismatch blocks local validation; will depend on CI.
 Effective Prompts / Instructions that worked: Repository instructions to log limitations.
 Decisions & Rationale: Note conflict and proceed with code changes relying on CI verification.


### PR DESCRIPTION
## Summary
- Note that the TCP scripting workflow now happens in a single messages view with inline editing
- Log that `dotnet workload install wpf` isn't recognized and restore/build/test fail due to Microsoft.CodeAnalysis.Common conflicts

## Testing
- `dotnet restore` *(fails: Microsoft.CodeAnalysis.Common version conflict)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: Microsoft.CodeAnalysis.Common version conflict)*
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.CodeAnalysis.Common version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68c09039732883269cdec1104d644061