### PR TITLE
feat: introduce service factories and unified add

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -5,6 +5,7 @@ using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using Factories = DesktopApplicationTemplate.UI.Factories;
 // Qualify service-layer types explicitly to avoid name clashes with UI services
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -166,6 +167,9 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<ScpAdvancedConfigViewModel>();
             services.AddTransient<SettingsPage>();
             services.AddTransient<Navigation.INavigationHandler, Navigation.MqttNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.FtpNavigationHandler>();
+            services.AddTransient<Factories.IServiceFactory, Factories.MqttServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.FtpServiceFactory>();
 
 
             // Load strongly typed settings

--- a/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
@@ -1,0 +1,47 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class FtpServiceFactory : IServiceFactory
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public string ServiceType => "FTP Server";
+
+        public FtpServiceFactory(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<FtpServerOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"FTP Server - {name}",
+                ServiceType = "FTP Server",
+                IsActive = false,
+                FtpOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
+            opt.Port = options.Port;
+            opt.RootPath = options.RootPath;
+            opt.AllowAnonymous = options.AllowAnonymous;
+            opt.Username = options.Username;
+            opt.Password = options.Password;
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/IServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/IServiceFactory.cs
@@ -1,0 +1,10 @@
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public interface IServiceFactory
+    {
+        string ServiceType { get; }
+        ServiceListModel Create(object options);
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
@@ -1,0 +1,87 @@
+using System;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class MqttServiceFactory : IServiceFactory
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+        private readonly MainViewModel _mainViewModel;
+
+        public string ServiceType => "MQTT";
+
+        public MqttServiceFactory(IServiceProvider services, MainView mainView, MainViewModel mainViewModel)
+        {
+            _services = services;
+            _mainView = mainView;
+            _mainViewModel = mainViewModel;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<MqttServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var newService = new ServiceListModel
+            {
+                DisplayName = $"MQTT - {name}",
+                ServiceType = "MQTT",
+                IsActive = false
+            };
+
+            _mainView.GetOrCreateServicePage(newService);
+
+            var opt = _services.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
+            opt.Host = options.Host;
+            opt.Port = options.Port;
+            opt.ClientId = options.ClientId;
+            opt.Username = options.Username;
+            opt.Password = options.Password;
+            opt.ConnectionType = options.ConnectionType;
+            opt.WillTopic = options.WillTopic;
+            opt.WillPayload = options.WillPayload;
+            opt.WillQualityOfService = options.WillQualityOfService;
+            opt.WillRetain = options.WillRetain;
+            opt.KeepAliveSeconds = options.KeepAliveSeconds;
+            opt.CleanSession = options.CleanSession;
+            opt.ReconnectDelay = options.ReconnectDelay;
+
+            if (newService.ServicePage is MqttTagSubscriptionsView mqttView)
+            {
+                var mqttVm = (MqttTagSubscriptionsViewModel)mqttView.DataContext!;
+                newService.ActiveChanged += active =>
+                {
+                    if (active)
+                    {
+                        _ = mqttVm.ConnectAsync();
+                    }
+                };
+                mqttVm.EditConnectionRequested += (_, _) =>
+                {
+                    var editView = _services.GetRequiredService<MqttEditConnectionView>();
+                    if (editView.DataContext is MqttEditConnectionViewModel vm)
+                    {
+                        var opt = _services.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
+                        vm.Load(opt);
+                        vm.HighlightMissingFields();
+                        vm.RequestClose += (_, _) =>
+                        {
+                            if (newService.ServicePage != null)
+                                _mainView.ShowPage(newService.ServicePage);
+                            _ = _mainViewModel.SaveServicesAsync();
+                        };
+                    }
+                    _mainView.ShowPage(editView);
+                };
+            }
+
+            return newService;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/ServiceFactoryOptions.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ServiceFactoryOptions.cs
@@ -1,0 +1,4 @@
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public record ServiceFactoryOptions<TOptions>(string Name, TOptions Options);
+}

--- a/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
@@ -8,14 +8,14 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
-    public class MqttNavigationHandler : INavigationHandler
+    public class FtpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly MainView _mainView;
 
-        public string ServiceType => "MQTT";
+        public string ServiceType => "FTP Server";
 
-        public MqttNavigationHandler(IServiceProvider services, MainView mainView)
+        public FtpNavigationHandler(IServiceProvider services, MainView mainView)
         {
             _services = services;
             _mainView = mainView;
@@ -23,15 +23,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
 
         public Page CreateView(string defaultName)
         {
-            var vm = _services.GetRequiredService<MqttCreateServiceViewModel>();
+            var vm = _services.GetRequiredService<FtpServerCreateViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<MqttServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FtpServerOptions>(name, options));
             vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
-            var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(_services, vm);
+            var view = ActivatorUtilities.CreateInstance<FtpServerCreateView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
-                var advVm = ActivatorUtilities.CreateInstance<MqttAdvancedConfigViewModel>(_services, opts);
-                var advView = _services.GetRequiredService<MqttAdvancedConfigView>();
+                var advVm = ActivatorUtilities.CreateInstance<FtpServerAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<FtpServerAdvancedConfigView>();
                 advView.Initialize(advVm);
                 advVm.Saved += _ => _mainView.ShowPage(view);
                 advVm.BackRequested += () => _mainView.ShowPage(view);
@@ -39,6 +39,5 @@ namespace DesktopApplicationTemplate.UI.Navigation
             };
             return view;
         }
-
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using System.Windows.Controls;
 
 namespace DesktopApplicationTemplate.UI.Navigation
@@ -7,6 +6,5 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         string ServiceType { get; }
         Page CreateView(string defaultName);
-        Task AddServiceAsync(string name, object options);
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Factories;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -225,29 +226,17 @@ namespace DesktopApplicationTemplate.UI.Views
 
 
 
-
-        internal void AddFtpService(string name, FtpServerOptions options)
+        internal async Task AddServiceAsync(string type, object options)
         {
-            var svc = new ServiceListModel
-            {
-                DisplayName = $"FTP Server - {name}",
-                ServiceType = "FTP Server",
-                IsActive = false,
-                FtpOptions = options
-            };
+            var factory = App.AppHost.Services.GetServices<IServiceFactory>()
+                .FirstOrDefault(f => f.ServiceType == type);
+            if (factory == null)
+                return;
 
+            var svc = factory.Create(options);
             svc.SetColorsByType();
             svc.LogAdded += _viewModel.OnServiceLogAdded;
             svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
-
-            var opt = App.AppHost.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
-            opt.Port = options.Port;
-            opt.RootPath = options.RootPath;
-            opt.AllowAnonymous = options.AllowAnonymous;
-            opt.Username = options.Username;
-            opt.Password = options.Password;
-
-            GetOrCreateServicePage(svc);
 
             _viewModel.Services.Add(svc);
             _logger?.LogInformation("Service {Name} added", svc.DisplayName);
@@ -255,6 +244,8 @@ namespace DesktopApplicationTemplate.UI.Views
             ServiceList.ScrollIntoView(svc);
             if (svc.ServicePage != null)
                 ShowPage(svc.ServicePage);
+            await _viewModel.SaveServicesAsync();
+            _logger?.LogDebug("AddService workflow completed");
         }
 
         private void OnEditRequested(ServiceListModel service)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Reusable service rule and screen abstractions with DI registration and view model integration.
 - Unified creation and edit workflows under `ServiceEditorViewModelBase<TOptions>` exposing `SaveCommand` and customizable `SaveButtonText`.
 - Service manager tracks task start times and writes statuses to `activeservices.txt` for running services.
+- Service factories convert options into initialized services and pages with a unified `AddServiceAsync` workflow.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -536,6 +536,7 @@ Latest Attempt: After replacing Moq event raises with direct MQTT client event i
 Latest Attempt: `dotnet workload install wpf` reported the workload ID is not recognized. After adding `IServiceRule` registration to `ScpDiRegistrationTests`, `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After moving script editor globals to a top-level class and adjusting RunAsync, the `dotnet` command was initially missing; installing the .NET SDK 8.0.404 enabled restore and build, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing.
 Newest Attempt: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
+Latest Attempt: After introducing service factories, the `dotnet` CLI is still missing; relying on CI for build and test.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- add IServiceFactory with Mqtt and FTP implementations
- register factories and navigation handlers via DI
- consolidate service addition logic into MainWindow.AddServiceAsync

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f3d0589c8326855ff13760041656