### PR TITLE
Use command for TCP script editor

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Views;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -77,6 +78,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         /// <summary>Command to open advanced TCP settings.</summary>
         public ICommand OpenAdvancedSettingsCommand { get; }
+
+        /// <summary>Command to open the script editor window.</summary>
+        public ICommand OpenScriptEditorCommand { get; }
 
         /// <summary>Raised when the advanced settings view should open.</summary>
         public event EventHandler? AdvancedSettingsRequested;
@@ -160,6 +164,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             ExportLogCommand = new RelayCommand(ExportLogs);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
             OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
+            OpenScriptEditorCommand = new RelayCommand(OpenScriptEditor);
         }
 
         /// <summary>Associates the view model with a service and its TCP options.</summary>
@@ -222,6 +227,23 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 ? $"{ServiceName}-PEAK-123456789"
                 : _options.LastTestMessage;
             _routing.UpdateMessage(ServiceName, TestMessage);
+        }
+
+        private void OpenScriptEditor()
+        {
+            var editor = new ScriptEditorWindow();
+            if (editor.DataContext is ScriptEditorViewModel svm)
+            {
+                svm.ScriptText = Script;
+                svm.TestMessage = TestMessage;
+            }
+
+            if (editor.ShowDialog() == true)
+            {
+                Script = editor.ScriptText;
+                TestMessage = editor.LastTestMessage;
+                Save();
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -39,7 +39,7 @@
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
                     <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
-                    <Button Content="Edit Script" Margin="10,0,0,0" Click="EditScript_Click"/>
+                    <Button Content="Edit Script" Margin="10,0,0,0" Command="{Binding OpenScriptEditorCommand}"/>
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
                 <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
 
@@ -23,24 +21,5 @@ namespace DesktopApplicationTemplate.UI.Views
                 vm.SetService(service);
         }
 
-        private void EditScript_Click(object sender, RoutedEventArgs e)
-        {
-            if (DataContext is not TcpServiceMessagesViewModel vm)
-                return;
-
-            var editor = new ScriptEditorWindow();
-            if (editor.DataContext is ScriptEditorViewModel svm)
-            {
-                svm.ScriptText = vm.Script;
-                svm.TestMessage = vm.TestMessage;
-            }
-
-            if (editor.ShowDialog() == true)
-            {
-                vm.Script = editor.ScriptText;
-                vm.TestMessage = editor.LastTestMessage;
-                vm.Save();
-            }
-        }
     }
 }

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -152,6 +152,7 @@ Newest Attempt: After updating TCP service persistence and tests, the `dotnet` c
 Current Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet workload install wpf` is unrecognized and `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
 Latest Attempt: After limiting ServiceMessageTableViewModel to five rows, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.
 Another Attempt: After wrapping the TCP service messages view in a ScrollViewer and capping table height, the `dotnet` command remains unavailable; build and tests are deferred to CI.
+Latest Attempt: After moving script editing to an ICommand, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add OpenScriptEditorCommand to TcpServiceMessagesViewModel and handle script editor dialog
- bind Edit Script button to the new command
- drop obsolete EditScript_Click handler

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15a2a3db48326902f1e040a89a7ca