### PR TITLE
Add factories for additional service types

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -195,6 +195,13 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<Navigation.INavigationHandler, Navigation.FtpNavigationHandler>();
             services.AddTransient<Factories.IServiceFactory, Factories.MqttServiceFactory>();
             services.AddTransient<Factories.IServiceFactory, Factories.FtpServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.HttpServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.TcpServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.HidServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.ScpServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.CsvServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.FileObserverServiceFactory>();
+            services.AddTransient<Factories.IServiceFactory, Factories.HeartbeatServiceFactory>();
 
 
             // Load strongly typed settings

--- a/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class CsvServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Csv;
+
+        public CsvServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<CsvServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.Csv.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.Csv,
+                IsActive = false,
+                CsvOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class FileObserverServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.FileObserver;
+
+        public FileObserverServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<FileObserverServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.FileObserver.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.FileObserver,
+                IsActive = false,
+                FileObserverOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class HeartbeatServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Heartbeat;
+
+        public HeartbeatServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<HeartbeatServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.Heartbeat.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.Heartbeat,
+                IsActive = false,
+                HeartbeatOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class HidServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Hid;
+
+        public HidServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<HidServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.Hid.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.Hid,
+                IsActive = false,
+                HidOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class HttpServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Http;
+
+        public HttpServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<HttpServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.Http.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.Http,
+                IsActive = false,
+                HttpOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class ScpServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Scp;
+
+        public ScpServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<ScpServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.Scp.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.Scp,
+                IsActive = false,
+                ScpOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
@@ -1,0 +1,38 @@
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public class TcpServiceFactory : IServiceFactory
+    {
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Tcp;
+
+        public TcpServiceFactory(MainView mainView)
+        {
+            _mainView = mainView;
+        }
+
+        public ServiceListModel Create(object optionsObj)
+        {
+            var ctx = (ServiceFactoryOptions<TcpServiceOptions>)optionsObj;
+            var name = ctx.Name;
+            var options = ctx.Options;
+
+            var svc = new ServiceListModel
+            {
+                DisplayName = $"{ServiceType.Tcp.ToLegacyString()} - {name}",
+                ServiceType = ServiceType.Tcp,
+                IsActive = false,
+                TcpOptions = options
+            };
+
+            _mainView.GetOrCreateServicePage(svc);
+
+            return svc;
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Unified creation and edit workflows under `ServiceEditorViewModelBase<TOptions>` exposing `SaveCommand` and customizable `SaveButtonText`.
 - Service manager tracks task start times and writes statuses to `activeservices.txt` for running services.
 - Service factories convert options into initialized services and pages with a unified `AddServiceAsync` workflow.
+- Factories added for HTTP, TCP, HID, SCP, CSV, File Observer, and Heartbeat services.
 - `ServiceType` enum clarifies supported service categories.
 - Migration routine converts legacy service type names to `ServiceType` and logs unmapped values.
 - `IServiceModule` interface enables service-specific DI registration and modules are discovered and registered automatically at startup.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -200,6 +200,7 @@ Latest Attempt: After documenting `ServiceType` and DI module patterns in the RE
 Latest Attempt: After introducing `ServiceTypeExtensions` for code mapping, the `dotnet` CLI is still missing; restore, build, and test commands could not run locally, so CI will verify.
 Latest Attempt: After binding settings dialogs to `ServiceType` enums, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Latest Attempt: After adding navigation handler tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
+Latest Attempt: After registering factories for additional services, the `dotnet` command is still missing; restore, build, and tests could not run locally so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- implement `IServiceFactory` classes for HTTP, TCP, HID, SCP, CSV, File Observer and Heartbeat services
- register new service factories with the application DI container
- document the new factories in the changelog and log the missing `dotnet` CLI in collaboration tips

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c2ecb06fc083269097c22327094399