### PR TITLE
Bind settings dialogs to ServiceType enum

### DIFF
--- a/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/SettingsViewModelPersistenceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -35,6 +36,34 @@ namespace DesktopApplicationTemplate.Tests
                 SettingsViewModel.FilePath = original;
                 SettingsViewModel.SaveConfirmationSuppressed = suppressOrig;
                 SettingsViewModel.CloseConfirmationSuppressed = closeOrig;
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void SaveAndLoad_PreservesPreferredServiceType()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var original = SettingsViewModel.FilePath;
+            SettingsViewModel.FilePath = Path.Combine(tempDir, "userSettings.json");
+            try
+            {
+                var vm = new SettingsViewModel { PreferredServiceType = ServiceType.Mqtt };
+                vm.Save();
+
+                var json = File.ReadAllText(SettingsViewModel.FilePath);
+                Assert.Contains(ServiceType.Mqtt.ToCode(), json);
+
+                var vm2 = new SettingsViewModel();
+                vm2.Load();
+                Assert.Equal(ServiceType.Mqtt, vm2.PreferredServiceType);
+            }
+            finally
+            {
+                SettingsViewModel.FilePath = original;
                 Directory.Delete(tempDir, true);
             }
 

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -10,5 +10,10 @@ namespace DesktopApplicationTemplate.Models
         public bool FirstRun { get; set; } = true;
         public bool SuppressSaveConfirmation { get; set; }
         public bool SuppressCloseConfirmation { get; set; }
+
+        /// <summary>
+        /// Preferred service category for new operations.
+        /// </summary>
+        public ServiceType PreferredServiceType { get; set; } = ServiceType.Tcp;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceEditorViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceEditorViewModelBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
 
@@ -12,6 +13,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 public abstract class ServiceEditorViewModelBase<TOptions> : ValidatableViewModelBase, ILoggingViewModel
 {
     private string _serviceName = string.Empty;
+    private ServiceType _serviceType;
 
     protected ServiceEditorViewModelBase(IServiceRule rule, ILoggingService? logger = null)
     {
@@ -49,6 +51,15 @@ public abstract class ServiceEditorViewModelBase<TOptions> : ValidatableViewMode
                 ClearErrors(nameof(ServiceName));
             OnPropertyChanged();
         }
+    }
+
+    /// <summary>
+    /// Type of the service being edited or created.
+    /// </summary>
+    public ServiceType ServiceType
+    {
+        get => _serviceType;
+        set { _serviceType = value; OnPropertyChanged(); }
     }
 
     /// <summary>

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -17,6 +18,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private bool _runServicesOnStartup;
         private bool _logTcpMessages = true;
         private bool _firstRun = true;
+        private ServiceType _preferredServiceType = ServiceType.Tcp;
         private static bool _suppressSaveConfirmation;
         private static bool _suppressCloseConfirmation;
         private bool _dirty;
@@ -40,6 +42,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public bool RunServicesOnStartup { get => _runServicesOnStartup; set { _runServicesOnStartup = value; _dirty = true; OnPropertyChanged(); } }
         public bool LogTcpMessages { get => _logTcpMessages; set { _logTcpMessages = value; _dirty = true; OnPropertyChanged(); } }
         public bool FirstRun { get => _firstRun; set { _firstRun = value; _dirty = true; OnPropertyChanged(); } }
+        public ServiceType PreferredServiceType { get => _preferredServiceType; set { _preferredServiceType = value; _dirty = true; OnPropertyChanged(); } }
+        public ServiceType[] ServiceTypes { get; } = Enum.GetValues<ServiceType>();
         public bool HasUnsavedChanges => _dirty;
 
         public void Load()
@@ -58,6 +62,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _runServicesOnStartup = obj.RunServicesOnStartup;
                 _logTcpMessages = obj.LogTcpMessages;
                 _firstRun = obj.FirstRun;
+                _preferredServiceType = obj.PreferredServiceType;
                 TcpLoggingEnabled = obj.LogTcpMessages;
                 SaveConfirmationSuppressed = obj.SuppressSaveConfirmation;
                 CloseConfirmationSuppressed = obj.SuppressCloseConfirmation;
@@ -74,6 +79,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 RunServicesOnStartup = _runServicesOnStartup,
                 LogTcpMessages = _logTcpMessages,
                 FirstRun = _firstRun,
+                PreferredServiceType = _preferredServiceType,
                 SuppressSaveConfirmation = SaveConfirmationSuppressed,
                 SuppressCloseConfirmation = CloseConfirmationSuppressed
             };

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -138,16 +138,15 @@ namespace DesktopApplicationTemplate.UI.Views
                     tcpVm.AdvancedSettingsRequested += (_, _) =>
                     {
                         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-                        vm.ServiceType = svc.ServiceType.ToLegacyString();
+                        vm.ServiceType = svc.ServiceType;
                         vm.Load(svc.DisplayName.Split(" - ").Last(), svc.TcpOptions ?? new TcpServiceOptions());
                         var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
                         editView.Initialize(vm);
 
                         vm.ServiceSaved += (name, opts) =>
                         {
-                            svc.DisplayName = $"{vm.ServiceType} - {name}";
-                            if (ServiceTypeExtensions.TryParse(vm.ServiceType, out var newType))
-                                svc.ServiceType = newType;
+                            svc.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
+                            svc.ServiceType = vm.ServiceType;
                             svc.TcpOptions = opts;
                             if (svc.ServicePage != null)
                                 ShowPage(svc.ServicePage);
@@ -476,15 +475,14 @@ namespace DesktopApplicationTemplate.UI.Views
         var tcpPage = GetOrCreateServicePage(service);
         var options = service.TcpOptions ?? new TcpServiceOptions();
         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-        vm.ServiceType = service.ServiceType.ToLegacyString();
+        vm.ServiceType = service.ServiceType;
         vm.Load(service.DisplayName.Split(" - ").Last(), options);
         var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"{vm.ServiceType} - {name}";
-            if (ServiceTypeExtensions.TryParse(vm.ServiceType, out var newType))
-                service.ServiceType = newType;
+            service.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
+            service.ServiceType = vm.ServiceType;
             service.TcpOptions = opts;
             if (tcpPage != null)
                 ShowPage(tcpPage);

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
@@ -17,6 +17,10 @@
             <CheckBox Content="Run Application UI on startup" IsChecked="{Binding RunUIOnStartup}"/>
             <CheckBox Content="Run background services on startup" IsChecked="{Binding RunServicesOnStartup}"/>
             <CheckBox Content="Log TCP messages" IsChecked="{Binding LogTcpMessages}"/>
+            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                <TextBlock Text="Preferred Service:" Margin="0,0,5,0"/>
+                <ComboBox ItemsSource="{Binding ServiceTypes}" SelectedItem="{Binding PreferredServiceType}" Width="150"/>
+            </StackPanel>
             <Border Background="WhiteSmoke" CornerRadius="8" Padding="10" Margin="0,10,0,10">
                 <Grid x:Name="NetworkConfigGrid">
                     <Grid.RowDefinitions>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Application registers global exception handlers that log errors, release input hooks, and shut down gracefully.
 - Unit test ensures `VisualTreeHelperExtensions.FindParent` locates the containing `TextBlock` for inline elements.
 - Tests confirm the main window delegates edit requests to service-type handlers.
+- Settings page offers a preferred service selector bound to `ServiceType` values.
 
 #### Changed
 - Service selection window wraps service icons within bounds using a fixed-width panel.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -198,6 +198,7 @@ Latest Attempt: After adding service comparison tests, the `dotnet` command rema
 Latest Attempt: Running in a Linux container, `dotnet` commands are unavailable and `pwsh` is missing for `tools/add-tip.ps1`; tests cannot launch and CI must verify.
 Latest Attempt: After documenting `ServiceType` and DI module patterns in the README, the `dotnet` CLI remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: After introducing `ServiceTypeExtensions` for code mapping, the `dotnet` CLI is still missing; restore, build, and test commands could not run locally, so CI will verify.
+Latest Attempt: After binding settings dialogs to `ServiceType` enums, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- allow settings to select a preferred service type using the `ServiceType` enum
- store the preferred service type in user settings with enum short codes
- switch service edit workflows to use enum-backed `ServiceType` properties

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e50e237c83269cd245097cb6a7e7