### PR TITLE
test: compare composed service with original

### DIFF
--- a/DesktopApplicationTemplate.Tests/ComposedServiceComparisonTests.cs
+++ b/DesktopApplicationTemplate.Tests/ComposedServiceComparisonTests.cs
@@ -1,0 +1,68 @@
+using DesktopApplicationTemplate.Services.Common;
+using DesktopApplicationTemplate.Tests.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class ComposedServiceComparisonTests
+{
+    [Fact]
+    public void Save_ValidInput_MatchesOriginalService()
+    {
+        var originalLogger = new TestLogger();
+        var original = new OriginalTestService(originalLogger);
+        string? originalName = null;
+        TestServiceOptions? originalOptions = null;
+        original.ServiceSaved += (n, o) => { originalName = n; originalOptions = o; };
+
+        var sampleLogger = new TestLogger();
+        var screen = new ServiceScreen<TestServiceOptions>(sampleLogger);
+        string? sampleName = null;
+        TestServiceOptions? sampleOptions = null;
+        screen.ServiceSaved += (n, o) => { sampleName = n; sampleOptions = o; };
+        var sample = new ComposedTestService(new ServiceRule(), screen);
+
+        var options = new TestServiceOptions(1234);
+
+        var originalResult = original.Save("Test", options);
+        var sampleResult = sample.Save("Test", options);
+
+        Assert.True(originalResult);
+        Assert.True(sampleResult);
+        Assert.Null(original.LastError);
+        Assert.Null(sample.LastError);
+        Assert.Equal(originalName, sampleName);
+        Assert.Equal(originalOptions, sampleOptions);
+        originalLogger.Entries.Should().Equal(sampleLogger.Entries);
+    }
+
+    [Fact]
+    public void Save_InvalidPort_MatchesOriginalService()
+    {
+        var originalLogger = new TestLogger();
+        var original = new OriginalTestService(originalLogger);
+        bool originalRaised = false;
+        original.ServiceSaved += (_, _) => originalRaised = true;
+
+        var sampleLogger = new TestLogger();
+        var screen = new ServiceScreen<TestServiceOptions>(sampleLogger);
+        bool sampleRaised = false;
+        screen.ServiceSaved += (_, _) => sampleRaised = true;
+        var sample = new ComposedTestService(new ServiceRule(), screen);
+
+        var options = new TestServiceOptions(70000);
+
+        var originalResult = original.Save("Test", options);
+        var sampleResult = sample.Save("Test", options);
+
+        Assert.False(originalResult);
+        Assert.False(sampleResult);
+        Assert.Equal(original.LastError, sample.LastError);
+        Assert.False(originalRaised);
+        Assert.False(sampleRaised);
+        originalLogger.Entries.Should().BeEmpty();
+        sampleLogger.Entries.Should().BeEmpty();
+    }
+}
+

--- a/DesktopApplicationTemplate.Tests/Services/OriginalTestService.cs
+++ b/DesktopApplicationTemplate.Tests/Services/OriginalTestService.cs
@@ -1,0 +1,52 @@
+using System;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.Tests.Services;
+
+/// <summary>
+/// Baseline service used to compare behaviors with <see cref="ComposedTestService"/>.
+/// </summary>
+public class OriginalTestService
+{
+    private readonly ILoggingService _logger;
+
+    /// <summary>
+    /// Gets the last validation error, if any.
+    /// </summary>
+    public string? LastError { get; private set; }
+
+    /// <summary>
+    /// Raised when the service successfully saves options.
+    /// </summary>
+    public event Action<string, TestServiceOptions>? ServiceSaved;
+
+    public OriginalTestService(ILoggingService logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Validates the name and options, logging around save when valid.
+    /// </summary>
+    public bool Save(string? name, TestServiceOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            LastError = "Name is required";
+            return false;
+        }
+
+        if (options.Port < 1 || options.Port > 65535)
+        {
+            LastError = "Port must be between 1 and 65535";
+            return false;
+        }
+
+        _logger.Log($"Saving service {name}", LogLevel.Debug);
+        ServiceSaved?.Invoke(name!, options);
+        _logger.Log($"Saved service {name}", LogLevel.Debug);
+        LastError = null;
+        return true;
+    }
+}
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -284,6 +284,7 @@
 - `TestCommon` library providing shared test helpers and fixtures referenced by all test projects.
 - `TestHelpers.CreateService` simplifies creating `ServiceListModel` instances in tests to reduce duplication.
 - Test-only composite service demonstrates reuse of `ServiceRule` and `ServiceScreen` in unit tests.
+- Comparison tests ensure composed sample service matches original implementation results and log formatting.
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
 - Guide on creating custom services and registering dependencies via `IServiceModule`.
 

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -194,6 +194,7 @@ Latest Attempt: After updating tests to use `ServiceType` enums, the `dotnet` co
 Latest Attempt: After wiring automatic service module registration, the `dotnet` command remains unavailable; restore, build, and tests could not run locally, so CI will verify.
 Latest Attempt: After relocating common service logic to a shared library, installed the .NET SDK 8.0.404 and attempted `dotnet workload install wpf` which reported the workload ID not recognized. `dotnet build DesktopApplicationTemplate.sln` failed with WPF-related type errors, and `dotnet test --settings tests.runsettings --no-build` executed only core tests while Windows-specific tests reported invalid arguments; relying on CI.
 Latest Attempt: After adding a test-only composite service, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
+Latest Attempt: After adding service comparison tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add `OriginalTestService` baseline for comparison
- test composed service matches original behavior and logging
- document test constraints in collaboration log

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d457b770832689d610c29f461207