### PR TITLE
feat: migrate legacy service type names

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -83,6 +83,15 @@ namespace DesktopApplicationTemplate.Service
             public int Order { get; set; }
         }
 
+        private sealed class ServiceInfoLegacy
+        {
+            public string DisplayName { get; set; } = string.Empty;
+            public string ServiceType { get; set; } = string.Empty;
+            public bool IsActive { get; set; }
+            public DateTime Created { get; set; }
+            public int Order { get; set; }
+        }
+
         private List<ServiceInfo> Load()
         {
             if (!File.Exists(_filePath))
@@ -102,13 +111,37 @@ namespace DesktopApplicationTemplate.Service
                             Order = cfg.Order
                         });
                     }
+                    else
+                    {
+                        _logger.LogWarning("Unmapped service type '{Type}' for '{Name}'", cfg.ServiceType, cfg.DisplayName);
+                    }
                 }
                 return results;
             }
             try
             {
                 var json = File.ReadAllText(_filePath);
-                return JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+                var legacy = JsonSerializer.Deserialize<List<ServiceInfoLegacy>>(json) ?? new List<ServiceInfoLegacy>();
+                var results = new List<ServiceInfo>();
+                foreach (var info in legacy)
+                {
+                    if (ServiceTypeJsonConverter.TryParse(info.ServiceType, out var type))
+                    {
+                        results.Add(new ServiceInfo
+                        {
+                            DisplayName = info.DisplayName,
+                            ServiceType = type,
+                            IsActive = info.IsActive,
+                            Created = info.Created,
+                            Order = info.Order
+                        });
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Unmapped service type '{Type}' for '{Name}'", info.ServiceType, info.DisplayName);
+                    }
+                }
+                return results;
             }
             catch
             {

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -313,6 +314,60 @@ namespace DesktopApplicationTemplate.Tests
             }
 
             ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void Load_ParsesLegacyServiceTypeNames()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            string oldPath = ServicePersistence.FilePath;
+            ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
+            try
+            {
+                File.WriteAllText(ServicePersistence.FilePath, "[{'DisplayName':'Svc','ServiceType':'FTP Server'}]".Replace(''','"'));
+                var logger = new ListLogger();
+                var loaded = ServicePersistence.Load(logger);
+                var info = Assert.Single(loaded);
+                Assert.Equal(ServiceType.Ftp, info.ServiceType);
+            }
+            finally
+            {
+                ServicePersistence.FilePath = oldPath;
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void Load_LogsUnmappedServiceTypes()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            string oldPath = ServicePersistence.FilePath;
+            ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
+            try
+            {
+                File.WriteAllText(ServicePersistence.FilePath, "[{'DisplayName':'Svc','ServiceType':'Unknown'}]".Replace(''','"'));
+                var logger = new ListLogger();
+                var loaded = ServicePersistence.Load(logger);
+                Assert.Empty(loaded);
+                Assert.Contains(logger.Messages, m => m.Contains("Unknown"));
+            }
+            finally
+            {
+                ServicePersistence.FilePath = oldPath;
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        private sealed class ListLogger : ILoggingService
+        {
+            public List<string> Messages { get; } = new();
+            public void Log(string message, LogLevel level = LogLevel.Information) => Messages.Add(message);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -145,7 +145,33 @@ namespace DesktopApplicationTemplate.Persistence
             }
             try
             {
-                var result = JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+                var legacy = JsonSerializer.Deserialize<List<LegacyServiceInfo>>(json) ?? new List<LegacyServiceInfo>();
+                var result = new List<ServiceInfo>();
+                foreach (var info in legacy)
+                {
+                    if (ServiceTypeJsonConverter.TryParse(info.ServiceType, out var type))
+                    {
+                        result.Add(new ServiceInfo
+                        {
+                            DisplayName = info.DisplayName,
+                            ServiceType = type,
+                            IsActive = info.IsActive,
+                            Created = info.Created,
+                            Order = info.Order,
+                            AssociatedServices = info.AssociatedServices ?? new List<string>(),
+                            TcpOptions = info.TcpOptions,
+                            FtpOptions = info.FtpOptions,
+                            HttpOptions = info.HttpOptions,
+                            CsvOptions = info.CsvOptions,
+                            TotalExecutionTimeMs = info.TotalExecutionTimeMs,
+                            ExecutionCount = info.ExecutionCount
+                        });
+                    }
+                    else
+                    {
+                        logger?.Log($"Unmapped service type '{info.ServiceType}' for '{info.DisplayName}'", LogLevel.Warning);
+                    }
+                }
 
                 foreach (var info in result)
                 {
@@ -202,6 +228,22 @@ namespace DesktopApplicationTemplate.Persistence
     {
         public string DisplayName { get; set; } = string.Empty;
         public ServiceType ServiceType { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime Created { get; set; }
+        public int Order { get; set; }
+        public List<string> AssociatedServices { get; set; } = new();
+        public TcpServiceOptions? TcpOptions { get; set; }
+        public FtpServerOptions? FtpOptions { get; set; }
+        public HttpServiceOptions? HttpOptions { get; set; }
+        public CsvServiceOptions? CsvOptions { get; set; }
+        public double TotalExecutionTimeMs { get; set; }
+        public int ExecutionCount { get; set; }
+    }
+
+    private class LegacyServiceInfo
+    {
+        public string DisplayName { get; set; } = string.Empty;
+        public string ServiceType { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
         public int Order { get; set; }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Service manager tracks task start times and writes statuses to `activeservices.txt` for running services.
 - Service factories convert options into initialized services and pages with a unified `AddServiceAsync` workflow.
 - `ServiceType` enum clarifies supported service categories.
+- Migration routine converts legacy service type names to `ServiceType` and logs unmapped values.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -188,6 +188,7 @@ Latest Attempt: After ensuring the SCP DI test registers `IServiceRule`, the `do
 Latest Attempt: After registering edit handlers through DI, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After converting service creation to enum lookups, the `dotnet` command remains unavailable; restore, build, and tests will run in CI.
 Latest Attempt: After adding ServiceType configuration binding for default services, the `dotnet` command remains unavailable; build and tests deferred to CI.
+Another Attempt: `dotnet` command still missing; restore, build, and test commands failed, relying on CI for verification.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- migrate persisted service entries with legacy service type strings and log unmapped names
- map service manager persistence to `ServiceType` and warn on unknown values
- document environment limitation with missing dotnet CLI

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c66168f88326b2531bd75bc02000