### PR TITLE
Add service factory and navigation handler tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
+++ b/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
@@ -1,0 +1,66 @@
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Navigation;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels.Http;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class NavigationHandlerTests
+{
+    static NavigationHandlerTests()
+    {
+        _ = new App();
+    }
+
+    [WindowsFact]
+    public async Task CreateView_ServiceSaved_AddsService()
+    {
+        var provider = App.AppHost.Services;
+        var mainView = provider.GetRequiredService<MainView>();
+        var handler = provider.GetKeyedService<INavigationHandler>(ServiceType.Http)!;
+        var createPage = handler.CreateView("svc");
+        var vm = (HttpCreateServiceViewModel)createPage.DataContext!;
+
+        var mainVm = (MainViewModel)typeof(MainView).GetField("_viewModel", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(mainView)!;
+        mainVm.Services.Clear();
+
+        vm.ServiceSaved?.Invoke("svc", new HttpServiceOptions { BaseUrl = "http://example" });
+        await Task.Delay(10);
+
+        Assert.Single(mainVm.Services);
+    }
+
+    [WindowsFact]
+    public void AdvancedConfig_ReturnsToCreateView()
+    {
+        var provider = App.AppHost.Services;
+        var mainView = provider.GetRequiredService<MainView>();
+        var handler = provider.GetKeyedService<INavigationHandler>(ServiceType.Http)!;
+        var createPage = handler.CreateView("svc");
+        mainView.ShowPage(createPage);
+        var vm = (HttpCreateServiceViewModel)createPage.DataContext!;
+        var frame = (Frame)typeof(MainView).GetField("ContentFrame", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(mainView)!;
+
+        vm.AdvancedConfigRequested?.Invoke(new HttpServiceOptions());
+        var advPage = (Page)frame.Content!;
+        Assert.NotSame(createPage, advPage);
+        var advVm = (HttpAdvancedConfigViewModel)advPage.DataContext!;
+        advVm.BackRequested?.Invoke();
+        Assert.Same(createPage, frame.Content);
+
+        vm.AdvancedConfigRequested?.Invoke(new HttpServiceOptions());
+        advPage = (Page)frame.Content!;
+        advVm = (HttpAdvancedConfigViewModel)advPage.DataContext!;
+        advVm.Saved?.Invoke(new HttpServiceOptions());
+        Assert.Same(createPage, frame.Content);
+    }
+}

--- a/DesktopApplicationTemplate.Tests/ServiceFactoryTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceFactoryTests.cs
@@ -1,0 +1,89 @@
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Views;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class ServiceFactoryTests
+{
+    static ServiceFactoryTests()
+    {
+        // Ensure the application's service provider is built for factory resolution
+        _ = new App();
+    }
+
+    public static IEnumerable<object[]> FactoryTypes() => new[]
+    {
+        new object[] { ServiceType.Mqtt },
+        new object[] { ServiceType.Ftp },
+        new object[] { ServiceType.Http },
+        new object[] { ServiceType.Tcp },
+        new object[] { ServiceType.Hid },
+        new object[] { ServiceType.Scp },
+        new object[] { ServiceType.Csv },
+        new object[] { ServiceType.FileObserver },
+        new object[] { ServiceType.Heartbeat }
+    };
+
+    [WindowsTheory]
+    [MemberData(nameof(FactoryTypes))]
+    public void Create_ReturnsServicePage(ServiceType type)
+    {
+        var provider = App.AppHost.Services;
+        var factory = provider.GetKeyedService<IServiceFactory>(type);
+        Assert.NotNull(factory);
+
+        object ctx = type switch
+        {
+            ServiceType.Mqtt => new ServiceFactoryOptions<MqttServiceOptions>("mqtt", new MqttServiceOptions
+            {
+                Host = "localhost",
+                Port = 1883,
+                ClientId = "client"
+            }),
+            ServiceType.Ftp => new ServiceFactoryOptions<FtpServerOptions>("ftp", new FtpServerOptions
+            {
+                RootPath = "."
+            }),
+            ServiceType.Http => new ServiceFactoryOptions<HttpServiceOptions>("http", new HttpServiceOptions
+            {
+                BaseUrl = "http://localhost"
+            }),
+            ServiceType.Tcp => new ServiceFactoryOptions<TcpServiceOptions>("tcp", new TcpServiceOptions
+            {
+                Host = "localhost",
+                Port = 1
+            }),
+            ServiceType.Hid => new ServiceFactoryOptions<HidServiceOptions>("hid", new HidServiceOptions()),
+            ServiceType.Scp => new ServiceFactoryOptions<ScpServiceOptions>("scp", new ScpServiceOptions
+            {
+                Host = "host",
+                Username = "user",
+                Password = "pwd",
+                LocalPath = "local",
+                RemotePath = "remote"
+            }),
+            ServiceType.Csv => new ServiceFactoryOptions<CsvServiceOptions>("csv", new CsvServiceOptions
+            {
+                OutputPath = "."
+            }),
+            ServiceType.FileObserver => new ServiceFactoryOptions<FileObserverServiceOptions>("fo", new FileObserverServiceOptions
+            {
+                FilePath = "."
+            }),
+            ServiceType.Heartbeat => new ServiceFactoryOptions<HeartbeatServiceOptions>("hb", new HeartbeatServiceOptions
+            {
+                BaseMessage = "ping"
+            }),
+            _ => throw new NotSupportedException()
+        };
+
+        var svc = factory!.Create(ctx);
+        Assert.NotNull(svc.ServicePage);
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -295,6 +295,7 @@
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
 - Guide on creating custom services and registering dependencies via `IServiceModule`.
 - README now explains `ServiceType`, dictionary-based edit handlers, and dynamic DI modules with a sample for adding a new service.
+- Tests verify service factories create pages and navigation handlers wire events.
 
 #### Changed
 - Consolidated GitHub Actions into a single `CI` workflow with collaboration instructions in `AGENTS.md`.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -510,6 +510,7 @@ Action Items: Rely on CI for verification.
 Related Commits/PRs:
 
 Latest Attempt: After reorganizing service views and view models into per-service subfolders, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
+Newest Attempt: After adding service factory and navigation handler tests, the `dotnet` CLI remains missing and `dotnet test --settings tests.runsettings` cannot run; relying on CI.
 
 [2025-08-29 16:00] Topic: UI test removal
 Context: Removed DesktopApplicationTemplate.UI.Tests project and WPF UI tests that hung due to initialization issues.


### PR DESCRIPTION
## Summary
- add coverage verifying service factories create pages
- test navigation handler wiring for service saving and advanced config navigation
- document missing local dotnet runtime

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4323cb6dc832696b251797b6a8ab3