### PR TITLE
Add Information log level with color mapping

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/LogLevel.cs
+++ b/DesktopApplicationTemplate.Core/Services/LogLevel.cs
@@ -9,8 +9,9 @@ namespace DesktopApplicationTemplate.Core.Services
     public enum LogLevel
     {
         Debug = 0,
-        Warning = 1,
-        Error = 2,
-        Critical = 3
+        Information = 1,
+        Warning = 2,
+        Error = 3,
+        Critical = 4
     }
 }

--- a/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/LoggingServiceTests.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Services;
+using FluentAssertions;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class LoggingServiceTests
+{
+    [Fact]
+    public void Log_InformationLevel_UsesBlueColor()
+    {
+        var temp = Path.GetTempFileName();
+        var service = new LoggingService(new NullRichTextLogger(), temp);
+        LogEntry? entry = null;
+        service.LogAdded += e => entry = e;
+
+        service.Log("test", LogLevel.Information);
+
+        entry.Should().NotBeNull();
+        entry!.Level.Should().Be(LogLevel.Information);
+        entry.Color.Should().Be("#0000FF");
+    }
+}

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.UI.Helpers;
 using FluentAssertions;
 using Xunit;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -19,13 +20,14 @@ public class TcpServiceMessagesViewModelTests
             Logs =
             {
                 new LogEntry { Message = "a", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Debug },
-                new LogEntry { Message = "b", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Error }
+                new LogEntry { Message = "b", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Information },
+                new LogEntry { Message = "c", Level = DesktopApplicationTemplate.Core.Services.LogLevel.Error }
             }
         };
 
-        vm.LogLevelFilter = DesktopApplicationTemplate.Core.Services.LogLevel.Error;
+        vm.LogLevelFilter = DesktopApplicationTemplate.Core.Services.LogLevel.Information;
 
-        vm.DisplayLogs.Should().ContainSingle().Which.Message.Should().Be("b");
+        vm.DisplayLogs.Select(l => l.Message).Should().Equal(new[] { "b", "c" });
     }
 
     [Fact]

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -59,6 +59,7 @@ namespace DesktopApplicationTemplate.UI.Services
         private static string LevelToColor(LogLevel level) => level switch
         {
             LogLevel.Debug => "#000000",
+            LogLevel.Information => "#0000FF",
             LogLevel.Warning => "#FFA500",
             LogLevel.Error => "#FF0000",
             LogLevel.Critical => "#8B0000",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -222,6 +222,7 @@
 #### Added
 - Logging service loads existing log file on startup and reloads entries when the minimum level changes.
 - Core `ILoggingService` interface and `LogLevel` enum shared across projects.
+- Information log level inserted between Debug and Warning with a default blue color.
 
 #### Fixed
 - Service persistence and logging tests stabilized by reloading options, awaiting file writes, and running settings-related tests sequentially.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -164,7 +164,8 @@ Latest Attempt: After wiring script output events to the TCP messages view, the 
 Latest Attempt: After exposing `ScriptGlobals` for TCP scripting, the `dotnet` command remains unavailable; relying on CI for build and test.
 Latest Attempt: After making the script editor `Globals` class public, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally so CI will verify.
 Latest Attempt: After mirroring script editor test message updates in the TCP messages view and cleaning up subscriptions on close, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b
+Latest Attempt: After adding an Information log level and logging tests, the `dotnet` command is still missing; restore, build, and test commands cannot run locally and CI will verify.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- insert Information between Debug and Warning in LogLevel enum
- map LogLevel.Information to blue in LoggingService
- add unit tests for Information level and update TCP log filter test

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c17b71946c83269773c217149db870