### PR TITLE
feat: add service navigation handlers

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -193,6 +193,13 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<SettingsPage>();
             services.AddTransient<Navigation.INavigationHandler, Navigation.MqttNavigationHandler>();
             services.AddTransient<Navigation.INavigationHandler, Navigation.FtpNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.HttpNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.TcpNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.HidNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.ScpNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.CsvNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.FileObserverNavigationHandler>();
+            services.AddTransient<Navigation.INavigationHandler, Navigation.HeartbeatNavigationHandler>();
             services.AddTransient<Factories.IServiceFactory, Factories.MqttServiceFactory>();
             services.AddTransient<Factories.IServiceFactory, Factories.FtpServiceFactory>();
             services.AddTransient<Factories.IServiceFactory, Factories.HttpServiceFactory>();

--- a/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class CsvNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Csv;
+
+        public CsvNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<CsvServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = _services.GetRequiredService<CsvServiceEditorView>();
+            view.Initialize(vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<CsvAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<CsvAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += _ => _mainView.ShowPage(view);
+                advVm.BackRequested += () => _mainView.ShowPage(view);
+                _mainView.ShowPage(advView);
+            };
+            return view;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class FileObserverNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.FileObserver;
+
+        public FileObserverNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<FileObserverCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FileObserverServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<FileObserverCreateServiceView>(_services, vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<FileObserverAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<FileObserverAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += _ => _mainView.ShowPage(view);
+                advVm.BackRequested += () => _mainView.ShowPage(view);
+                _mainView.ShowPage(advView);
+            };
+            return view;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class HeartbeatNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Heartbeat;
+
+        public HeartbeatNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<HeartbeatCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<HeartbeatCreateServiceView>(_services, vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<HeartbeatAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<HeartbeatAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += _ => _mainView.ShowPage(view);
+                advVm.BackRequested += () => _mainView.ShowPage(view);
+                _mainView.ShowPage(advView);
+            };
+            return view;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class HidNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Hid;
+
+        public HidNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<HidCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HidServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<HidCreateServiceView>(_services, vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<HidAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<HidAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += _ => _mainView.ShowPage(view);
+                advVm.BackRequested += () => _mainView.ShowPage(view);
+                _mainView.ShowPage(advView);
+            };
+            return view;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class HttpNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Http;
+
+        public HttpNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<HttpCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HttpServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<HttpCreateServiceView>(_services, vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<HttpAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<HttpAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += _ => _mainView.ShowPage(view);
+                advVm.BackRequested += () => _mainView.ShowPage(view);
+                _mainView.ShowPage(advView);
+            };
+            return view;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class ScpNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Scp;
+
+        public ScpNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<ScpCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<ScpServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<ScpCreateServiceView>(_services, vm);
+            vm.AdvancedConfigRequested += opts =>
+            {
+                var advVm = ActivatorUtilities.CreateInstance<ScpAdvancedConfigViewModel>(_services, opts);
+                var advView = _services.GetRequiredService<ScpAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += _ => _mainView.ShowPage(view);
+                advVm.BackRequested += () => _mainView.ShowPage(view);
+                _mainView.ShowPage(advView);
+            };
+            return view;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Navigation
+{
+    public class TcpNavigationHandler : INavigationHandler
+    {
+        private readonly IServiceProvider _services;
+        private readonly MainView _mainView;
+
+        public ServiceType ServiceType => ServiceType.Tcp;
+
+        public TcpNavigationHandler(IServiceProvider services, MainView mainView)
+        {
+            _services = services;
+            _mainView = mainView;
+        }
+
+        public Page CreateView(string defaultName)
+        {
+            var vm = _services.GetRequiredService<TcpCreateServiceViewModel>();
+            vm.ServiceName = defaultName;
+            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<TcpServiceOptions>(name, options));
+            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var view = ActivatorUtilities.CreateInstance<TcpCreateServiceView>(_services, vm);
+            return view;
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 ### Navigation & UI
 #### Added
 - Navigation helpers for HTTP, HID, File Observer, Heartbeat, CSV Creator, and SCP services with tests ensuring double-click opens edit views.
+- Creation navigation handlers for HTTP, TCP, HID, SCP, CSV, File Observer, and Heartbeat services.
 - Application logo displayed in the main window navigation bar.
 - Navigation bar `HeaderBar` supports drag and toggles window state on double-click.
 - Popup-based `FilterPanel` user control for in-place service filtering.


### PR DESCRIPTION
## Summary
- add navigation handlers for HTTP, TCP, HID, SCP, CSV, File Observer, and Heartbeat services
- register navigation handlers with DI container
- document new service navigation handlers in changelog

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ee8b06608326a209f223d53ca737