### PR TITLE
Add edit service handler dispatch tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewEditServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewEditServiceTests.cs
@@ -1,0 +1,72 @@
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class MainViewEditServiceTests
+{
+    public static IEnumerable<object[]> ServiceTypes() =>
+        Enum.GetValues<ServiceType>().Select(t => new object[] { t });
+
+    [WindowsTheory]
+    [MemberData(nameof(ServiceTypes))]
+    public void EditService_InvokesCorrectHandler(ServiceType type)
+    {
+        // Arrange
+        var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
+        var mocks = Enum.GetValues<ServiceType>()
+            .ToDictionary(t => t, _ => new Mock<IEditServiceHandler>());
+        var dict = mocks.ToDictionary(k => k.Key, v => v.Value.Object);
+        typeof(MainView).GetField("_editHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, dict);
+
+        var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var service = TestHelpers.CreateService(type, "svc");
+
+        // Act
+        method.Invoke(view, new object[] { service });
+
+        // Assert
+        foreach (var kvp in mocks)
+        {
+            if (kvp.Key == type)
+            {
+                kvp.Value.Verify(h => h.Edit(service), Times.Once);
+            }
+            else
+            {
+                kvp.Value.Verify(h => h.Edit(It.IsAny<ServiceListModel>()), Times.Never);
+            }
+        }
+    }
+
+    [WindowsFact]
+    public void EditService_UnknownType_NoHandlerCalled()
+    {
+        // Arrange
+        var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
+        var mocks = Enum.GetValues<ServiceType>()
+            .ToDictionary(t => t, _ => new Mock<IEditServiceHandler>());
+        var dict = mocks.ToDictionary(k => k.Key, v => v.Value.Object);
+        typeof(MainView).GetField("_editHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, dict);
+        var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var service = new ServiceListModel { ServiceType = (ServiceType)999, DisplayName = "Unknown" };
+
+        // Act
+        method.Invoke(view, new object[] { service });
+
+        // Assert
+        foreach (var kvp in mocks.Values)
+        {
+            kvp.Verify(h => h.Edit(It.IsAny<ServiceListModel>()), Times.Never);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -53,21 +53,21 @@ namespace DesktopApplicationTemplate.UI
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Mqtt, sp => service => sp.GetRequiredService<MainView>().EditMqtt(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Heartbeat, sp => service => sp.GetRequiredService<MainView>().EditHeartbeat(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Hid, sp => service => sp.GetRequiredService<MainView>().EditHid(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Csv, sp => service => sp.GetRequiredService<MainView>().EditCsv(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.FileObserver, sp => service => sp.GetRequiredService<MainView>().EditFileObserver(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Scp, sp => service => sp.GetRequiredService<MainView>().EditScp(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Tcp, sp => service => sp.GetRequiredService<MainView>().EditTcp(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Http, sp => service => sp.GetRequiredService<MainView>().EditHttp(service));
-            services.AddKeyedSingleton<Action<ServiceListModel>>(ServiceType.Ftp, sp => service => sp.GetRequiredService<MainView>().EditFtp(service));
-            services.AddSingleton<IDictionary<ServiceType, Action<ServiceListModel>>>(sp =>
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditMqtt(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHeartbeat(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHid(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Csv, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditCsv(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.FileObserver, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditFileObserver(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Scp, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditScp(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Tcp, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditTcp(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Http, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHttp(service)));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Ftp, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditFtp(service)));
+            services.AddSingleton<IDictionary<ServiceType, IEditServiceHandler>>(sp =>
             {
-                var handlers = new Dictionary<ServiceType, Action<ServiceListModel>>();
+                var handlers = new Dictionary<ServiceType, IEditServiceHandler>();
                 foreach (ServiceType type in Enum.GetValues<ServiceType>())
                 {
-                    var handler = sp.GetKeyedService<Action<ServiceListModel>>(type);
+                    var handler = sp.GetKeyedService<IEditServiceHandler>(type);
                     if (handler != null)
                     {
                         handlers[type] = handler;

--- a/DesktopApplicationTemplate.UI/Services/DelegateEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/Services/DelegateEditServiceHandler.cs
@@ -1,0 +1,20 @@
+using System;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI;
+
+/// <summary>
+/// Adapter that invokes an <see cref="Action{T}"/> when editing a service.
+/// </summary>
+public class DelegateEditServiceHandler : IEditServiceHandler
+{
+    private readonly Action<ServiceListModel> _action;
+
+    public DelegateEditServiceHandler(Action<ServiceListModel> action)
+    {
+        _action = action;
+    }
+
+    /// <inheritdoc />
+    public void Edit(ServiceListModel service) => _action(service);
+}

--- a/DesktopApplicationTemplate.UI/Services/IEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/Services/IEditServiceHandler.cs
@@ -1,0 +1,15 @@
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI;
+
+/// <summary>
+/// Handles edit requests for a specific service type.
+/// </summary>
+public interface IEditServiceHandler
+{
+    /// <summary>
+    /// Executes the edit workflow for the specified service.
+    /// </summary>
+    /// <param name="service">Service to edit.</param>
+    void Edit(ServiceListModel service);
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -32,9 +32,9 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         private readonly MainViewModel _viewModel;
         private readonly ILogger<MainView>? _logger;
-        private readonly IDictionary<ServiceType, Action<ServiceListModel>> _editHandlers;
+        private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
 
-        public MainView(MainViewModel viewModel, IDictionary<ServiceType, Action<ServiceListModel>> editHandlers)
+        public MainView(MainViewModel viewModel, IDictionary<ServiceType, IEditServiceHandler> editHandlers)
         {
             InitializeComponent();
             _viewModel = viewModel;
@@ -260,7 +260,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         if (_editHandlers.TryGetValue(service.ServiceType, out var handler))
         {
-            handler(service);
+            handler.Edit(service);
             return;
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Service list displays the last execution duration and most recent input message beneath each service name.
 - Application registers global exception handlers that log errors, release input hooks, and shut down gracefully.
 - Unit test ensures `VisualTreeHelperExtensions.FindParent` locates the containing `TextBlock` for inline elements.
+- Tests confirm the main window delegates edit requests to service-type handlers.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -549,6 +549,7 @@ Latest Attempt: Installed .NET SDK 8.0.404; `dotnet restore` succeeded but `dotn
 Current Attempt: After logging unrecognized service types in EditService, the `dotnet` CLI remains unavailable; restore, build, and tests could not run locally—relying on CI.
 Latest Attempt: After replacing TCP view model service type strings with enums, the `dotnet` CLI is still missing; build and tests deferred to CI.
 Latest Attempt: After converting several [Fact] tests to [Theory], `dotnet test --settings tests.runsettings` failed because the `dotnet` command is not found; relying on CI.
+Latest Attempt: After adding edit service handler tests, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- introduce `IEditServiceHandler` and delegate adapter for service edit workflows
- wire main window to keyed handler dictionary and update DI registrations
- add tests confirming correct handler selection and unknown type behavior

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cd0f703c83268652443030a7e19c