### PR TITLE
Inject service factory and navigation handler dictionaries

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -1,10 +1,9 @@
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.Views;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Moq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Windows.Controls;
 using Xunit;
@@ -34,17 +33,13 @@ public class MainViewCreateNavigationTests
         };
         foreach (var kvp in handlerMocks)
         {
-            kvp.Value.SetupGet(h => h.ServiceType).Returns(kvp.Key);
+            kvp.Value.Setup(h => h.CreateView(kvp.Key.ToLegacyString())).Returns(new Page());
         }
         var expectedPage = new Page();
         handlerMocks[type].Setup(h => h.CreateView(type.ToLegacyString())).Returns(expectedPage);
-        var services = new ServiceCollection();
-        foreach (var m in handlerMocks.Values)
-            services.AddSingleton(m.Object);
-        var provider = services.BuildServiceProvider();
-        var host = new Mock<IHost>();
-        host.Setup(h => h.Services).Returns(provider);
-        typeof(App).GetProperty("AppHost")!.GetSetMethod(true)!.Invoke(null, new object[] { host.Object });
+        var dict = handlerMocks.ToDictionary(k => k.Key, v => v.Value.Object);
+        typeof(MainView).GetField("_navigationHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, dict);
         typeof(MainView).GetField("_createServicePage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .SetValue(view, null);
         var method = typeof(MainView).GetMethod("NavigateTo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
@@ -75,10 +70,8 @@ public class MainViewCreateNavigationTests
         var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
         typeof(MainView).GetField("ContentFrame")!.SetValue(view, new Frame());
         typeof(MainView).GetField("HomeContentGrid")!.SetValue(view, new Grid());
-        var services = new ServiceCollection().BuildServiceProvider();
-        var host = new Mock<IHost>();
-        host.Setup(h => h.Services).Returns(services);
-        typeof(App).GetProperty("AppHost")!.GetSetMethod(true)!.Invoke(null, new object[] { host.Object });
+        typeof(MainView).GetField("_navigationHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, new Dictionary<ServiceType, INavigationHandler>());
         var method = typeof(MainView).GetMethod("NavigateTo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
         // Act

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -191,24 +191,50 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<ScpAdvancedConfigView>();
             services.AddTransient<ScpAdvancedConfigViewModel>();
             services.AddTransient<SettingsPage>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.MqttNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.FtpNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.HttpNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.TcpNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.HidNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.ScpNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.CsvNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.FileObserverNavigationHandler>();
-            services.AddTransient<Navigation.INavigationHandler, Navigation.HeartbeatNavigationHandler>();
-            services.AddTransient<Factories.IServiceFactory, Factories.MqttServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.FtpServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.HttpServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.TcpServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.HidServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.ScpServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.CsvServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.FileObserverServiceFactory>();
-            services.AddTransient<Factories.IServiceFactory, Factories.HeartbeatServiceFactory>();
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Mqtt, sp => new Navigation.MqttNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Ftp, sp => new Navigation.FtpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Http, sp => new Navigation.HttpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Tcp, sp => new Navigation.TcpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Hid, sp => new Navigation.HidNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Scp, sp => new Navigation.ScpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Csv, sp => new Navigation.CsvNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.FileObserver, sp => new Navigation.FileObserverNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Heartbeat, sp => new Navigation.HeartbeatNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddSingleton<IDictionary<ServiceType, Navigation.INavigationHandler>>(sp =>
+            {
+                var handlers = new Dictionary<ServiceType, Navigation.INavigationHandler>();
+                foreach (ServiceType type in Enum.GetValues<ServiceType>())
+                {
+                    var handler = sp.GetKeyedService<Navigation.INavigationHandler>(type);
+                    if (handler != null)
+                    {
+                        handlers[type] = handler;
+                    }
+                }
+                return handlers;
+            });
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Mqtt, sp => new Factories.MqttServiceFactory(sp, () => sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Ftp, sp => new Factories.FtpServiceFactory(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Http, sp => new Factories.HttpServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Tcp, sp => new Factories.TcpServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Hid, sp => new Factories.HidServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Scp, sp => new Factories.ScpServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Csv, sp => new Factories.CsvServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.FileObserver, sp => new Factories.FileObserverServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Heartbeat, sp => new Factories.HeartbeatServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddSingleton<IDictionary<ServiceType, Factories.IServiceFactory>>(sp =>
+            {
+                var factories = new Dictionary<ServiceType, Factories.IServiceFactory>();
+                foreach (ServiceType type in Enum.GetValues<ServiceType>())
+                {
+                    var factory = sp.GetKeyedService<Factories.IServiceFactory>(type);
+                    if (factory != null)
+                    {
+                        factories[type] = factory;
+                    }
+                }
+                return factories;
+            });
 
 
             // Load strongly typed settings

--- a/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class CsvServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Csv;
 
-        public CsvServiceFactory(MainView mainView)
+        public CsvServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 CsvOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class FileObserverServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.FileObserver;
 
-        public FileObserverServiceFactory(MainView mainView)
+        public FileObserverServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 FileObserverOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,14 +10,14 @@ namespace DesktopApplicationTemplate.UI.Factories
     public class FtpServiceFactory : IServiceFactory
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Ftp;
 
-        public FtpServiceFactory(IServiceProvider services, MainView mainView)
+        public FtpServiceFactory(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -33,7 +34,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 FtpOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
             opt.Port = options.Port;

--- a/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class HeartbeatServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Heartbeat;
 
-        public HeartbeatServiceFactory(MainView mainView)
+        public HeartbeatServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 HeartbeatOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class HidServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Hid;
 
-        public HidServiceFactory(MainView mainView)
+        public HidServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 HidOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class HttpServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Http;
 
-        public HttpServiceFactory(MainView mainView)
+        public HttpServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 HttpOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
@@ -11,15 +11,15 @@ namespace DesktopApplicationTemplate.UI.Factories
     public class MqttServiceFactory : IServiceFactory
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
         private readonly MainViewModel _mainViewModel;
 
         public ServiceType ServiceType => ServiceType.Mqtt;
 
-        public MqttServiceFactory(IServiceProvider services, MainView mainView, MainViewModel mainViewModel)
+        public MqttServiceFactory(IServiceProvider services, Func<MainView> getMainView, MainViewModel mainViewModel)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
             _mainViewModel = mainViewModel;
         }
 
@@ -36,7 +36,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 IsActive = false
             };
 
-            _mainView.GetOrCreateServicePage(newService);
+            _getMainView().GetOrCreateServicePage(newService);
 
             var opt = _services.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
             opt.Host = options.Host;
@@ -74,11 +74,11 @@ namespace DesktopApplicationTemplate.UI.Factories
                         vm.RequestClose += (_, _) =>
                         {
                             if (newService.ServicePage != null)
-                                _mainView.ShowPage(newService.ServicePage);
+                                _getMainView().ShowPage(newService.ServicePage);
                             _ = _mainViewModel.SaveServicesAsync();
                         };
                     }
-                    _mainView.ShowPage(editView);
+                    _getMainView().ShowPage(editView);
                 };
             }
 

--- a/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class ScpServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Scp;
 
-        public ScpServiceFactory(MainView mainView)
+        public ScpServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 ScpOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
@@ -7,13 +8,13 @@ namespace DesktopApplicationTemplate.UI.Factories
 {
     public class TcpServiceFactory : IServiceFactory
     {
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Tcp;
 
-        public TcpServiceFactory(MainView mainView)
+        public TcpServiceFactory(Func<MainView> getMainView)
         {
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public ServiceListModel Create(object optionsObj)
@@ -30,7 +31,7 @@ namespace DesktopApplicationTemplate.UI.Factories
                 TcpOptions = options
             };
 
-            _mainView.GetOrCreateServicePage(svc);
+            _getMainView().GetOrCreateServicePage(svc);
 
             return svc;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
@@ -12,22 +12,23 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class CsvNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Csv;
 
-        public CsvNavigationHandler(IServiceProvider services, MainView mainView)
+        public CsvNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<CsvServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<CsvServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = _services.GetRequiredService<CsvServiceEditorView>();
             view.Initialize(vm);
             vm.AdvancedConfigRequested += opts =>
@@ -35,9 +36,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 var advVm = ActivatorUtilities.CreateInstance<CsvAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<CsvAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class FileObserverNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.FileObserver;
 
-        public FileObserverNavigationHandler(IServiceProvider services, MainView mainView)
+        public FileObserverNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<FileObserverCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FileObserverServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FileObserverServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<FileObserverCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<FileObserverAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<FileObserverAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class FtpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Ftp;
 
-        public FtpNavigationHandler(IServiceProvider services, MainView mainView)
+        public FtpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<FtpServerCreateViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FtpServerOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FtpServerOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<FtpServerCreateView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<FtpServerAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<FtpServerAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class HeartbeatNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Heartbeat;
 
-        public HeartbeatNavigationHandler(IServiceProvider services, MainView mainView)
+        public HeartbeatNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<HeartbeatCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<HeartbeatCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<HeartbeatAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<HeartbeatAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class HidNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Hid;
 
-        public HidNavigationHandler(IServiceProvider services, MainView mainView)
+        public HidNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<HidCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HidServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HidServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<HidCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<HidAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<HidAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class HttpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Http;
 
-        public HttpNavigationHandler(IServiceProvider services, MainView mainView)
+        public HttpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<HttpCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HttpServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HttpServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<HttpCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<HttpAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<HttpAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class MqttNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Mqtt;
 
-        public MqttNavigationHandler(IServiceProvider services, MainView mainView)
+        public MqttNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<MqttCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<MqttServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<MqttServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<MqttAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<MqttAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
@@ -12,31 +12,32 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class ScpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Scp;
 
-        public ScpNavigationHandler(IServiceProvider services, MainView mainView)
+        public ScpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<ScpCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<ScpServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<ScpServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<ScpCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
             {
                 var advVm = ActivatorUtilities.CreateInstance<ScpAdvancedConfigViewModel>(_services, opts);
                 var advView = _services.GetRequiredService<ScpAdvancedConfigView>();
                 advView.Initialize(advVm);
-                advVm.Saved += _ => _mainView.ShowPage(view);
-                advVm.BackRequested += () => _mainView.ShowPage(view);
-                _mainView.ShowPage(advView);
+                advVm.Saved += _ => mainView.ShowPage(view);
+                advVm.BackRequested += () => mainView.ShowPage(view);
+                mainView.ShowPage(advView);
             };
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
@@ -12,22 +12,23 @@ namespace DesktopApplicationTemplate.UI.Navigation
     public class TcpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
-        private readonly MainView _mainView;
+        private readonly Func<MainView> _getMainView;
 
         public ServiceType ServiceType => ServiceType.Tcp;
 
-        public TcpNavigationHandler(IServiceProvider services, MainView mainView)
+        public TcpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
             _services = services;
-            _mainView = mainView;
+            _getMainView = getMainView;
         }
 
         public Page CreateView(string defaultName)
         {
             var vm = _services.GetRequiredService<TcpCreateServiceViewModel>();
             vm.ServiceName = defaultName;
-            vm.ServiceSaved += (name, options) => _ = _mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<TcpServiceOptions>(name, options));
-            vm.EditCancelled += _mainView.ShowCreateServiceSelectionPage;
+            var mainView = _getMainView();
+            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<TcpServiceOptions>(name, options));
+            vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<TcpCreateServiceView>(_services, vm);
             return view;
         }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualBasic;
 using DesktopApplicationTemplate.UI.Helpers;
-using System.Linq;
 using System.Windows.Media;
 using DesktopApplicationTemplate.Models;
 using System.Windows.Input;
@@ -32,12 +31,20 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly MainViewModel _viewModel;
         private readonly ILogger<MainView>? _logger;
         private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
+        private readonly IDictionary<ServiceType, IServiceFactory> _serviceFactories;
+        private readonly IDictionary<ServiceType, INavigationHandler> _navigationHandlers;
 
-        public MainView(MainViewModel viewModel, IDictionary<ServiceType, IEditServiceHandler> editHandlers)
+        public MainView(
+            MainViewModel viewModel,
+            IDictionary<ServiceType, IEditServiceHandler> editHandlers,
+            IDictionary<ServiceType, IServiceFactory> serviceFactories,
+            IDictionary<ServiceType, INavigationHandler> navigationHandlers)
         {
             InitializeComponent();
             _viewModel = viewModel;
             _editHandlers = editHandlers;
+            _serviceFactories = serviceFactories;
+            _navigationHandlers = navigationHandlers;
             if (App.AppHost.Services.GetService(typeof(ILoggerFactory)) is ILoggerFactory factory)
             {
                 _logger = factory.CreateLogger<MainView>();
@@ -214,12 +221,11 @@ namespace DesktopApplicationTemplate.UI.Views
         private void NavigateTo(ServiceType serviceType)
         {
             var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType.ToLegacyString();
-            var handler = App.AppHost.Services.GetServices<INavigationHandler>()
-                .FirstOrDefault(h => h.ServiceType == serviceType);
-            if (handler == null)
-                return;
-            var view = handler.CreateView(defaultName);
-            ShowPage(view);
+            if (_navigationHandlers.TryGetValue(serviceType, out var handler))
+            {
+                var view = handler.CreateView(defaultName);
+                ShowPage(view);
+            }
         }
 
 
@@ -232,9 +238,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         internal async Task AddServiceAsync(ServiceType type, object options)
         {
-            var factory = App.AppHost.Services.GetServices<IServiceFactory>()
-                .FirstOrDefault(f => f.ServiceType == type);
-            if (factory == null)
+            if (!_serviceFactories.TryGetValue(type, out var factory))
                 return;
 
             var svc = factory.Create(options);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -97,6 +97,7 @@
 - App domain unhandled exception handler is asynchronous and awaits dispatcher shutdown.
 - Main window resolves edit workflows through a DI-injected handler dictionary instead of a large if/else chain.
 - Edit handlers register with DI keyed by `ServiceType`, and the main window receives a dictionary constructed from those registrations.
+- Main window now receives service factory and navigation handler dictionaries from DI for constant-time lookups.
 
 #### Fixed
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -201,6 +201,7 @@ Latest Attempt: After introducing `ServiceTypeExtensions` for code mapping, the 
 Latest Attempt: After binding settings dialogs to `ServiceType` enums, the `dotnet` command remains unavailable; restore, build, and test steps cannot run locally and CI will verify.
 Latest Attempt: After adding navigation handler tests, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Latest Attempt: After registering factories for additional services, the `dotnet` command is still missing; restore, build, and tests could not run locally so CI will verify.
+Latest Attempt: After injecting service factory and navigation handler dictionaries into MainView, the `dotnet` command remains unavailable; restore, build, and tests could not run locally, so CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- inject service factory and navigation handler dictionaries into MainView
- register keyed factories and navigation handlers in App startup
- update navigation tests and docs

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f06732088326b23c7012f8a3d3c2