### PR TITLE
Limit service message table to five rows

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServiceMessageTableViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceMessageTableViewModelTests.cs
@@ -16,4 +16,16 @@ public class ServiceMessageTableViewModelTests
         Assert.Equal("in2", vm.Messages[0].IncomingMessage);
         Assert.True((DateTime.Now - vm.Messages[0].Timestamp).TotalSeconds < 5);
     }
+
+    [Fact]
+    public void AddMessage_LimitsToFiveRows()
+    {
+        var vm = new ServiceMessageTableViewModel();
+        for (int i = 0; i < 6; i++)
+            vm.AddMessage($"in{i}", $"out{i}", $"dest{i}");
+
+        Assert.Equal(5, vm.Messages.Count);
+        Assert.Equal("in5", vm.Messages[0].IncomingMessage);
+        Assert.Equal("in1", vm.Messages[^1].IncomingMessage);
+    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -9,6 +9,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     /// </summary>
     public class ServiceMessageTableViewModel : ViewModelBase
     {
+        private const int MaxRows = 5;
+
         /// <summary>Collection of service message rows.</summary>
         public ObservableCollection<ServiceMessageRow> Messages { get; } = new();
 
@@ -25,6 +27,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 Destination = destination ?? string.Empty,
                 Timestamp = DateTime.Now
             });
+
+            if (Messages.Count > MaxRows)
+                Messages.RemoveAt(Messages.Count - 1);
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@
 - TCP service messages view removes script editors and adds a test message input bound to view model.
 - TCP scripting workflow consolidated into the messages view, enabling inline script editing and execution.
 - TCP options persist the last test message and preload it when reopening the service.
+- Service message table retains only the five most recent entries.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -150,6 +150,7 @@ Latest Attempt: After removing TCP script controls and adding a test message pro
 Latest Attempt: After adding the script editor window, the `dotnet` command remains unavailable; build and tests will run in CI.
 Newest Attempt: After updating TCP service persistence and tests, the `dotnet` command is still missing; restore, build, and test commands could not run locally so CI will verify.
 Current Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet workload install wpf` is unrecognized and `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
+Latest Attempt: After limiting ServiceMessageTableViewModel to five rows, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- cap ServiceMessageTableViewModel to five rows
- add unit test verifying table limit
- document table row limit and CI reliance for missing dotnet CLI

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e9495dec83269c5e1bb28346899c