### PR TITLE
Handle unhandled exceptions with hook cleanup

### DIFF
--- a/DesktopApplicationTemplate.Tests/AppExceptionHandlerTests.cs
+++ b/DesktopApplicationTemplate.Tests/AppExceptionHandlerTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Windows.Threading;
+using DesktopApplicationTemplate.UI;
+using DesktopApplicationTemplate.UI.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests
+{
+    public class AppExceptionHandlerTests
+    {
+        [Fact]
+        public void DispatcherUnhandledException_InvokesHookRelease()
+        {
+            var app = new App();
+            var called = false;
+            HookReleaseHelper.ReleaseAction = () => called = true;
+            var args = new DispatcherUnhandledExceptionEventArgs(Dispatcher.CurrentDispatcher, new InvalidOperationException(), false);
+
+            app.OnDispatcherUnhandledException(app, args);
+
+            called.Should().BeTrue();
+            args.Handled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AppDomainUnhandledException_InvokesHookRelease()
+        {
+            var app = new App();
+            var called = false;
+            HookReleaseHelper.ReleaseAction = () => called = true;
+            var args = new UnhandledExceptionEventArgs(new InvalidOperationException(), false);
+
+            app.OnAppDomainUnhandledException(app, args);
+
+            called.Should().BeTrue();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -15,6 +15,8 @@ using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
 using System.IO;
 using System.Windows;
+using System;
+using System.Windows.Threading;
 
 
 namespace DesktopApplicationTemplate.UI
@@ -25,6 +27,9 @@ namespace DesktopApplicationTemplate.UI
 
         public App()
         {
+            DispatcherUnhandledException += OnDispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+
             AppHost = Host.CreateDefaultBuilder()
                 .ConfigureLogging(builder => builder.AddConsole().AddDebug())
                 .ConfigureAppConfiguration((context, config) =>
@@ -172,6 +177,31 @@ namespace DesktopApplicationTemplate.UI
             services.AddOptions<FileObserverServiceOptions>();
             services.AddOptions<CsvServiceOptions>();
             services.AddOptions<ScpServiceOptions>();
+        }
+
+        internal void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            var logger = AppHost.Services.GetService<ILogger<App>>();
+            logger?.LogError(e.Exception, "Unhandled dispatcher exception");
+            HookReleaseHelper.Release();
+            e.Handled = true;
+            Shutdown();
+        }
+
+        internal void OnAppDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+        {
+            var logger = AppHost.Services.GetService<ILogger<App>>();
+            if (e.ExceptionObject is Exception ex)
+            {
+                logger?.LogError(ex, "Unhandled domain exception");
+            }
+            else
+            {
+                logger?.LogError("Unhandled domain exception");
+            }
+
+            HookReleaseHelper.Release();
+            Current?.Dispatcher.Invoke(() => Current.Shutdown());
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Startup event")]

--- a/DesktopApplicationTemplate.UI/Helpers/HookReleaseHelper.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/HookReleaseHelper.cs
@@ -1,0 +1,31 @@
+using System;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    /// <summary>
+    /// Provides methods to release input hooks such as HID devices or keyboard simulators.
+    /// </summary>
+    public static class HookReleaseHelper
+    {
+        /// <summary>
+        /// Optional callback for tests to observe hook release.
+        /// </summary>
+        public static Action? ReleaseAction { get; set; }
+
+        /// <summary>
+        /// Releases any installed HID or keyboard hooks.
+        /// </summary>
+        public static void Release()
+        {
+            try
+            {
+                KeyboardSimulator.Reset();
+            }
+            finally
+            {
+                ReleaseAction?.Invoke();
+            }
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - TCP service messages view displays script output next to the test message.
 - FTP service view hosts a log panel displaying service-specific entries.
 - Service list displays the last execution duration and most recent input message beneath each service name.
+- Application registers global exception handlers that log errors, release input hooks, and shut down gracefully.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -524,6 +524,7 @@ Newest Attempt: After adding a test for ScriptEditor RunCommand updating TcpServ
 Latest Attempt: Removed async lambdas in MainWindow to satisfy VSTHRD analyzers; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeed, but `dotnet test --settings tests.runsettings` fails because the Microsoft.WindowsDesktop.App runtime is missing.
 Current Attempt: After persisting script editor test messages, `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Newest Attempt: After ensuring the script editor returns processed output, `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
+Latest Attempt: Exception handler tests added, but `dotnet` command remains unavailable so restore, build, and test steps could not execute; relying on CI for verification.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- register dispatcher and AppDomain unhandled exception handlers in App
- release HID/keyboard hooks via HookReleaseHelper and log before shutdown
- add tests verifying handlers invoke cleanup and mark dispatcher exceptions handled

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9c30a2883268e483e4365372c4c