### PR TITLE
Dispatch script editor updates on UI thread

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Media;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
@@ -91,32 +92,41 @@ public class ScriptEditorViewModel : ViewModelBase
         var code = ScriptText + "\nProcess(message);";
         var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(Globals));
         var diagnostics = script.Compile();
-        ErrorsChanged?.Invoke(diagnostics);
+        await Application.Current.Dispatcher.InvokeAsync(() => ErrorsChanged?.Invoke(diagnostics));
 
         if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
         {
-            OutputMessage = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
-            OutputBrush = Brushes.Red;
+            await Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                OutputMessage = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+                OutputBrush = Brushes.Red;
+            });
             return;
         }
 
         try
         {
             var result = await script.RunAsync(globals);
-            OutputMessage = result.ReturnValue;
-            OutputBrush = Brushes.Black;
-            _lastTestMessage = TestMessage;
+            await Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                OutputMessage = result.ReturnValue;
+                OutputBrush = Brushes.Black;
+                _lastTestMessage = TestMessage;
+            });
         }
         catch (Exception ex)
         {
-            OutputMessage = ex.ToString();
-            OutputBrush = Brushes.Red;
+            await Application.Current.Dispatcher.InvokeAsync(() =>
+            {
+                OutputMessage = ex.ToString();
+                OutputBrush = Brushes.Red;
+            });
         }
     }
 
     private void Save() => RequestClose?.Invoke(this, new ScriptSavedEventArgs(ScriptText, _lastTestMessage));
 
-    private class Globals
+    public class Globals
     {
         public string message = string.Empty;
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,6 +102,8 @@
 - Output message textbox uses a one-way binding to avoid runtime errors on the read-only `OutputMessage` property.
 - Script editor window removes `Text` binding from AvalonEdit control to prevent XAML parse exceptions.
 - Made `ScriptGlobals` public so TCP scripts can access the `message` field without protection-level errors.
+- Made `ScriptEditorViewModel.Globals` public so scripts can access the `message` field without protection-level errors.
+- Script editor dispatches output and error highlights to the UI thread so results appear when Run is clicked.
 
 ### HID Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -159,7 +159,8 @@ Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet t
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc
+Latest Attempt: After making the script editor `Globals` class public, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally so CI will verify.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.
@@ -500,6 +501,7 @@ Decisions & Rationale: Note conflict and proceed with code changes relying on CI
 Action Items: Resolve package versions in future work.
 Latest Attempt: After bumping Microsoft.CodeAnalysis packages to 4.12.0, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with CS1061 'DocumentLine' missing `BackgroundColor` and VSTHRD100/101 analyzer errors; `dotnet workload install wpf` still reports Workload ID not recognized. Relying on CI for validation.
 Next Attempt: Installed .NET SDK 8.0.404, replaced `DocumentLine.BackgroundColor` with a line transformer, and converted async lambdas to `AsyncRelayCommand`; `dotnet build DesktopApplicationTemplate.sln` now succeeds but `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
+Current Attempt: `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` report command not found; relying on CI for validation.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- run script editor output and error highlighting on the UI thread so results display
- document the change in the changelog
- log missing `dotnet` CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c167d0454c8326b8d9ae91b09a91fa