### PR TITLE
test: add VisualTreeHelperExtensions FindParent test

### DIFF
--- a/DesktopApplicationTemplate.Tests/VisualTreeHelperExtensionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/VisualTreeHelperExtensionsTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using DesktopApplicationTemplate.UI.Helpers;
+using FluentAssertions;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class VisualTreeHelperExtensionsTests
+{
+    [WindowsFact]
+    public void FindParent_Returns_TextBlock_For_Inline()
+    {
+        Exception? exception = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var run = new Run("child");
+                var textBlock = new TextBlock(run);
+
+                var parent = VisualTreeHelperExtensions.FindParent<TextBlock>(run);
+
+                parent.Should().BeSameAs(textBlock);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        exception.Should().BeNull();
+    }
+}
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 - FTP service view hosts a log panel displaying service-specific entries.
 - Service list displays the last execution duration and most recent input message beneath each service name.
 - Application registers global exception handlers that log errors, release input hooks, and shut down gracefully.
+- Unit test ensures `VisualTreeHelperExtensions.FindParent` locates the containing `TextBlock` for inline elements.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -533,6 +533,7 @@ Latest Attempt: After implementing HID cleanup disposal, the `dotnet` command re
 Latest Attempt: After replacing Moq event raises with direct MQTT client event invocations in MqttServiceTests, `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: `dotnet workload install wpf` reported the workload ID is not recognized. After adding `IServiceRule` registration to `ScpDiRegistrationTests`, `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After moving script editor globals to a top-level class and adjusting RunAsync, the `dotnet` command was initially missing; installing the .NET SDK 8.0.404 enabled restore and build, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing.
+Newest Attempt: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- add Windows-only test verifying `FindParent` locates a containing `TextBlock`
- document test addition in the changelog
- log WindowsDesktop runtime absence during test execution

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln`
- `dotnet test --settings tests.runsettings` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing; will rely on CI)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ed6569888326949119227713eb47