### PR TITLE
Propagate script editor output to TCP messages view

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -262,4 +262,17 @@ public class TcpServiceMessagesViewModelTests
         script.Should().Contain("Process");
         last.Should().Be("msg");
     }
+
+    [Fact]
+    public async Task OpenScriptEditor_RunCommand_UpdatesOutputMessage()
+    {
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        var editor = new ScriptEditorViewModel();
+        editor.OutputGenerated += output => vm.OutputMessage = output;
+        editor.TestMessage = "test";
+
+        await ((AsyncRelayCommand)editor.RunCommand).ExecuteAsync(null);
+
+        vm.OutputMessage.Should().Be("test");
+    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -81,6 +81,7 @@ public class ScriptEditorViewModel : ViewModelBase
 
     public event EventHandler<ScriptSavedEventArgs>? RequestClose;
     public event Action<IEnumerable<Diagnostic>>? ErrorsChanged;
+    public event Action<string>? OutputGenerated;
 
     public ScriptEditorViewModel()
     {
@@ -102,6 +103,7 @@ public class ScriptEditorViewModel : ViewModelBase
             await _jtf.SwitchToMainThreadAsync();
             OutputMessage = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
             OutputBrush = Brushes.Red;
+            OutputGenerated?.Invoke(OutputMessage);
             return;
         }
 
@@ -112,12 +114,14 @@ public class ScriptEditorViewModel : ViewModelBase
             OutputMessage = result.ReturnValue;
             OutputBrush = Brushes.Black;
             _lastTestMessage = TestMessage;
+            OutputGenerated?.Invoke(OutputMessage);
         }
         catch (Exception ex)
         {
             await _jtf.SwitchToMainThreadAsync();
             OutputMessage = ex.ToString();
             OutputBrush = Brushes.Red;
+            OutputGenerated?.Invoke(OutputMessage);
         }
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -289,11 +289,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 if (!string.IsNullOrWhiteSpace(Script))
                     svm.ScriptText = Script;
                 svm.TestMessage = TestMessage;
-                svm.PropertyChanged += (_, e) =>
-                {
-                    if (e.PropertyName == nameof(ScriptEditorViewModel.OutputMessage))
-                        OutputMessage = svm.OutputMessage;
-                };
+                svm.OutputGenerated += output => OutputMessage = output;
             }
 
             if (editor.ShowDialog() == true)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@
 - ServiceMessageTableView limits height to keep the table compact.
 - Replaced main window navigation logo with a text header.
 - Script editor exposes the built-in script via `DefaultScript`, and TCP service messages view loads it when no script is provided.
+- Script editor raises an `OutputGenerated` event and TCP service messages view updates its output message when scripts run.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -158,6 +158,7 @@ Latest Attempt: After removing the application logo and adding header text, `dot
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After wiring script output events to the TCP messages view, the `dotnet` CLI is still missing; restore, build, and test steps could not run and will be validated in CI.
 Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.
 Latest Attempt: After making the script editor `Globals` class public, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b


### PR DESCRIPTION
## Summary
- raise OutputGenerated event from ScriptEditorViewModel
- update TcpServiceMessagesViewModel to consume script output
- test that script execution updates TCP messages output

## Testing
- ⚠️ `dotnet restore` *(command not found: dotnet)*
- ⚠️ `dotnet build DesktopApplicationTemplate.sln` *(command not found: dotnet)*
- ⚠️ `dotnet test --settings tests.runsettings` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c171511db88326a207ca3fe88dfd8f