### PR TITLE
docs: document service types

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ no manual configuration is required.
 
 ## Services overview
 
+For details on each service enumeration, see [Service Types](docs/ServiceTypes.md).
+
 The UI exposes several built in service types. A brief description of each is shown below.
 
 - **HID** – configure HID devices, forward output to another service, set debounce and key down times, select USB protocol (2.0/3.0) and apply custom formatting.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -266,6 +266,7 @@
 ### Documentation & CI
 #### Added
 - Section on working in restricted environments and reminder to log limitations in collaboration docs.
+- Documented `ServiceType` enum values in `docs/ServiceTypes.md` and linked from README.
 - Documented architecture and coding standards in `AGENTS.md`.
 - `CONTRIBUTING.md` and PR template enforcing CI-only testing with a CI badge in the README.
 - `/test` comment workflow to run CI on demand.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -183,6 +183,7 @@ Latest Attempt: After replacing ColorCanvas with ColorPicker to resolve color pi
 Latest Attempt: After updating VisualTreeHelperExtensions to traverse the logical tree when an element is not a Visual, installed the .NET SDK 8.0.404 and ran `dotnet test --settings tests.runsettings`; core tests passed but DesktopApplicationTemplate.Tests aborted because the Microsoft.WindowsDesktop.App 8.0.0 runtime is missing, and `dotnet workload install wpf` reports the workload ID is not recognized on Linux.
 Latest Attempt: After extending FindParent<T> to handle non-visual elements like `Run` without throwing and adding tests, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Latest Attempt: After ensuring the SCP DI test registers `IServiceRule`, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Current Attempt: `dotnet` CLI is missing in the current container; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.

--- a/docs/ServiceTypes.md
+++ b/docs/ServiceTypes.md
@@ -1,0 +1,16 @@
+# Service Types
+
+The application uses the `ServiceType` enum to categorize built-in services. The table below lists each value and the service it represents.
+
+| Enum value | Service description |
+|------------|--------------------|
+| `Mqtt` | Publishes and subscribes to topics using the MQTT protocol. |
+| `Http` | Sends HTTP requests with configurable headers and body content. |
+| `Ftp` | Transfers files using the File Transfer Protocol. |
+| `Hid` | Handles Human Interface Devices and forwards input to other services. |
+| `Csv` | Generates CSV files from values produced by other services. |
+| `FileObserver` | Watches directories for new files and can trigger service actions. |
+| `Scp` | Moves files over SSH using the SCP protocol. |
+| `Tcp` | Hosts a TCP server for testing message processing scripts. |
+| `Heartbeat` | Emits periodic heartbeat messages for health monitoring. |
+


### PR DESCRIPTION
## Summary
- add ServiceTypes.md describing each ServiceType enum value
- link service type documentation from README
- note missing dotnet CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c212349320832691e3b33a50fcd670