### PR TITLE
Add test for script editor RunCommand without saving

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -275,4 +275,27 @@ public class TcpServiceMessagesViewModelTests
 
         vm.OutputMessage.Should().Be("test");
     }
+
+    [Fact]
+    public async Task OpenScriptEditor_RunCommand_DoesNotPersistWithoutSave()
+    {
+        var options = new TcpServiceOptions();
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
+
+        var editor = new ScriptEditorViewModel();
+        editor.OutputGenerated += output => vm.OutputMessage = output;
+        editor.TestMessage = "test";
+
+        await ((AsyncRelayCommand)editor.RunCommand).ExecuteAsync(null);
+
+        vm.OutputMessage.Should().Be("test");
+        options.OutputMessage.Should().BeEmpty();
+    }
 }

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -504,6 +504,7 @@ Latest Attempt: After bumping Microsoft.CodeAnalysis packages to 4.12.0, `dotnet
 Next Attempt: Installed .NET SDK 8.0.404, replaced `DocumentLine.BackgroundColor` with a line transformer, and converted async lambdas to `AsyncRelayCommand`; `dotnet build DesktopApplicationTemplate.sln` now succeeds but `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
 Current Attempt: `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` report command not found; relying on CI for validation.
 Latest Attempt: After updating ScriptEditorViewModel to use JoinableTaskFactory, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded. `dotnet workload install wpf` still reports Workload ID not recognized, and `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
+Newest Attempt: After adding a test for ScriptEditor RunCommand updating TcpServiceMessagesViewModel without saving, the `dotnet` command is still missing; restore, build, and test commands cannot run locally and CI will handle verification.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- verify TcpServiceMessagesViewModel updates OutputMessage when the script editor runs without saving
- log missing `dotnet` CLI when attempting to build and test

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1726a31608326942eb0705663abac