### PR TITLE
Document ServiceType and DI modules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,37 @@ The UI exposes several built in service types. A brief description of each is sh
 
 Each service has an editor page where the parameters and test messages can be modified.  A **Help** button is available on these pages to display common ASCII commands (ACK, NAK, ENQ, ETX) which can be inserted when building protocol messages.
 
+## Extending the application
+
+`ServiceType` is an enum that identifies each supported service category. It is serialized using short codes and still recognizes legacy names so existing configurations continue to load.
+
+Dictionary-based edit handlers are registered for each `ServiceType` and injected into the main window as a lookup. When a user edits a service, the window resolves the handler from that dictionary instead of relying on large switch statements, making it easy to plug in new handlers.
+
+Dynamic DI modules are enabled by `services.AddServiceModules()`, which scans assemblies for `IServiceModule` implementations and calls their `RegisterServices` methods. Dropping a new module into the application automatically registers its services without manual wiring.
+
+### Adding a new service example
+
+1. Add a value to the `ServiceType` enum.
+2. Implement the service and its UI components.
+3. Create an `IServiceModule` for DI registration:
+
+   ```csharp
+   public class SampleServiceModule : IServiceModule
+   {
+       public ServiceType Type => ServiceType.Sample;
+
+       public void RegisterServices(IServiceCollection services)
+       {
+           services.AddSingleton<SampleService>();
+           services.AddTransient<SampleCreateViewModel>();
+           services.AddTransient<SampleEditViewModel>();
+           services.AddTransient<SamplePage>();
+       }
+   }
+   ```
+
+4. Wire up navigation and edit handlers for the new `ServiceType` and document any changes.
+
 ## Testing services locally
 
 After building the solution, run the UI project and navigate to the desired service page. Most services expose a test action (for example, "Send" on the HTTP page or "Test Script" on the TCP page) that can be executed locally. Logs for each service are displayed next to the editor fields.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -287,6 +287,7 @@
 - Comparison tests ensure composed sample service matches original implementation results and log formatting.
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
 - Guide on creating custom services and registering dependencies via `IServiceModule`.
+- README now explains `ServiceType`, dictionary-based edit handlers, and dynamic DI modules with a sample for adding a new service.
 
 #### Changed
 - Consolidated GitHub Actions into a single `CI` workflow with collaboration instructions in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -196,6 +196,7 @@ Latest Attempt: After relocating common service logic to a shared library, insta
 Latest Attempt: After adding a test-only composite service, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After adding service comparison tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: Running in a Linux container, `dotnet` commands are unavailable and `pwsh` is missing for `tools/add-tip.ps1`; tests cannot launch and CI must verify.
+Latest Attempt: After documenting `ServiceType` and DI module patterns in the README, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- explain ServiceType enum, dictionary-based edit handlers, and auto-discovered DI modules in the README
- note the new service workflow with an IServiceModule example
- log missing dotnet CLI in collaboration tips and document change in changelog

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d8aa74d08326bb42df452b821747