### PR TITLE
Improve service log view scrolling and wrapping

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -23,10 +23,10 @@
                 <Button Content="Export Log" Width="100" Margin="10,0,0,0" Command="{Binding ExportLogCommand}" Background="#CCCCFF"/>
                 <Button Content="Clear Log" Width="100" Margin="10,0,0,0" Command="{Binding ClearLogCommand}" Background="#FFCCCC"/>
             </StackPanel>
-            <ListBox Grid.Row="1" ItemsSource="{Binding DisplayLogs}">
+            <ListBox Grid.Row="1" ItemsSource="{Binding DisplayLogs}" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" MinHeight="150">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <TextBlock Text="{Binding Message}" Foreground="{Binding Color}" />
+                        <TextBlock Text="{Binding Message}" Foreground="{Binding Color}" TextWrapping="Wrap" Margin="0,0,0,5" />
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -502,3 +502,11 @@ Effective Prompts / Instructions that worked: User request to confirm control re
 Decisions & Rationale: Explicit project entries and namespace qualification ensure the control loads across views.
 Action Items: Rely on CI for validation.
 Related Commits/PRs:
+[2025-10-02 09:00] Topic: Service log view scrollbars
+Context: Adjusted ServiceLogView ListBox to show scrollbars and wrap text.
+Observations: Updated XAML with auto scrollbars, text wrapping, and margin for clearer log entries.
+Codex Limitations noticed: dotnet CLI is unavailable; unable to run restore, build, or tests.
+Effective Prompts / Instructions that worked: User request to expose more log text in the UI.
+Decisions & Rationale: Improve log readability; document missing tooling and rely on CI for validation.
+Action Items: Rely on CI for verification.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- show scrollbars and wrapped entries in ServiceLogView
- log missing dotnet CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1596778b483268c51956491edffcb