### PR TITLE
Add log panel to FTP service view

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml
@@ -4,6 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:BooleanToBrushConverter x:Key="BooleanToBrushConverter" TrueBrush="Green" FalseBrush="Red"/>
@@ -12,6 +13,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
@@ -65,5 +67,6 @@
                 </ListBox.ItemTemplate>
             </ListBox>
         </GroupBox>
+        <shared:ServiceLogView x:Name="LogView" Grid.Row="5" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -7,13 +7,19 @@ namespace DesktopApplicationTemplate.UI.Views
     /// <summary>
     /// View displaying FTP server status and transfers.
     /// </summary>
-    public partial class FTPServiceView : Page
+    public partial class FTPServiceView : Page, IServiceLogHost
     {
         public FTPServiceView(FtpServiceViewModel viewModel, ILoggingService logger)
         {
             InitializeComponent();
             DataContext = viewModel;
             viewModel.Logger = logger;
+        }
+
+        /// <inheritdoc />
+        public void SetServiceContext(ServiceViewModel service)
+        {
+            LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Script editor window with Roslyn-based syntax highlighting and run/save commands.
 - TCP service messages view adds an Edit Script button for modifying scripts and test messages.
 - TCP service messages view displays script output next to the test message.
+- FTP service view hosts a service log panel displaying service-specific entries.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -171,6 +171,7 @@ Latest Attempt: After ensuring TCP scripts return their results, the `dotnet` co
 Latest Attempt: After confirming TcpServiceMessagesViewModel.SaveAsync usage, `dotnet restore` succeeded but `dotnet build` reported VSTHRD100/101 analyzer errors; tests could not run locally and CI will verify.
 Latest Attempt: After ensuring TcpServiceMessagesViewModel.OutputMessage setter always raises PropertyChanged, the `dotnet` command remains unavailable; restore, build, and test steps will run in CI.
 Latest Attempt: After converting RunInitialScript to async and updating SetService, the `dotnet` CLI is still missing; `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` could not run locally and will be verified in CI.
+Latest Attempt: After adding a log panel to the FTP service view, the `dotnet` command remains unavailable; restore, build, and test steps could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- display service logs in FTP service view
- host-specific log panel bound via IServiceLogHost
- document missing `dotnet` CLI during validation

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ac03331483269fb1dfd43f6c15ec