### PR TITLE
Use ServiceType in message routing

### DIFF
--- a/DesktopApplicationTemplate.Tests/MessageRoutingServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MessageRoutingServiceTests.cs
@@ -1,3 +1,4 @@
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using Xunit;
 
@@ -10,10 +11,10 @@ namespace DesktopApplicationTemplate.Tests
         {
             var routing = new MessageRoutingService();
 
-            routing.UpdateMessage("svc", "first");
-            routing.UpdateMessage("svc", "second");
+            routing.UpdateMessage(ServiceType.Tcp, "svc", "first");
+            routing.UpdateMessage(ServiceType.Tcp, "svc", "second");
 
-            var found = routing.TryGetMessage("svc", out var message);
+            var found = routing.TryGetMessage(ServiceType.Tcp, "svc", out var message);
 
             Assert.True(found);
             Assert.Equal("second", message);
@@ -23,9 +24,9 @@ namespace DesktopApplicationTemplate.Tests
         public void ResolveTokens_ReplacesWithLatestMessage()
         {
             var routing = new MessageRoutingService();
-            routing.UpdateMessage("svc", "hello");
+            routing.UpdateMessage(ServiceType.Tcp, "svc", "hello");
 
-            var result = routing.ResolveTokens("{svc.Message}");
+            var result = routing.ResolveTokens("{Tcp.svc.Message}");
 
             Assert.Equal("hello", result);
         }
@@ -34,7 +35,7 @@ namespace DesktopApplicationTemplate.Tests
         public void ResolveTokens_ReturnsEmpty_WhenUnknown()
         {
             var routing = new MessageRoutingService();
-            var result = routing.ResolveTokens("{missing.Message}");
+            var result = routing.ResolveTokens("{Tcp.missing.Message}");
             Assert.Equal(string.Empty, result);
         }
     }

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -104,7 +104,7 @@ public class TcpServiceMessagesViewModelTests
         vm.SetService(service);
 
         vm.TestMessage.Should().Be("svc-PEAK-123456789");
-        routing.TryGetMessage("svc", out var message).Should().BeTrue();
+        routing.TryGetMessage(ServiceType.Tcp, "svc", out var message).Should().BeTrue();
         message.Should().Be("svc-PEAK-123456789");
     }
 
@@ -116,7 +116,7 @@ public class TcpServiceMessagesViewModelTests
             TcpOptions = new TcpServiceOptions()
         };
         var routing = new MessageRoutingService();
-        routing.UpdateMessage("svc", "last");
+        routing.UpdateMessage(ServiceType.Tcp, "svc", "last");
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing);
 
         vm.SetService(service);
@@ -321,7 +321,7 @@ public class TcpServiceMessagesViewModelTests
         vm.OutputMessage.Should().Be("test");
         options.OutputMessage.Should().Be("test");
         options.LastTestMessage.Should().Be("test");
-        routing.TryGetMessage("svc", out var message).Should().BeTrue();
+        routing.TryGetMessage(ServiceType.Tcp, "svc", out var message).Should().BeTrue();
         message.Should().Be("test");
         editor.OutputGenerated -= OnOutput;
     }

--- a/DesktopApplicationTemplate.UI/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IMessageRoutingService.cs
@@ -1,3 +1,5 @@
+using DesktopApplicationTemplate.Models;
+
 namespace DesktopApplicationTemplate.UI.Services;
 
 /// <summary>
@@ -8,20 +10,22 @@ public interface IMessageRoutingService
     /// <summary>
     /// Updates the latest message for the specified service.
     /// </summary>
+    /// <param name="serviceType">The category of the service.</param>
     /// <param name="serviceName">The unique name of the service.</param>
     /// <param name="message">The message to store.</param>
-    void UpdateMessage(string serviceName, string message);
+    void UpdateMessage(ServiceType serviceType, string serviceName, string message);
 
     /// <summary>
     /// Attempts to retrieve the latest message for the specified service.
     /// </summary>
+    /// <param name="serviceType">The category of the service.</param>
     /// <param name="serviceName">The unique name of the service.</param>
     /// <param name="message">The message, if found.</param>
     /// <returns><c>true</c> if a message exists for the service; otherwise, <c>false</c>.</returns>
-    bool TryGetMessage(string serviceName, out string? message);
+    bool TryGetMessage(ServiceType serviceType, string serviceName, out string? message);
 
     /// <summary>
-    /// Resolves <c>{ServiceName.Message}</c> tokens within the provided template.
+    /// Resolves <c>{ServiceType.ServiceName.Message}</c> tokens within the provided template.
     /// </summary>
     /// <param name="template">The template containing message tokens.</param>
     /// <returns>The template with tokens replaced by their corresponding messages.</returns>

--- a/DesktopApplicationTemplate.UI/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/MessageRoutingService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Services;
 
@@ -10,9 +11,9 @@ namespace DesktopApplicationTemplate.UI.Services;
 /// </summary>
 public class MessageRoutingService : IMessageRoutingService
 {
-    private readonly ConcurrentDictionary<string, string> _messages = new();
+    private readonly ConcurrentDictionary<(ServiceType, string), string> _messages = new();
     private readonly ILoggingService? _logger;
-    private static readonly Regex TokenRegex = new(@"\{([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
+    private static readonly Regex TokenRegex = new(@"\{([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MessageRoutingService"/> class.
@@ -24,19 +25,19 @@ public class MessageRoutingService : IMessageRoutingService
     }
 
     /// <inheritdoc />
-    public void UpdateMessage(string serviceName, string message)
+    public void UpdateMessage(ServiceType serviceType, string serviceName, string message)
     {
         if (string.IsNullOrWhiteSpace(serviceName))
             throw new ArgumentException("Service name cannot be null or whitespace.", nameof(serviceName));
 
-        _logger?.Log($"Updating message for {serviceName}", LogLevel.Debug);
-        _messages.AddOrUpdate(serviceName, _ => message ?? string.Empty, (_, _) => message ?? string.Empty);
-        _logger?.Log($"Message for {serviceName} updated", LogLevel.Debug);
+        _logger?.Log($"Updating message for {serviceType}.{serviceName}", LogLevel.Debug);
+        _messages.AddOrUpdate((serviceType, serviceName), _ => message ?? string.Empty, (_, _) => message ?? string.Empty);
+        _logger?.Log($"Message for {serviceType}.{serviceName} updated", LogLevel.Debug);
     }
 
     /// <inheritdoc />
-    public bool TryGetMessage(string serviceName, out string? message)
-        => _messages.TryGetValue(serviceName, out message);
+    public bool TryGetMessage(ServiceType serviceType, string serviceName, out string? message)
+        => _messages.TryGetValue((serviceType, serviceName), out message);
 
     /// <inheritdoc />
     public string ResolveTokens(string template)
@@ -47,8 +48,12 @@ public class MessageRoutingService : IMessageRoutingService
         _logger?.Log($"Resolving tokens in '{template}'", LogLevel.Debug);
         string result = TokenRegex.Replace(template, m =>
         {
-            var name = m.Groups[1].Value;
-            return _messages.TryGetValue(name, out var msg) ? msg : string.Empty;
+            var typeStr = m.Groups[1].Value;
+            var name = m.Groups[2].Value;
+            return Enum.TryParse<ServiceType>(typeStr, out var type) &&
+                   _messages.TryGetValue((type, name), out var msg)
+                ? msg
+                : string.Empty;
         });
         _logger?.Log($"Resolved template to '{result}'", LogLevel.Debug);
         return result;

--- a/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/TcpServiceMessagesViewModel.cs
@@ -93,6 +93,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly IMessageRoutingService _routing;
         private TcpServiceOptions _options = new();
 
+        /// <summary>Type of the service associated with these messages.</summary>
+        public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
+
         private string _serviceName = string.Empty;
 
         /// <summary>Name of the service associated with these messages.</summary>
@@ -191,6 +194,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
             _options = service.TcpOptions ?? new TcpServiceOptions();
+            ServiceType = service.ServiceType;
             ServiceName = service.DisplayName.Split(" - ").Last();
             Script = string.IsNullOrWhiteSpace(_options.Script)
                 ? ScriptEditorViewModel.DefaultScript
@@ -252,7 +256,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             _options.LastTestMessage = TestMessage;
             _options.Script = Script;
-            _routing.UpdateMessage(ServiceName, TestMessage);
+            _routing.UpdateMessage(ServiceType, ServiceName, TestMessage);
             try
             {
                 OutputMessage = await RunScriptAsync().ConfigureAwait(false);
@@ -285,7 +289,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return;
 
             if (string.IsNullOrWhiteSpace(_options.LastTestMessage) &&
-                _routing.TryGetMessage(ServiceName, out var routed))
+                _routing.TryGetMessage(ServiceType, ServiceName, out var routed))
             {
                 TestMessage = routed ?? string.Empty;
             }
@@ -295,7 +299,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     ? $"{ServiceName}-PEAK-123456789"
                     : _options.LastTestMessage;
             }
-            _routing.UpdateMessage(ServiceName, TestMessage);
+            _routing.UpdateMessage(ServiceType, ServiceName, TestMessage);
         }
 
         private async Task OpenScriptEditorAsync()
@@ -313,7 +317,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 OutputMessage = _options.OutputMessage = output;
                 TestMessage = svm.TestMessage;
                 _options.LastTestMessage = svm.TestMessage;
-                _routing.UpdateMessage(ServiceName, svm.TestMessage);
+                _routing.UpdateMessage(ServiceType, ServiceName, svm.TestMessage);
             }
 
             void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -202,7 +202,7 @@
 #### Changed
 - `MqttService` refactored with options-based constructor, clean reconnect logic, and consolidated publish methods.
 - `MqttServiceViewModel` uses `MqttServiceOptions` for settings and delegates token resolution to `MessageRoutingService`.
-- `MessageRoutingService` tracks latest messages per service and resolves `{ServiceName.Message}` tokens before publishing.
+ - `MessageRoutingService` tracks latest messages per service and resolves `{ServiceType.ServiceName.Message}` tokens before publishing.
 - `MqttTagSubscriptionsViewModel` consolidated to a single subscription collection with unified properties.
 - `MqttTagSubscriptionsViewModel` passes updated options to `MqttService.ConnectAsync` and logs connection success or failure.
 - Topics now appear in the subscription list before broker subscribe and log errors when the call fails; the Add button disables when no topic is provided.
@@ -274,6 +274,7 @@
 - Moved `ILoggingService`, `LogLevel`, and `LogEntry` into the core library so tests no longer depend on the Windows project.
 - `LogEntry` now stores colors as hex strings instead of `System.Windows.Media.Brush`.
 - Log displays now use a common style and show newest entries first.
+- Message routing tokens now use `ServiceType.ServiceName` and routing APIs accept a `ServiceType` parameter.
 
 ### Documentation & CI
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -556,6 +556,7 @@ Current Attempt: After logging unrecognized service types in EditService, the `d
 Latest Attempt: After replacing TCP view model service type strings with enums, the `dotnet` CLI is still missing; build and tests deferred to CI.
 Latest Attempt: After converting several [Fact] tests to [Theory], `dotnet test --settings tests.runsettings` failed because the `dotnet` command is not found; relying on CI.
 Latest Attempt: After adding edit service handler tests, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
+Latest Attempt: `dotnet` command not found during logging helper update; unable to run restore, build, or tests and will rely on CI.
 Related Commits/PRs:
 [2025-10-01 09:00] Topic: EditorButtonBar namespace
 Context: Verified EditorButtonBar build action and updated consuming views to use an assembly-qualified namespace.


### PR DESCRIPTION
## Summary
- require `ServiceType` in message routing API and use `{ServiceType.ServiceName.Message}` tokens
- track service type in `TcpServiceMessagesViewModel`
- document new message routing token format

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dd85c4a88326bad699827e12a09c