### PR TITLE
Display script output in TCP service messages

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -162,6 +162,27 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
+    public void Save_ComputesOutputMessage()
+    {
+        var options = new TcpServiceOptions();
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
+        vm.Script = "string Process(string message) => message + \"!\";";
+        vm.TestMessage = "hi";
+
+        vm.Save();
+
+        vm.OutputMessage.Should().Be("hi!");
+        options.OutputMessage.Should().Be("hi!");
+    }
+
+    [Fact]
     public void SetService_LoadsScript()
     {
         var service = new ServiceViewModel

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -10,6 +10,9 @@ using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -107,6 +110,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private string _script = string.Empty;
 
+        private string _outputMessage = string.Empty;
+
         /// <summary>Message used for testing communication.</summary>
         public string TestMessage
         {
@@ -127,6 +132,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 if (_script == value) return;
                 _script = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>Result of executing the test message with the current script.</summary>
+        public string OutputMessage
+        {
+            get => _outputMessage;
+            private set
+            {
+                if (_outputMessage == value) return;
+                _outputMessage = value ?? string.Empty;
                 OnPropertyChanged();
             }
         }
@@ -175,6 +192,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _options = service.TcpOptions ?? new TcpServiceOptions();
             ServiceName = service.DisplayName.Split(" - ").Last();
             Script = _options.Script;
+            OutputMessage = _options.OutputMessage;
         }
 
         /// <summary>Updates network and scripting settings.</summary>
@@ -216,6 +234,33 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _options.LastTestMessage = TestMessage;
             _options.Script = Script;
             _routing.UpdateMessage(ServiceName, TestMessage);
+            OutputMessage = RunScript();
+            _options.OutputMessage = OutputMessage;
+        }
+
+        private string RunScript()
+        {
+            var globals = new ScriptGlobals { message = TestMessage };
+            var code = Script + "\nProcess(message);";
+            var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
+            var diagnostics = script.Compile();
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+
+            try
+            {
+                var result = script.RunAsync(globals).GetAwaiter().GetResult();
+                return result.ReturnValue ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                return ex.ToString();
+            }
+        }
+
+        private class ScriptGlobals
+        {
+            public string message = string.Empty;
         }
 
         private void InitializeTestMessage()
@@ -236,6 +281,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 svm.ScriptText = Script;
                 svm.TestMessage = TestMessage;
+                svm.PropertyChanged += (_, e) =>
+                {
+                    if (e.PropertyName == nameof(ScriptEditorViewModel.OutputMessage))
+                        OutputMessage = svm.OutputMessage;
+                };
             }
 
             if (editor.ShowDialog() == true)

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -40,6 +40,8 @@
                     <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
                     <Button Content="Edit Script" Margin="10,0,0,0" Command="{Binding OpenScriptEditorCommand}"/>
+                    <TextBox Text="{Binding OutputMessage}" Width="300"
+                             IsReadOnly="True" Margin="10,0,0,0" Background="#EDEDED"/>
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
                 <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Reusable `ServiceMessageTableView` and `ServiceMessageTableViewModel` display recent service messages with default columns, integrated into the TCP service view.
 - Script editor window with Roslyn-based syntax highlighting and run/save commands.
 - TCP service messages view adds an Edit Script button for modifying scripts and test messages.
+- TCP service messages view displays script output next to the test message.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -153,6 +153,7 @@ Current Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build`
 Latest Attempt: After limiting ServiceMessageTableViewModel to five rows, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.
 Another Attempt: After wrapping the TCP service messages view in a ScrollViewer and capping table height, the `dotnet` command remains unavailable; build and tests are deferred to CI.
 Latest Attempt: After moving script editing to an ICommand, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally and CI will verify.
+Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- show script execution results in TCP service messages view
- evaluate script on save and persist output
- document script output in changelog and tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c15aff34748326a003136e8d48b3b5