### PR TITLE
Refactor string visibility converter

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/Converters.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/Converters.cs
@@ -23,19 +23,6 @@ namespace DesktopApplicationTemplate.UI.Helpers
         }
     }
 
-    public class StringNullOrEmptyToVisibilityConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return string.IsNullOrWhiteSpace(value as string) ? Visibility.Visible : Visibility.Collapsed;
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
     public class NullToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/DesktopApplicationTemplate.UI/Helpers/StringNullOrEmptyToVisibilityConverter.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/StringNullOrEmptyToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public class StringNullOrEmptyToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return string.IsNullOrWhiteSpace(value as string) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Removed assembly-qualified namespaces from HTTP and MQTT views so converters and enums resolve during build.
 - Updated Roslyn scripting packages to 4.12.0 to resolve dependency conflicts.
 - Replaced DocumentLine.BackgroundColor usage with a line transformer and switched async lambdas to AsyncRelayCommand to satisfy threading analyzers.
+- Extracted `StringNullOrEmptyToVisibilityConverter` into its own file so XAML views compile independently.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -148,6 +148,7 @@ Latest Attempt: After updating ServiceLogView build metadata and reverting HttpS
 Latest Attempt: After removing TCP script controls and adding a test message property, the `dotnet` command is still missing; build and tests will run in CI.
 Latest Attempt: After adding the script editor window, the `dotnet` command remains unavailable; build and tests will run in CI.
 Newest Attempt: After updating TCP service persistence and tests, the `dotnet` command is still missing; restore, build, and test commands could not run locally so CI will verify.
+Current Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet workload install wpf` is unrecognized and `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- isolate `StringNullOrEmptyToVisibilityConverter` into its own helper file
- document converter refactor and note test limitations

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c096edba688326bbf9bac24e1806a8