### PR TITLE
Handle non-visual ancestors when walking visual tree

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/VisualTreeHelperExtensions.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/VisualTreeHelperExtensions.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Media;
+using System.Windows.Media.Media3D;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
@@ -12,8 +13,16 @@ namespace DesktopApplicationTemplate.UI.Helpers
             {
                 if (parent is T correctlyTyped)
                     return correctlyTyped;
-                parent = VisualTreeHelper.GetParent(parent);
+
+                parent = parent switch
+                {
+                    FrameworkElement fe => fe.Parent,
+                    FrameworkContentElement fce => fce.Parent,
+                    Visual or Visual3D => VisualTreeHelper.GetParent(parent),
+                    _ => LogicalTreeHelper.GetParent(parent)
+                };
             }
+
             return null;
         }
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,7 @@
 - TCP script execution returns the processing result instead of null by returning the value from `Process`.
 - Script editor Run command returns the processed message so the output field updates instead of showing null.
 - Service message table disables auto-generated columns to prevent duplicate columns.
+- `VisualTreeHelperExtensions.FindParent` now falls back to the logical tree for non-visual ancestors.
 
 - Marked main window as Windows-only to silence cross-platform analyzer warnings.
 - Corrected `LogEntry` namespace usage and removed obsolete global log handler to restore build after introducing the shared log view.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -180,6 +180,7 @@ Latest Attempt: After renaming ServiceViewModel to ServiceListModel, `dotnet wor
 Latest Attempt: After adding execution duration and message tracking to ServiceListModel and installing the .NET SDK 8.0.404, `dotnet restore` and `dotnet build` succeeded but `dotnet test --settings tests.runsettings` failed because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After guarding HID message formatting with try/catch, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
 Latest Attempt: After replacing ColorCanvas with ColorPicker to resolve color picker crashes, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
+Latest Attempt: After updating VisualTreeHelperExtensions to traverse the logical tree when an element is not a Visual, installed the .NET SDK 8.0.404 and ran `dotnet test --settings tests.runsettings`; core tests passed but DesktopApplicationTemplate.Tests aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing, and `dotnet workload install wpf` reports the workload ID is not recognized on Linux.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- fall back to logical tree when a parent isn't a `Visual`
- document visual tree fix in changelog
- record missing WindowsDesktop runtime while attempting tests

## Testing
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ec17c7a083268a12a1372d56a321