### PR TITLE
Make TCP script execution asynchronous

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -124,7 +124,7 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
-    public void Save_UpdatesLastTestMessage()
+    public async Task SaveAsync_UpdatesLastTestMessage()
     {
         var options = new TcpServiceOptions();
         var service = new ServiceViewModel
@@ -137,13 +137,13 @@ public class TcpServiceMessagesViewModelTests
         vm.SetService(service);
         vm.TestMessage = "test";
 
-        vm.Save();
+        await vm.SaveAsync();
 
         options.LastTestMessage.Should().Be("test");
     }
 
     [Fact]
-    public void Save_UpdatesScript()
+    public async Task SaveAsync_UpdatesScript()
     {
         var options = new TcpServiceOptions();
         var service = new ServiceViewModel
@@ -156,13 +156,13 @@ public class TcpServiceMessagesViewModelTests
         vm.SetService(service);
         vm.Script = "return message;";
 
-        vm.Save();
+        await vm.SaveAsync();
 
         options.Script.Should().Be("return message;");
     }
 
     [Fact]
-    public void Save_ComputesOutputMessage()
+    public async Task SaveAsync_ComputesOutputMessage()
     {
         var options = new TcpServiceOptions();
         var service = new ServiceViewModel
@@ -176,7 +176,7 @@ public class TcpServiceMessagesViewModelTests
         vm.Script = "string Process(string message) => message + \"!\";";
         vm.TestMessage = "hi";
 
-        vm.Save();
+        await vm.SaveAsync();
 
         vm.OutputMessage.Should().Be("hi!");
         options.OutputMessage.Should().Be("hi!");
@@ -215,7 +215,7 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
-    public void Save_DefaultScript_NoProtectionLevelErrors()
+    public async Task SaveAsync_DefaultScript_NoProtectionLevelErrors()
     {
         var options = new TcpServiceOptions();
         var service = new ServiceViewModel
@@ -228,7 +228,7 @@ public class TcpServiceMessagesViewModelTests
         vm.SetService(service);
         vm.TestMessage = "ping";
 
-        vm.Save();
+        await vm.SaveAsync();
 
         vm.OutputMessage.Should().Be("ping");
         vm.OutputMessage.Should().NotContain("protection level");

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -385,7 +385,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 if (svc.ServicePage?.DataContext is TcpServiceMessagesViewModel tcpVm)
                 {
-                    tcpVm.Save();
+                    tcpVm.SaveAsync().GetAwaiter().GetResult();
                 }
             }
             ServicePersistence.Save(Services);

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
@@ -14,7 +15,6 @@ using DesktopApplicationTemplate.UI.Views;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
-using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -23,7 +23,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     /// </summary>
     public class TcpServiceMessagesViewModel : ViewModelBase, ILoggingViewModel
     {
-        private static readonly JoinableTaskFactory _jtf = new(new JoinableTaskContext());
         private LogLevel _logLevelFilter = LogLevel.Debug;
 
         /// <summary>Table view model for displaying message history.</summary>
@@ -184,7 +183,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             ExportLogCommand = new RelayCommand(ExportLogs);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
             OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
-            OpenScriptEditorCommand = new RelayCommand(OpenScriptEditor);
+            OpenScriptEditorCommand = new AsyncRelayCommand(OpenScriptEditorAsync);
         }
 
         /// <summary>Associates the view model with a service and its TCP options.</summary>
@@ -234,36 +233,33 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);
 
         /// <summary>Saves the current test message to options and routing.</summary>
-        public void Save()
+        public async Task SaveAsync()
         {
             _options.LastTestMessage = TestMessage;
             _options.Script = Script;
             _routing.UpdateMessage(ServiceName, TestMessage);
-            OutputMessage = RunScript();
+            OutputMessage = await RunScriptAsync().ConfigureAwait(false);
             _options.OutputMessage = OutputMessage;
         }
 
-        private string RunScript()
+        private async Task<string> RunScriptAsync()
         {
-            return _jtf.Run(async () =>
-            {
-                var globals = new ScriptGlobals { message = TestMessage };
-                var code = Script + "\nProcess(message);";
-                var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
-                var diagnostics = script.Compile();
-                if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-                    return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+            var globals = new ScriptGlobals { message = TestMessage };
+            var code = Script + "\nProcess(message);";
+            var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
+            var diagnostics = script.Compile();
+            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+                return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
 
-                try
-                {
-                    var result = await script.RunAsync(globals).ConfigureAwait(false);
-                    return result.ReturnValue ?? string.Empty;
-                }
-                catch (Exception ex)
-                {
-                    return ex.ToString();
-                }
-            });
+            try
+            {
+                var result = await script.RunAsync(globals).ConfigureAwait(false);
+                return result.ReturnValue ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                return ex.ToString();
+            }
         }
 
         public class ScriptGlobals
@@ -282,7 +278,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _routing.UpdateMessage(ServiceName, TestMessage);
         }
 
-        private void OpenScriptEditor()
+        private async Task OpenScriptEditorAsync()
         {
             var editor = new ScriptEditorWindow();
             if (editor.DataContext is not ScriptEditorViewModel svm)
@@ -315,7 +311,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 Script = editor.ScriptText;
                 TestMessage = editor.LastTestMessage;
-                Save();
+                await SaveAsync().ConfigureAwait(false);
             }
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Replaced main window navigation logo with a text header.
 - Script editor exposes the built-in script via `DefaultScript`, and TCP service messages view loads it when no script is provided.
 - Script editor raises an `OutputGenerated` event and TCP service messages view updates its output message when scripts run.
+- TcpServiceMessagesViewModel executes scripts asynchronously and awaits results when saving.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -138,6 +138,7 @@ Latest Attempt: After importing the Helpers namespace into App startup to resolv
 Newest Attempt: While unifying log views, the `dotnet` command remained unavailable; build and tests deferred to CI.
 Latest Attempt: After correcting LogEntry namespaces and removing the global log level handler, the `dotnet` CLI is still missing; relying on CI for build and test.
 Another Attempt: After fixing ServiceLogView namespace bindings and command delegates, the `dotnet` command remains unavailable; restore, build, and tests must run in CI.
+Latest Attempt: After converting TcpServiceMessagesViewModel script execution to async and updating related tests, the `dotnet` CLI is still missing; `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` all report command not found.
 Newest Attempt: After qualifying XAML namespaces and marking MQTT subscription view model as Windows-only, the `dotnet` CLI is still missing; relying on CI for build and test.
 Latest Attempt: After aligning log view model with shared log entry and adding assembly-qualified namespaces, the `dotnet` command remains unavailable; build and tests will run in CI.
 Latest Attempt: After including ServiceLogView.xaml as a Page and qualifying the HttpServiceView shared namespace, the `dotnet` CLI is still missing; restore, build, and test commands cannot run locally, so CI will verify.


### PR DESCRIPTION
## Summary
1. Run TCP scripts asynchronously via `RunScriptAsync` and `SaveAsync`, awaiting script results.
2. Invoke the script editor through an `AsyncRelayCommand` and persist edited scripts asynchronously.
3. Update `MainViewModel` and tests to use the new async save pattern.
4. Record async save change in the changelog and note CLI limitations in collaboration tips.

## Testing
- ⚠️ `dotnet restore` *(missing: command not found)*
- ⚠️ `dotnet build DesktopApplicationTemplate.sln` *(missing: command not found)*
- ⚠️ `dotnet test --settings tests.runsettings` *(missing: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c176c8a9388326b5066d31aab89c1f