### PR TITLE
Use enum for log view model type

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -82,7 +82,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             Filters.PropertyChanged += (_, __) => ApplyFilters();
             LoadServices();
             ApplyFilters();
-            LogViewModel = new ServiceLogViewModel("Main", "Main", AllLogs);
+            LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs);
             LogViewModel.PropertyChanged += (s, e) =>
             {
                 if (e.PropertyName == nameof(ServiceLogViewModel.DisplayLogs))

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
@@ -16,15 +16,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private ObservableCollection<LogEntry> _logs;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceLogViewModel"/> class
+        /// with default values.
+        /// </summary>
+        public ServiceLogViewModel()
+            : this(ServiceType.Mqtt, new ObservableCollection<LogEntry>())
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ServiceLogViewModel"/> class.
         /// </summary>
-        /// <param name="serviceName">The name of the service.</param>
-        /// <param name="serviceType">The type of the service.</param>
+        /// <param name="type">The category of service associated with these logs.</param>
         /// <param name="logs">The collection of log entries to display.</param>
-        public ServiceLogViewModel(string serviceName, string serviceType, ObservableCollection<LogEntry> logs)
+        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs)
         {
-            ServiceName = serviceName;
-            ServiceType = serviceType;
+            Type = type;
             _logs = logs;
             RefreshLogCommand = new RelayCommand(RefreshLogs);
             ExportLogCommand = new RelayCommand(() => ExportLogs(Path.Combine(Path.GetTempPath(), "exported_logs.txt")));
@@ -32,14 +39,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         /// <summary>
-        /// Gets the service name associated with the logs.
+        /// Gets the service category associated with the logs.
         /// </summary>
-        public string ServiceName { get; }
-
-        /// <summary>
-        /// Gets the service type associated with the logs.
-        /// </summary>
-        public string ServiceType { get; }
+        public ServiceType Type { get; }
 
         /// <summary>
         /// Gets or sets the log level filter.

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -18,7 +20,8 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public void SetServiceContext(ServiceListModel service)
         {
-            LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
+            Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
+            LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -16,6 +16,7 @@ using DesktopApplicationTemplate.UI.Services;
 
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Views
@@ -45,7 +46,8 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public void SetServiceContext(ServiceListModel service)
         {
-            LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
+            Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
+            LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Views;
 
@@ -22,6 +24,7 @@ public partial class MqttTagSubscriptionsView : Page, IServiceLogHost
     /// <inheritdoc />
     public void SetServiceContext(ServiceListModel service)
     {
-        LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
+        Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
+        LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -16,7 +18,8 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public void SetServiceContext(ServiceListModel service)
         {
-            LogView.DataContext = new ServiceLogViewModel(service.DisplayName, service.ServiceType, service.Logs);
+            Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
+            LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
             if (DataContext is TcpServiceMessagesViewModel vm)
                 vm.SetService(service);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Adjusted solution and project references so cross-platform assemblies depend only on the core while Windows projects also reference `DesktopApplicationTemplate.Windows`.
 - Replaced `ServiceCreated`/`ServiceUpdated` with unified `ServiceSaved` events and centralized `ServiceName` validation in `ServiceEditorViewModelBase`.
 - Windows service host sets explicit `ServiceName` and `DisplayName` values with the application name and installer uses the same constant.
+- Replaced verbose `ServiceName` strings with `ServiceType` enum properties for log view models.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -555,3 +555,12 @@ Effective Prompts / Instructions that worked: User request to expose more log te
 Decisions & Rationale: Improve log readability; document missing tooling and rely on CI for validation.
 Action Items: Rely on CI for verification.
 Related Commits/PRs:
+
+[2025-10-04 10:00] Topic: Service log type enum
+Context: Replaced ServiceLogViewModel's service name string with a ServiceType enum property.
+Observations: Updated service views to parse type and dropped redundant name parameter.
+Codex Limitations noticed: dotnet CLI not installed; restore, build, and test commands could not run.
+Effective Prompts / Instructions that worked: User request to simplify log model constructors.
+Decisions & Rationale: Use ServiceType enum to streamline log view configuration.
+Action Items: Rely on CI for validation.
+Related Commits/PRs:


### PR DESCRIPTION
## Summary
- replace ServiceLogViewModel's string properties with a ServiceType enum
- parse service types when creating log views
- document environment limitations

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2124226748326a97b847566e07198