### PR TITLE
Log unrecognized edit service types

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -113,10 +113,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private void EditService(ServiceListModel? service)
         {
             var target = service ?? SelectedService;
-            if (target != null)
+            if (target == null)
+                return;
+
+            if (!ServiceTypeJsonConverter.TryParse(target.ServiceType, out _))
             {
-                EditRequested?.Invoke(target);
+                _logger?.Log($"Unrecognized service type '{target.ServiceType}'", LogLevel.Warning);
+                return;
             }
+
+            EditRequested?.Invoke(target);
         }
 
         private void AddService()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Script editor unsubscribes handlers on close and mirrors test message changes to the TCP messages view.
 - Renamed `SaveServices` to `SaveServicesAsync` and updated callers to await it, removing blocking calls.
 - Replaced Xceed `ColorCanvas` with `ColorPicker` to prevent XAML parse exceptions when selecting service colors.
+- Edit service workflow logs and ignores unrecognized service types.
 
 
 ### HID Service

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -541,6 +541,7 @@ Latest Attempt: After moving script editor globals to a top-level class and adju
 Newest Attempt: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and `dotnet build DesktopApplicationTemplate.sln` succeeded, but `dotnet test --settings tests.runsettings` aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing; relying on CI.
 Latest Attempt: After introducing service factories, the `dotnet` CLI is still missing; relying on CI for build and test.
 Latest Attempt: Installed .NET SDK 8.0.404; `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed with missing MainView in FtpServiceFactory. CI will verify.
+Current Attempt: After logging unrecognized service types in EditService, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally—relying on CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- guard `EditService` against unknown service types
- log and skip edit requests when service type is not recognized
- document environment inability to run dotnet CLI

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ae39d43883269c91c1d98dbd2696