### PR TITLE
Fix service color picker crash

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml
@@ -13,7 +13,7 @@
         </ResourceDictionary>
     </Window.Resources>
     <Grid>
-        <toolkit:ColorCanvas x:Name="ColorCanvas"/>
+        <toolkit:ColorPicker x:Name="ColorPicker" />
         <Button Content="OK" Width="80" HorizontalAlignment="Right" VerticalAlignment="Bottom"
                 Margin="0,0,10,10" Click="Ok_Click"/>
     </Grid>

--- a/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ColorPickerWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
         }
 
-        public System.Windows.Media.Color ChosenColor => ColorCanvas.SelectedColor ?? System.Windows.Media.Colors.Transparent;
+        public System.Windows.Media.Color ChosenColor => ColorPicker.SelectedColor ?? System.Windows.Media.Colors.Transparent;
 
         private void Ok_Click(object sender, RoutedEventArgs e)
         {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -122,6 +122,7 @@
 - Script editor uses a `JoinableTaskFactory` to switch to the UI thread and remove VSTHRD001 analyzer warnings.
 - Script editor unsubscribes handlers on close and mirrors test message changes to the TCP messages view.
 - Renamed `SaveServices` to `SaveServicesAsync` and updated callers to await it, removing blocking calls.
+- Replaced Xceed `ColorCanvas` with `ColorPicker` to prevent XAML parse exceptions when selecting service colors.
 
 
 ### HID Service

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -178,6 +178,7 @@ Latest Attempt: After disabling auto-generated columns in ServiceMessageTableVie
 Latest Attempt: After renaming ServiceViewModel to ServiceListModel, `dotnet workload install wpf` reported the workload ID not recognized. `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
 Latest Attempt: After adding execution duration and message tracking to ServiceListModel and installing the .NET SDK 8.0.404, `dotnet restore` and `dotnet build` succeeded but `dotnet test --settings tests.runsettings` failed because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After guarding HID message formatting with try/catch, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
+Latest Attempt: After replacing ColorCanvas with ColorPicker to resolve color picker crashes, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- replace Xceed ColorCanvas with ColorPicker
- log environment limitation

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1deb1889c8326a4529bc4cd5342ce