### PR TITLE
Wrap TCP messages view in ScrollViewer

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -11,8 +11,8 @@
               IsReadOnly="True"
               HeadersVisibility="Column"
               RowHeaderWidth="0"
-              Height="360"
-              ScrollViewer.VerticalScrollBarVisibility="Auto">
+                MaxHeight="200"
+                ScrollViewer.VerticalScrollBarVisibility="Auto">
         <DataGrid.Columns>
             <DataGridTextColumn Header="Incoming" Binding="{Binding IncomingMessage}" Width="*"/>
             <DataGridTextColumn Header="Outgoing" Binding="{Binding OutgoingMessage}" Width="*"/>

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -3,47 +3,48 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
-    <Grid Margin="20">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-
-        <Grid Grid.Row="0" Margin="0,0,0,10">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-
-            <StackPanel Grid.Column="0">
-                <TextBlock Text="Incoming Data" FontWeight="Bold" Margin="0,0,0,5"/>
-                <ListBox ItemsSource="{Binding IncomingData}"/>
-            </StackPanel>
-
-            <StackPanel Grid.Column="1">
-                <TextBlock Text="Outgoing Results" FontWeight="Bold" Margin="0,0,0,5"/>
-                <ListBox ItemsSource="{Binding OutgoingResults}"/>
-            </StackPanel>
-        </Grid>
-
-        <Grid Grid.Row="1" Margin="0,10,0,0">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid Margin="20">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
-                <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
-                <Button Content="Edit Script" Margin="10,0,0,0" Click="EditScript_Click"/>
-            </StackPanel>
-            <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
-            <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
-            <shared:ServiceLogView Grid.Row="3" x:Name="LogView" />
+
+            <Grid Grid.Row="0" Margin="0,0,0,10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="Incoming Data" FontWeight="Bold" Margin="0,0,0,5"/>
+                    <ListBox ItemsSource="{Binding IncomingData}"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="1">
+                    <TextBlock Text="Outgoing Results" FontWeight="Bold" Margin="0,0,0,5"/>
+                    <ListBox ItemsSource="{Binding OutgoingResults}"/>
+                </StackPanel>
+            </Grid>
+
+            <Grid Grid.Row="1" Margin="0,10,0,0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
+                    <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                    <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
+                    <Button Content="Edit Script" Margin="10,0,0,0" Click="EditScript_Click"/>
+                </StackPanel>
+                <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
+                <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
+                <shared:ServiceLogView Grid.Row="3" x:Name="LogView" />
+            </Grid>
         </Grid>
-    </Grid>
+    </ScrollViewer>
 </Page>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,8 @@
 - TCP scripting workflow consolidated into the messages view, enabling inline script editing and execution.
 - TCP options persist the last test message and preload it when reopening the service.
 - Service message table retains only the five most recent entries.
+- TCP service messages view wrapped in a ScrollViewer with adjusted row sizing.
+- ServiceMessageTableView limits height to keep the table compact.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -151,6 +151,7 @@ Latest Attempt: After adding the script editor window, the `dotnet` command rema
 Newest Attempt: After updating TCP service persistence and tests, the `dotnet` command is still missing; restore, build, and test commands could not run locally so CI will verify.
 Current Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet workload install wpf` is unrecognized and `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Latest Attempt: After limiting ServiceMessageTableViewModel to five rows, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.
+Another Attempt: After wrapping the TCP service messages view in a ScrollViewer and capping table height, the `dotnet` command remains unavailable; build and tests are deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- allow scrolling in TCP service messages view and ensure log row expands
- limit service message table height to keep view compact
- note inability to run `dotnet` locally

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1586fa1908326bba88102a9e9f239