### PR TITLE
Parse ServiceType codes from configuration defaults

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -75,10 +75,36 @@ namespace DesktopApplicationTemplate.Service
             }
         }
 
+        private sealed class ServiceInfoConfig
+        {
+            public string DisplayName { get; set; } = string.Empty;
+            public string ServiceType { get; set; } = string.Empty;
+            public bool IsActive { get; set; }
+            public int Order { get; set; }
+        }
+
         private List<ServiceInfo> Load()
         {
             if (!File.Exists(_filePath))
-                return new List<ServiceInfo>();
+            {
+                var configs = _config.GetSection("Services").Get<List<ServiceInfoConfig>>() ?? new List<ServiceInfoConfig>();
+                var results = new List<ServiceInfo>();
+                foreach (var cfg in configs)
+                {
+                    if (ServiceTypeJsonConverter.TryParse(cfg.ServiceType, out var type))
+                    {
+                        results.Add(new ServiceInfo
+                        {
+                            DisplayName = cfg.DisplayName,
+                            ServiceType = type,
+                            IsActive = cfg.IsActive,
+                            Created = DateTime.Now,
+                            Order = cfg.Order
+                        });
+                    }
+                }
+                return results;
+            }
             try
             {
                 var json = File.ReadAllText(_filePath);

--- a/DesktopApplicationTemplate.Service/appsettings.Development.json
+++ b/DesktopApplicationTemplate.Service/appsettings.Development.json
@@ -5,6 +5,14 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "Services": [
+    {
+      "DisplayName": "Heartbeat",
+      "ServiceType": "HB",
+      "IsActive": true,
+      "Order": 0
+    }
+  ],
   "Heartbeat": {
     "Message": "PING",
     "IntervalSeconds": 30

--- a/DesktopApplicationTemplate.Service/appsettings.json
+++ b/DesktopApplicationTemplate.Service/appsettings.json
@@ -5,6 +5,14 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "Services": [
+    {
+      "DisplayName": "Heartbeat",
+      "ServiceType": "HB",
+      "IsActive": true,
+      "Order": 0
+    }
+  ],
   "Heartbeat": {
     "Message": "PING",
     "IntervalSeconds": 30

--- a/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
@@ -47,5 +47,32 @@ namespace DesktopApplicationTemplate.Tests
             }
             ConsoleTestLogger.LogPass();
         }
+
+        [Theory]
+        [InlineData("HB")]
+        [InlineData("Heartbeat")]
+        public void Sync_LoadsServicesFromConfiguration(string typeValue)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString());
+            var tempFile = Path.Combine(tempDir, "services.json");
+
+            var configValues = new Dictionary<string, string?>
+            {
+                {"Services:0:DisplayName", "Svc1"},
+                {"Services:0:ServiceType", typeValue},
+                {"Services:0:IsActive", "true"},
+                {"Services:0:Order", "0"},
+                {"Heartbeat:Message", "HB"},
+                {"Heartbeat:IntervalSeconds", "1"}
+            };
+            IConfiguration config = new ConfigurationBuilder()
+                .AddInMemoryCollection(configValues)
+                .Build();
+
+            using var manager = new ServiceManager(NullLogger<ServiceManager>.Instance, config, tempFile);
+            manager.Sync();
+            Assert.Contains("Svc1", manager.ActiveServices);
+            ConsoleTestLogger.LogPass();
+        }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Replaced verbose `ServiceName` strings with `ServiceType` enum properties for log view models.
 - Service persistence now stores `ServiceType` as short codes and reads legacy string names.
 - Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
+- `ServiceManager` loads default services from configuration using `ServiceType` short codes and accepts legacy names.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -187,6 +187,7 @@ Latest Attempt: After extending FindParent<T> to handle non-visual elements like
 Latest Attempt: After ensuring the SCP DI test registers `IServiceRule`, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After registering edit handlers through DI, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After converting service creation to enum lookups, the `dotnet` command remains unavailable; restore, build, and tests will run in CI.
+Latest Attempt: After adding ServiceType configuration binding for default services, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- Store ServiceType short codes in default appsettings for the service host
- Load default services from configuration, parsing both short codes and legacy names
- Add coverage for configuration-based service loading

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c481520c8326b82ee661a468ca10