### PR TITLE
Make app domain exception handler async

### DIFF
--- a/DesktopApplicationTemplate.Tests/AppExceptionHandlerTests.cs
+++ b/DesktopApplicationTemplate.Tests/AppExceptionHandlerTests.cs
@@ -4,6 +4,8 @@ using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Helpers;
 using FluentAssertions;
 using Xunit;
+using System.Threading.Tasks;
+using System.Reflection;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -15,7 +17,12 @@ namespace DesktopApplicationTemplate.Tests
             var app = new App();
             var called = false;
             HookReleaseHelper.ReleaseAction = () => called = true;
-            var args = new DispatcherUnhandledExceptionEventArgs(Dispatcher.CurrentDispatcher, new InvalidOperationException(), false);
+            var args = (DispatcherUnhandledExceptionEventArgs)Activator.CreateInstance(
+                typeof(DispatcherUnhandledExceptionEventArgs),
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new object[] { Dispatcher.CurrentDispatcher, new InvalidOperationException() },
+                null)!;
 
             app.OnDispatcherUnhandledException(app, args);
 
@@ -24,14 +31,14 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
-        public void AppDomainUnhandledException_InvokesHookRelease()
+        public async Task AppDomainUnhandledException_InvokesHookRelease()
         {
             var app = new App();
             var called = false;
             HookReleaseHelper.ReleaseAction = () => called = true;
             var args = new UnhandledExceptionEventArgs(new InvalidOperationException(), false);
 
-            app.OnAppDomainUnhandledException(app, args);
+            await app.OnAppDomainUnhandledExceptionAsync(app, args);
 
             called.Should().BeTrue();
         }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Windows;
 using System;
 using System.Windows.Threading;
+using System.Threading.Tasks;
 
 
 namespace DesktopApplicationTemplate.UI
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI
         public App()
         {
             DispatcherUnhandledException += OnDispatcherUnhandledException;
-            AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += HandleAppDomainUnhandledException;
 
             AppHost = Host.CreateDefaultBuilder()
                 .ConfigureLogging(builder => builder.AddConsole().AddDebug())
@@ -188,7 +189,13 @@ namespace DesktopApplicationTemplate.UI
             Shutdown();
         }
 
-        internal void OnAppDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+        private void HandleAppDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+        {
+            _ = OnAppDomainUnhandledExceptionAsync(sender, e);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD001:Use SwitchToMainThreadAsync to switch to the UI thread", Justification = "Dispatcher is sufficient for shutdown")]
+        internal async Task OnAppDomainUnhandledExceptionAsync(object? sender, UnhandledExceptionEventArgs e)
         {
             var logger = AppHost.Services.GetService<ILogger<App>>();
             if (e.ExceptionObject is Exception ex)
@@ -201,7 +208,10 @@ namespace DesktopApplicationTemplate.UI
             }
 
             HookReleaseHelper.Release();
-            Current?.Dispatcher.Invoke(() => Current.Shutdown());
+            if (Current is not null)
+            {
+                await Current.Dispatcher.InvokeAsync(() => Current.Shutdown());
+            }
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Startup event")]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,7 @@
 - TcpServiceMessagesViewModel logs script execution results and exceptions.
 - Restricted `TcpServiceMessagesViewModel.OutputMessage` setter to internal to prevent external modification.
 - TcpServiceMessagesViewModel runs the initial script asynchronously to avoid blocking.
+- App domain unhandled exception handler is asynchronous and awaits dispatcher shutdown.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -138,6 +138,7 @@ Latest Attempt: After importing the Helpers namespace into App startup to resolv
 Newest Attempt: While unifying log views, the `dotnet` command remained unavailable; build and tests deferred to CI.
 Latest Attempt: After correcting LogEntry namespaces and removing the global log level handler, the `dotnet` CLI is still missing; relying on CI for build and test.
 Another Attempt: After fixing ServiceLogView namespace bindings and command delegates, the `dotnet` command remains unavailable; restore, build, and tests must run in CI.
+Latest Attempt: Installed .NET SDK 8.0.404; `dotnet restore` and `dotnet build` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After converting TcpServiceMessagesViewModel script execution to async and updating related tests, the `dotnet` CLI is still missing; `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` all report command not found.
 Newest Attempt: After qualifying XAML namespaces and marking MQTT subscription view model as Windows-only, the `dotnet` CLI is still missing; relying on CI for build and test.
 Latest Attempt: After aligning log view model with shared log entry and adding assembly-qualified namespaces, the `dotnet` command remains unavailable; build and tests will run in CI.


### PR DESCRIPTION
## Summary
- make app domain unhandled exception handler asynchronous
- await dispatcher shutdown in app domain handler
- update tests and documentation

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c0f24bcc8326b4feabd7d3f02f0d