### PR TITLE
Handle non-visual elements in FindParent

### DIFF
--- a/DesktopApplicationTemplate.Tests/VisualTreeHelperExtensionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/VisualTreeHelperExtensionsTests.cs
@@ -37,5 +37,33 @@ public class VisualTreeHelperExtensionsTests
 
         exception.Should().BeNull();
     }
+
+    [WindowsFact]
+    public void FindParent_On_Unattached_Run_Does_Not_Throw()
+    {
+        Exception? exception = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var run = new Run("child");
+
+                var parent = VisualTreeHelperExtensions.FindParent<TextBlock>(run);
+
+                parent.Should().BeNull();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        exception.Should().BeNull();
+    }
 }
 

--- a/DesktopApplicationTemplate.UI/Helpers/VisualTreeHelperExtensions.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/VisualTreeHelperExtensions.cs
@@ -18,6 +18,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 {
                     FrameworkElement fe => fe.Parent,
                     FrameworkContentElement fce => fce.Parent,
+                    ContentElement ce => ContentOperations.GetParent(ce),
                     Visual or Visual3D => VisualTreeHelper.GetParent(parent),
                     _ => LogicalTreeHelper.GetParent(parent)
                 };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -100,6 +100,7 @@
 - Script editor Run command returns the processed message so the output field updates instead of showing null.
 - Service message table disables auto-generated columns to prevent duplicate columns.
 - `VisualTreeHelperExtensions.FindParent` now falls back to the logical tree for non-visual ancestors.
+- `FindParent<T>` now supports non-visual elements (e.g., `Run`) without throwing.
 
 - Marked main window as Windows-only to silence cross-platform analyzer warnings.
 - Corrected `LogEntry` namespace usage and removed obsolete global log handler to restore build after introducing the shared log view.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -181,6 +181,7 @@ Latest Attempt: After adding execution duration and message tracking to ServiceL
 Latest Attempt: After guarding HID message formatting with try/catch, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
 Latest Attempt: After replacing ColorCanvas with ColorPicker to resolve color picker crashes, the `dotnet` command is still missing; restore, build, and tests deferred to CI.
 Latest Attempt: After updating VisualTreeHelperExtensions to traverse the logical tree when an element is not a Visual, installed the .NET SDK 8.0.404 and ran `dotnet test --settings tests.runsettings`; core tests passed but DesktopApplicationTemplate.Tests aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing, and `dotnet workload install wpf` reports the workload ID is not recognized on Linux.
+Latest Attempt: After extending FindParent<T> to handle non-visual elements like `Run` without throwing and adding tests, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- allow FindParent<T> to traverse content elements
- cover unattached Run scenarios in FindParent tests
- document FindParent<T> support for non-visual elements in changelog

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1efbbbc388326bc2f47f1f5ecf85b