### PR TITLE
docs: note missing dotnet CLI for EditorButtonBar rebuild

### DIFF
--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -498,4 +498,5 @@ Codex Limitations noticed: `dotnet` CLI not installed; restore/build/test comman
 Effective Prompts / Instructions that worked: User request to confirm control references and build settings.
 Decisions & Rationale: Explicit project entries and namespace qualification ensure the control loads across views.
 Action Items: Rely on CI for validation.
+Latest Attempt: Rebuild could not be performed because the `dotnet` CLI is still unavailable; control resolution will rely on CI.
 Related Commits/PRs:


### PR DESCRIPTION
## Summary
- log missing `dotnet` CLI while reconfirming EditorButtonBar setup

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09c1b3cac832693d4744afa40fa7c