### PR TITLE
Track script editor handlers in TCP messages view model

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.ComponentModel;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
@@ -284,15 +285,33 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private void OpenScriptEditor()
         {
             var editor = new ScriptEditorWindow();
-            if (editor.DataContext is ScriptEditorViewModel svm)
+            if (editor.DataContext is not ScriptEditorViewModel svm)
+                return;
+
+            if (!string.IsNullOrWhiteSpace(Script))
+                svm.ScriptText = Script;
+            svm.TestMessage = TestMessage;
+
+            void OnOutputGenerated(string output)
             {
-                if (!string.IsNullOrWhiteSpace(Script))
-                    svm.ScriptText = Script;
-                svm.TestMessage = TestMessage;
-                svm.OutputGenerated += output => OutputMessage = output;
+                OutputMessage = _options.OutputMessage = output;
             }
 
-            if (editor.ShowDialog() == true)
+            void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+            {
+                if (e.PropertyName == nameof(ScriptEditorViewModel.TestMessage))
+                    TestMessage = svm.TestMessage;
+            }
+
+            svm.OutputGenerated += OnOutputGenerated;
+            svm.PropertyChanged += OnPropertyChanged;
+
+            var result = editor.ShowDialog() == true;
+
+            svm.OutputGenerated -= OnOutputGenerated;
+            svm.PropertyChanged -= OnPropertyChanged;
+
+            if (result)
             {
                 Script = editor.ScriptText;
                 TestMessage = editor.LastTestMessage;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,7 @@
 - Made `ScriptEditorViewModel.Globals` public so scripts can access the `message` field without protection-level errors.
 - Script editor dispatches output and error highlights to the UI thread so results appear when Run is clicked.
 - Script editor uses a `JoinableTaskFactory` to switch to the UI thread and remove VSTHRD001 analyzer warnings.
+- Script editor unsubscribes handlers on close and mirrors test message changes to the TCP messages view.
 
 
 ### HID Service

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -161,6 +161,7 @@ Latest Attempt: After exposing the default TCP script and adding tests, the `dot
 Latest Attempt: After wiring script output events to the TCP messages view, the `dotnet` CLI is still missing; restore, build, and test steps could not run and will be validated in CI.
 Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.
 Latest Attempt: After making the script editor `Globals` class public, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally so CI will verify.
+Latest Attempt: After mirroring script editor test message updates in the TCP messages view and cleaning up subscriptions on close, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- mirror script editor test message updates in TCP messages view
- clean up script editor event subscriptions and sync output option
- document handler updates and log missing dotnet CLI

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c175c859b88326b5a77fd995a4c196