### PR TITLE
Disable auto-generated columns in service message table

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -5,6 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d">
     <DataGrid ItemsSource="{Binding Messages}"
+              AutoGenerateColumns="False"
               CanUserAddRows="False"
               CanUserDeleteRows="False"
               CanUserResizeColumns="True"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,6 +94,7 @@
 - TCP service messages view always updates the output message, even when unchanged, ensuring script results appear.
 - TCP script execution returns the processing result instead of null by returning the value from `Process`.
 - Script editor Run command returns the processed message so the output field updates instead of showing null.
+- Service message table disables auto-generated columns to prevent duplicate columns.
 
 - Marked main window as Windows-only to silence cross-platform analyzer warnings.
 - Corrected `LogEntry` namespace usage and removed obsolete global log handler to restore build after introducing the shared log view.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -172,6 +172,7 @@ Latest Attempt: After confirming TcpServiceMessagesViewModel.SaveAsync usage, `d
 Latest Attempt: After ensuring TcpServiceMessagesViewModel.OutputMessage setter always raises PropertyChanged, the `dotnet` command remains unavailable; restore, build, and test steps will run in CI.
 Latest Attempt: After converting RunInitialScript to async and updating SetService, the `dotnet` CLI is still missing; `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` could not run locally and will be verified in CI.
 Current Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing.
+Latest Attempt: After disabling auto-generated columns in ServiceMessageTableView, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- disable auto-generated columns for the TCP service message table to stop duplicate sets of columns
- note missing dotnet CLI in collaboration tips
- document the change in the unreleased changelog

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ad6daa808326bf34ed3ee5671976