### PR TITLE
Handle HID formatting errors

### DIFF
--- a/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
@@ -37,6 +37,32 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
+        public void BuildMessage_InvalidFormat_DoesNotForward()
+        {
+            bool forwarded = false;
+            MessageForwarder.ForwardAction = (_, _) => forwarded = true;
+
+            var logger = new Mock<ILoggingService>();
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new HidViewModel(helper) { Logger = logger.Object };
+            vm.MessageTemplate = "test";
+            vm.FormatTemplate = "{0"; // malformed format string
+
+            bool reset = false;
+            KeyboardSimulator.ResetAction = () => reset = true;
+            vm.BuildCommand.Execute(null);
+
+            Assert.Equal(string.Empty, vm.FinalMessage);
+            Assert.False(forwarded);
+            Assert.True(reset);
+            logger.Verify(l => l.Log(It.Is<string>(s => s.Contains("formatting")), LogLevel.Error), Times.Once);
+            MessageForwarder.ForwardAction = null;
+            KeyboardSimulator.ResetAction = null;
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
         public void DataFlowProperties_RaisePropertyChanged()
         {
             var logger = new Mock<ILoggingService>();

--- a/DesktopApplicationTemplate.UI/Services/KeyboardSimulator.cs
+++ b/DesktopApplicationTemplate.UI/Services/KeyboardSimulator.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Provides helpers for resetting any simulated keyboard state.
+    /// </summary>
+    public static class KeyboardSimulator
+    {
+        /// <summary>
+        /// Optional hook for tests to observe resets.
+        /// </summary>
+        public static Action? ResetAction { get; set; }
+
+        /// <summary>
+        /// Resets any simulated keyboard state.
+        /// </summary>
+        public static void Reset()
+        {
+            ResetAction?.Invoke();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+using System;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
@@ -104,13 +105,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             Logger?.Log("Building HID message", LogLevel.Debug);
             IncomingData = MessageTemplate;
             ProcessingData = FormatTemplate ?? "{0}";
-            FinalMessage = string.Format(ProcessingData, IncomingData);
-            OutgoingData = FinalMessage;
-            Logger?.Log($"Final HID message: {FinalMessage}", LogLevel.Debug);
-            if (!string.IsNullOrWhiteSpace(AttachedService))
+            try
             {
-                Logger?.Log($"Forwarding message to {AttachedService}", LogLevel.Debug);
-                MessageForwarder.Forward(AttachedService, FinalMessage);
+                FinalMessage = string.Format(ProcessingData, IncomingData);
+                OutgoingData = FinalMessage;
+                Logger?.Log($"Final HID message: {FinalMessage}", LogLevel.Debug);
+                if (!string.IsNullOrWhiteSpace(AttachedService))
+                {
+                    Logger?.Log($"Forwarding message to {AttachedService}", LogLevel.Debug);
+                    MessageForwarder.Forward(AttachedService, FinalMessage);
+                }
+            }
+            catch (FormatException ex)
+            {
+                Logger?.Log($"HID message formatting failed: {ex.Message}", LogLevel.Error);
+                return;
+            }
+            finally
+            {
+                KeyboardSimulator.Reset();
             }
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -127,6 +127,9 @@
 - HID service view includes a data flow diagram showing incoming, processed, and outgoing data bound to the view model.
 - HID service creation, edit, and advanced configuration views with navigation tests.
 
+#### Fixed
+- HidViewModel now logs formatting errors and resets simulated keyboard state, skipping message forwarding when templates are malformed.
+
 ### FTP Service
 #### Added
 - FTP service creation, edit, and advanced configuration views with DI registration, validation, and navigation tests.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -176,6 +176,7 @@ Latest Attempt: While verifying TcpServiceMessagesView log host implementation, 
 Latest Attempt: After disabling auto-generated columns in ServiceMessageTableView, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: After renaming ServiceViewModel to ServiceListModel, `dotnet workload install wpf` reported the workload ID not recognized. `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Latest Attempt: After adding execution duration and message tracking to ServiceListModel and installing the .NET SDK 8.0.404, `dotnet restore` and `dotnet build` succeeded but `dotnet test --settings tests.runsettings` failed because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
+Latest Attempt: After guarding HID message formatting with try/catch, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- guard HID message formatting and reset simulated keyboard state
- test HID formatting error path

## Testing
- `dotnet restore` (fails: command not found)
- `dotnet build DesktopApplicationTemplate.sln` (fails: command not found)
- `dotnet test --settings tests.runsettings` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1b7d7370883268370df9501f31da7