### PR TITLE
docs: log Linux test limitation and missing PowerShell

### DIFF
--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -195,6 +195,7 @@ Latest Attempt: After wiring automatic service module registration, the `dotnet`
 Latest Attempt: After relocating common service logic to a shared library, installed the .NET SDK 8.0.404 and attempted `dotnet workload install wpf` which reported the workload ID not recognized. `dotnet build DesktopApplicationTemplate.sln` failed with WPF-related type errors, and `dotnet test --settings tests.runsettings --no-build` executed only core tests while Windows-specific tests reported invalid arguments; relying on CI.
 Latest Attempt: After adding a test-only composite service, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After adding service comparison tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
+Latest Attempt: Running in a Linux container, `dotnet` commands are unavailable and `pwsh` is missing for `tools/add-tip.ps1`; tests cannot launch and CI must verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- document that dotnet CLI and PowerShell are unavailable in the Linux container, preventing test execution

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d73845848326b8b186c4d1bc6a19