### PR TITLE
Refactor tests to theory with TCP inline data

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -41,8 +41,9 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public async Task RemoveServiceCommand_LogsLifecycle()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public async Task RemoveServiceCommand_LogsLifecycle(ServiceType type, string name)
         {
             var logger = new Mock<ILoggingService>();
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
@@ -56,7 +57,7 @@ namespace DesktopApplicationTemplate.Tests
             try
             {
                 var vm = new MainViewModel(csv, networkVm, network.Object, logger.Object, servicesPath);
-                var service = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
+                var service = TestHelpers.CreateService(type, name);
                 vm.Services.Add(service);
                 vm.SelectedService = service;
 
@@ -75,15 +76,16 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public void ClearLogs_RemovesEntries()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public void ClearLogs_RemovesEntries(ServiceType type, string name)
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
+            var svc = TestHelpers.CreateService(type, name);
             svc.Logs.Add(new LogEntry { Message = "test" });
             vm.Services.Add(svc);
             vm.SelectedService = svc;
@@ -94,15 +96,16 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public void ExportDisplayedLogs_WritesFile()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public void ExportDisplayedLogs_WritesFile(ServiceType type, string name)
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var vm = new MainViewModel(csv, networkVm, network.Object);
-            var svc = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
+            var svc = TestHelpers.CreateService(type, name);
             svc.Logs.Add(new LogEntry { Message = "first" });
             vm.Services.Add(svc);
             vm.SelectedService = svc;
@@ -116,8 +119,9 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public void RefreshLogs_RaisesPropertyChanged()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public void RefreshLogs_RaisesPropertyChanged(ServiceType type, string name)
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
@@ -126,6 +130,9 @@ namespace DesktopApplicationTemplate.Tests
             var vm = new MainViewModel(csv, networkVm, network.Object);
             bool raised = false;
             vm.PropertyChanged += (s, e) => { if (e.PropertyName == "DisplayLogs") raised = true; };
+            var svc = TestHelpers.CreateService(type, name);
+            vm.Services.Add(svc);
+            vm.SelectedService = svc;
 
             vm.RefreshLogs();
 
@@ -182,8 +189,9 @@ namespace DesktopApplicationTemplate.Tests
             }
         }
 
-        [Fact]
-        public async Task ServiceCounts_Update_OnAddRemoveActivation()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public async Task ServiceCounts_Update_OnAddRemoveActivation(ServiceType type, string name)
         {
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
@@ -203,7 +211,7 @@ namespace DesktopApplicationTemplate.Tests
                     if (e.PropertyName == nameof(MainViewModel.ServicesCreated)) createdChanges++;
                     if (e.PropertyName == nameof(MainViewModel.CurrentActiveServices)) activeChanges++;
                 };
-                var svc = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
+                var svc = TestHelpers.CreateService(type, name);
                 svc.ActiveChanged += vm.OnServiceActiveChanged;
                 vm.AddServiceForTest(svc);
 

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -33,8 +33,9 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public void GenerateServiceName_SkipsExistingNames()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public void GenerateServiceName_SkipsExistingNames(ServiceType type, string baseName)
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir);
@@ -44,18 +45,21 @@ namespace DesktopApplicationTemplate.Tests
             var netVm = new NetworkConfigurationViewModel(net);
             var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
-            main.Services.Add(TestHelpers.CreateService(ServiceType.Tcp, "TCP1"));
-            main.Services.Add(TestHelpers.CreateService(ServiceType.Tcp, "TCP2"));
+            main.Services.Add(TestHelpers.CreateService(type, baseName));
+            var secondName = baseName[..^1] + "2";
+            main.Services.Add(TestHelpers.CreateService(type, secondName));
 
-            var name = main.GenerateServiceName(ServiceType.Tcp);
-            Assert.Equal("TCP3", name);
+            var name = main.GenerateServiceName(type);
+            var expected = baseName[..^1] + "3";
+            Assert.Equal(expected, name);
 
             Directory.Delete(tempDir, true);
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public void RenameService_AppendsNumericSuffix_WhenNameExists()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public void RenameService_AppendsNumericSuffix_WhenNameExists(ServiceType type, string baseName)
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempDir);
@@ -65,19 +69,20 @@ namespace DesktopApplicationTemplate.Tests
             var netVm = new NetworkConfigurationViewModel(net);
             var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
-            var svc1 = TestHelpers.CreateService(ServiceType.Tcp, "TCP1");
-            var svc2 = TestHelpers.CreateService(ServiceType.Tcp, "TCP2");
+            var svc1 = TestHelpers.CreateService(type, baseName);
+            var svc2 = TestHelpers.CreateService(type, baseName[..^1] + "2");
             main.Services.Add(svc1);
             main.Services.Add(svc2);
 
-            var desired = "TCP1";
+            var desired = baseName;
             if (main.Services.Any(s => s != svc2 && s.DisplayName.Split(" - ").Last().Equals(desired, StringComparison.OrdinalIgnoreCase)))
             {
                 desired = main.GenerateServiceName(svc2.ServiceType);
             }
             svc2.DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(svc2.ServiceType)} - {desired}";
 
-            Assert.Equal("TCP - TCP3", svc2.DisplayName);
+            var expected = $"{ServiceTypeJsonConverter.ToLegacyString(type)} - {baseName[..^1] + "3"}";
+            Assert.Equal(expected, svc2.DisplayName);
 
             Directory.Delete(tempDir, true);
             ConsoleTestLogger.LogPass();

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -79,8 +79,9 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        [Fact]
-        public void SaveAndLoad_PreservesTcpOptions()
+        [Theory]
+        [InlineData(ServiceType.Tcp, "TCP1")]
+        public void SaveAndLoad_PreservesTcpOptions(ServiceType type, string name)
         {
             var host = Host.CreateDefaultBuilder()
                 .ConfigureServices(s => s.Configure<TcpServiceOptions>(_ => { }))
@@ -100,7 +101,7 @@ namespace DesktopApplicationTemplate.Tests
 
                 var services = new List<ServiceListModel>
                 {
-                    TestHelpers.CreateService(ServiceType.Tcp, "One")
+                    TestHelpers.CreateService(type, name)
                     {
                         IsActive=false,
                         Order=0,

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -547,6 +547,7 @@ Latest Attempt: After introducing service factories, the `dotnet` CLI is still m
 Latest Attempt: Installed .NET SDK 8.0.404; `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` and `dotnet test --settings tests.runsettings` failed with missing MainView in FtpServiceFactory. CI will verify.
 Current Attempt: After logging unrecognized service types in EditService, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally—relying on CI.
 Latest Attempt: After replacing TCP view model service type strings with enums, the `dotnet` CLI is still missing; build and tests deferred to CI.
+Latest Attempt: After converting several [Fact] tests to [Theory], `dotnet test --settings tests.runsettings` failed because the `dotnet` command is not found; relying on CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- parameterized several service-related tests to use `[Theory]` with TCP inline data
- documented local `dotnet` CLI absence in collaboration tips

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c950e860832680e386e7de5d321b