### PR TITLE
Register edit handlers via keyed DI

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -53,7 +53,28 @@ namespace DesktopApplicationTemplate.UI
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddSingleton<IDictionary<ServiceType, Action<ServiceListModel>>>(_ => new Dictionary<ServiceType, Action<ServiceListModel>>());
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Mqtt, sp => service => sp.GetRequiredService<MainView>().EditMqtt(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Heartbeat, sp => service => sp.GetRequiredService<MainView>().EditHeartbeat(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Hid, sp => service => sp.GetRequiredService<MainView>().EditHid(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Csv, sp => service => sp.GetRequiredService<MainView>().EditCsv(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.FileObserver, sp => service => sp.GetRequiredService<MainView>().EditFileObserver(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Scp, sp => service => sp.GetRequiredService<MainView>().EditScp(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Tcp, sp => service => sp.GetRequiredService<MainView>().EditTcp(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Http, sp => service => sp.GetRequiredService<MainView>().EditHttp(service));
+            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Ftp, sp => service => sp.GetRequiredService<MainView>().EditFtp(service));
+            services.AddSingleton<IDictionary<ServiceType, Action<ServiceListModel>>>(sp =>
+            {
+                var handlers = new Dictionary<ServiceType, Action<ServiceListModel>>();
+                foreach (ServiceType type in Enum.GetValues<ServiceType>())
+                {
+                    var handler = sp.GetKeyedService<Action<ServiceListModel>>(type);
+                    if (handler != null)
+                    {
+                        handlers[type] = handler;
+                    }
+                }
+                return handlers;
+            });
             services.AddSingleton<MainView>();
             services.AddSingleton<IStartupService, StartupService>();
             services.AddSingleton<IProcessRunner, ProcessRunner>();

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -39,8 +39,6 @@ namespace DesktopApplicationTemplate.UI.Views
             InitializeComponent();
             _viewModel = viewModel;
             _editHandlers = editHandlers;
-            _editHandlers.Clear();
-            RegisterEditHandlers();
             if (App.AppHost.Services.GetService(typeof(ILoggerFactory)) is ILoggerFactory factory)
             {
                 _logger = factory.CreateLogger<MainView>();
@@ -88,18 +86,6 @@ namespace DesktopApplicationTemplate.UI.Views
             ShowHome();
         }
 
-        private void RegisterEditHandlers()
-        {
-            _editHandlers[ServiceType.Mqtt] = EditMqtt;
-            _editHandlers[ServiceType.Heartbeat] = EditHeartbeat;
-            _editHandlers[ServiceType.Hid] = EditHid;
-            _editHandlers[ServiceType.Csv] = EditCsv;
-            _editHandlers[ServiceType.FileObserver] = EditFileObserver;
-            _editHandlers[ServiceType.Scp] = EditScp;
-            _editHandlers[ServiceType.Tcp] = EditTcp;
-            _editHandlers[ServiceType.Http] = EditHttp;
-            _editHandlers[ServiceType.Ftp] = EditFtp;
-        }
 
         public Page? GetOrCreateServicePage(ServiceListModel svc)
         {
@@ -286,7 +272,7 @@ namespace DesktopApplicationTemplate.UI.Views
         }
     }
 
-    private void EditMqtt(ServiceListModel service)
+    internal void EditMqtt(ServiceListModel service)
     {
         var tagPage = GetOrCreateServicePage(service);
         var options = App.AppHost.Services.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
@@ -318,7 +304,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditHeartbeat(ServiceListModel service)
+    internal void EditHeartbeat(ServiceListModel service)
     {
         var hbPage = GetOrCreateServicePage(service);
         var options = service.HeartbeatOptions ?? new HeartbeatServiceOptions();
@@ -351,7 +337,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditHid(ServiceListModel service)
+    internal void EditHid(ServiceListModel service)
     {
         var hidPage = GetOrCreateServicePage(service);
         var options = service.HidOptions ?? new HidServiceOptions();
@@ -384,7 +370,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditCsv(ServiceListModel service)
+    internal void EditCsv(ServiceListModel service)
     {
         var csvPage = GetOrCreateServicePage(service);
         var options = service.CsvOptions ?? new CsvServiceOptions();
@@ -418,7 +404,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditFileObserver(ServiceListModel service)
+    internal void EditFileObserver(ServiceListModel service)
     {
         var foPage = GetOrCreateServicePage(service);
         var options = service.FileObserverOptions ?? new FileObserverServiceOptions();
@@ -451,7 +437,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditScp(ServiceListModel service)
+    internal void EditScp(ServiceListModel service)
     {
         var scpPage = GetOrCreateServicePage(service);
         var options = service.ScpOptions ?? new ScpServiceOptions();
@@ -486,7 +472,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditTcp(ServiceListModel service)
+    internal void EditTcp(ServiceListModel service)
     {
         var tcpPage = GetOrCreateServicePage(service);
         var options = service.TcpOptions ?? new TcpServiceOptions();
@@ -513,7 +499,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditHttp(ServiceListModel service)
+    internal void EditHttp(ServiceListModel service)
     {
         var httpPage = GetOrCreateServicePage(service);
         var options = service.HttpOptions ?? new HttpServiceOptions();
@@ -546,7 +532,7 @@ namespace DesktopApplicationTemplate.UI.Views
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
 
-    private void EditFtp(ServiceListModel service)
+    internal void EditFtp(ServiceListModel service)
     {
         var ftpPage = GetOrCreateServicePage(service);
         var options = service.FtpOptions ?? new FtpServerOptions();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -85,6 +85,7 @@
 - TcpServiceMessagesViewModel runs the initial script asynchronously to avoid blocking.
 - App domain unhandled exception handler is asynchronous and awaits dispatcher shutdown.
 - Main window resolves edit workflows through a DI-injected handler dictionary instead of a large if/else chain.
+- Edit handlers register with DI keyed by `ServiceType`, and the main window receives a dictionary constructed from those registrations.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -185,6 +185,7 @@ Latest Attempt: After replacing ColorCanvas with ColorPicker to resolve color pi
 Latest Attempt: After updating VisualTreeHelperExtensions to traverse the logical tree when an element is not a Visual, installed the .NET SDK 8.0.404 and ran `dotnet test --settings tests.runsettings`; core tests passed but DesktopApplicationTemplate.Tests aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing, and `dotnet workload install wpf` reports the workload ID is not recognized on Linux.
 Latest Attempt: After extending FindParent<T> to handle non-visual elements like `Run` without throwing and adding tests, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Latest Attempt: After ensuring the SCP DI test registers `IServiceRule`, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After registering edit handlers through DI, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- Register edit workflows as keyed DI services in `App` and build the handler dictionary from those registrations
- Remove manual edit handler registration in `MainView` and expose handlers for DI use
- Log inability to run tests due to missing .NET SDK

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c228e62aec8326a1b2ace8f815d258