### PR TITLE
refactor: remove service-specific references from MainView

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
-using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
-using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.Core.Models;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualBasic;
 using DesktopApplicationTemplate.UI.Helpers;
 using System.Windows.Media;
 using System.Windows.Input;
@@ -105,15 +102,15 @@ namespace DesktopApplicationTemplate.UI.Views
 
             if (svc.ServicePage != null)
             {
-                if (svc.ServicePage.DataContext is ILoggingViewModel vm && vm.Logger is LoggingService logger)
+                if (svc.ServicePage.DataContext is ILoggingViewModel vm && vm.Logger is not null)
                 {
                     if (svc.ServiceType == ServiceType.Mqtt)
                     {
-                        logger.LogAdded += entry => _viewModel.OnServiceLogAdded(svc, entry);
+                        vm.Logger.LogAdded += entry => _viewModel.OnServiceLogAdded(svc, entry);
                     }
                     else
                     {
-                        logger.LogAdded += entry =>
+                        vm.Logger.LogAdded += entry =>
                         {
                             var brush = (Brush?)new BrushConverter().ConvertFromString(entry.Color);
                             svc.AddLog(entry.Message, brush, entry.Level);
@@ -131,34 +128,6 @@ namespace DesktopApplicationTemplate.UI.Views
                     logHost.SetServiceContext(svc);
                 }
 
-                if (svc.ServiceType == ServiceType.Tcp && svc.ServicePage.DataContext is TcpServiceMessagesViewModel tcpVm)
-                {
-                    tcpVm.AdvancedSettingsRequested += (_, _) =>
-                    {
-                        var vm = App.AppHost.Services.GetRequiredService<TcpEditServiceViewModel>();
-                        vm.ServiceType = svc.ServiceType;
-                        vm.Load(svc.DisplayName.Split(" - ").Last(), svc.TcpOptions ?? new TcpServiceOptions());
-                        var editView = App.AppHost.Services.GetRequiredService<Tcp.TcpEditServiceView>();
-                        editView.Initialize(vm);
-
-                        vm.ServiceSaved += (name, opts) =>
-                        {
-                            svc.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
-                            svc.ServiceType = vm.ServiceType;
-                            svc.TcpOptions = opts;
-                            if (svc.ServicePage != null)
-                                ShowPage(svc.ServicePage);
-                            _ = _viewModel.SaveServicesAsync();
-                        };
-                        vm.EditCancelled += () =>
-                        {
-                            if (svc.ServicePage != null)
-                                ShowPage(svc.ServicePage);
-                        };
-
-                        ShowPage(editView);
-                    };
-                }
             }
 
             return svc.ServicePage;

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -204,6 +204,7 @@ Latest Attempt: After registering factories for additional services, the `dotnet
 Latest Attempt: After injecting service factory and navigation handler dictionaries into MainView, the `dotnet` command remains unavailable; restore, build, and tests could not run locally, so CI will verify.
 Latest Attempt: After extracting edit workflows into dedicated handler classes, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally and CI will verify.
 Latest Attempt: After introducing a DI-based page resolver dictionary, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
+Latest Attempt: After removing service-specific references from MainView, the `dotnet` command is still missing; build and test commands cannot run locally and CI will verify.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- simplify MainView to rely solely on interface-based handlers and logging
- document unavailable `dotnet` CLI in collaboration tips

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43c6036ac8326ac1aca9c1d33eee4