### PR TITLE
Invoke MQTT client events directly in tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MqttServiceTests.cs
@@ -32,7 +32,7 @@ public class MqttServiceTests
         service.ConnectionStateChanged += (_, c) => state = c;
 
         await service.ConnectAsync();
-        client.Raise(c => c.ConnectedAsync += null!, new MqttClientConnectedEventArgs(new MqttClientConnectResult()));
+        await ((dynamic)client.Object).ConnectedAsync.Invoke(new MqttClientConnectedEventArgs(new MqttClientConnectResult()));
 
         Assert.True(state);
         ConsoleTestLogger.LogPass();
@@ -218,7 +218,7 @@ public class MqttServiceTests
     }
 
     [Fact]
-    public void DisconnectedEvent_RaisesConnectionStateChanged_AndLogs()
+    public async Task DisconnectedEvent_RaisesConnectionStateChanged_AndLogs()
     {
         var client = new Mock<IMqttClient>();
         var logger = new Mock<ILoggingService>();
@@ -226,8 +226,7 @@ public class MqttServiceTests
         bool? state = null;
         service.ConnectionStateChanged += (_, c) => state = c;
 
-        client.Raise(
-            c => c.DisconnectedAsync += null!,
+        await ((dynamic)client.Object).DisconnectedAsync.Invoke(
             new MqttClientDisconnectedEventArgs(
                 false,
                 new MqttClientConnectResult(),

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -528,6 +528,7 @@ Current Attempt: After persisting script editor test messages, `dotnet` CLI rema
 Newest Attempt: After ensuring the script editor returns processed output, `dotnet` CLI is still missing; restore, build, and test commands cannot run locally and CI will verify.
 Latest Attempt: Exception handler tests added, but `dotnet` command remains unavailable so restore, build, and test steps could not execute; relying on CI for verification.
 Latest Attempt: After implementing HID cleanup disposal, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
+Latest Attempt: After replacing Moq event raises with direct MQTT client event invocations in MqttServiceTests, `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- replace Moq event raises in `MqttServiceTests` with direct asynchronous event invocations
- document test run limitation in collaboration tips

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e16f86ac8326a22a4b7c9fccda80