### PR TITLE
Load default TCP script by default

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -199,6 +199,42 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
+    public void SetService_NoScript_UsesDefault()
+    {
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = new TcpServiceOptions()
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+
+        vm.SetService(service);
+
+        vm.Script.Should().Be(ScriptEditorViewModel.DefaultScript);
+    }
+
+    [Fact]
+    public void Save_DefaultScript_RunsMessage()
+    {
+        var options = new TcpServiceOptions();
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
+        vm.TestMessage = "ping";
+
+        vm.Save();
+
+        vm.OutputMessage.Should().Be("ping");
+        options.OutputMessage.Should().Be("ping");
+    }
+
+    [Fact]
     public async Task ScriptEditor_RunCommand_ProcessesMessage()
     {
         var editor = new ScriptEditorViewModel();

--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -13,7 +13,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 
 public class ScriptEditorViewModel : ViewModelBase
 {
-    private string _scriptText = "string Process(string message)\n{\n    return message;\n}";
+    public const string DefaultScript = "string Process(string message)\n{\n    return message;\n}";
+
+    private string _scriptText = DefaultScript;
     private string _testMessage = string.Empty;
     private string _outputMessage = string.Empty;
     private Brush _outputBrush = Brushes.Black;

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -193,7 +193,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (service == null) throw new ArgumentNullException(nameof(service));
             _options = service.TcpOptions ?? new TcpServiceOptions();
             ServiceName = service.DisplayName.Split(" - ").Last();
-            Script = _options.Script;
+            Script = string.IsNullOrWhiteSpace(_options.Script)
+                ? ScriptEditorViewModel.DefaultScript
+                : _options.Script;
             OutputMessage = _options.OutputMessage;
         }
 
@@ -284,7 +286,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var editor = new ScriptEditorWindow();
             if (editor.DataContext is ScriptEditorViewModel svm)
             {
-                svm.ScriptText = Script;
+                if (!string.IsNullOrWhiteSpace(Script))
+                    svm.ScriptText = Script;
                 svm.TestMessage = TestMessage;
                 svm.PropertyChanged += (_, e) =>
                 {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -68,6 +68,7 @@
 - TCP service messages view wrapped in a ScrollViewer with adjusted row sizing.
 - ServiceMessageTableView limits height to keep the table compact.
 - Replaced main window navigation logo with a text header.
+- Script editor exposes the built-in script via `DefaultScript`, and TCP service messages view loads it when no script is provided.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -157,6 +157,7 @@ Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot
 Latest Attempt: After removing the application logo and adding header text, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with XAML errors and `dotnet test --settings tests.runsettings` produced similar errors; relying on CI for validation.
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
+Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- expose built-in script as `ScriptEditorViewModel.DefaultScript`
- default TCP messages view to built-in script when no script is provided
- exercise default script in TcpServiceMessagesViewModel tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c165aa8488832683bd330f7df33598