### PR TITLE
refactor: use ServiceType enum for TCP navigation

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -111,7 +111,6 @@ namespace DesktopApplicationTemplate.Tests
                             Port = 42,
                             UseUdp = true,
                             Mode = TcpServiceMode.Sending,
-                            ServiceType = "TCP",
                             InputMessage = "in",
                             Script = "return message;",
                             OutputMessage = "out",
@@ -127,7 +126,6 @@ namespace DesktopApplicationTemplate.Tests
                 opt.Port = 100;
                 opt.UseUdp = false;
                 opt.Mode = TcpServiceMode.Listening;
-                opt.ServiceType = "changed";
                 opt.InputMessage = "changed";
                 opt.Script = "changed";
                 opt.OutputMessage = "changed";
@@ -144,7 +142,6 @@ namespace DesktopApplicationTemplate.Tests
                 Assert.Equal("return message;", info.TcpOptions.Script);
                 Assert.Equal("out", info.TcpOptions.OutputMessage);
                 Assert.Equal("last", info.TcpOptions.LastTestMessage);
-                Assert.Equal("TCP", info.TcpOptions.ServiceType);
 
                 // global options restored
                 var restored = host.Services.GetRequiredService<IOptions<TcpServiceOptions>>().Value;
@@ -156,7 +153,6 @@ namespace DesktopApplicationTemplate.Tests
                 Assert.Equal("return message;", restored.Script);
                 Assert.Equal("out", restored.OutputMessage);
                 Assert.Equal("last", restored.LastTestMessage);
-                Assert.Equal("TCP", restored.ServiceType);
             }
             finally
             {

--- a/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpCreateServiceViewModelTests.cs
@@ -15,7 +15,6 @@ public class TcpCreateServiceViewModelTests
         var vm = new TcpCreateServiceViewModel(rule)
         {
             ServiceName = "svc",
-            ServiceType = "Custom",
             Host = "host",
             Port = 1234,
             UseUdp = true,
@@ -33,7 +32,6 @@ public class TcpCreateServiceViewModelTests
         Assert.Equal(1234, received.Port);
         Assert.True(received.UseUdp);
         Assert.Equal(TcpServiceMode.ReceiveAndSend, received.Mode);
-        Assert.Equal("Custom", received.ServiceType);
     }
 
     [Fact]

--- a/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpEditServiceViewModelTests.cs
@@ -11,7 +11,7 @@ public class TcpEditServiceViewModelTests
     [Fact]
     public void SaveCommand_Raises_ServiceSaved()
     {
-        var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening, ServiceType = "Old" };
+        var options = new TcpServiceOptions { Host = "h", Port = 1, UseUdp = false, Mode = TcpServiceMode.Listening };
         IServiceRule rule = new ServiceRule();
         var vm = new TcpEditServiceViewModel(rule);
         vm.Load("svc", options);
@@ -19,7 +19,6 @@ public class TcpEditServiceViewModelTests
         vm.Port = 2;
         vm.UseUdp = true;
         vm.Mode = TcpServiceMode.Sending;
-        vm.ServiceType = "Custom";
         string? name = null;
         TcpServiceOptions? received = null;
         vm.ServiceSaved += (n, o) => { name = n; received = o; };
@@ -32,7 +31,6 @@ public class TcpEditServiceViewModelTests
         Assert.Equal(2, received.Port);
         Assert.True(received.UseUdp);
         Assert.Equal(TcpServiceMode.Sending, received.Mode);
-        Assert.Equal("Custom", received.ServiceType);
     }
 
 

--- a/DesktopApplicationTemplate.Tests/TcpServiceOptionsTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceOptionsTests.cs
@@ -18,7 +18,6 @@ public class TcpServiceOptionsTests
         Assert.Equal(0, options.Port);
         Assert.False(options.UseUdp);
         Assert.Equal(TcpServiceMode.Listening, options.Mode);
-        Assert.Equal(string.Empty, options.ServiceType);
         Assert.Equal(string.Empty, options.InputMessage);
         Assert.Equal(string.Empty, options.Script);
         Assert.Equal(string.Empty, options.OutputMessage);
@@ -34,7 +33,6 @@ public class TcpServiceOptionsTests
             ["TcpService:Port"] = "9000",
             ["TcpService:UseUdp"] = "true",
             ["TcpService:Mode"] = "Sending",
-            ["TcpService:ServiceType"] = "Custom",
             ["TcpService:InputMessage"] = "hi",
             ["TcpService:Script"] = "return message;",
             ["TcpService:OutputMessage"] = "hi",
@@ -56,7 +54,6 @@ public class TcpServiceOptionsTests
         Assert.Equal(9000, options.Port);
         Assert.True(options.UseUdp);
         Assert.Equal(TcpServiceMode.Sending, options.Mode);
-        Assert.Equal("Custom", options.ServiceType);
         Assert.Equal("hi", options.InputMessage);
         Assert.Equal("return message;", options.Script);
         Assert.Equal("hi", options.OutputMessage);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -35,7 +35,6 @@ namespace DesktopApplicationTemplate.Persistence
                         Port = s.TcpOptions.Port,
                         UseUdp = s.TcpOptions.UseUdp,
                         Mode = s.TcpOptions.Mode,
-                        ServiceType = s.TcpOptions.ServiceType,
                         InputMessage = s.TcpOptions.InputMessage,
                         Script = s.TcpOptions.Script,
                         OutputMessage = s.TcpOptions.OutputMessage,
@@ -160,7 +159,6 @@ namespace DesktopApplicationTemplate.Persistence
                             value.Port = info.TcpOptions.Port;
                             value.UseUdp = info.TcpOptions.UseUdp;
                             value.Mode = info.TcpOptions.Mode;
-                            value.ServiceType = info.TcpOptions.ServiceType;
                             value.InputMessage = info.TcpOptions.InputMessage;
                             value.Script = info.TcpOptions.Script;
                             value.OutputMessage = info.TcpOptions.OutputMessage;

--- a/DesktopApplicationTemplate.UI/Services/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.UI/Services/TcpServiceOptions.cs
@@ -38,11 +38,6 @@ namespace DesktopApplicationTemplate.UI.Services
         public TcpServiceMode Mode { get; set; } = TcpServiceMode.Listening;
 
         /// <summary>
-        /// Type label for the service.
-        /// </summary>
-        public string ServiceType { get; set; } = string.Empty;
-
-        /// <summary>
         /// Sample message used for testing script transformations.
         /// </summary>
         public string InputMessage { get; set; } = string.Empty;

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpCreateServiceViewModel.cs
@@ -13,7 +13,6 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private int _port;
     private bool _useUdp;
     private TcpServiceMode _mode;
-    private string _serviceType = "TCP";
 
     /// <summary>
     /// Current options.
@@ -87,24 +86,6 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
-    /// <summary>
-    /// Type label for the service.
-    /// </summary>
-    public string ServiceType
-    {
-        get => _serviceType;
-        set
-        {
-            _serviceType = value;
-            var error = Rule.ValidateRequired(value, "Service type");
-            if (error is not null)
-                AddError(nameof(ServiceType), error);
-            else
-                ClearErrors(nameof(ServiceType));
-            OnPropertyChanged();
-        }
-    }
-
     /// <inheritdoc />
     protected override void OnSave()
     {
@@ -118,7 +99,6 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         Options.Port = Port;
         Options.UseUdp = UseUdp;
         Options.Mode = Mode;
-        Options.ServiceType = ServiceType;
         Logger?.Log("TCP create options finished", LogLevel.Debug);
         RaiseServiceSaved(Options);
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpEditServiceViewModel.cs
@@ -14,7 +14,6 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     private int _port;
     private bool _useUdp;
     private TcpServiceMode _mode;
-    private string _serviceType = "TCP";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpEditServiceViewModel"/> class.
@@ -35,7 +34,6 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         Port = _options.Port;
         UseUdp = _options.UseUdp;
         Mode = _options.Mode;
-        ServiceType = _options.ServiceType;
     }
 
 
@@ -98,24 +96,6 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
-    /// <summary>
-    /// Type label for the service.
-    /// </summary>
-    public string ServiceType
-    {
-        get => _serviceType;
-        set
-        {
-            _serviceType = value;
-            var error = Rule.ValidateRequired(value, "Service type");
-            if (error is not null)
-                AddError(nameof(ServiceType), error);
-            else
-                ClearErrors(nameof(ServiceType));
-            OnPropertyChanged();
-        }
-    }
-
     /// <inheritdoc />
     protected override void OnSave()
     {
@@ -128,7 +108,6 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         _options.Port = Port;
         _options.UseUdp = UseUdp;
         _options.Mode = Mode;
-        _options.ServiceType = ServiceType;
         RaiseServiceSaved(_options);
     }
 

--- a/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpCreateServiceView.xaml
@@ -18,7 +18,6 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" /> <!-- Service Name -->
-                <RowDefinition Height="Auto" /> <!-- Service Type -->
                 <RowDefinition Height="Auto" /> <!-- Host -->
                 <RowDefinition Height="Auto" /> <!-- Port -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
@@ -42,24 +41,8 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Service Type" Style="{StaticResource FormLabel}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="1" Grid.Column="1">
-                <TextBox x:Name="ServiceTypeBox" Text="{Binding ServiceType, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
-                    <TextBox.Style>
-                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
-                            <Style.Triggers>
-                                <Trigger Property="Validation.HasError" Value="True">
-                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBox.Style>
-                </TextBox>
-                <TextBlock Text="TCP" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceTypeBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            </Grid>
-
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="2" Grid.Column="1">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -74,8 +57,8 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="3" Grid.Column="1">
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="2" Grid.Column="1">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -90,12 +73,12 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <CheckBox Grid.Row="3" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
+            <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"

--- a/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/TcpEditServiceView.xaml
@@ -18,7 +18,6 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" /> <!-- Service Name -->
-                <RowDefinition Height="Auto" /> <!-- Service Type -->
                 <RowDefinition Height="Auto" /> <!-- Host -->
                 <RowDefinition Height="Auto" /> <!-- Port -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
@@ -42,24 +41,8 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Service Type" Style="{StaticResource FormLabel}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
             <Grid Grid.Row="1" Grid.Column="1">
-                <TextBox x:Name="ServiceTypeBox" Text="{Binding ServiceType, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
-                    <TextBox.Style>
-                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
-                            <Style.Triggers>
-                                <Trigger Property="Validation.HasError" Value="True">
-                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBox.Style>
-                </TextBox>
-                <TextBlock Text="TCP" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceTypeBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-            </Grid>
-
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="2" Grid.Column="1">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -74,8 +57,8 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="3" Grid.Column="1">
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="2" Grid.Column="1">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -90,12 +73,12 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <CheckBox Grid.Row="3" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
+            <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveAutomationName="Save TCP Service"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Removed `MainView` KeyDown handler; pressing Escape no longer returns to the home page.
 - Removed unused `HomePage` view and `PackUriSchemeInitializer`.
 - TCP create and edit views inline UDP and mode options, removing the separate advanced configuration view.
+- TCP create and edit view models remove string-based service type fields, using `ServiceType` enum for navigation.
 - TCP service messages view removes script editors and adds a test message input bound to view model.
 - TCP scripting workflow consolidated into the messages view, enabling inline script editing and execution.
 - TCP options persist the last test message and preload it when reopening the service.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -543,6 +543,7 @@ Newest Attempt: Installed the .NET SDK 8.0.404 via script; `dotnet restore` and 
 Latest Attempt: After introducing service factories, the `dotnet` CLI is still missing; relying on CI for build and test.
 Latest Attempt: Installed .NET SDK 8.0.404; `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed with missing MainView in FtpServiceFactory. CI will verify.
 Current Attempt: After logging unrecognized service types in EditService, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally—relying on CI.
+Latest Attempt: After replacing TCP view model service type strings with enums, the `dotnet` CLI is still missing; build and tests deferred to CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- drop string ServiceType from TCP options and view models
- update TCP create/edit views and persistence to rely on ServiceType enum
- adjust tests and docs for enum-based navigation

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c1caf16483268b2c0ca19dd27eef