### PR TITLE
Register ServiceRule in SCP DI test

### DIFF
--- a/DesktopApplicationTemplate.Tests/ScpDiRegistrationTests.cs
+++ b/DesktopApplicationTemplate.Tests/ScpDiRegistrationTests.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -17,6 +18,7 @@ public class ScpDiRegistrationTests
         services.AddLogging();
         services.AddSingleton<IRichTextLogger, NullRichTextLogger>();
         services.AddSingleton<ILoggingService, LoggingService>();
+        services.AddSingleton<IServiceRule, ServiceRule>();
         services.AddSingleton<SaveConfirmationHelper>();
         services.AddTransient<ScpCreateServiceViewModel>();
         services.AddTransient<ScpCreateServiceView>();

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -529,6 +529,7 @@ Newest Attempt: After ensuring the script editor returns processed output, `dotn
 Latest Attempt: Exception handler tests added, but `dotnet` command remains unavailable so restore, build, and test steps could not execute; relying on CI for verification.
 Latest Attempt: After implementing HID cleanup disposal, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Latest Attempt: After replacing Moq event raises with direct MQTT client event invocations in MqttServiceTests, `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
+Latest Attempt: `dotnet workload install wpf` reported the workload ID is not recognized. After adding `IServiceRule` registration to `ScpDiRegistrationTests`, `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- ensure SCP dependency injection test registers `IServiceRule`
- log WPF workload install failure and missing WindowsDesktop runtime

## Testing
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e58f297c83269a8270749b57d30b