### PR TITLE
Persist ServiceType as short codes

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/ServiceTypeJsonConverterTests.cs
+++ b/DesktopApplicationTemplate.Core.Tests/ServiceTypeJsonConverterTests.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using DesktopApplicationTemplate.Core.Converters;
+using DesktopApplicationTemplate.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Core.Tests;
+
+public class ServiceTypeJsonConverterTests
+{
+    [Theory]
+    [InlineData(ServiceType.Tcp, "\"TC\"")]
+    [InlineData(ServiceType.Mqtt, "\"MQ\"")]
+    public void Write_UsesShortCode(ServiceType type, string expected)
+    {
+        JsonSerializer.Serialize(type).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("TC", ServiceType.Tcp)]
+    [InlineData("TCP", ServiceType.Tcp)]
+    [InlineData("FTP Server", ServiceType.Ftp)]
+    [InlineData("MQ", ServiceType.Mqtt)]
+    public void Read_ParsesCodesAndLegacyNames(string code, ServiceType expected)
+    {
+        var json = $"\"{code}\"";
+        JsonSerializer.Deserialize<ServiceType>(json).Should().Be(expected);
+    }
+}

--- a/DesktopApplicationTemplate.Core/Converters/ServiceTypeJsonConverter.cs
+++ b/DesktopApplicationTemplate.Core/Converters/ServiceTypeJsonConverter.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Core.Converters;
+
+/// <summary>
+/// Converts <see cref="ServiceType"/> values to short string codes for persistence
+/// and supports reading legacy names.
+/// </summary>
+public sealed class ServiceTypeJsonConverter : JsonConverter<ServiceType>
+{
+    private static readonly Dictionary<ServiceType, string> CodeMap = new()
+    {
+        { ServiceType.Mqtt, "MQ" },
+        { ServiceType.Http, "HT" },
+        { ServiceType.Ftp, "FT" },
+        { ServiceType.Hid, "HD" },
+        { ServiceType.Csv, "CV" },
+        { ServiceType.FileObserver, "FO" },
+        { ServiceType.Scp, "SC" },
+        { ServiceType.Tcp, "TC" },
+        { ServiceType.Heartbeat, "HB" }
+    };
+
+    private static readonly Dictionary<string, ServiceType> LegacyMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "MQ", ServiceType.Mqtt },
+        { "MQTT", ServiceType.Mqtt },
+        { "HT", ServiceType.Http },
+        { "HTTP", ServiceType.Http },
+        { "FT", ServiceType.Ftp },
+        { "FTP", ServiceType.Ftp },
+        { "FTP Server", ServiceType.Ftp },
+        { "HD", ServiceType.Hid },
+        { "HID", ServiceType.Hid },
+        { "CV", ServiceType.Csv },
+        { "CSV", ServiceType.Csv },
+        { "CSV Creator", ServiceType.Csv },
+        { "FO", ServiceType.FileObserver },
+        { "File Observer", ServiceType.FileObserver },
+        { "SC", ServiceType.Scp },
+        { "SCP", ServiceType.Scp },
+        { "TC", ServiceType.Tcp },
+        { "TCP", ServiceType.Tcp },
+        { "HB", ServiceType.Heartbeat },
+        { "Heartbeat", ServiceType.Heartbeat }
+    };
+
+    public override ServiceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return TryParse(value, out var result) ? result : default;
+    }
+
+    public override void Write(Utf8JsonWriter writer, ServiceType value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(ToCode(value));
+    }
+
+    public static bool TryParse(string? value, out ServiceType result)
+    {
+        if (value != null && LegacyMap.TryGetValue(value, out result))
+        {
+            return true;
+        }
+
+        return Enum.TryParse(value, true, out result);
+    }
+
+    public static string ToCode(ServiceType type) =>
+        CodeMap.TryGetValue(type, out var code) ? code : type.ToString();
+
+    public static string ToLegacyString(ServiceType type)
+    {
+        // Return one of the legacy names for display, defaulting to code.
+        return type switch
+        {
+            ServiceType.Ftp => "FTP",
+            ServiceType.Mqtt => "MQTT",
+            ServiceType.Http => "HTTP",
+            ServiceType.Tcp => "TCP",
+            ServiceType.Hid => "HID",
+            ServiceType.Csv => "CSV Creator",
+            ServiceType.FileObserver => "File Observer",
+            ServiceType.Scp => "SCP",
+            ServiceType.Heartbeat => "Heartbeat",
+            _ => ToCode(type)
+        };
+    }
+}

--- a/DesktopApplicationTemplate.Core/Models/ServiceType.cs
+++ b/DesktopApplicationTemplate.Core/Models/ServiceType.cs
@@ -3,6 +3,7 @@ namespace DesktopApplicationTemplate.Models
     /// <summary>
     /// Identifies the supported service categories within the application.
     /// </summary>
+    [System.Text.Json.Serialization.JsonConverter(typeof(DesktopApplicationTemplate.Core.Converters.ServiceTypeJsonConverter))]
     public enum ServiceType
     {
         Mqtt,

--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -8,13 +8,15 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Converters;
 
 namespace DesktopApplicationTemplate.Service
 {
     public class ServiceInfo
     {
         public string DisplayName { get; set; } = string.Empty;
-        public string ServiceType { get; set; } = string.Empty;
+        public ServiceType ServiceType { get; set; }
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
         public int Order { get; set; }
@@ -34,13 +36,13 @@ namespace DesktopApplicationTemplate.Service
             public CancellationTokenSource CancellationTokenSource { get; init; } = default!;
             public Task Task { get; init; } = default!;
             public DateTime StartTime { get; init; }
-            public string ServiceType { get; init; } = string.Empty;
+            public ServiceType ServiceType { get; init; }
         }
 
         private sealed class ServiceRecord
         {
             public string Name { get; init; } = string.Empty;
-            public string ServiceType { get; init; } = string.Empty;
+            public ServiceType ServiceType { get; init; }
             public DateTime StartTime { get; init; }
             public string Status { get; set; } = string.Empty;
         }
@@ -131,7 +133,7 @@ namespace DesktopApplicationTemplate.Service
 
         private async Task RunServiceLoop(ServiceInfo info, CancellationToken token)
         {
-            if (info.ServiceType == "Heartbeat")
+            if (info.ServiceType == ServiceType.Heartbeat)
             {
                 var hb = _config.GetSection("Heartbeat");
                 var message = hb.GetValue<string>("Message", "PING");
@@ -196,7 +198,7 @@ namespace DesktopApplicationTemplate.Service
             {
                 var pid = Process.GetCurrentProcess().Id;
                 var lines = _records.Values
-                    .Select(r => $"{pid}\t{r.Name}\t{r.ServiceType}\t{r.StartTime:o}\t{r.Status}")
+                    .Select(r => $"{pid}\t{r.Name}\t{ServiceTypeJsonConverter.ToLegacyString(r.ServiceType)}\t{r.StartTime:o}\t{r.Status}")
                     .ToArray();
                 File.WriteAllLines(_activeServicesFilePath, lines);
             }

--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -1,4 +1,4 @@
-using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Persistence;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Helpers;

--- a/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.Service;
+using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
@@ -18,8 +19,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 var services = new[]
                 {
-                    new ServiceInfo { DisplayName = "Svc1", ServiceType = "Heartbeat", IsActive = true, Order = 0 },
-                    new ServiceInfo { DisplayName = "Svc2", ServiceType = "TCP", IsActive = false, Order = 1 }
+                    new ServiceInfo { DisplayName = "Svc1", ServiceType = ServiceType.Heartbeat, IsActive = true, Order = 0 },
+                    new ServiceInfo { DisplayName = "Svc2", ServiceType = ServiceType.Tcp, IsActive = false, Order = 1 }
                 };
                 File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
 

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -1,3 +1,4 @@
+using DesktopApplicationTemplate.Persistence;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -4,12 +4,14 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Converters;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.UI;
 
-namespace DesktopApplicationTemplate.UI.Services
+namespace DesktopApplicationTemplate.Persistence
 {
     public static class ServicePersistence
     {
@@ -73,10 +75,12 @@ namespace DesktopApplicationTemplate.UI.Services
                     };
                 }
 
+                ServiceTypeJsonConverter.TryParse(s.ServiceType, out var type);
+
                 data.Add(new ServiceInfo
                 {
                     DisplayName = s.DisplayName,
-                    ServiceType = s.ServiceType,
+                    ServiceType = type,
                     IsActive = s.IsActive,
                     Created = DateTime.Now,
                     Order = index++,
@@ -148,7 +152,7 @@ namespace DesktopApplicationTemplate.UI.Services
 
                 foreach (var info in result)
                 {
-                    if (info.ServiceType == "TCP" && info.TcpOptions != null)
+                    if (info.ServiceType == ServiceType.Tcp && info.TcpOptions != null)
                     {
                         var opt = App.AppHost?.Services.GetService<IOptions<TcpServiceOptions>>();
                         if (opt != null)
@@ -165,7 +169,7 @@ namespace DesktopApplicationTemplate.UI.Services
                             value.LastTestMessage = info.TcpOptions.LastTestMessage;
                         }
                     }
-                    if ((info.ServiceType == "FTP Server" || info.ServiceType == "FTP") && info.FtpOptions != null)
+                    if (info.ServiceType == ServiceType.Ftp && info.FtpOptions != null)
                     {
                         try
                         {
@@ -201,7 +205,7 @@ namespace DesktopApplicationTemplate.UI.Services
     public class ServiceInfo
     {
         public string DisplayName { get; set; } = string.Empty;
-        public string ServiceType { get; set; } = string.Empty;
+        public ServiceType ServiceType { get; set; }
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
         public int Order { get; set; }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -11,7 +11,9 @@ using System.Windows.Input;
 using WpfBrushes = System.Windows.Media.Brushes;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Persistence;
+using DesktopApplicationTemplate.Core.Converters;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
@@ -202,7 +204,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 var svc = new ServiceListModel
                 {
                     DisplayName = info.DisplayName,
-                    ServiceType = info.ServiceType,
+                    ServiceType = ServiceTypeJsonConverter.ToLegacyString(info.ServiceType),
                     IsActive = info.IsActive,
                     Order = info.Order,
                     TcpOptions = info.TcpOptions,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Replaced `ServiceCreated`/`ServiceUpdated` with unified `ServiceSaved` events and centralized `ServiceName` validation in `ServiceEditorViewModelBase`.
 - Windows service host sets explicit `ServiceName` and `DisplayName` values with the application name and installer uses the same constant.
 - Replaced verbose `ServiceName` strings with `ServiceType` enum properties for log view models.
+- Service persistence now stores `ServiceType` as short codes and reads legacy string names.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -158,6 +158,7 @@ Latest Attempt: After moving script editing to an ICommand, the `dotnet` CLI rem
 Newest Attempt: `dotnet` command still missing; restore, build, and tests cannot run locally and CI will verify.
 Latest Attempt: After removing the application logo and adding header text, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with XAML errors and `dotnet test --settings tests.runsettings` produced similar errors; relying on CI for validation.
 Latest Attempt: Installed .NET SDK 8.0.404 and built successfully, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App runtime is missing; relying on CI.
+Latest Attempt: After storing service types as short codes, the `dotnet` command is still missing; build and tests deferred to CI.
 Newest Attempt: After extracting ScriptGlobals into its own class for TCP script execution, the `dotnet` command remains unavailable; restore, build, and test steps could not run locally and CI will verify.
 Latest Attempt: After fixing the script editor binding error, the `dotnet` command remains unavailable; restore, build, and tests cannot run locally, so CI will verify.
 Latest Attempt: After adding script execution logging to TcpServiceMessagesViewModel, the `dotnet` command is still missing; restore, build, and tests cannot run locally and CI will verify.


### PR DESCRIPTION
## Summary
- add `ServiceTypeJsonConverter` to serialize enum as short codes with legacy name fallback
- persist enum-based `ServiceType` values and map to legacy display strings
- update Windows service manager and add unit tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c222700a888326a10b41f02fb9ce37