### PR TITLE
Document service module discovery in DI configuration

### DIFF
--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -34,7 +34,7 @@ namespace DesktopApplicationTemplate.Service
 
             return builder.ConfigureServices((hostContext, services) =>
             {
-                services.AddServiceModules();
+                services.AddServiceModules(); // Discovers IServiceModule implementations in loaded assemblies
                 services.AddHostedService<Worker>(); // register the background service
                 services.AddCommonServices();
                 services.AddFtpServer(builder => builder

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -55,7 +55,7 @@ namespace DesktopApplicationTemplate.UI
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddServiceModules();
+            services.AddServiceModules(); // Scans loaded assemblies for IServiceModule implementations and lets them register services
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditMqtt(service)));
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHeartbeat(service)));
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditHid(service)));
@@ -67,6 +67,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Ftp, sp => new DelegateEditServiceHandler(service => sp.GetRequiredService<MainView>().EditFtp(service)));
             services.AddSingleton<IDictionary<ServiceType, IEditServiceHandler>>(sp =>
             {
+                // Build a lookup of edit handlers by resolving each keyed registration for every ServiceType value
                 var handlers = new Dictionary<ServiceType, IEditServiceHandler>();
                 foreach (ServiceType type in Enum.GetValues<ServiceType>())
                 {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -301,6 +301,7 @@
 - Core unit test project targets cross-platform `net8.0` for broader compatibility.
 - Removed WPF workload installation steps; WPF ships with the Windows .NET SDK.
 - Removed `DesktopApplicationTemplate.UI.Tests` project and WPF-specific unit tests.
+- Clarified DI configuration with comments explaining service module discovery and service-type handler dictionary construction.
 
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -196,6 +196,7 @@ Latest Attempt: After relocating common service logic to a shared library, insta
 Latest Attempt: After adding a test-only composite service, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Latest Attempt: After adding service comparison tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: Running in a Linux container, `dotnet` commands are unavailable and `pwsh` is missing for `tools/add-tip.ps1`; tests cannot launch and CI must verify.
+Current Attempt: While documenting DI configuration comments, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- clarify that AddServiceModules scans assemblies for IServiceModule implementations
- explain how ServiceType keyed edit handler dictionary is built
- log environment limits and note DI comments in changelog

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d96062e4832682dd1b0e49035594