### PR TITLE
Persist script editor test results

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -111,6 +111,24 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
+    public void ServiceName_NoPriorMessage_UsesRoutingMessage()
+    {
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = new TcpServiceOptions()
+        };
+        var routing = new MessageRoutingService();
+        routing.UpdateMessage("svc", "last");
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing);
+
+        vm.SetService(service);
+
+        vm.TestMessage.Should().Be("last");
+    }
+
+    [Fact]
     public void ServiceName_WithPriorMessage_UsesStored()
     {
         var service = new ServiceViewModel
@@ -282,7 +300,7 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
-    public async Task OpenScriptEditor_RunCommand_DoesNotPersistWithoutSave()
+    public async Task OpenScriptEditor_RunCommand_PersistsOutputAndTestMessage()
     {
         var options = new TcpServiceOptions();
         var service = new ServiceViewModel
@@ -291,7 +309,8 @@ public class TcpServiceMessagesViewModelTests
             ServiceType = "TCP",
             TcpOptions = options
         };
-        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        var routing = new MessageRoutingService();
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing);
         vm.SetService(service);
         var editor = new ScriptEditorViewModel();
 
@@ -302,7 +321,10 @@ public class TcpServiceMessagesViewModelTests
         await ((AsyncRelayCommand)editor.RunCommand).ExecuteAsync(null);
 
         vm.OutputMessage.Should().Be("test");
-        options.OutputMessage.Should().BeEmpty();
+        options.OutputMessage.Should().Be("test");
+        options.LastTestMessage.Should().Be("test");
+        routing.TryGetMessage("svc", out var message).Should().BeTrue();
+        message.Should().Be("test");
         editor.OutputGenerated -= OnOutput;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -274,9 +274,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (string.IsNullOrWhiteSpace(ServiceName))
                 return;
 
-            TestMessage = string.IsNullOrWhiteSpace(_options.LastTestMessage)
-                ? $"{ServiceName}-PEAK-123456789"
-                : _options.LastTestMessage;
+            if (string.IsNullOrWhiteSpace(_options.LastTestMessage) &&
+                _routing.TryGetMessage(ServiceName, out var routed))
+            {
+                TestMessage = routed ?? string.Empty;
+            }
+            else
+            {
+                TestMessage = string.IsNullOrWhiteSpace(_options.LastTestMessage)
+                    ? $"{ServiceName}-PEAK-123456789"
+                    : _options.LastTestMessage;
+            }
             _routing.UpdateMessage(ServiceName, TestMessage);
         }
 
@@ -293,6 +301,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             void OnOutputGenerated(string output)
             {
                 OutputMessage = _options.OutputMessage = output;
+                TestMessage = svm.TestMessage;
+                _options.LastTestMessage = svm.TestMessage;
+                _routing.UpdateMessage(ServiceName, svm.TestMessage);
             }
 
             void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,7 @@
 - Application startup tolerates a missing `MainView` service, preventing test crashes when the window isn't registered.
 - Application shutdown tolerates a missing `MainViewModel` service, preventing test crashes when it's not registered.
 - SCP service creation validates required fields and disables the Create command when inputs are invalid.
+- Script editor Run command now persists test messages and outputs, falling back to the last routed message when no prior test exists.
 - Marked main window as Windows-only to silence cross-platform analyzer warnings.
 - Corrected `LogEntry` namespace usage and removed obsolete global log handler to restore build after introducing the shared log view.
 - Fixed ServiceLogView namespace references and command delegates so main, HTTP, and TCP views compile consistently.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -513,6 +513,7 @@ Current Attempt: `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`
 Latest Attempt: After updating ScriptEditorViewModel to use JoinableTaskFactory, `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded. `dotnet workload install wpf` still reports Workload ID not recognized, and `dotnet test --settings tests.runsettings` aborts because the Microsoft.WindowsDesktop.App runtime is missing.
 Newest Attempt: After adding a test for ScriptEditor RunCommand updating TcpServiceMessagesViewModel without saving, the `dotnet` command is still missing; restore, build, and test commands cannot run locally and CI will handle verification.
 Latest Attempt: Removed async lambdas in MainWindow to satisfy VSTHRD analyzers; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings` fails because the Microsoft.WindowsDesktop.App runtime is missing.
+Current Attempt: After persisting script editor test messages, `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- Default TCP test message to the most recently routed message when no prior value exists
- Preserve test message and output when running scripts, updating options and routing
- Verify script editor persistence and routing behavior with additional unit tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1857f15e48326b97557de8cd9163b