### PR TITLE
feat: add automatic service module registration

### DIFF
--- a/DesktopApplicationTemplate.Core/Modules/IServiceModule.cs
+++ b/DesktopApplicationTemplate.Core/Modules/IServiceModule.cs
@@ -1,0 +1,21 @@
+using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Defines a module that can register services with the dependency injection container.
+/// </summary>
+public interface IServiceModule
+{
+    /// <summary>
+    /// Gets the service type represented by this module.
+    /// </summary>
+    ServiceType Type { get; }
+
+    /// <summary>
+    /// Registers services with the provided service collection.
+    /// </summary>
+    /// <param name="services">The service collection to register with.</param>
+    void RegisterServices(IServiceCollection services);
+}

--- a/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Extension methods for registering <see cref="IServiceModule"/> implementations.
+/// </summary>
+public static class ServiceModuleExtensions
+{
+    /// <summary>
+    /// Scans the provided assemblies for <see cref="IServiceModule"/> implementations and
+    /// invokes their registration methods.
+    /// </summary>
+    /// <param name="services">The service collection to populate.</param>
+    /// <param name="assemblies">Assemblies to scan. If none are provided, the current app domain assemblies are used.</param>
+    public static void AddServiceModules(this IServiceCollection services, params Assembly[] assemblies)
+    {
+        assemblies ??= Array.Empty<Assembly>();
+        if (assemblies.Length == 0)
+        {
+            assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        }
+
+        var moduleType = typeof(IServiceModule);
+        var modules = assemblies
+            .SelectMany(a => a.GetTypes())
+            .Where(t => moduleType.IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
+            .Select(t => Activator.CreateInstance(t) as IServiceModule)
+            .Where(m => m is not null);
+
+        foreach (var module in modules!)
+        {
+            module.RegisterServices(services);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using System.Linq;
 using System;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Service.Services;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
@@ -32,6 +33,7 @@ namespace DesktopApplicationTemplate.Service
 
             return builder.ConfigureServices((hostContext, services) =>
             {
+                services.AddServiceModules();
                 services.AddHostedService<Worker>(); // register the background service
                 services.AddSingleton<IServiceRule, ServiceRule>();
                 services.AddTransient(typeof(IServiceScreen<>), typeof(ServiceScreen<>));

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -1,5 +1,6 @@
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Core.Models;
@@ -53,6 +54,7 @@ namespace DesktopApplicationTemplate.UI
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
+            services.AddServiceModules();
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditMqtt(service)));
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHeartbeat(service)));
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHid(service)));

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Service factories convert options into initialized services and pages with a unified `AddServiceAsync` workflow.
 - `ServiceType` enum clarifies supported service categories.
 - Migration routine converts legacy service type names to `ServiceType` and logs unmapped values.
+- `IServiceModule` interface enables service-specific DI registration and modules are discovered and registered automatically at startup.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -191,6 +191,7 @@ Latest Attempt: After adding ServiceType configuration binding for default servi
 Another Attempt: `dotnet` command still missing; restore, build, and test commands failed, relying on CI for verification.
 Latest Attempt: After introducing a `TestHelpers.CreateService` method and refactoring tests, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After updating tests to use `ServiceType` enums, the `dotnet` command is still missing; restore, build, and test steps could not run locally and CI will verify.
+Latest Attempt: After wiring automatic service module registration, the `dotnet` command remains unavailable; restore, build, and tests could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add `IServiceModule` interface for per-service DI configuration
- scan assemblies on startup to register discovered service modules
- document service module system

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cfb68a448326be55be7ac5d8b6bf