### PR TITLE
Run initial TCP script asynchronously

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -92,7 +92,7 @@ public class ScriptEditorViewModel : ViewModelBase
     private async Task RunAsync()
     {
         var globals = new Globals { message = TestMessage };
-        var code = ScriptText + "\nProcess(message);";
+        var code = ScriptText + "\nreturn Process(message);";
         var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(Globals));
         var diagnostics = script.Compile();
         await _jtf.SwitchToMainThreadAsync();
@@ -111,7 +111,7 @@ public class ScriptEditorViewModel : ViewModelBase
         {
             var result = await script.RunAsync(globals);
             await _jtf.SwitchToMainThreadAsync();
-            OutputMessage = result.ReturnValue;
+            OutputMessage = result.ReturnValue ?? string.Empty;
             OutputBrush = Brushes.Black;
             _lastTestMessage = TestMessage;
             OutputGenerated?.Invoke(OutputMessage);

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -196,6 +196,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 ? ScriptEditorViewModel.DefaultScript
                 : _options.Script;
             OutputMessage = _options.OutputMessage;
+            _ = RunInitialScriptAsync();
+        }
+
+        private async Task RunInitialScriptAsync()
+        {
+            try
+            {
+                OutputMessage = await RunScriptAsync().ConfigureAwait(false);
+                Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
+            }
+            catch (Exception ex)
+            {
+                OutputMessage = ex.ToString();
+                Logger?.Log($"Script execution failed: {ex}", LogLevel.Error);
+            }
+            _options.OutputMessage = OutputMessage;
         }
 
         /// <summary>Updates network and scripting settings.</summary>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - TcpServiceMessagesViewModel executes scripts asynchronously and awaits results when saving.
 - TcpServiceMessagesViewModel logs script execution results and exceptions.
 - Restricted `TcpServiceMessagesViewModel.OutputMessage` setter to internal to prevent external modification.
+- TcpServiceMessagesViewModel runs the initial script asynchronously to avoid blocking.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.
@@ -91,6 +92,7 @@
 - Script editor Run command now persists test messages and outputs, falling back to the last routed message when no prior test exists.
 - TCP service messages view always updates the output message, even when unchanged, ensuring script results appear.
 - TCP script execution returns the processing result instead of null by returning the value from `Process`.
+- Script editor Run command returns the processed message so the output field updates instead of showing null.
 
 - Marked main window as Windows-only to silence cross-platform analyzer warnings.
 - Corrected `LogEntry` namespace usage and removed obsolete global log handler to restore build after introducing the shared log view.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -170,6 +170,7 @@ Latest Attempt: After restricting TcpServiceMessagesViewModel.OutputMessage sett
 Latest Attempt: After ensuring TCP scripts return their results, the `dotnet` command is still missing; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: After confirming TcpServiceMessagesViewModel.SaveAsync usage, `dotnet restore` succeeded but `dotnet build` reported VSTHRD100/101 analyzer errors; tests could not run locally and CI will verify.
 Latest Attempt: After ensuring TcpServiceMessagesViewModel.OutputMessage setter always raises PropertyChanged, the `dotnet` command remains unavailable; restore, build, and test steps will run in CI.
+Latest Attempt: After converting RunInitialScript to async and updating SetService, the `dotnet` CLI is still missing; `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` could not run locally and will be verified in CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
@@ -516,6 +517,7 @@ Latest Attempt: After updating ScriptEditorViewModel to use JoinableTaskFactory,
 Newest Attempt: After adding a test for ScriptEditor RunCommand updating TcpServiceMessagesViewModel without saving, the `dotnet` command is still missing; restore, build, and test commands cannot run locally and CI will handle verification.
 Latest Attempt: Removed async lambdas in MainWindow to satisfy VSTHRD analyzers; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings` fails because the Microsoft.WindowsDesktop.App runtime is missing.
 Current Attempt: After persisting script editor test messages, `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally and CI will verify.
+Newest Attempt: After ensuring the script editor returns processed output, `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- run the TCP service's initial script asynchronously to avoid blocking
- return the processed message when running scripts from the editor
- document test environment limitations

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a6bc042c8326a4ecb9a07118cd5e