### PR TITLE
Qualify views namespace for EditorButtonBar

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -59,6 +59,13 @@
     <Compile Update="Views/Shared/ServiceMessageTableView.xaml.cs">
       <DependentUpon>ServiceMessageTableView.xaml</DependentUpon>
     </Compile>
+    <Page Update="Views/Shared/EditorButtonBar.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Update="Views/Shared/EditorButtonBar.xaml.cs">
+      <DependentUpon>EditorButtonBar.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   </Project>

--- a/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CsvServiceEditorView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserverEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerCreateView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/FtpServerEditView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FtpServerEditView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/HeartbeatEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HeartbeatEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HidEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/HttpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/HttpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/HttpEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttCreateServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:svc="clr-namespace:DesktopApplicationTemplate.UI.Services"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MqttEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">

--- a/DesktopApplicationTemplate.UI/Views/ScpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScpCreateServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/ScpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScpEditServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml
@@ -1,7 +1,7 @@
 <Page x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       x:Name="Root">
     <Grid Margin="20">
         <Grid.RowDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
@@ -5,7 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />

--- a/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
@@ -5,7 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Updated Roslyn scripting packages to 4.12.0 to resolve dependency conflicts.
 - Replaced DocumentLine.BackgroundColor usage with a line transformer and switched async lambdas to AsyncRelayCommand to satisfy threading analyzers.
 - Extracted `StringNullOrEmptyToVisibilityConverter` into its own file so XAML views compile independently.
+- EditorButtonBar included as a Page with code-behind dependency and referenced via an assembly-qualified views namespace across consuming views.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -491,3 +491,11 @@ Action Items: Resolve package versions in future work.
 Latest Attempt: After bumping Microsoft.CodeAnalysis packages to 4.12.0, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with CS1061 'DocumentLine' missing `BackgroundColor` and VSTHRD100/101 analyzer errors; `dotnet workload install wpf` still reports Workload ID not recognized. Relying on CI for validation.
 Next Attempt: Installed .NET SDK 8.0.404, replaced `DocumentLine.BackgroundColor` with a line transformer, and converted async lambdas to `AsyncRelayCommand`; `dotnet build DesktopApplicationTemplate.sln` now succeeds but `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
 Related Commits/PRs:
+[2025-10-01 09:00] Topic: EditorButtonBar namespace
+Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.
+Observations: Added Page/DependentUpon entries and ensured all references use `views` with assembly qualifier.
+Codex Limitations noticed: `dotnet` CLI not installed; restore/build/test commands could not run.
+Effective Prompts / Instructions that worked: User request to confirm control references and build settings.
+Decisions & Rationale: Explicit project entries and namespace qualification ensure the control loads across views.
+Action Items: Rely on CI for validation.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- Ensure EditorButtonBar XAML compiles with Page build action and code-behind dependency.
- Reference EditorButtonBar via assembly-qualified views namespace across consuming views.
- Note missing `dotnet` CLI preventing local build and test.

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09a0ad6148326b28b280e7737cc1a