### PR TITLE
Add service creation test helper

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
@@ -23,8 +23,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 Services =
                 {
-                    new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http, IsActive = true, Order = 0 },
-                    new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = ServiceType.Tcp, IsActive = true, Order = 1 }
+                    TestHelpers.CreateService(ServiceType.Http, "HTTP1") { IsActive = true, Order = 0 },
+                    TestHelpers.CreateService(ServiceType.Tcp, "TCP1") { IsActive = true, Order = 1 }
                 },
                 Filters = { NameFilter = "HTTP" }
             };

--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -24,17 +24,13 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            vm.Services.Add(new ServiceListModel
+            vm.Services.Add(TestHelpers.CreateService(ServiceType.Http, "HTTP1")
             {
-                DisplayName = "HTTP - HTTP1",
-                ServiceType = ServiceType.Http,
                 IsActive = false,
                 Order = 0
             });
-            vm.Services.Add(new ServiceListModel
+            vm.Services.Add(TestHelpers.CreateService(ServiceType.Http, "HTTP3")
             {
-                DisplayName = "HTTP - HTTP3",
-                ServiceType = ServiceType.Http,
                 IsActive = false,
                 Order = 1
             });
@@ -60,7 +56,7 @@ namespace DesktopApplicationTemplate.Tests
             try
             {
                 var vm = new MainViewModel(csv, networkVm, network.Object, logger.Object, servicesPath);
-                var service = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
+                var service = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
                 vm.Services.Add(service);
                 vm.SelectedService = service;
 
@@ -87,7 +83,7 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
+            var svc = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
             svc.Logs.Add(new LogEntry { Message = "test" });
             vm.Services.Add(svc);
             vm.SelectedService = svc;
@@ -106,7 +102,7 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
+            var svc = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
             svc.Logs.Add(new LogEntry { Message = "first" });
             vm.Services.Add(svc);
             vm.SelectedService = svc;
@@ -156,7 +152,7 @@ namespace DesktopApplicationTemplate.Tests
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = new ServiceListModel { DisplayName = "MQTT - Test", ServiceType = ServiceType.Mqtt };
+            var svc = TestHelpers.CreateService(ServiceType.Mqtt, "Test");
             vm.Services.Add(svc);
 
             MqttEditConnectionViewModel? captured = null;
@@ -207,7 +203,7 @@ namespace DesktopApplicationTemplate.Tests
                     if (e.PropertyName == nameof(MainViewModel.ServicesCreated)) createdChanges++;
                     if (e.PropertyName == nameof(MainViewModel.CurrentActiveServices)) activeChanges++;
                 };
-                var svc = new ServiceListModel { DisplayName = "HTTP - HTTP1", ServiceType = ServiceType.Http };
+                var svc = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
                 svc.ActiveChanged += vm.OnServiceActiveChanged;
                 vm.AddServiceForTest(svc);
 

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -18,8 +18,8 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void AddLog_ReferenceUpdatesAssociatedServices()
         {
-            var a = new ServiceListModel { DisplayName = "Heartbeat - A", ServiceType = ServiceType.Heartbeat };
-            var b = new ServiceListModel { DisplayName = "TCP - B", ServiceType = ServiceType.Tcp };
+            var a = TestHelpers.CreateService(ServiceType.Heartbeat, "A");
+            var b = TestHelpers.CreateService(ServiceType.Tcp, "B");
             var services = new List<ServiceListModel> { a, b };
             ServiceListModel.ResolveService = (type, name) =>
                 services.Find(s => s.ServiceType == type && s.DisplayName.Split(" - ").Last() == name);
@@ -44,8 +44,8 @@ namespace DesktopApplicationTemplate.Tests
             var netVm = new NetworkConfigurationViewModel(net);
             var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
-            main.Services.Add(new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = ServiceType.Tcp });
-            main.Services.Add(new ServiceListModel { DisplayName = "TCP - TCP2", ServiceType = ServiceType.Tcp });
+            main.Services.Add(TestHelpers.CreateService(ServiceType.Tcp, "TCP1"));
+            main.Services.Add(TestHelpers.CreateService(ServiceType.Tcp, "TCP2"));
 
             var name = main.GenerateServiceName(ServiceType.Tcp);
             Assert.Equal("TCP3", name);
@@ -65,8 +65,8 @@ namespace DesktopApplicationTemplate.Tests
             var netVm = new NetworkConfigurationViewModel(net);
             var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
-            var svc1 = new ServiceListModel { DisplayName = "TCP - TCP1", ServiceType = ServiceType.Tcp };
-            var svc2 = new ServiceListModel { DisplayName = "TCP - TCP2", ServiceType = ServiceType.Tcp };
+            var svc1 = TestHelpers.CreateService(ServiceType.Tcp, "TCP1");
+            var svc2 = TestHelpers.CreateService(ServiceType.Tcp, "TCP2");
             main.Services.Add(svc1);
             main.Services.Add(svc2);
 

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -100,10 +100,8 @@ namespace DesktopApplicationTemplate.Tests
 
                 var services = new List<ServiceListModel>
                 {
-                    new ServiceListModel
+                    TestHelpers.CreateService(ServiceType.Tcp, "One")
                     {
-                        DisplayName="TCP - One",
-                        ServiceType=ServiceType.Tcp,
                         IsActive=false,
                         Order=0,
                         TcpOptions = new TcpServiceOptions
@@ -187,10 +185,8 @@ namespace DesktopApplicationTemplate.Tests
 
                 var services = new List<ServiceListModel>
                 {
-                    new ServiceListModel
+                    TestHelpers.CreateService(ServiceType.Ftp, "One")
                     {
-                        DisplayName = "FTP Server - One",
-                        ServiceType = ServiceType.Ftp,
                         IsActive = false,
                         Order = 0,
                         FtpOptions = new FtpServerOptions
@@ -262,10 +258,8 @@ namespace DesktopApplicationTemplate.Tests
 
                 var services = new List<ServiceListModel>
                 {
-                    new ServiceListModel
+                    TestHelpers.CreateService(ServiceType.Ftp, "One")
                     {
-                        DisplayName = "FTP - One",
-                        ServiceType = ServiceType.Ftp,
                         IsActive = false,
                         Order = 0,
                         FtpOptions = new FtpServerOptions

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -95,10 +95,8 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ServiceName_NoPriorMessage_UsesDefault()
     {
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions()
         };
         var routing = new MessageRoutingService();
@@ -113,10 +111,8 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ServiceName_NoPriorMessage_UsesRoutingMessage()
     {
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions()
         };
         var routing = new MessageRoutingService();
@@ -131,10 +127,8 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void ServiceName_WithPriorMessage_UsesStored()
     {
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions { LastTestMessage = "hello" }
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -147,10 +141,8 @@ public class TcpServiceMessagesViewModelTests
     public async Task SaveAsync_UpdatesLastTestMessage()
     {
         var options = new TcpServiceOptions();
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -166,10 +158,8 @@ public class TcpServiceMessagesViewModelTests
     public async Task SaveAsync_UpdatesScript()
     {
         var options = new TcpServiceOptions();
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -185,10 +175,8 @@ public class TcpServiceMessagesViewModelTests
     public async Task SaveAsync_ComputesOutputMessage()
     {
         var options = new TcpServiceOptions();
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -205,10 +193,8 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void SetService_LoadsScript()
     {
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions { Script = "return message;" }
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -221,10 +207,8 @@ public class TcpServiceMessagesViewModelTests
     [Fact]
     public void SetService_NoScript_UsesDefault()
     {
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = new TcpServiceOptions()
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -238,10 +222,8 @@ public class TcpServiceMessagesViewModelTests
     public async Task SaveAsync_DefaultScript_NoProtectionLevelErrors()
     {
         var options = new TcpServiceOptions();
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -259,10 +241,8 @@ public class TcpServiceMessagesViewModelTests
     public async Task SaveAsync_CustomScript_ReturnsTransformedMessage()
     {
         var options = new TcpServiceOptions();
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
@@ -323,10 +303,8 @@ public class TcpServiceMessagesViewModelTests
     public async Task OpenScriptEditor_RunCommand_PersistsOutputAndTestMessage()
     {
         var options = new TcpServiceOptions();
-        var service = new ServiceListModel
+        var service = TestHelpers.CreateService(ServiceType.Tcp, "svc")
         {
-            DisplayName = "TCP - svc",
-            ServiceType = ServiceType.Tcp,
             TcpOptions = options
         };
         var routing = new MessageRoutingService();

--- a/DesktopApplicationTemplate.Tests/TestHelpers.cs
+++ b/DesktopApplicationTemplate.Tests/TestHelpers.cs
@@ -1,0 +1,14 @@
+using DesktopApplicationTemplate.Core.Converters;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public static class TestHelpers
+{
+    public static ServiceListModel CreateService(ServiceType type, string name) => new ServiceListModel
+    {
+        ServiceType = type,
+        DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(type)} - {name}"
+    };
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -279,6 +279,7 @@
 - `CONTRIBUTING.md` and PR template enforcing CI-only testing with a CI badge in the README.
 - `/test` comment workflow to run CI on demand.
 - `TestCommon` library providing shared test helpers and fixtures referenced by all test projects.
+- `TestHelpers.CreateService` simplifies creating `ServiceListModel` instances in tests to reduce duplication.
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
 
 #### Changed

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -189,6 +189,7 @@ Latest Attempt: After registering edit handlers through DI, the `dotnet` command
 Latest Attempt: After converting service creation to enum lookups, the `dotnet` command remains unavailable; restore, build, and tests will run in CI.
 Latest Attempt: After adding ServiceType configuration binding for default services, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Another Attempt: `dotnet` command still missing; restore, build, and test commands failed, relying on CI for verification.
+Latest Attempt: After introducing a `TestHelpers.CreateService` method and refactoring tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add `TestHelpers.CreateService` to centralize service list creation for tests
- refactor tests to use helper and reduce duplication
- document helper in changelog and collaboration notes

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c7dab1948326afa522e391595a48