### PR TITLE
Expose ScriptGlobals for TCP scripts

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -215,7 +215,7 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
-    public void Save_DefaultScript_RunsMessage()
+    public void Save_DefaultScript_NoProtectionLevelErrors()
     {
         var options = new TcpServiceOptions();
         var service = new ServiceViewModel
@@ -231,6 +231,7 @@ public class TcpServiceMessagesViewModelTests
         vm.Save();
 
         vm.OutputMessage.Should().Be("ping");
+        vm.OutputMessage.Should().NotContain("protection level");
         options.OutputMessage.Should().Be("ping");
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -265,7 +265,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             });
         }
 
-        private class ScriptGlobals
+        public class ScriptGlobals
         {
             public string message = string.Empty;
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,6 +101,7 @@
 - EditorButtonBar included as a Page with code-behind dependency and referenced via an assembly-qualified views namespace across consuming views.
 - Output message textbox uses a one-way binding to avoid runtime errors on the read-only `OutputMessage` property.
 - Script editor window removes `Text` binding from AvalonEdit control to prevent XAML parse exceptions.
+- Made `ScriptGlobals` public so TCP scripts can access the `message` field without protection-level errors.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -158,6 +158,7 @@ Latest Attempt: After removing the application logo and adding header text, `dot
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- expose `ScriptGlobals` in `TcpServiceMessagesViewModel` so Roslyn scripts can access the `message` field
- guard against protection-level errors with a regression test for the default TCP script
- document the change and note test limitations

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1669ec3ec8326a131cb4bc9f635be