### PR TITLE
Use JoinableTaskFactory in script editor

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -2,18 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
+using Microsoft.VisualStudio.Threading;
 using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
 
 public class ScriptEditorViewModel : ViewModelBase
 {
+    private static readonly JoinableTaskFactory _jtf = new(new JoinableTaskContext());
+
     public const string DefaultScript = "string Process(string message)\n{\n    return message;\n}";
 
     private string _scriptText = DefaultScript;
@@ -92,35 +94,30 @@ public class ScriptEditorViewModel : ViewModelBase
         var code = ScriptText + "\nProcess(message);";
         var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(Globals));
         var diagnostics = script.Compile();
-        await Application.Current.Dispatcher.InvokeAsync(() => ErrorsChanged?.Invoke(diagnostics));
+        await _jtf.SwitchToMainThreadAsync();
+        ErrorsChanged?.Invoke(diagnostics);
 
         if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
         {
-            await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                OutputMessage = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
-                OutputBrush = Brushes.Red;
-            });
+            await _jtf.SwitchToMainThreadAsync();
+            OutputMessage = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+            OutputBrush = Brushes.Red;
             return;
         }
 
         try
         {
             var result = await script.RunAsync(globals);
-            await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                OutputMessage = result.ReturnValue;
-                OutputBrush = Brushes.Black;
-                _lastTestMessage = TestMessage;
-            });
+            await _jtf.SwitchToMainThreadAsync();
+            OutputMessage = result.ReturnValue;
+            OutputBrush = Brushes.Black;
+            _lastTestMessage = TestMessage;
         }
         catch (Exception ex)
         {
-            await Application.Current.Dispatcher.InvokeAsync(() =>
-            {
-                OutputMessage = ex.ToString();
-                OutputBrush = Brushes.Red;
-            });
+            await _jtf.SwitchToMainThreadAsync();
+            OutputMessage = ex.ToString();
+            OutputBrush = Brushes.Red;
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,6 +104,7 @@
 - Made `ScriptGlobals` public so TCP scripts can access the `message` field without protection-level errors.
 - Made `ScriptEditorViewModel.Globals` public so scripts can access the `message` field without protection-level errors.
 - Script editor dispatches output and error highlights to the UI thread so results appear when Run is clicked.
+- Script editor uses a `JoinableTaskFactory` to switch to the UI thread and remove VSTHRD001 analyzer warnings.
 
 
 ### HID Service

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -502,6 +502,7 @@ Action Items: Resolve package versions in future work.
 Latest Attempt: After bumping Microsoft.CodeAnalysis packages to 4.12.0, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with CS1061 'DocumentLine' missing `BackgroundColor` and VSTHRD100/101 analyzer errors; `dotnet workload install wpf` still reports Workload ID not recognized. Relying on CI for validation.
 Next Attempt: Installed .NET SDK 8.0.404, replaced `DocumentLine.BackgroundColor` with a line transformer, and converted async lambdas to `AsyncRelayCommand`; `dotnet build DesktopApplicationTemplate.sln` now succeeds but `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
 Current Attempt: `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` report command not found; relying on CI for validation.
+Latest Attempt: After updating ScriptEditorViewModel to use JoinableTaskFactory, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded. `dotnet workload install wpf` still reports Workload ID not recognized, and `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- switch ScriptEditorViewModel to a JoinableTaskFactory for main-thread work
- document build environment notes and changelog entry

## Testing
- `dotnet workload install wpf` *(fails: Workload ID wpf is not recognized)*
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c16d0ff87883268c7edad36bb0b326