### PR TITLE
docs: add custom service guide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -284,6 +284,7 @@
 - `TestCommon` library providing shared test helpers and fixtures referenced by all test projects.
 - `TestHelpers.CreateService` simplifies creating `ServiceListModel` instances in tests to reduce duplication.
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
+- Guide on creating custom services and registering dependencies via `IServiceModule`.
 
 #### Changed
 - Consolidated GitHub Actions into a single `CI` workflow with collaboration instructions in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -578,3 +578,12 @@ Effective Prompts / Instructions that worked: User request to simplify log model
 Decisions & Rationale: Use ServiceType enum to streamline log view configuration.
 Action Items: Rely on CI for validation.
 Related Commits/PRs:
+[2025-10-05 10:00] Topic: Custom service guide
+Context: Added documentation detailing component reuse and IServiceModule for new services.
+Observations: Created docs/CustomServiceGuide.md with steps for adding a service type and registering dependencies.
+Codex Limitations noticed: dotnet CLI not installed; restore, build, and test commands could not run locally. PowerShell unavailable so entry appended manually.
+Effective Prompts / Instructions that worked: User request for guidance on extending services.
+Decisions & Rationale: Provide a reference to help contributors reuse existing components.
+Action Items: Rely on CI for validation.
+Related Commits/PRs:
+

--- a/docs/CustomServiceGuide.md
+++ b/docs/CustomServiceGuide.md
@@ -1,0 +1,40 @@
+# Custom Service Guide
+
+This guide explains how to extend the application with new services by reusing existing components and `IServiceModule`.
+
+## Reuse shared components
+
+- **ServiceRule**: central validation helper injected into create and edit view models for required field checks.
+- **ServiceScreen**: wraps user interactions for options models and exposes events that views can bind to.
+- **Base view models**: inherit from `ServiceCreateViewModelBase` and `ServiceEditViewModelBase` to get common save logic, logging, and navigation.
+- **Shared controls**: components such as `ServiceLogView` and `ServiceMessageTableView` provide consistent UI panels that can be embedded in new service pages.
+
+## Register dependencies with `IServiceModule`
+
+`IServiceModule` allows each service to package its DI registrations. Implement the interface for your service and expose the corresponding `ServiceType`:
+
+```csharp
+public class SampleServiceModule : IServiceModule
+{
+    public ServiceType Type => ServiceType.Sample;
+
+    public void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<SampleService>();
+        services.AddTransient<SampleCreateViewModel>();
+        services.AddTransient<SampleEditViewModel>();
+        services.AddTransient<SamplePage>();
+    }
+}
+```
+
+Modules are discovered at startup by calling `services.AddServiceModules()` during host configuration.
+
+## Adding a new service type
+
+1. **Update the enum** – add a value to `ServiceType` to identify the service.
+2. **Create options and implementation** – define an options class and the runtime service that executes the work.
+3. **Build the UI** – create view models and views, reusing `ServiceRule`, `ServiceScreen`, and base classes for common behavior.
+4. **Implement an `IServiceModule`** – register the service, view models, and views with the DI container.
+5. **Wire up navigation** – add create and edit handlers or factory entries so the main window can navigate to the new views.
+6. **Test and document** – run `dotnet` commands and update docs as needed.


### PR DESCRIPTION
## Summary
- add guide for reusing components and IServiceModule when building custom services
- document environment constraints in collaboration tips
- note new guide in changelog

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d347c8388326aa08d0f897b8cd0c