### PR TITLE
Add ServiceType enum for service identification

### DIFF
--- a/DesktopApplicationTemplate.Core/Models/ServiceType.cs
+++ b/DesktopApplicationTemplate.Core/Models/ServiceType.cs
@@ -1,0 +1,18 @@
+namespace DesktopApplicationTemplate.Models
+{
+    /// <summary>
+    /// Identifies the supported service categories within the application.
+    /// </summary>
+    public enum ServiceType
+    {
+        Mqtt,
+        Http,
+        Ftp,
+        Hid,
+        Csv,
+        FileObserver,
+        Scp,
+        Tcp,
+        Heartbeat
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Unified creation and edit workflows under `ServiceEditorViewModelBase<TOptions>` exposing `SaveCommand` and customizable `SaveButtonText`.
 - Service manager tracks task start times and writes statuses to `activeservices.txt` for running services.
 - Service factories convert options into initialized services and pages with a unified `AddServiceAsync` workflow.
+- `ServiceType` enum clarifies supported service categories.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -537,6 +537,7 @@ Latest Attempt: `dotnet workload install wpf` reported the workload ID is not re
 Latest Attempt: After moving script editor globals to a top-level class and adjusting RunAsync, the `dotnet` command was initially missing; installing the .NET SDK 8.0.404 enabled restore and build, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing.
 Newest Attempt: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After introducing service factories, the `dotnet` CLI is still missing; relying on CI for build and test.
+Latest Attempt: Installed .NET SDK 8.0.404; `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed with missing MainView in FtpServiceFactory. CI will verify.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
### Summary
- add ServiceType enum with members Mqtt, Http, Ftp, Hid, Csv, FileObserver, Scp, Tcp, Heartbeat
- document the new enum in changelog

### Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: MainView type missing in FtpServiceFactory)*
- `dotnet test --settings tests.runsettings` *(build errors: MainView missing in FtpServiceFactory, 2 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c210e0cb5083268875ebf5b517ce13