### PR TITLE
Extract ScriptGlobals into standalone class

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptGlobals.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptGlobals.cs
@@ -1,0 +1,6 @@
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+public class ScriptGlobals
+{
+    public string Message { get; set; } = string.Empty;
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -268,8 +268,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task<string> RunScriptAsync()
         {
-            var globals = new ScriptGlobals { message = TestMessage };
-            var code = Script + "\nreturn Process(message);";
+            var globals = new ScriptGlobals { Message = TestMessage };
+            var code = Script + "\nreturn Process(Message);";
             var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
             var diagnostics = script.Compile();
             if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
@@ -277,11 +277,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             var result = await script.RunAsync(globals).ConfigureAwait(false);
             return result.ReturnValue ?? string.Empty;
-        }
-
-        public class ScriptGlobals
-        {
-            public string message = string.Empty;
         }
 
         private void InitializeTestMessage()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -116,7 +116,7 @@
 - EditorButtonBar included as a Page with code-behind dependency and referenced via an assembly-qualified views namespace across consuming views.
 - Output message textbox uses a one-way binding to avoid runtime errors on the read-only `OutputMessage` property.
 - Script editor window removes `Text` binding from AvalonEdit control to prevent XAML parse exceptions.
-- Made `ScriptGlobals` public so TCP scripts can access the `message` field without protection-level errors.
+- Extracted `ScriptGlobals` into a public top-level class with a `Message` property so scripts can access test messages without protection-level errors.
 - Made `ScriptEditorViewModel.Globals` public so scripts can access the `message` field without protection-level errors.
 - Script editor dispatches output and error highlights to the UI thread so results appear when Run is clicked.
 - Script editor uses a `JoinableTaskFactory` to switch to the UI thread and remove VSTHRD001 analyzer warnings.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -158,6 +158,7 @@ Latest Attempt: After moving script editing to an ICommand, the `dotnet` CLI rem
 Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot run locally and CI will verify.
 Latest Attempt: After removing the application logo and adding header text, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with XAML errors and `dotnet test --settings tests.runsettings` produced similar errors; relying on CI for validation.
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
+Newest Attempt: After extracting ScriptGlobals into its own class for TCP script execution, the `dotnet` command remains unavailable; restore, build, and test steps could not run locally and CI will verify.
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After adding script execution logging to TcpServiceMessagesViewModel, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.
 Latest Attempt: After exposing the default TCP script and adding tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.


### PR DESCRIPTION
## Summary
- move ScriptGlobals to a public top-level class with a Message property
- update TCP script runner to use ScriptGlobals.Message and return Process(Message)
- document environment limitation running dotnet CLI

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e8641b848326856496b510c3f91b