### PR TITLE
Fix OutputMessage binding

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml
@@ -40,7 +40,7 @@
                     <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
                     <Button Content="Edit Script" Margin="10,0,0,0" Command="{Binding OpenScriptEditorCommand}"/>
-                    <TextBox Text="{Binding OutputMessage}" Width="300"
+                    <TextBox Text="{Binding OutputMessage, Mode=OneWay}" Width="300"
                              IsReadOnly="True" Margin="10,0,0,0" Background="#EDEDED"/>
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,7 @@
 - Extracted `StringNullOrEmptyToVisibilityConverter` into its own file so XAML views compile independently.
 - Qualified helper namespaces with explicit assembly references so `StringNullOrEmptyToVisibilityConverter` resolves across service views.
 - EditorButtonBar included as a Page with code-behind dependency and referenced via an assembly-qualified views namespace across consuming views.
+- Output message textbox uses a one-way binding to avoid runtime errors on the read-only `OutputMessage` property.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -155,6 +155,7 @@ Another Attempt: After wrapping the TCP service messages view in a ScrollViewer 
 Latest Attempt: After moving script editing to an ICommand, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally and CI will verify.
 Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot run locally and CI will verify.
 Latest Attempt: After removing the application logo and adding header text, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with XAML errors and `dotnet test --settings tests.runsettings` produced similar errors; relying on CI for validation.
+Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- prevent TwoWay binding errors by binding OutputMessage textbox OneWay
- document test runtime limitation

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c162261b8083268eefa11fa9c04ac8