### PR TITLE
Add test-only composite service demonstrating component reuse

### DIFF
--- a/DesktopApplicationTemplate.Tests/ComposedTestServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ComposedTestServiceTests.cs
@@ -1,0 +1,49 @@
+using DesktopApplicationTemplate.Services.Common;
+using DesktopApplicationTemplate.Tests.Services;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class ComposedTestServiceTests
+{
+    [Fact]
+    public void Save_ValidInput_RaisesServiceSaved()
+    {
+        var rule = new ServiceRule();
+        var screen = new ServiceScreen<TestServiceOptions>();
+        string? capturedName = null;
+        TestServiceOptions? capturedOptions = null;
+        screen.ServiceSaved += (name, options) =>
+        {
+            capturedName = name;
+            capturedOptions = options;
+        };
+
+        var service = new ComposedTestService(rule, screen);
+        var options = new TestServiceOptions(1234);
+
+        var result = service.Save("Test", options);
+
+        Assert.True(result);
+        Assert.Null(service.LastError);
+        Assert.Equal("Test", capturedName);
+        Assert.Equal(options, capturedOptions);
+    }
+
+    [Fact]
+    public void Save_InvalidName_ReturnsFalseAndDoesNotRaiseEvent()
+    {
+        var rule = new ServiceRule();
+        var screen = new ServiceScreen<TestServiceOptions>();
+        var service = new ComposedTestService(rule, screen);
+        bool raised = false;
+        screen.ServiceSaved += (_, _) => raised = true;
+
+        var result = service.Save(string.Empty, new TestServiceOptions(10));
+
+        Assert.False(result);
+        Assert.NotNull(service.LastError);
+        Assert.False(raised);
+    }
+}
+

--- a/DesktopApplicationTemplate.Tests/Services/ComposedTestService.cs
+++ b/DesktopApplicationTemplate.Tests/Services/ComposedTestService.cs
@@ -1,0 +1,52 @@
+using System;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.Tests.Services;
+
+/// <summary>
+/// Demonstrates composing existing validation and screen services.
+/// </summary>
+public class ComposedTestService
+{
+    private readonly IServiceRule _rule;
+    private readonly IServiceScreen<TestServiceOptions> _screen;
+
+    /// <summary>
+    /// Gets the last validation error, if any.
+    /// </summary>
+    public string? LastError { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposedTestService"/> class.
+    /// </summary>
+    public ComposedTestService(IServiceRule rule, IServiceScreen<TestServiceOptions> screen)
+    {
+        _rule = rule ?? throw new ArgumentNullException(nameof(rule));
+        _screen = screen ?? throw new ArgumentNullException(nameof(screen));
+    }
+
+    /// <summary>
+    /// Validates and saves the provided options via the composed screen service.
+    /// </summary>
+    /// <param name="name">Service name to validate.</param>
+    /// <param name="options">Options to save.</param>
+    /// <returns><c>true</c> when valid; otherwise, <c>false</c>.</returns>
+    public bool Save(string? name, TestServiceOptions options)
+    {
+        LastError = _rule.ValidateRequired(name, "Name") ?? _rule.ValidatePort(options.Port);
+        if (LastError != null)
+        {
+            return false;
+        }
+
+        _screen.Save(name!, options);
+        return true;
+    }
+}
+
+/// <summary>
+/// Options consumed by <see cref="ComposedTestService"/>.
+/// </summary>
+/// <param name="Port">Port to validate.</param>
+public record TestServiceOptions(int Port);
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -283,6 +283,7 @@
 - `/test` comment workflow to run CI on demand.
 - `TestCommon` library providing shared test helpers and fixtures referenced by all test projects.
 - `TestHelpers.CreateService` simplifies creating `ServiceListModel` instances in tests to reduce duplication.
+- Test-only composite service demonstrates reuse of `ServiceRule` and `ServiceScreen` in unit tests.
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
 - Guide on creating custom services and registering dependencies via `IServiceModule`.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -193,6 +193,7 @@ Latest Attempt: After introducing a `TestHelpers.CreateService` method and refac
 Latest Attempt: After updating tests to use `ServiceType` enums, the `dotnet` command is still missing; restore, build, and test steps could not run locally and CI will verify.
 Latest Attempt: After wiring automatic service module registration, the `dotnet` command remains unavailable; restore, build, and tests could not run locally, so CI will verify.
 Latest Attempt: After relocating common service logic to a shared library, installed the .NET SDK 8.0.404 and attempted `dotnet workload install wpf` which reported the workload ID not recognized. `dotnet build DesktopApplicationTemplate.sln` failed with WPF-related type errors, and `dotnet test --settings tests.runsettings --no-build` executed only core tests while Windows-specific tests reported invalid arguments; relying on CI.
+Latest Attempt: After adding a test-only composite service, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add `ComposedTestService` to demonstrate DI composition using `ServiceRule` and `ServiceScreen`
- cover composite service behavior with new unit tests
- document the new test service and note CLI limitations

## Testing
- `dotnet restore` *(fails: command not found: dotnet)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found: dotnet)*
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d44fecac8326956c34ad0ffc652a