### PR TITLE
Use ServiceType enum for service creation

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
@@ -23,8 +23,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 Services =
                 {
-                    new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP", IsActive = true, Order = 0 },
-                    new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = "TCP", IsActive = true, Order = 1 }
+                    new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http, IsActive = true, Order = 0 },
+                    new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = ServiceType.Tcp, IsActive = true, Order = 1 }
                 },
                 Filters = { NameFilter = "HTTP" }
             };

--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -27,19 +27,19 @@ namespace DesktopApplicationTemplate.Tests
             vm.Services.Add(new ServiceListModel
             {
                 DisplayName = "HTTP - HTTP1",
-                ServiceType = "HTTP",
+                ServiceType = ServiceType.Http,
                 IsActive = false,
                 Order = 0
             });
             vm.Services.Add(new ServiceListModel
             {
                 DisplayName = "HTTP - HTTP3",
-                ServiceType = "HTTP",
+                ServiceType = ServiceType.Http,
                 IsActive = false,
                 Order = 1
             });
 
-            string next = vm.GenerateServiceName("HTTP");
+            string next = vm.GenerateServiceName(ServiceType.Http);
 
             Assert.Equal("HTTP4", next);
             ConsoleTestLogger.LogPass();
@@ -60,7 +60,7 @@ namespace DesktopApplicationTemplate.Tests
             try
             {
                 var vm = new MainViewModel(csv, networkVm, network.Object, logger.Object, servicesPath);
-                var service = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
+                var service = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
                 vm.Services.Add(service);
                 vm.SelectedService = service;
 
@@ -87,7 +87,7 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
+            var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
             svc.Logs.Add(new LogEntry { Message = "test" });
             vm.Services.Add(svc);
             vm.SelectedService = svc;
@@ -106,7 +106,7 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
+            var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
             svc.Logs.Add(new LogEntry { Message = "first" });
             vm.Services.Add(svc);
             vm.SelectedService = svc;
@@ -156,7 +156,7 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = new ServiceListModel { DisplayName = "MQTT - Test", ServiceType = "MQTT" };
+            var svc = new ServiceListModel { DisplayName = "MQTT - Test", ServiceType = ServiceType.Mqtt };
             vm.Services.Add(svc);
 
             MqttEditConnectionViewModel? captured = null;
@@ -207,7 +207,7 @@ namespace DesktopApplicationTemplate.Tests
                     if (e.PropertyName == nameof(MainViewModel.ServicesCreated)) createdChanges++;
                     if (e.PropertyName == nameof(MainViewModel.CurrentActiveServices)) activeChanges++;
                 };
-                var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = "HTTP" };
+                var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
                 svc.ActiveChanged += vm.OnServiceActiveChanged;
                 vm.AddServiceForTest(svc);
 

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -1,7 +1,8 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Core.Models;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Converters;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -17,8 +18,8 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void AddLog_ReferenceUpdatesAssociatedServices()
         {
-            var a = new ServiceListModel { DisplayName = "Heartbeat - A", ServiceType = "Heartbeat" };
-            var b = new ServiceListModel { DisplayName = "TCP - B", ServiceType = "TCP" };
+            var a = new ServiceListModel { DisplayName = "Heartbeat - A", ServiceType = ServiceType.Heartbeat };
+            var b = new ServiceListModel { DisplayName = "TCP - B", ServiceType = ServiceType.Tcp };
             var services = new List<ServiceListModel> { a, b };
             ServiceListModel.ResolveService = (type, name) =>
                 services.Find(s => s.ServiceType == type && s.DisplayName.Split(" - ").Last() == name);
@@ -43,10 +44,10 @@ namespace DesktopApplicationTemplate.Tests
             var netVm = new NetworkConfigurationViewModel(net);
             var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
-            main.Services.Add(new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = "TCP" });
-            main.Services.Add(new ServiceListModel { DisplayName = "TCP - TCP2", ServiceType = "TCP" });
+            main.Services.Add(new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = ServiceType.Tcp });
+            main.Services.Add(new ServiceListModel { DisplayName = "TCP - TCP2", ServiceType = ServiceType.Tcp });
 
-            var name = main.GenerateServiceName("TCP");
+            var name = main.GenerateServiceName(ServiceType.Tcp);
             Assert.Equal("TCP3", name);
 
             Directory.Delete(tempDir, true);
@@ -64,8 +65,8 @@ namespace DesktopApplicationTemplate.Tests
             var netVm = new NetworkConfigurationViewModel(net);
             var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
-            var svc1 = new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = "TCP" };
-            var svc2 = new ServiceListModel { DisplayName = "TCP - TCP2", ServiceType = "TCP" };
+            var svc1 = new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = ServiceType.Tcp };
+            var svc2 = new ServiceListModel { DisplayName = "TCP - TCP2", ServiceType = ServiceType.Tcp };
             main.Services.Add(svc1);
             main.Services.Add(svc2);
 
@@ -74,7 +75,7 @@ namespace DesktopApplicationTemplate.Tests
             {
                 desired = main.GenerateServiceName(svc2.ServiceType);
             }
-            svc2.DisplayName = $"{svc2.ServiceType} - {desired}";
+            svc2.DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(svc2.ServiceType)} - {desired}";
 
             Assert.Equal("TCP - TCP3", svc2.DisplayName);
 

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -2,6 +2,7 @@ using DesktopApplicationTemplate.Persistence;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI;
+using DesktopApplicationTemplate.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,8 +28,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 var services = new List<ServiceListModel>
                 {
-                    new ServiceListModel{DisplayName="A", ServiceType="Heartbeat", IsActive=true, Order=0},
-                    new ServiceListModel{DisplayName="B", ServiceType="TCP", IsActive=false, Order=1}
+                    new ServiceListModel{DisplayName="A", ServiceType=ServiceType.Heartbeat, IsActive=true, Order=0},
+                    new ServiceListModel{DisplayName="B", ServiceType=ServiceType.Tcp, IsActive=false, Order=1}
                 };
                 services[0].AssociatedServices.Add("B");
                 services[1].AssociatedServices.Add("A");
@@ -58,8 +59,8 @@ namespace DesktopApplicationTemplate.Tests
             ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
             try
             {
-                var a = new ServiceListModel { DisplayName = "A", ServiceType = "TCP" };
-                var b = new ServiceListModel { DisplayName = "B", ServiceType = "TCP" };
+                var a = new ServiceListModel { DisplayName = "A", ServiceType = ServiceType.Tcp };
+                var b = new ServiceListModel { DisplayName = "B", ServiceType = ServiceType.Tcp };
                 a.AssociatedServices.Add("B");
                 b.AssociatedServices.Add("A");
                 var services = new List<ServiceListModel> { a, b };
@@ -101,7 +102,7 @@ namespace DesktopApplicationTemplate.Tests
                     new ServiceListModel
                     {
                         DisplayName="TCP - One",
-                        ServiceType="TCP",
+                        ServiceType=ServiceType.Tcp,
                         IsActive=false,
                         Order=0,
                         TcpOptions = new TcpServiceOptions
@@ -192,7 +193,7 @@ namespace DesktopApplicationTemplate.Tests
                     new ServiceListModel
                     {
                         DisplayName = "FTP Server - One",
-                        ServiceType = "FTP Server",
+                        ServiceType = ServiceType.Ftp,
                         IsActive = false,
                         Order = 0,
                         FtpOptions = new FtpServerOptions
@@ -267,7 +268,7 @@ namespace DesktopApplicationTemplate.Tests
                     new ServiceListModel
                     {
                         DisplayName = "FTP - One",
-                        ServiceType = "FTP",
+                        ServiceType = ServiceType.Ftp,
                         IsActive = false,
                         Order = 0,
                         FtpOptions = new FtpServerOptions

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -98,7 +98,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions()
         };
         var routing = new MessageRoutingService();
@@ -116,7 +116,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions()
         };
         var routing = new MessageRoutingService();
@@ -134,7 +134,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions { LastTestMessage = "hello" }
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -150,7 +150,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -169,7 +169,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -188,7 +188,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -208,7 +208,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions { Script = "return message;" }
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -224,7 +224,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions()
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -241,7 +241,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -262,7 +262,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -326,7 +326,7 @@ public class TcpServiceMessagesViewModelTests
         var service = new ServiceListModel
         {
             DisplayName = "TCP - svc",
-            ServiceType = "TCP",
+            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var routing = new MessageRoutingService();

--- a/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
@@ -2,6 +2,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -10,7 +11,7 @@ namespace DesktopApplicationTemplate.UI.Factories
         private readonly IServiceProvider _services;
         private readonly MainView _mainView;
 
-        public string ServiceType => "FTP Server";
+        public ServiceType ServiceType => ServiceType.Ftp;
 
         public FtpServiceFactory(IServiceProvider services, MainView mainView)
         {
@@ -27,7 +28,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"FTP Server - {name}",
-                ServiceType = "FTP Server",
+                ServiceType = ServiceType.Ftp,
                 IsActive = false,
                 FtpOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/IServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/IServiceFactory.cs
@@ -1,10 +1,11 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public interface IServiceFactory
     {
-        string ServiceType { get; }
+        ServiceType ServiceType { get; }
         ServiceListModel Create(object options);
     }
 }

--- a/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
@@ -4,6 +4,7 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -13,7 +14,7 @@ namespace DesktopApplicationTemplate.UI.Factories
         private readonly MainView _mainView;
         private readonly MainViewModel _mainViewModel;
 
-        public string ServiceType => "MQTT";
+        public ServiceType ServiceType => ServiceType.Mqtt;
 
         public MqttServiceFactory(IServiceProvider services, MainView mainView, MainViewModel mainViewModel)
         {
@@ -31,7 +32,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var newService = new ServiceListModel
             {
                 DisplayName = $"MQTT - {name}",
-                ServiceType = "MQTT",
+                ServiceType = ServiceType.Mqtt,
                 IsActive = false
             };
 

--- a/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
@@ -5,6 +5,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -13,7 +14,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         private readonly IServiceProvider _services;
         private readonly MainView _mainView;
 
-        public string ServiceType => "FTP Server";
+        public ServiceType ServiceType => ServiceType.Ftp;
 
         public FtpNavigationHandler(IServiceProvider services, MainView mainView)
         {

--- a/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
@@ -1,10 +1,11 @@
 using System.Windows.Controls;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
     public interface INavigationHandler
     {
-        string ServiceType { get; }
+        ServiceType ServiceType { get; }
         Page CreateView(string defaultName);
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
@@ -5,6 +5,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -13,7 +14,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         private readonly IServiceProvider _services;
         private readonly MainView _mainView;
 
-        public string ServiceType => "MQTT";
+        public ServiceType ServiceType => ServiceType.Mqtt;
 
         public MqttNavigationHandler(IServiceProvider services, MainView mainView)
         {

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -27,7 +27,7 @@ namespace DesktopApplicationTemplate.Persistence
                 CsvServiceOptions? csv = null;
                 FtpServerOptions? ftp = null;
                 HttpServiceOptions? http = null;
-                if (s.ServiceType == "TCP" && s.TcpOptions != null)
+                if (s.ServiceType == ServiceType.Tcp && s.TcpOptions != null)
                 {
                     tcp = new TcpServiceOptions
                     {
@@ -43,7 +43,7 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
-                if ((s.ServiceType == "FTP Server" || s.ServiceType == "FTP") && s.FtpOptions != null)
+                if (s.ServiceType == ServiceType.Ftp && s.FtpOptions != null)
                 {
                     ftp = new FtpServerOptions
                     {
@@ -55,7 +55,7 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
-                if (s.ServiceType == "HTTP" && s.HttpOptions != null)
+                if (s.ServiceType == ServiceType.Http && s.HttpOptions != null)
                 {
                     http = new HttpServiceOptions
                     {
@@ -65,7 +65,7 @@ namespace DesktopApplicationTemplate.Persistence
                         ClientCertificatePath = s.HttpOptions.ClientCertificatePath
                     };
                 }
-                if (s.ServiceType == "CSV Creator" && s.CsvOptions != null)
+                if (s.ServiceType == ServiceType.Csv && s.CsvOptions != null)
                 {
                     csv = new CsvServiceOptions
                     {
@@ -75,12 +75,10 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
-                ServiceTypeJsonConverter.TryParse(s.ServiceType, out var type);
-
                 data.Add(new ServiceInfo
                 {
                     DisplayName = s.DisplayName,
-                    ServiceType = type,
+                    ServiceType = s.ServiceType,
                     IsActive = s.IsActive,
                     Created = DateTime.Now,
                     Order = index++,

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -1,20 +1,22 @@
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Converters;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class CreateServiceViewModel : ViewModelBase
     {
-        public record ServiceTypeMetadata(string Type, string DisplayText, string Icon);
+        public record ServiceTypeMetadata(ServiceType Type, string DisplayText, string Icon);
 
         public ObservableCollection<ServiceTypeMetadata> ServiceTypes { get; } = new()
         {
-            new("TCP", "TCP", "🔗"),
-            new("HTTP", "HTTP", "🌐"),
-            new("CSV Creator", "CSV Creator", "📄"),
-            new("SCP", "SCP", "📦"),
-            new("MQTT", "MQTT", "📡"),
-            new("FTP Server", "FTP Server", "🖥️")
+            new(ServiceType.Tcp, "TCP", "🔗"),
+            new(ServiceType.Http, "HTTP", "🌐"),
+            new(ServiceType.Csv, "CSV Creator", "📄"),
+            new(ServiceType.Scp, "SCP", "📦"),
+            new(ServiceType.Mqtt, "MQTT", "📡"),
+            new(ServiceType.Ftp, "FTP Server", "🖥️")
         };
 
         private readonly HashSet<string> _existingNames;
@@ -24,14 +26,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _existingNames = existingNames != null ? new HashSet<string>(existingNames) : new HashSet<string>();
         }
 
-        public string GenerateDefaultName(string serviceType)
+        public string GenerateDefaultName(ServiceType serviceType)
         {
+            var typeName = ServiceTypeJsonConverter.ToLegacyString(serviceType);
             int index = 1;
-            while (_existingNames.Contains($"{serviceType}{index}"))
+            while (_existingNames.Contains($"{typeName}{index}"))
             {
                 index++;
             }
-            return $"{serviceType}{index}";
+            return $"{typeName}{index}";
         }
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -1,4 +1,3 @@
-using DesktopApplicationTemplate.Models;
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
@@ -70,7 +69,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceListModel.ResolveService = (type, name) =>
                 Services.FirstOrDefault(s =>
-                    s.ServiceType.Equals(type, StringComparison.OrdinalIgnoreCase) &&
+                    s.ServiceType == type &&
                     s.DisplayName.Split(" - ").Last().Equals(name, StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrWhiteSpace(servicesFilePath))
             {
@@ -116,12 +115,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (target == null)
                 return;
 
-            if (!ServiceTypeJsonConverter.TryParse(target.ServiceType, out _))
-            {
-                _logger?.Log($"Unrecognized service type '{target.ServiceType}'", LogLevel.Warning);
-                return;
-            }
-
             EditRequested?.Invoke(target);
         }
 
@@ -132,19 +125,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _logger?.Log("AddService completed", LogLevel.Debug);
         }
 
-        internal string GenerateServiceName(string serviceType)
+        internal string GenerateServiceName(ServiceType serviceType)
         {
+            var typeName = ServiceTypeJsonConverter.ToLegacyString(serviceType);
             int index = 1;
             foreach (var svc in Services.Where(s => s.ServiceType == serviceType))
             {
                 var namePart = svc.DisplayName.Split(" - ").Last();
-                if (namePart.StartsWith(serviceType) &&
-                    int.TryParse(namePart.Substring(serviceType.Length), out int n) && n >= index)
+                if (namePart.StartsWith(typeName) &&
+                    int.TryParse(namePart.Substring(typeName.Length), out int n) && n >= index)
                 {
                     index = n + 1;
                 }
             }
-            return $"{serviceType}{index}";
+            return $"{typeName}{index}";
         }
 
         private async Task RemoveSelectedServiceAsync()
@@ -154,7 +148,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _logger?.Log($"Removing service {SelectedService.DisplayName}", LogLevel.Debug);
                 var index = Services.IndexOf(SelectedService);
                 SelectedService.AddLog("Service removed", WpfBrushes.Red);
-                if (!SelectedService.ServiceType.Contains("CSV", StringComparison.OrdinalIgnoreCase))
+                if (SelectedService.ServiceType != ServiceType.Csv)
                     _csvService.RemoveColumnsForService(SelectedService.DisplayName);
                 SelectedService.LogAdded -= OnServiceLogAdded;
                 SelectedService.ActiveChanged -= OnServiceActiveChanged;
@@ -210,7 +204,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 var svc = new ServiceListModel
                 {
                     DisplayName = info.DisplayName,
-                    ServiceType = ServiceTypeJsonConverter.ToLegacyString(info.ServiceType),
+                    ServiceType = info.ServiceType,
                     IsActive = info.IsActive,
                     Order = info.Order,
                     TcpOptions = info.TcpOptions,
@@ -225,7 +219,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 svc.SetColorsByType();
                 svc.LogAdded += OnServiceLogAdded;
                 svc.ActiveChanged += OnServiceActiveChanged;
-                if (!svc.ServiceType.Contains("CSV", StringComparison.OrdinalIgnoreCase))
+                if (svc.ServiceType != ServiceType.Csv)
                     _csvService.EnsureColumnsForService(svc.DisplayName);
                 Services.Add(svc);
                 _logger?.Log($"Loaded service {svc.DisplayName}", LogLevel.Debug);
@@ -245,7 +239,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     !svc.DisplayName.Contains(Filters.NameFilter, StringComparison.OrdinalIgnoreCase))
                     return false;
 
-                if (Filters.TypeFilter != "All" && svc.ServiceType != Filters.TypeFilter)
+                if (Filters.TypeFilter != "All" &&
+                    ServiceTypeJsonConverter.TryParse(Filters.TypeFilter, out var fType) &&
+                    svc.ServiceType != fType)
                     return false;
 
                 if (Filters.StatusFilter == "Active" && !svc.IsActive)
@@ -261,7 +257,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void OnServiceLogAdded(ServiceListModel svc, LogEntry entry)
         {
             AllLogs.Insert(0, entry);
-            if (svc.ServiceType != "CSV Creator" && Services.Any(s => s.ServiceType == "CSV Creator"))
+            if (svc.ServiceType != ServiceType.Csv && Services.Any(s => s.ServiceType == ServiceType.Csv))
             {
                 try
                 {

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Converters;
 using WpfBrush = System.Windows.Media.Brush;
 using WpfBrushes = System.Windows.Media.Brushes;
 
@@ -14,7 +15,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     public class ServiceListModel : ViewModelBase
     {
         public string DisplayName { get; set; } = string.Empty;
-        public string ServiceType { get; set; } = string.Empty;
+        public ServiceType ServiceType { get; set; }
         [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 
@@ -147,7 +148,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public CsvServiceOptions? CsvOptions { get; set; }
 
-        public static Func<string, string, ServiceListModel?>? ResolveService { get; set; }
+        public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
 
         private bool _isActive;
         public bool IsActive
@@ -207,17 +208,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var m = Regex.Match(message, @"^([^.]+)\.([^.]+)\.(.+)$");
             if (m.Success && ResolveService != null)
             {
-                var type = m.Groups[1].Value;
+                var typeStr = m.Groups[1].Value;
                 var name = m.Groups[2].Value;
                 var msg = m.Groups[3].Value;
-                var target = ResolveService(type, name);
-                if (target != null && target != this)
+                if (ServiceTypeJsonConverter.TryParse(typeStr, out var type))
                 {
-                    if (!AssociatedServices.Contains(target.DisplayName))
-                        AssociatedServices.Add(target.DisplayName);
-                    if (!target.AssociatedServices.Contains(DisplayName))
-                        target.AssociatedServices.Add(DisplayName);
-                    target.AddLog(msg, color, level, false);
+                    var target = ResolveService(type, name);
+                    if (target != null && target != this)
+                    {
+                        if (!AssociatedServices.Contains(target.DisplayName))
+                            AssociatedServices.Add(target.DisplayName);
+                        if (!target.AssociatedServices.Contains(DisplayName))
+                            target.AssociatedServices.Add(DisplayName);
+                        target.AddLog(msg, color, level, false);
+                    }
                 }
             }
         }
@@ -226,14 +230,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             (BackgroundColor, BorderColor) = ServiceType switch
             {
-                "TCP" => (WpfBrushes.LightBlue, WpfBrushes.DarkBlue),
-                "HTTP" => (WpfBrushes.LightGreen, WpfBrushes.DarkGreen),
-                "File Observer" => (WpfBrushes.LightSalmon, WpfBrushes.DarkSalmon),
-                "HID" => (WpfBrushes.LightYellow, WpfBrushes.Goldenrod),
-                "Heartbeat" => (WpfBrushes.LightPink, WpfBrushes.DeepPink),
-                "SCP" => (WpfBrushes.LightCyan, WpfBrushes.CadetBlue),
-                "MQTT" => (WpfBrushes.LightGoldenrodYellow, WpfBrushes.Goldenrod),
-                "FTP Server" or "FTP" => (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
+                ServiceType.Tcp => (WpfBrushes.LightBlue, WpfBrushes.DarkBlue),
+                ServiceType.Http => (WpfBrushes.LightGreen, WpfBrushes.DarkGreen),
+                ServiceType.FileObserver => (WpfBrushes.LightSalmon, WpfBrushes.DarkSalmon),
+                ServiceType.Hid => (WpfBrushes.LightYellow, WpfBrushes.Goldenrod),
+                ServiceType.Heartbeat => (WpfBrushes.LightPink, WpfBrushes.DeepPink),
+                ServiceType.Scp => (WpfBrushes.LightCyan, WpfBrushes.CadetBlue),
+                ServiceType.Mqtt => (WpfBrushes.LightGoldenrodYellow, WpfBrushes.Goldenrod),
+                ServiceType.Ftp => (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
+                ServiceType.Csv => (WpfBrushes.LightGray, WpfBrushes.Gray),
                 _ => (WpfBrushes.LightGray, WpfBrushes.Gray)
             };
             OnPropertyChanged(nameof(BackgroundColor));

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -2,14 +2,15 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
     public partial class CreateServicePage : Page
     {
         private readonly CreateServiceViewModel _viewModel;
-        public event Action<string, string>? ServiceCreated;
-        public event Action<string>? ServiceTypeSelected;
+        public event Action<string, ServiceType>? ServiceCreated;
+        public event Action<ServiceType>? ServiceTypeSelected;
         public event Action? Cancelled;
 
         public CreateServicePage(CreateServiceViewModel viewModel)
@@ -24,7 +25,7 @@ namespace DesktopApplicationTemplate.UI.Views
             if (sender is Button { DataContext: CreateServiceViewModel.ServiceTypeMetadata meta } button)
             {
                 var name = _viewModel.GenerateDefaultName(meta.Type);
-                if (meta.Type is "MQTT" or "TCP" or "Heartbeat" or "FTP" or "FTP Server" or "HTTP" or "HID" or "CSV Creator" or "File Observer" or "SCP")
+                if (meta.Type is ServiceType.Mqtt or ServiceType.Tcp or ServiceType.Heartbeat or ServiceType.Ftp or ServiceType.Http or ServiceType.Hid or ServiceType.Csv or ServiceType.FileObserver or ServiceType.Scp)
                 {
                     ServiceTypeSelected?.Invoke(meta.Type);
                     return;
@@ -33,7 +34,7 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
-        public string GenerateDefaultName(string type) => _viewModel.GenerateDefaultName(type);
+        public string GenerateDefaultName(ServiceType type) => _viewModel.GenerateDefaultName(type);
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {

--- a/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FTPServiceView.xaml.cs
@@ -20,8 +20,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public void SetServiceContext(ServiceListModel service)
         {
-            Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
-            LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
+            LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/HttpServiceView.xaml.cs
@@ -46,8 +46,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public void SetServiceContext(ServiceListModel service)
         {
-            Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
-            LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
+            LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -94,15 +94,15 @@ namespace DesktopApplicationTemplate.UI.Views
 
             svc.ServicePage = svc.ServiceType switch
             {
-                "TCP" => App.AppHost.Services.GetRequiredService<TcpServiceMessagesView>(),
-                "HTTP" => App.AppHost.Services.GetRequiredService<HttpServiceView>(),
-                "File Observer" => App.AppHost.Services.GetRequiredService<FileObserverView>(),
-                "HID" => App.AppHost.Services.GetRequiredService<HidViews>(),
-                "Heartbeat" => App.AppHost.Services.GetRequiredService<HeartbeatView>(),
-                "SCP" => App.AppHost.Services.GetRequiredService<SCPServiceView>(),
-                "MQTT" => App.AppHost.Services.GetRequiredService<MqttTagSubscriptionsView>(),
-                "FTP Server" or "FTP" => App.AppHost.Services.GetRequiredService<FTPServiceView>(),
-                "CSV Creator" => App.AppHost.Services.GetRequiredService<CsvServiceView>(),
+                ServiceType.Tcp => App.AppHost.Services.GetRequiredService<TcpServiceMessagesView>(),
+                ServiceType.Http => App.AppHost.Services.GetRequiredService<HttpServiceView>(),
+                ServiceType.FileObserver => App.AppHost.Services.GetRequiredService<FileObserverView>(),
+                ServiceType.Hid => App.AppHost.Services.GetRequiredService<HidViews>(),
+                ServiceType.Heartbeat => App.AppHost.Services.GetRequiredService<HeartbeatView>(),
+                ServiceType.Scp => App.AppHost.Services.GetRequiredService<SCPServiceView>(),
+                ServiceType.Mqtt => App.AppHost.Services.GetRequiredService<MqttTagSubscriptionsView>(),
+                ServiceType.Ftp => App.AppHost.Services.GetRequiredService<FTPServiceView>(),
+                ServiceType.Csv => App.AppHost.Services.GetRequiredService<CsvServiceView>(),
                 _ => null
             };
 
@@ -110,7 +110,7 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 if (svc.ServicePage.DataContext is ILoggingViewModel vm && vm.Logger is LoggingService logger)
                 {
-                    if (svc.ServiceType == "MQTT")
+                    if (svc.ServiceType == ServiceType.Mqtt)
                     {
                         logger.LogAdded += entry => _viewModel.OnServiceLogAdded(svc, entry);
                     }
@@ -134,12 +134,12 @@ namespace DesktopApplicationTemplate.UI.Views
                     logHost.SetServiceContext(svc);
                 }
 
-                if (svc.ServiceType == "TCP" && svc.ServicePage.DataContext is TcpServiceMessagesViewModel tcpVm)
+                if (svc.ServiceType == ServiceType.Tcp && svc.ServicePage.DataContext is TcpServiceMessagesViewModel tcpVm)
                 {
                     tcpVm.AdvancedSettingsRequested += (_, _) =>
                     {
                         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-                        vm.ServiceType = svc.ServiceType;
+                        vm.ServiceType = ServiceTypeJsonConverter.ToLegacyString(svc.ServiceType);
                         vm.Load(svc.DisplayName.Split(" - ").Last(), svc.TcpOptions ?? new TcpServiceOptions());
                         var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
                         editView.Initialize(vm);
@@ -147,7 +147,8 @@ namespace DesktopApplicationTemplate.UI.Views
                         vm.ServiceSaved += (name, opts) =>
                         {
                             svc.DisplayName = $"{vm.ServiceType} - {name}";
-                            svc.ServiceType = vm.ServiceType;
+                            if (ServiceTypeJsonConverter.TryParse(vm.ServiceType, out var newType))
+                                svc.ServiceType = newType;
                             svc.TcpOptions = opts;
                             if (svc.ServicePage != null)
                                 ShowPage(svc.ServicePage);
@@ -189,7 +190,7 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 var svc = new ServiceListModel
                 {
-                    DisplayName = $"{type} - {name}",
+                    DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(type)} - {name}",
                     ServiceType = type,
                     IsActive = false
                 };
@@ -212,9 +213,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private CreateServicePage? _createServicePage;
 
-        private void NavigateTo(string serviceType)
+        private void NavigateTo(ServiceType serviceType)
         {
-            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType;
+            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? ServiceTypeJsonConverter.ToLegacyString(serviceType);
             var handler = App.AppHost.Services.GetServices<INavigationHandler>()
                 .FirstOrDefault(h => h.ServiceType == serviceType);
             if (handler == null)
@@ -231,7 +232,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
 
 
-        internal async Task AddServiceAsync(string type, object options)
+        internal async Task AddServiceAsync(ServiceType type, object options)
         {
             var factory = App.AppHost.Services.GetServices<IServiceFactory>()
                 .FirstOrDefault(f => f.ServiceType == type);
@@ -257,8 +258,7 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         _logger?.LogDebug("Edit requested for {Name}", service.DisplayName);
 
-        if (ServiceTypeJsonConverter.TryParse(service.ServiceType, out var type) &&
-            _editHandlers.TryGetValue(type, out var handler))
+        if (_editHandlers.TryGetValue(service.ServiceType, out var handler))
         {
             handler(service);
             return;
@@ -477,14 +477,15 @@ namespace DesktopApplicationTemplate.UI.Views
         var tcpPage = GetOrCreateServicePage(service);
         var options = service.TcpOptions ?? new TcpServiceOptions();
         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-        vm.ServiceType = service.ServiceType;
+        vm.ServiceType = ServiceTypeJsonConverter.ToLegacyString(service.ServiceType);
         vm.Load(service.DisplayName.Split(" - ").Last(), options);
         var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
             service.DisplayName = $"{vm.ServiceType} - {name}";
-            service.ServiceType = vm.ServiceType;
+            if (ServiceTypeJsonConverter.TryParse(vm.ServiceType, out var newType))
+                service.ServiceType = newType;
             service.TcpOptions = opts;
             if (tcpPage != null)
                 ShowPage(tcpPage);
@@ -643,7 +644,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     {
                         namePart = _viewModel.GenerateServiceName(svc.ServiceType);
                     }
-                    svc.DisplayName = $"{svc.ServiceType} - {namePart}";
+                    svc.DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(svc.ServiceType)} - {namePart}";
                     await _viewModel.SaveServicesAsync();
                 }
             }

--- a/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MqttTagSubscriptionsView.xaml.cs
@@ -24,7 +24,6 @@ public partial class MqttTagSubscriptionsView : Page, IServiceLogHost
     /// <inheritdoc />
     public void SetServiceContext(ServiceListModel service)
     {
-        Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
-        LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
+        LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/TcpServiceMessagesView.xaml.cs
@@ -18,8 +18,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public void SetServiceContext(ServiceListModel service)
         {
-            Enum.TryParse<ServiceType>(service.ServiceType, true, out var type);
-            LogView.DataContext = new ServiceLogViewModel(type, service.Logs);
+            LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
             if (DataContext is TcpServiceMessagesViewModel vm)
                 vm.SetService(service);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Windows service host sets explicit `ServiceName` and `DisplayName` values with the application name and installer uses the same constant.
 - Replaced verbose `ServiceName` strings with `ServiceType` enum properties for log view models.
 - Service persistence now stores `ServiceType` as short codes and reads legacy string names.
+- Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -186,6 +186,7 @@ Latest Attempt: After updating VisualTreeHelperExtensions to traverse the logica
 Latest Attempt: After extending FindParent<T> to handle non-visual elements like `Run` without throwing and adding tests, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Latest Attempt: After ensuring the SCP DI test registers `IServiceRule`, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After registering edit handlers through DI, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After converting service creation to enum lookups, the `dotnet` command remains unavailable; restore, build, and tests will run in CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- Refactor service creation to rely on `ServiceType` enum rather than string identifiers
- Update factories, navigation handlers, and view models to create services via enum lookups
- Document environment constraint preventing local `dotnet` execution

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2af5ecc888326b10c0ca220a7510e