### PR TITLE
Fix script editor binding for AvalonEdit control

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml
@@ -10,7 +10,6 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <avalonEdit:TextEditor x:Name="Editor"
-                               Text="{Binding ScriptText, UpdateSourceTrigger=PropertyChanged}"
                                SyntaxHighlighting="C#"
                                ShowLineNumbers="True" />
         <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,5,0,5">

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Media;
 using ICSharpCode.AvalonEdit.Document;
@@ -18,8 +19,20 @@ public partial class ScriptEditorWindow : Window
         InitializeComponent();
         var vm = new ScriptEditorViewModel();
         DataContext = vm;
+        Editor.Text = vm.ScriptText;
+        Editor.TextChanged += (_, _) => vm.ScriptText = Editor.Text;
+        vm.PropertyChanged += OnViewModelPropertyChanged;
         vm.RequestClose += OnRequestClose;
         vm.ErrorsChanged += HighlightErrors;
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is not ScriptEditorViewModel vm || e.PropertyName != nameof(ScriptEditorViewModel.ScriptText))
+            return;
+
+        if (Editor.Text != vm.ScriptText)
+            Editor.Text = vm.ScriptText;
     }
 
     private void OnRequestClose(object? sender, ScriptSavedEventArgs e)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,7 @@
 - Qualified helper namespaces with explicit assembly references so `StringNullOrEmptyToVisibilityConverter` resolves across service views.
 - EditorButtonBar included as a Page with code-behind dependency and referenced via an assembly-qualified views namespace across consuming views.
 - Output message textbox uses a one-way binding to avoid runtime errors on the read-only `OutputMessage` property.
+- Script editor window removes `Text` binding from AvalonEdit control to prevent XAML parse exceptions.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -156,6 +156,7 @@ Latest Attempt: After moving script editing to an ICommand, the `dotnet` CLI rem
 Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot run locally and CI will verify.
 Latest Attempt: After removing the application logo and adding header text, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with XAML errors and `dotnet test --settings tests.runsettings` produced similar errors; relying on CI for validation.
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
+Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- avoid XAML parse crash by removing Text binding from AvalonEdit TextEditor and syncing text in code-behind
- document script editor binding fix in changelog and collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c163d82e6c8326a5eb1ff423d57ea7