### PR TITLE
Run TCP script on view load

### DIFF
--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -256,6 +256,47 @@ public class TcpServiceMessagesViewModelTests
     }
 
     [Fact]
+    public async Task SaveAsync_CustomScript_ReturnsTransformedMessage()
+    {
+        var options = new TcpServiceOptions();
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+        vm.SetService(service);
+        vm.TestMessage = "ping";
+        vm.Script = "string Process(string message)\n{\n    return message.ToUpperInvariant();\n}";
+
+        await vm.SaveAsync();
+
+        vm.OutputMessage.Should().Be("PING");
+    }
+
+    [Fact]
+    public void SetService_RunsScriptAndPopulatesOutput()
+    {
+        var options = new TcpServiceOptions
+        {
+            Script = "string Process(string message)\n{\n    return message + \"!\";\n}"
+        };
+        var service = new ServiceViewModel
+        {
+            DisplayName = "TCP - svc",
+            ServiceType = "TCP",
+            TcpOptions = options
+        };
+        var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
+
+        vm.SetService(service);
+
+        vm.OutputMessage.Should().Be("svc-PEAK-123456789!");
+        options.OutputMessage.Should().Be("svc-PEAK-123456789!");
+    }
+
+    [Fact]
     public async Task ScriptEditor_RunCommand_ProcessesMessage()
     {
         var editor = new ScriptEditorViewModel();

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -196,6 +196,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 ? ScriptEditorViewModel.DefaultScript
                 : _options.Script;
             OutputMessage = _options.OutputMessage;
+            RunInitialScript();
         }
 
         /// <summary>Updates network and scripting settings.</summary>
@@ -253,7 +254,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private async Task<string> RunScriptAsync()
         {
             var globals = new ScriptGlobals { message = TestMessage };
-            var code = Script + "\nProcess(message);";
+            var code = Script + "\nreturn Process(message);";
             var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
             var diagnostics = script.Compile();
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
@@ -261,6 +262,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             var result = await script.RunAsync(globals).ConfigureAwait(false);
             return result.ReturnValue ?? string.Empty;
+        }
+
+        private void RunInitialScript()
+        {
+            try
+            {
+                OutputMessage = RunScriptAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                OutputMessage = ex.ToString();
+            }
+            _options.OutputMessage = OutputMessage;
         }
 
         public class ScriptGlobals

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,8 @@
 - SCP service creation validates required fields and disables the Create command when inputs are invalid.
 - Script editor Run command now persists test messages and outputs, falling back to the last routed message when no prior test exists.
 - TCP service messages view always updates the output message, even when unchanged, ensuring script results appear.
+- TCP script execution returns the processing result instead of null by returning the value from `Process`.
+- TCP service messages view runs the script with the test message on load, populating the output automatically.
 
 - Marked main window as Windows-only to silence cross-platform analyzer warnings.
 - Corrected `LogEntry` namespace usage and removed obsolete global log handler to restore build after introducing the shared log view.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -167,6 +167,7 @@ Latest Attempt: After mirroring script editor test message updates in the TCP me
 Latest Attempt: After adding an Information log level and logging tests, the `dotnet` command is still missing; restore, build, and test commands cannot run locally and CI will verify.
 Latest Attempt: Renamed SaveServices to SaveServicesAsync, but the `dotnet` command remains unavailable; build and tests deferred to CI.
 Latest Attempt: After restricting TcpServiceMessagesViewModel.OutputMessage setter to internal, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally and CI will verify.
+Latest Attempt: After ensuring TCP scripts return their results, the `dotnet` command is still missing; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: After confirming TcpServiceMessagesViewModel.SaveAsync usage, `dotnet restore` succeeded but `dotnet build` reported VSTHRD100/101 analyzer errors; tests could not run locally and CI will verify.
 Latest Attempt: After ensuring TcpServiceMessagesViewModel.OutputMessage setter always raises PropertyChanged, the `dotnet` command remains unavailable; restore, build, and test steps will run in CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
@@ -515,6 +516,7 @@ Latest Attempt: After updating ScriptEditorViewModel to use JoinableTaskFactory,
 Newest Attempt: After adding a test for ScriptEditor RunCommand updating TcpServiceMessagesViewModel without saving, the `dotnet` command is still missing; restore, build, and test commands cannot run locally and CI will handle verification.
 Latest Attempt: Removed async lambdas in MainWindow to satisfy VSTHRD analyzers; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings` fails because the Microsoft.WindowsDesktop.App runtime is missing.
 Current Attempt: After persisting script editor test messages, `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally and CI will verify.
+Latest Attempt: After enabling automatic script execution on view load, the `dotnet` CLI is still missing; restore, build, and test commands could not run locally and CI will verify.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- execute TCP script with the current test message when the messages view loads
- add test confirming output is generated on SetService
- document automatic script execution and note tooling limits

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a0f5392483268bf5ed3f372ab63f