### PR TITLE
Expose script editor globals to fix access error

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -116,7 +116,7 @@ public class ScriptEditorViewModel : ViewModelBase
 
     private void Save() => RequestClose?.Invoke(this, new ScriptSavedEventArgs(ScriptText, _lastTestMessage));
 
-    private class Globals
+    public class Globals
     {
         public string message = string.Empty;
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,6 +102,7 @@
 - Output message textbox uses a one-way binding to avoid runtime errors on the read-only `OutputMessage` property.
 - Script editor window removes `Text` binding from AvalonEdit control to prevent XAML parse exceptions.
 - Made `ScriptGlobals` public so TCP scripts can access the `message` field without protection-level errors.
+- Made `ScriptEditorViewModel.Globals` public so scripts can access the `message` field without protection-level errors.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -159,7 +159,8 @@ Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet t
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
+Latest Attempt: After making the script editor `Globals` class public, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally so CI will verify.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- make `ScriptEditorViewModel.Globals` public so scripts can access the `message` field
- note tooling limitation in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c167d0454c8326b8d9ae91b09a91fa