### PR TITLE
Centralize ServiceType code mapping

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/ServiceTypeExtensionsTests.cs
+++ b/DesktopApplicationTemplate.Core.Tests/ServiceTypeExtensionsTests.cs
@@ -1,0 +1,35 @@
+using DesktopApplicationTemplate.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Core.Tests;
+
+public class ServiceTypeExtensionsTests
+{
+    [Theory]
+    [InlineData(ServiceType.Mqtt, "MQ")]
+    [InlineData(ServiceType.Http, "HT")]
+    public void ToCode_ReturnsExpectedShortCode(ServiceType type, string expected)
+    {
+        type.ToCode().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("TC", ServiceType.Tcp)]
+    [InlineData("TCP", ServiceType.Tcp)]
+    [InlineData("FTP Server", ServiceType.Ftp)]
+    public void TryParse_HandlesCodesAndLegacyNames(string input, ServiceType expected)
+    {
+        ServiceTypeExtensions.TryParse(input, out var result).Should().BeTrue();
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(ServiceType.Ftp, "FTP")]
+    [InlineData(ServiceType.Csv, "CSV Creator")]
+    public void ToLegacyString_ReturnsFriendlyName(ServiceType type, string expected)
+    {
+        type.ToLegacyString().Should().Be(expected);
+    }
+}
+

--- a/DesktopApplicationTemplate.Core/Converters/ServiceTypeJsonConverter.cs
+++ b/DesktopApplicationTemplate.Core/Converters/ServiceTypeJsonConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DesktopApplicationTemplate.Models;
@@ -7,87 +6,20 @@ using DesktopApplicationTemplate.Models;
 namespace DesktopApplicationTemplate.Core.Converters;
 
 /// <summary>
-/// Converts <see cref="ServiceType"/> values to short string codes for persistence
-/// and supports reading legacy names.
+/// Converts <see cref="ServiceType"/> values to short codes for persistence
+/// and parses legacy names.
 /// </summary>
 public sealed class ServiceTypeJsonConverter : JsonConverter<ServiceType>
 {
-    private static readonly Dictionary<ServiceType, string> CodeMap = new()
-    {
-        { ServiceType.Mqtt, "MQ" },
-        { ServiceType.Http, "HT" },
-        { ServiceType.Ftp, "FT" },
-        { ServiceType.Hid, "HD" },
-        { ServiceType.Csv, "CV" },
-        { ServiceType.FileObserver, "FO" },
-        { ServiceType.Scp, "SC" },
-        { ServiceType.Tcp, "TC" },
-        { ServiceType.Heartbeat, "HB" }
-    };
-
-    private static readonly Dictionary<string, ServiceType> LegacyMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        { "MQ", ServiceType.Mqtt },
-        { "MQTT", ServiceType.Mqtt },
-        { "HT", ServiceType.Http },
-        { "HTTP", ServiceType.Http },
-        { "FT", ServiceType.Ftp },
-        { "FTP", ServiceType.Ftp },
-        { "FTP Server", ServiceType.Ftp },
-        { "HD", ServiceType.Hid },
-        { "HID", ServiceType.Hid },
-        { "CV", ServiceType.Csv },
-        { "CSV", ServiceType.Csv },
-        { "CSV Creator", ServiceType.Csv },
-        { "FO", ServiceType.FileObserver },
-        { "File Observer", ServiceType.FileObserver },
-        { "SC", ServiceType.Scp },
-        { "SCP", ServiceType.Scp },
-        { "TC", ServiceType.Tcp },
-        { "TCP", ServiceType.Tcp },
-        { "HB", ServiceType.Heartbeat },
-        { "Heartbeat", ServiceType.Heartbeat }
-    };
-
     public override ServiceType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var value = reader.GetString();
-        return TryParse(value, out var result) ? result : default;
+        return ServiceTypeExtensions.TryParse(value, out var result) ? result : default;
     }
 
     public override void Write(Utf8JsonWriter writer, ServiceType value, JsonSerializerOptions options)
     {
-        writer.WriteStringValue(ToCode(value));
-    }
-
-    public static bool TryParse(string? value, out ServiceType result)
-    {
-        if (value != null && LegacyMap.TryGetValue(value, out result))
-        {
-            return true;
-        }
-
-        return Enum.TryParse(value, true, out result);
-    }
-
-    public static string ToCode(ServiceType type) =>
-        CodeMap.TryGetValue(type, out var code) ? code : type.ToString();
-
-    public static string ToLegacyString(ServiceType type)
-    {
-        // Return one of the legacy names for display, defaulting to code.
-        return type switch
-        {
-            ServiceType.Ftp => "FTP",
-            ServiceType.Mqtt => "MQTT",
-            ServiceType.Http => "HTTP",
-            ServiceType.Tcp => "TCP",
-            ServiceType.Hid => "HID",
-            ServiceType.Csv => "CSV Creator",
-            ServiceType.FileObserver => "File Observer",
-            ServiceType.Scp => "SCP",
-            ServiceType.Heartbeat => "Heartbeat",
-            _ => ToCode(type)
-        };
+        writer.WriteStringValue(value.ToCode());
     }
 }
+

--- a/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+namespace DesktopApplicationTemplate.Models;
+
+/// <summary>
+/// Provides helpers for converting <see cref="ServiceType"/> values to and from
+/// short string codes used in persistence and configuration.
+/// </summary>
+public static class ServiceTypeExtensions
+{
+    private static readonly Dictionary<ServiceType, string> CodeMap = new()
+    {
+        { ServiceType.Mqtt, "MQ" },
+        { ServiceType.Http, "HT" },
+        { ServiceType.Ftp, "FT" },
+        { ServiceType.Hid, "HD" },
+        { ServiceType.Csv, "CV" },
+        { ServiceType.FileObserver, "FO" },
+        { ServiceType.Scp, "SC" },
+        { ServiceType.Tcp, "TC" },
+        { ServiceType.Heartbeat, "HB" }
+    };
+
+    private static readonly Dictionary<string, ServiceType> LegacyMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "MQ", ServiceType.Mqtt },
+        { "MQTT", ServiceType.Mqtt },
+        { "HT", ServiceType.Http },
+        { "HTTP", ServiceType.Http },
+        { "FT", ServiceType.Ftp },
+        { "FTP", ServiceType.Ftp },
+        { "FTP Server", ServiceType.Ftp },
+        { "HD", ServiceType.Hid },
+        { "HID", ServiceType.Hid },
+        { "CV", ServiceType.Csv },
+        { "CSV", ServiceType.Csv },
+        { "CSV Creator", ServiceType.Csv },
+        { "FO", ServiceType.FileObserver },
+        { "File Observer", ServiceType.FileObserver },
+        { "SC", ServiceType.Scp },
+        { "SCP", ServiceType.Scp },
+        { "TC", ServiceType.Tcp },
+        { "TCP", ServiceType.Tcp },
+        { "HB", ServiceType.Heartbeat },
+        { "Heartbeat", ServiceType.Heartbeat }
+    };
+
+    /// <summary>
+    /// Converts a <see cref="ServiceType"/> to its short code representation.
+    /// </summary>
+    public static string ToCode(this ServiceType type) =>
+        CodeMap.TryGetValue(type, out var code) ? code : type.ToString();
+
+    /// <summary>
+    /// Tries to parse a short code or legacy name into a <see cref="ServiceType"/>.
+    /// </summary>
+    public static bool TryParse(string? value, out ServiceType result)
+    {
+        if (value != null && LegacyMap.TryGetValue(value, out result))
+        {
+            return true;
+        }
+
+        return Enum.TryParse(value, true, out result);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="ServiceType"/> to one of its legacy display strings,
+    /// defaulting to the short code if no legacy name exists.
+    /// </summary>
+    public static string ToLegacyString(this ServiceType type) =>
+        type switch
+        {
+            ServiceType.Ftp => "FTP",
+            ServiceType.Mqtt => "MQTT",
+            ServiceType.Http => "HTTP",
+            ServiceType.Tcp => "TCP",
+            ServiceType.Hid => "HID",
+            ServiceType.Csv => "CSV Creator",
+            ServiceType.FileObserver => "File Observer",
+            ServiceType.Scp => "SCP",
+            ServiceType.Heartbeat => "Heartbeat",
+            _ => type.ToCode()
+        };
+}
+

--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Core.Converters;
 
 namespace DesktopApplicationTemplate.Service
 {
@@ -100,7 +99,7 @@ namespace DesktopApplicationTemplate.Service
                 var results = new List<ServiceInfo>();
                 foreach (var cfg in configs)
                 {
-                    if (ServiceTypeJsonConverter.TryParse(cfg.ServiceType, out var type))
+                    if (ServiceTypeExtensions.TryParse(cfg.ServiceType, out var type))
                     {
                         results.Add(new ServiceInfo
                         {
@@ -125,7 +124,7 @@ namespace DesktopApplicationTemplate.Service
                 var results = new List<ServiceInfo>();
                 foreach (var info in legacy)
                 {
-                    if (ServiceTypeJsonConverter.TryParse(info.ServiceType, out var type))
+                    if (ServiceTypeExtensions.TryParse(info.ServiceType, out var type))
                     {
                         results.Add(new ServiceInfo
                         {
@@ -257,7 +256,7 @@ namespace DesktopApplicationTemplate.Service
             {
                 var pid = Process.GetCurrentProcess().Id;
                 var lines = _records.Values
-                    .Select(r => $"{pid}\t{r.Name}\t{ServiceTypeJsonConverter.ToLegacyString(r.ServiceType)}\t{r.StartTime:o}\t{r.Status}")
+                    .Select(r => $"{pid}\t{r.Name}\t{r.ServiceType.ToLegacyString()}\t{r.StartTime:o}\t{r.Status}")
                     .ToArray();
                 File.WriteAllLines(_activeServicesFilePath, lines);
             }

--- a/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
@@ -1,6 +1,5 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Core.Converters;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
@@ -16,10 +15,10 @@ namespace DesktopApplicationTemplate.Tests
         [InlineData(ServiceType.Ftp)]
         public void GenerateDefaultName_ReturnsIncrementedName(ServiceType type)
         {
-            var existing = new[] { $"{ServiceTypeJsonConverter.ToLegacyString(type)}1" };
+            var existing = new[] { $"{type.ToLegacyString()}1" };
             var vm = new CreateServiceViewModel(existing);
             var name = vm.GenerateDefaultName(type);
-            Assert.Equal($"{ServiceTypeJsonConverter.ToLegacyString(type)}2", name);
+            Assert.Equal($"{type.ToLegacyString()}2", name);
             ConsoleTestLogger.LogPass();
         }
     }

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -2,7 +2,6 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Core.Converters;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -79,9 +78,9 @@ namespace DesktopApplicationTemplate.Tests
             {
                 desired = main.GenerateServiceName(svc2.ServiceType);
             }
-            svc2.DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(svc2.ServiceType)} - {desired}";
+            svc2.DisplayName = $"{svc2.ServiceType.ToLegacyString()} - {desired}";
 
-            var expected = $"{ServiceTypeJsonConverter.ToLegacyString(type)} - {baseName[..^1] + "3"}";
+            var expected = $"{type.ToLegacyString()} - {baseName[..^1] + "3"}";
             Assert.Equal(expected, svc2.DisplayName);
 
             Directory.Delete(tempDir, true);

--- a/DesktopApplicationTemplate.Tests/TestHelpers.cs
+++ b/DesktopApplicationTemplate.Tests/TestHelpers.cs
@@ -1,4 +1,3 @@
-using DesktopApplicationTemplate.Core.Converters;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 
@@ -9,6 +8,6 @@ public static class TestHelpers
     public static ServiceListModel CreateService(ServiceType type, string name) => new ServiceListModel
     {
         ServiceType = type,
-        DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(type)} - {name}"
+        DisplayName = $"{type.ToLegacyString()} - {name}"
     };
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Core.Converters;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.Options;
@@ -149,7 +148,7 @@ namespace DesktopApplicationTemplate.Persistence
                 var result = new List<ServiceInfo>();
                 foreach (var info in legacy)
                 {
-                    if (ServiceTypeJsonConverter.TryParse(info.ServiceType, out var type))
+                    if (ServiceTypeExtensions.TryParse(info.ServiceType, out var type))
                     {
                         result.Add(new ServiceInfo
                         {

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Core.Converters;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -28,7 +27,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public string GenerateDefaultName(ServiceType serviceType)
         {
-            var typeName = ServiceTypeJsonConverter.ToLegacyString(serviceType);
+            var typeName = serviceType.ToLegacyString();
             int index = 1;
             while (_existingNames.Contains($"{typeName}{index}"))
             {

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -11,7 +11,6 @@ using WpfBrushes = System.Windows.Media.Brushes;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Persistence;
-using DesktopApplicationTemplate.Core.Converters;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 
@@ -127,7 +126,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         internal string GenerateServiceName(ServiceType serviceType)
         {
-            var typeName = ServiceTypeJsonConverter.ToLegacyString(serviceType);
+            var typeName = serviceType.ToLegacyString();
             int index = 1;
             foreach (var svc in Services.Where(s => s.ServiceType == serviceType))
             {
@@ -240,7 +239,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     return false;
 
                 if (Filters.TypeFilter != "All" &&
-                    ServiceTypeJsonConverter.TryParse(Filters.TypeFilter, out var fType) &&
+                    ServiceTypeExtensions.TryParse(Filters.TypeFilter, out var fType) &&
                     svc.ServiceType != fType)
                     return false;
 

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -6,7 +6,6 @@ using System.Windows.Controls;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Core.Converters;
 using WpfBrush = System.Windows.Media.Brush;
 using WpfBrushes = System.Windows.Media.Brushes;
 
@@ -211,7 +210,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 var typeStr = m.Groups[1].Value;
                 var name = m.Groups[2].Value;
                 var msg = m.Groups[3].Value;
-                if (ServiceTypeJsonConverter.TryParse(typeStr, out var type))
+                if (ServiceTypeExtensions.TryParse(typeStr, out var type))
                 {
                     var target = ResolveService(type, name);
                     if (target != null && target != this)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -20,7 +20,6 @@ using DesktopApplicationTemplate.UI;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using DesktopApplicationTemplate.Core.Converters;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -139,7 +138,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     tcpVm.AdvancedSettingsRequested += (_, _) =>
                     {
                         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-                        vm.ServiceType = ServiceTypeJsonConverter.ToLegacyString(svc.ServiceType);
+                        vm.ServiceType = svc.ServiceType.ToLegacyString();
                         vm.Load(svc.DisplayName.Split(" - ").Last(), svc.TcpOptions ?? new TcpServiceOptions());
                         var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
                         editView.Initialize(vm);
@@ -147,7 +146,7 @@ namespace DesktopApplicationTemplate.UI.Views
                         vm.ServiceSaved += (name, opts) =>
                         {
                             svc.DisplayName = $"{vm.ServiceType} - {name}";
-                            if (ServiceTypeJsonConverter.TryParse(vm.ServiceType, out var newType))
+                            if (ServiceTypeExtensions.TryParse(vm.ServiceType, out var newType))
                                 svc.ServiceType = newType;
                             svc.TcpOptions = opts;
                             if (svc.ServicePage != null)
@@ -190,7 +189,7 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 var svc = new ServiceListModel
                 {
-                    DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(type)} - {name}",
+                    DisplayName = $"{type.ToLegacyString()} - {name}",
                     ServiceType = type,
                     IsActive = false
                 };
@@ -215,7 +214,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void NavigateTo(ServiceType serviceType)
         {
-            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? ServiceTypeJsonConverter.ToLegacyString(serviceType);
+            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType.ToLegacyString();
             var handler = App.AppHost.Services.GetServices<INavigationHandler>()
                 .FirstOrDefault(h => h.ServiceType == serviceType);
             if (handler == null)
@@ -477,14 +476,14 @@ namespace DesktopApplicationTemplate.UI.Views
         var tcpPage = GetOrCreateServicePage(service);
         var options = service.TcpOptions ?? new TcpServiceOptions();
         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-        vm.ServiceType = ServiceTypeJsonConverter.ToLegacyString(service.ServiceType);
+        vm.ServiceType = service.ServiceType.ToLegacyString();
         vm.Load(service.DisplayName.Split(" - ").Last(), options);
         var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
             service.DisplayName = $"{vm.ServiceType} - {name}";
-            if (ServiceTypeJsonConverter.TryParse(vm.ServiceType, out var newType))
+            if (ServiceTypeExtensions.TryParse(vm.ServiceType, out var newType))
                 service.ServiceType = newType;
             service.TcpOptions = opts;
             if (tcpPage != null)
@@ -644,7 +643,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     {
                         namePart = _viewModel.GenerateServiceName(svc.ServiceType);
                     }
-                    svc.DisplayName = $"{ServiceTypeJsonConverter.ToLegacyString(svc.ServiceType)} - {namePart}";
+                    svc.DisplayName = $"{svc.ServiceType.ToLegacyString()} - {namePart}";
                     await _viewModel.SaveServicesAsync();
                 }
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `ServiceType` enum clarifies supported service categories.
 - Migration routine converts legacy service type names to `ServiceType` and logs unmapped values.
 - `IServiceModule` interface enables service-specific DI registration and modules are discovered and registered automatically at startup.
+- Static `ServiceTypeExtensions` maps service types to short codes for reuse in serialization and configuration.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -197,6 +197,7 @@ Latest Attempt: After adding a test-only composite service, the `dotnet` command
 Latest Attempt: After adding service comparison tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: Running in a Linux container, `dotnet` commands are unavailable and `pwsh` is missing for `tools/add-tip.ps1`; tests cannot launch and CI must verify.
 Latest Attempt: After documenting `ServiceType` and DI module patterns in the README, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
+Latest Attempt: After introducing `ServiceTypeExtensions` for code mapping, the `dotnet` CLI is still missing; restore, build, and test commands could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add `ServiceTypeExtensions` for short code mapping
- use mapping in serialization and service configuration
- cover new utility with unit tests

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e02154048326af1e47ae33e6c104