### PR TITLE
feat(ui): resolve service pages via DI dictionary

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -36,6 +36,7 @@ using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
 using System.IO;
 using System.Windows;
+using System.Windows.Controls;
 using System;
 using System.Windows.Threading;
 using System.Collections.Generic;
@@ -135,6 +136,27 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CsvService>();
             services.AddSingleton<CsvServiceView>();
             services.AddSingleton<SettingsViewModel>();
+            services.AddKeyedTransient<Page>(ServiceType.Tcp, sp => sp.GetRequiredService<TcpServiceMessagesView>());
+            services.AddKeyedTransient<Page>(ServiceType.Http, sp => sp.GetRequiredService<HttpServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.FileObserver, sp => sp.GetRequiredService<FileObserverView>());
+            services.AddKeyedTransient<Page>(ServiceType.Hid, sp => sp.GetRequiredService<HidViews>());
+            services.AddKeyedTransient<Page>(ServiceType.Heartbeat, sp => sp.GetRequiredService<HeartbeatView>());
+            services.AddKeyedTransient<Page>(ServiceType.Scp, sp => sp.GetRequiredService<SCPServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.Mqtt, sp => sp.GetRequiredService<MqttTagSubscriptionsView>());
+            services.AddKeyedTransient<Page>(ServiceType.Ftp, sp => sp.GetRequiredService<FTPServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.Csv, sp => sp.GetRequiredService<CsvServiceView>());
+            services.AddSingleton<IDictionary<ServiceType, Func<Page>>>(sp => new Dictionary<ServiceType, Func<Page>>
+            {
+                [ServiceType.Tcp] = () => sp.GetKeyedService<Page>(ServiceType.Tcp)!,
+                [ServiceType.Http] = () => sp.GetKeyedService<Page>(ServiceType.Http)!,
+                [ServiceType.FileObserver] = () => sp.GetKeyedService<Page>(ServiceType.FileObserver)!,
+                [ServiceType.Hid] = () => sp.GetKeyedService<Page>(ServiceType.Hid)!,
+                [ServiceType.Heartbeat] = () => sp.GetKeyedService<Page>(ServiceType.Heartbeat)!,
+                [ServiceType.Scp] = () => sp.GetKeyedService<Page>(ServiceType.Scp)!,
+                [ServiceType.Mqtt] = () => sp.GetKeyedService<Page>(ServiceType.Mqtt)!,
+                [ServiceType.Ftp] = () => sp.GetKeyedService<Page>(ServiceType.Ftp)!,
+                [ServiceType.Csv] = () => sp.GetKeyedService<Page>(ServiceType.Csv)!,
+            });
             services.AddTransient<SplashWindow>();
             services.AddTransient<CreateServicePage>();
             services.AddTransient<CreateServiceViewModel>();

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -6,7 +6,6 @@ using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.Factories;
-using DesktopApplicationTemplate.UI.Views.Tcp;
 using DesktopApplicationTemplate.Core.Models;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,18 +33,21 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
         private readonly IDictionary<ServiceType, IServiceFactory> _serviceFactories;
         private readonly IDictionary<ServiceType, INavigationHandler> _navigationHandlers;
+        private readonly IDictionary<ServiceType, Func<Page>> _pageResolvers;
 
         public MainView(
             MainViewModel viewModel,
             IDictionary<ServiceType, IEditServiceHandler> editHandlers,
             IDictionary<ServiceType, IServiceFactory> serviceFactories,
-            IDictionary<ServiceType, INavigationHandler> navigationHandlers)
+            IDictionary<ServiceType, INavigationHandler> navigationHandlers,
+            IDictionary<ServiceType, Func<Page>> pageResolvers)
         {
             InitializeComponent();
             _viewModel = viewModel;
             _editHandlers = editHandlers;
             _serviceFactories = serviceFactories;
             _navigationHandlers = navigationHandlers;
+            _pageResolvers = pageResolvers;
             if (App.AppHost.Services.GetService(typeof(ILoggerFactory)) is ILoggerFactory factory)
             {
                 _logger = factory.CreateLogger<MainView>();
@@ -96,22 +98,10 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public Page? GetOrCreateServicePage(ServiceListModel svc)
         {
-            if (svc.ServicePage != null)
-                return svc.ServicePage;
-
-            svc.ServicePage = svc.ServiceType switch
+            if (svc.ServicePage == null && _pageResolvers.TryGetValue(svc.ServiceType, out var factory))
             {
-                ServiceType.Tcp => App.AppHost.Services.GetRequiredService<TcpServiceMessagesView>(),
-                ServiceType.Http => App.AppHost.Services.GetRequiredService<HttpServiceView>(),
-                ServiceType.FileObserver => App.AppHost.Services.GetRequiredService<FileObserverView>(),
-                ServiceType.Hid => App.AppHost.Services.GetRequiredService<HidViews>(),
-                ServiceType.Heartbeat => App.AppHost.Services.GetRequiredService<HeartbeatView>(),
-                ServiceType.Scp => App.AppHost.Services.GetRequiredService<SCPServiceView>(),
-                ServiceType.Mqtt => App.AppHost.Services.GetRequiredService<MqttTagSubscriptionsView>(),
-                ServiceType.Ftp => App.AppHost.Services.GetRequiredService<FTPServiceView>(),
-                ServiceType.Csv => App.AppHost.Services.GetRequiredService<CsvServiceView>(),
-                _ => null
-            };
+                svc.ServicePage = factory();
+            }
 
             if (svc.ServicePage != null)
             {
@@ -148,7 +138,7 @@ namespace DesktopApplicationTemplate.UI.Views
                         var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
                         vm.ServiceType = svc.ServiceType;
                         vm.Load(svc.DisplayName.Split(" - ").Last(), svc.TcpOptions ?? new TcpServiceOptions());
-                        var editView = App.AppHost.Services.GetRequiredService<TcpEditServiceView>();
+                        var editView = App.AppHost.Services.GetRequiredService<Tcp.TcpEditServiceView>();
                         editView.Initialize(vm);
 
                         vm.ServiceSaved += (name, opts) =>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -99,6 +99,7 @@
 - Edit handlers register with DI keyed by `ServiceType`, and the main window receives a dictionary constructed from those registrations.
 - Dedicated edit handler classes replace delegate wrappers, moving edit logic out of `MainView`.
 - Main window now receives service factory and navigation handler dictionaries from DI for constant-time lookups.
+- Main window resolves service pages through a DI-injected dictionary instead of a service-type switch.
 - Service views and view models reorganized into per-service subfolders with updated namespaces.
 
 #### Fixed

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -203,6 +203,7 @@ Latest Attempt: After adding navigation handler tests, the `dotnet` command rema
 Latest Attempt: After registering factories for additional services, the `dotnet` command is still missing; restore, build, and tests could not run locally so CI will verify.
 Latest Attempt: After injecting service factory and navigation handler dictionaries into MainView, the `dotnet` command remains unavailable; restore, build, and tests could not run locally, so CI will verify.
 Latest Attempt: After extracting edit workflows into dedicated handler classes, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally and CI will verify.
+Latest Attempt: After introducing a DI-based page resolver dictionary, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- add keyed page registrations and resolver dictionary
- inject page factories into MainView and remove switch
- document DI-based page resolution

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43a5c2c0c83268d0c589d2a981d2e