### PR TITLE
Dispose HID ViewModel to reset keyboard state

### DIFF
--- a/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/HidViewModelTests.cs
@@ -83,5 +83,22 @@ namespace DesktopApplicationTemplate.Tests
 
             ConsoleTestLogger.LogPass();
         }
+
+        [Fact]
+        public void Dispose_ReleasesKeyboard()
+        {
+            bool reset = false;
+            KeyboardSimulator.ResetAction = () => reset = true;
+            var logger = new Mock<ILoggingService>();
+            var helper = new SaveConfirmationHelper(logger.Object);
+            var vm = new HidViewModel(helper);
+
+            vm.Dispose();
+
+            Assert.True(reset);
+            KeyboardSimulator.ResetAction = null;
+
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -258,6 +258,9 @@ namespace DesktopApplicationTemplate.UI
                 await vm.SaveServicesAsync().ConfigureAwait(false);
             }
 
+            var hid = AppHost.Services.GetService<HidViewModel>();
+            hid?.Dispose();
+
             await AppHost.StopAsync();
             AppHost.Dispose();
             base.OnExit(e);

--- a/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/HidViewModel.cs
@@ -7,7 +7,7 @@ using DesktopApplicationTemplate.Core.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class HidViewModel : ViewModelBase
+    public class HidViewModel : ViewModelBase, IDisposable
     {
         private string _messageTemplate = string.Empty;
         public string MessageTemplate
@@ -131,6 +131,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             Logger?.Log("Saving HID configuration", LogLevel.Debug);
             _saveHelper.Show();
+        }
+
+        /// <summary>
+        /// Releases any simulated key presses.
+        /// </summary>
+        public void Dispose()
+        {
+            KeyboardSimulator.Reset();
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -130,6 +130,7 @@
 
 #### Fixed
 - HidViewModel now logs formatting errors and resets simulated keyboard state, skipping message forwarding when templates are malformed.
+- HidViewModel releases simulated key presses on disposal, and `App.OnExit` invokes this cleanup to restore the keyboard state.
 
 ### FTP Service
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -525,6 +525,7 @@ Latest Attempt: Removed async lambdas in MainWindow to satisfy VSTHRD analyzers;
 Current Attempt: After persisting script editor test messages, `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Newest Attempt: After ensuring the script editor returns processed output, `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
 Latest Attempt: Exception handler tests added, but `dotnet` command remains unavailable so restore, build, and test steps could not execute; relying on CI for verification.
+Latest Attempt: After implementing HID cleanup disposal, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- implement `IDisposable` on `HidViewModel` to reset simulated key presses
- call `HidViewModel.Dispose` from `App.OnExit` so keyboard state restores on shutdown
- test that disposing `HidViewModel` triggers keyboard reset

## Testing
- `dotnet restore` *(fails: dotnet: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: dotnet: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1babccba883269edac14635da7dd5