### PR TITLE
Run TCP script using JoinableTaskFactory

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Xceed.Wpf.Toolkit" Version="4.7.25103.5738" />
     <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
     <PackageReference Include="RoslynPad.Editor.Windows" Version="4.12.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -13,6 +13,7 @@ using DesktopApplicationTemplate.UI.Views;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -21,6 +22,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     /// </summary>
     public class TcpServiceMessagesViewModel : ViewModelBase, ILoggingViewModel
     {
+        private static readonly JoinableTaskFactory _jtf = new(new JoinableTaskContext());
         private LogLevel _logLevelFilter = LogLevel.Debug;
 
         /// <summary>Table view model for displaying message history.</summary>
@@ -240,22 +242,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private string RunScript()
         {
-            var globals = new ScriptGlobals { message = TestMessage };
-            var code = Script + "\nProcess(message);";
-            var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
-            var diagnostics = script.Compile();
-            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-                return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+            return _jtf.Run(async () =>
+            {
+                var globals = new ScriptGlobals { message = TestMessage };
+                var code = Script + "\nProcess(message);";
+                var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
+                var diagnostics = script.Compile();
+                if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                    return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
 
-            try
-            {
-                var result = script.RunAsync(globals).GetAwaiter().GetResult();
-                return result.ReturnValue ?? string.Empty;
-            }
-            catch (Exception ex)
-            {
-                return ex.ToString();
-            }
+                try
+                {
+                    var result = await script.RunAsync(globals).ConfigureAwait(false);
+                    return result.ReturnValue ?? string.Empty;
+                }
+                catch (Exception ex)
+                {
+                    return ex.ToString();
+                }
+            });
         }
 
         private class ScriptGlobals


### PR DESCRIPTION
## Summary
- avoid synchronous script execution by running via JoinableTaskFactory in `TcpServiceMessagesViewModel`
- add Microsoft.VisualStudio.Threading package to support joinable tasks

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: MC3074/MC3072 errors for WPF XAML types)*
- `dotnet test --settings tests.runsettings --no-build` *(partial: core tests passed, UI tests not executed due to invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68c16013a9fc8326b61bf294f0c624bc