### PR TITLE
Log TCP script execution results

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -238,7 +238,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _options.LastTestMessage = TestMessage;
             _options.Script = Script;
             _routing.UpdateMessage(ServiceName, TestMessage);
-            OutputMessage = await RunScriptAsync().ConfigureAwait(false);
+            try
+            {
+                OutputMessage = await RunScriptAsync().ConfigureAwait(false);
+                Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
+            }
+            catch (Exception ex)
+            {
+                OutputMessage = ex.ToString();
+                Logger?.Log($"Script execution failed: {ex}", LogLevel.Error);
+            }
             _options.OutputMessage = OutputMessage;
         }
 
@@ -251,15 +260,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
                 return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
 
-            try
-            {
-                var result = await script.RunAsync(globals).ConfigureAwait(false);
-                return result.ReturnValue ?? string.Empty;
-            }
-            catch (Exception ex)
-            {
-                return ex.ToString();
-            }
+            var result = await script.RunAsync(globals).ConfigureAwait(false);
+            return result.ReturnValue ?? string.Empty;
         }
 
         public class ScriptGlobals

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Script editor exposes the built-in script via `DefaultScript`, and TCP service messages view loads it when no script is provided.
 - Script editor raises an `OutputGenerated` event and TCP service messages view updates its output message when scripts run.
 - TcpServiceMessagesViewModel executes scripts asynchronously and awaits results when saving.
+- TcpServiceMessagesViewModel logs script execution results and exceptions.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -158,6 +158,7 @@ Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot
 Latest Attempt: After removing the application logo and adding header text, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with XAML errors and `dotnet test --settings tests.runsettings` produced similar errors; relying on CI for validation.
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
+Latest Attempt: After adding script execution logging to TcpServiceMessagesViewModel, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.
 Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After wiring script output events to the TCP messages view, the `dotnet` CLI is still missing; restore, build, and test steps could not run and will be validated in CI.
 Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.


### PR DESCRIPTION
## Summary
- log TcpServiceMessagesViewModel script execution success or failure with exception details
- document missing dotnet CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c178eacfe08326af9bb83763f89513