### PR TITLE
Use ServiceType enums in unit tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
@@ -1,4 +1,6 @@
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Converters;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -6,18 +8,18 @@ namespace DesktopApplicationTemplate.Tests
     public class CreateServiceViewModelTests
     {
         [Theory]
-        [InlineData("TCP")]
-        [InlineData("HTTP")]
-        [InlineData("CSV Creator")]
-        [InlineData("SCP")]
-        [InlineData("MQTT")]
-        [InlineData("FTP Server")]
-        public void GenerateDefaultName_ReturnsIncrementedName(string type)
+        [InlineData(ServiceType.Tcp)]
+        [InlineData(ServiceType.Http)]
+        [InlineData(ServiceType.Csv)]
+        [InlineData(ServiceType.Scp)]
+        [InlineData(ServiceType.Mqtt)]
+        [InlineData(ServiceType.Ftp)]
+        public void GenerateDefaultName_ReturnsIncrementedName(ServiceType type)
         {
-            var existing = new[] { $"{type}1" };
+            var existing = new[] { $"{ServiceTypeJsonConverter.ToLegacyString(type)}1" };
             var vm = new CreateServiceViewModel(existing);
             var name = vm.GenerateDefaultName(type);
-            Assert.Equal($"{type}2", name);
+            Assert.Equal($"{ServiceTypeJsonConverter.ToLegacyString(type)}2", name);
             ConsoleTestLogger.LogPass();
         }
     }

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -91,7 +91,7 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void RecordExecutionTime_ComputesAverageAndTracksLastExecution()
         {
-            var vm = new ServiceListModel();
+            var vm = new ServiceListModel { ServiceType = ServiceType.Tcp };
             vm.RecordExecutionTime(TimeSpan.FromMilliseconds(100));
             vm.RecordExecutionTime(TimeSpan.FromMilliseconds(50));
 
@@ -104,7 +104,7 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void RecordExecutionTime_Throws_When_Negative()
         {
-            var vm = new ServiceListModel();
+            var vm = new ServiceListModel { ServiceType = ServiceType.Tcp };
             Assert.Throws<ArgumentException>(() => vm.RecordExecutionTime(TimeSpan.FromMilliseconds(-1)));
             ConsoleTestLogger.LogPass();
         }
@@ -112,7 +112,7 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void AddLog_UpdatesLastInputMessage()
         {
-            var vm = new ServiceListModel();
+            var vm = new ServiceListModel { ServiceType = ServiceType.Tcp };
             vm.AddLog("hello world");
 
             Assert.Equal("hello world", vm.LastInputMessage);

--- a/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using Xunit;
 
@@ -32,14 +34,20 @@ namespace DesktopApplicationTemplate.Tests
 
                 using var manager = new ServiceManager(NullLogger<ServiceManager>.Instance, config, tempFile);
                 manager.Sync();
-                Assert.Contains("Svc1", manager.ActiveServices);
-                Assert.DoesNotContain("Svc2", manager.ActiveServices);
+
+                var runningField = typeof(ServiceManager).GetField("_running", BindingFlags.Instance | BindingFlags.NonPublic)!;
+                var running = (IDictionary<string, object>)runningField.GetValue(manager)!;
+                Assert.Contains(running.Values, r =>
+                    (ServiceType)r.GetType().GetProperty("ServiceType")!.GetValue(r)! == ServiceType.Heartbeat);
+                Assert.DoesNotContain(running.Values, r =>
+                    (ServiceType)r.GetType().GetProperty("ServiceType")!.GetValue(r)! == ServiceType.Tcp);
 
                 services[0].IsActive = false;
                 File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
                 manager.Sync();
 
-                Assert.Empty(manager.ActiveServices);
+                running = (IDictionary<string, object>)runningField.GetValue(manager)!;
+                Assert.Empty(running);
             }
             finally
             {
@@ -49,9 +57,9 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Theory]
-        [InlineData("HB")]
-        [InlineData("Heartbeat")]
-        public void Sync_LoadsServicesFromConfiguration(string typeValue)
+        [InlineData("HB", ServiceType.Heartbeat)]
+        [InlineData("Heartbeat", ServiceType.Heartbeat)]
+        public void Sync_LoadsServicesFromConfiguration(string typeValue, ServiceType expected)
         {
             var tempDir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString());
             var tempFile = Path.Combine(tempDir, "services.json");
@@ -71,7 +79,12 @@ namespace DesktopApplicationTemplate.Tests
 
             using var manager = new ServiceManager(NullLogger<ServiceManager>.Instance, config, tempFile);
             manager.Sync();
-            Assert.Contains("Svc1", manager.ActiveServices);
+
+            var load = typeof(ServiceManager).GetMethod("Load", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var infos = (List<ServiceInfo>)load.Invoke(manager, null)!;
+            var info = Assert.Single(infos);
+            Assert.Equal(expected, info.ServiceType);
+            Assert.True(info.IsActive);
             ConsoleTestLogger.LogPass();
         }
     }

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -190,6 +190,7 @@ Latest Attempt: After converting service creation to enum lookups, the `dotnet` 
 Latest Attempt: After adding ServiceType configuration binding for default services, the `dotnet` command remains unavailable; build and tests deferred to CI.
 Another Attempt: `dotnet` command still missing; restore, build, and test commands failed, relying on CI for verification.
 Latest Attempt: After introducing a `TestHelpers.CreateService` method and refactoring tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After updating tests to use `ServiceType` enums, the `dotnet` command is still missing; restore, build, and test steps could not run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- set ServiceType on standalone ServiceListModel instances
- drive CreateServiceViewModel tests with ServiceType enum values
- compare ServiceManager behavior using ServiceType enums instead of strings

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cb8d5ab08326b930891b956657da