### PR TITLE
Refactor service editing to use ServiceType enum and DI handlers

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewEditServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewEditServiceTests.cs
@@ -1,11 +1,14 @@
 using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels.Csv;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Runtime.Serialization;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests;
@@ -15,25 +18,22 @@ public class MainViewEditServiceTests
     public static IEnumerable<object[]> ServiceTypes() =>
         Enum.GetValues<ServiceType>().Select(t => new object[] { t });
 
-    [WindowsTheory]
+    [Theory]
     [MemberData(nameof(ServiceTypes))]
     public void EditService_InvokesCorrectHandler(ServiceType type)
     {
-        // Arrange
-        var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
+        var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
+        var network = new Mock<INetworkConfigurationService>();
+        var networkVm = new NetworkConfigurationViewModel(network.Object);
         var mocks = Enum.GetValues<ServiceType>()
             .ToDictionary(t => t, _ => new Mock<IEditServiceHandler>());
         var dict = mocks.ToDictionary(k => k.Key, v => v.Value.Object);
-        typeof(MainView).GetField("_editHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(view, dict);
-
-        var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var vm = new MainViewModel(csv, networkVm, network.Object, dict);
         var service = TestHelpers.CreateService(type, "svc");
 
-        // Act
-        method.Invoke(view, new object[] { service });
+        vm.EditServiceCommand.Execute(service);
 
-        // Assert
         foreach (var kvp in mocks)
         {
             if (kvp.Key == type)
@@ -47,23 +47,21 @@ public class MainViewEditServiceTests
         }
     }
 
-    [WindowsFact]
+    [Fact]
     public void EditService_UnknownType_NoHandlerCalled()
     {
-        // Arrange
-        var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
+        var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
+        var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
+        var network = new Mock<INetworkConfigurationService>();
+        var networkVm = new NetworkConfigurationViewModel(network.Object);
         var mocks = Enum.GetValues<ServiceType>()
             .ToDictionary(t => t, _ => new Mock<IEditServiceHandler>());
         var dict = mocks.ToDictionary(k => k.Key, v => v.Value.Object);
-        typeof(MainView).GetField("_editHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(view, dict);
-        var method = typeof(MainView).GetMethod("OnEditRequested", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        var service = new ServiceListModel { ServiceType = (ServiceType)999, DisplayName = "Unknown" };
+        var vm = new MainViewModel(csv, networkVm, network.Object, dict);
+        var service = new ServiceListModel { Type = (ServiceType)999, DisplayName = "Unknown" };
 
-        // Act
-        method.Invoke(view, new object[] { service });
+        vm.EditServiceCommand.Execute(service);
 
-        // Assert
         foreach (var kvp in mocks.Values)
         {
             kvp.Verify(h => h.Edit(It.IsAny<ServiceListModel>()), Times.Never);

--- a/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
@@ -5,6 +5,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Csv;
 using DesktopApplicationTemplate.Models;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -20,7 +21,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object)
+            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>())
             {
                 Services =
                 {

--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -4,7 +4,9 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
 using DesktopApplicationTemplate.UI.ViewModels.Csv;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI;
 using Moq;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using DesktopApplicationTemplate.Models;
@@ -25,7 +27,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
             vm.Services.Add(TestHelpers.CreateService(ServiceType.Http, "HTTP1")
             {
                 IsActive = false,
@@ -58,7 +60,7 @@ namespace DesktopApplicationTemplate.Tests
             var oldPath = ServicePersistence.FilePath;
             try
             {
-                var vm = new MainViewModel(csv, networkVm, network.Object, logger.Object, servicesPath);
+                var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>(), logger.Object, servicesPath);
                 var service = TestHelpers.CreateService(type, name);
                 vm.Services.Add(service);
                 vm.SelectedService = service;
@@ -86,7 +88,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
             var svc = TestHelpers.CreateService(type, name);
             svc.Logs.Add(new LogEntry { Message = "test" });
             vm.Services.Add(svc);
@@ -106,7 +108,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
             var svc = TestHelpers.CreateService(type, name);
             svc.Logs.Add(new LogEntry { Message = "first" });
             vm.Services.Add(svc);
@@ -129,7 +131,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
             bool raised = false;
             vm.PropertyChanged += (s, e) => { if (e.PropertyName == "DisplayLogs") raised = true; };
             var svc = TestHelpers.CreateService(type, name);
@@ -143,43 +145,28 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
-        public void EditServiceCommand_LoadsCurrentMqttOptions()
+        public void EditServiceCommand_InvokesHandler()
         {
-            var options = Options.Create(new MqttServiceOptions
-            {
-                Host = "existing",
-                Port = 1883,
-                ClientId = "client"
-            });
-            var client = new Mock<IMqttClient>();
-            client.Setup(c => c.ConnectAsync(It.IsAny<MqttClientOptions>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new MqttClientConnectResult());
-            var service = new MqttService(client.Object, options, Mock.Of<IMessageRoutingService>(), Mock.Of<ILoggingService>());
-
             var configPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".json");
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
+            var handler = new Mock<IEditServiceHandler>();
+            var handlers = new Dictionary<ServiceType, IEditServiceHandler> { { ServiceType.Mqtt, handler.Object } };
+            var vm = new MainViewModel(csv, networkVm, network.Object, handlers);
             var svc = TestHelpers.CreateService(ServiceType.Mqtt, "Test");
             vm.Services.Add(svc);
 
-            MqttEditConnectionViewModel? captured = null;
-            vm.EditRequested += _ => captured = new MqttEditConnectionViewModel(service, options);
-
             vm.EditServiceCommand.Execute(svc);
 
-            Assert.NotNull(captured);
-            Assert.Equal("existing", captured!.Host);
-            Assert.Equal(1883, captured.Port);
-            Assert.Equal("client", captured.ClientId);
+            handler.Verify(h => h.Edit(svc), Times.Once);
             ConsoleTestLogger.LogPass();
         }
 
         private class TestMainViewModel : MainViewModel
         {
             public TestMainViewModel(CsvService csv, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService)
-                : base(csv, networkConfig, networkService)
+                : base(csv, networkConfig, networkService, new Dictionary<ServiceType, IEditServiceHandler>())
             {
             }
 
@@ -248,7 +235,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object);
+            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
 
             bool raised = false;
             vm.AddServiceRequested += () => raised = true;

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -22,7 +22,7 @@ namespace DesktopApplicationTemplate.Tests
             var b = TestHelpers.CreateService(ServiceType.Tcp, "B");
             var services = new List<ServiceListModel> { a, b };
             ServiceListModel.ResolveService = (type, name) =>
-                services.Find(s => s.ServiceType == type && s.DisplayName.Split(" - ").Last() == name);
+                services.Find(s => s.Type == type && s.DisplayName.Split(" - ").Last() == name);
 
             a.AddLog("TCP.B.Test message");
 
@@ -43,7 +43,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(csvVm);
             var net = new StubNetworkService();
             var netVm = new NetworkConfigurationViewModel(net);
-            var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
+            var main = new MainViewModel(csv, netVm, net, new Dictionary<ServiceType, IEditServiceHandler>(), servicesFilePath: Path.Combine(tempDir, "services.json"));
 
             main.Services.Add(TestHelpers.CreateService(type, baseName));
             var secondName = baseName[..^1] + "2";
@@ -67,7 +67,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(csvVm);
             var net = new StubNetworkService();
             var netVm = new NetworkConfigurationViewModel(net);
-            var main = new MainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
+            var main = new MainViewModel(csv, netVm, net, new Dictionary<ServiceType, IEditServiceHandler>(), servicesFilePath: Path.Combine(tempDir, "services.json"));
 
             var svc1 = TestHelpers.CreateService(type, baseName);
             var svc2 = TestHelpers.CreateService(type, baseName[..^1] + "2");
@@ -77,9 +77,9 @@ namespace DesktopApplicationTemplate.Tests
             var desired = baseName;
             if (main.Services.Any(s => s != svc2 && s.DisplayName.Split(" - ").Last().Equals(desired, StringComparison.OrdinalIgnoreCase)))
             {
-                desired = main.GenerateServiceName(svc2.ServiceType);
+                desired = main.GenerateServiceName(svc2.Type);
             }
-            svc2.DisplayName = $"{svc2.ServiceType.ToLegacyString()} - {desired}";
+            svc2.DisplayName = $"{svc2.Type.ToLegacyString()} - {desired}";
 
             var expected = $"{type.ToLegacyString()} - {baseName[..^1] + "3"}";
             Assert.Equal(expected, svc2.DisplayName);
@@ -91,7 +91,7 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void RecordExecutionTime_ComputesAverageAndTracksLastExecution()
         {
-            var vm = new ServiceListModel { ServiceType = ServiceType.Tcp };
+            var vm = new ServiceListModel { Type = ServiceType.Tcp };
             vm.RecordExecutionTime(TimeSpan.FromMilliseconds(100));
             vm.RecordExecutionTime(TimeSpan.FromMilliseconds(50));
 
@@ -104,7 +104,7 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void RecordExecutionTime_Throws_When_Negative()
         {
-            var vm = new ServiceListModel { ServiceType = ServiceType.Tcp };
+            var vm = new ServiceListModel { Type = ServiceType.Tcp };
             Assert.Throws<ArgumentException>(() => vm.RecordExecutionTime(TimeSpan.FromMilliseconds(-1)));
             ConsoleTestLogger.LogPass();
         }
@@ -112,7 +112,7 @@ namespace DesktopApplicationTemplate.Tests
         [Fact]
         public void AddLog_UpdatesLastInputMessage()
         {
-            var vm = new ServiceListModel { ServiceType = ServiceType.Tcp };
+            var vm = new ServiceListModel { Type = ServiceType.Tcp };
             vm.AddLog("hello world");
 
             Assert.Equal("hello world", vm.LastInputMessage);

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -29,8 +29,8 @@ namespace DesktopApplicationTemplate.Tests
             {
                 var services = new List<ServiceListModel>
                 {
-                    new ServiceListModel{DisplayName="A", ServiceType=ServiceType.Heartbeat, IsActive=true, Order=0},
-                    new ServiceListModel{DisplayName="B", ServiceType=ServiceType.Tcp, IsActive=false, Order=1}
+                    new ServiceListModel{DisplayName="A", Type=ServiceType.Heartbeat, IsActive=true, Order=0},
+                    new ServiceListModel{DisplayName="B", Type=ServiceType.Tcp, IsActive=false, Order=1}
                 };
                 services[0].AssociatedServices.Add("B");
                 services[1].AssociatedServices.Add("A");
@@ -60,8 +60,8 @@ namespace DesktopApplicationTemplate.Tests
             ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
             try
             {
-                var a = new ServiceListModel { DisplayName = "A", ServiceType = ServiceType.Tcp };
-                var b = new ServiceListModel { DisplayName = "B", ServiceType = ServiceType.Tcp };
+                var a = new ServiceListModel { DisplayName = "A", Type = ServiceType.Tcp };
+                var b = new ServiceListModel { DisplayName = "B", Type = ServiceType.Tcp };
                 a.AssociatedServices.Add("B");
                 b.AssociatedServices.Add("A");
                 var services = new List<ServiceListModel> { a, b };

--- a/DesktopApplicationTemplate.Tests/TestHelpers.cs
+++ b/DesktopApplicationTemplate.Tests/TestHelpers.cs
@@ -7,7 +7,7 @@ public static class TestHelpers
 {
     public static ServiceListModel CreateService(ServiceType type, string name) => new ServiceListModel
     {
-        ServiceType = type,
+        Type = type,
         DisplayName = $"{type.ToLegacyString()} - {name}"
     };
 }

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -30,14 +30,14 @@ public class TcpEditServiceHandler : IEditServiceHandler
         var tcpPage = _view.GetOrCreateServicePage(service);
         var options = service.TcpOptions ?? new TcpServiceOptions();
         var vm = _services.GetRequiredService<TcpEditServiceViewModel>();
-        vm.ServiceType = service.ServiceType;
+        vm.ServiceType = service.Type;
         vm.Load(service.DisplayName.Split(" - ").Last(), options);
         var editView = _services.GetRequiredService<TcpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
             service.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
-            service.ServiceType = vm.ServiceType;
+            service.Type = vm.ServiceType;
             service.TcpOptions = opts;
             if (tcpPage != null)
                 _view.ShowPage(tcpPage);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -27,7 +27,7 @@ namespace DesktopApplicationTemplate.Persistence
                 CsvServiceOptions? csv = null;
                 FtpServerOptions? ftp = null;
                 HttpServiceOptions? http = null;
-                if (s.ServiceType == ServiceType.Tcp && s.TcpOptions != null)
+                if (s.Type == ServiceType.Tcp && s.TcpOptions != null)
                 {
                     tcp = new TcpServiceOptions
                     {
@@ -42,7 +42,7 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
-                if (s.ServiceType == ServiceType.Ftp && s.FtpOptions != null)
+                if (s.Type == ServiceType.Ftp && s.FtpOptions != null)
                 {
                     ftp = new FtpServerOptions
                     {
@@ -54,7 +54,7 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
-                if (s.ServiceType == ServiceType.Http && s.HttpOptions != null)
+                if (s.Type == ServiceType.Http && s.HttpOptions != null)
                 {
                     http = new HttpServiceOptions
                     {
@@ -64,7 +64,7 @@ namespace DesktopApplicationTemplate.Persistence
                         ClientCertificatePath = s.HttpOptions.ClientCertificatePath
                     };
                 }
-                if (s.ServiceType == ServiceType.Csv && s.CsvOptions != null)
+                if (s.Type == ServiceType.Csv && s.CsvOptions != null)
                 {
                     csv = new CsvServiceOptions
                     {
@@ -77,7 +77,7 @@ namespace DesktopApplicationTemplate.Persistence
                 data.Add(new ServiceInfo
                 {
                     DisplayName = s.DisplayName,
-                    ServiceType = s.ServiceType,
+                    ServiceType = s.Type,
                     IsActive = s.IsActive,
                     Created = DateTime.Now,
                     Order = index++,

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -14,6 +14,7 @@ using DesktopApplicationTemplate.Persistence;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -39,7 +40,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand AddServiceCommand { get; }
         public ICommand RemoveServiceCommand { get; }
         public ICommand EditServiceCommand { get; }
-        public event Action<ServiceListModel>? EditRequested;
         public int ServicesCreated => Services.Count;
         public int CurrentActiveServices => Services.Count(s => s.IsActive);
 
@@ -56,20 +56,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly CsvService _csvService;
         private readonly ILoggingService? _logger;
         private readonly INetworkConfigurationService _networkService;
+        private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
-        public MainViewModel(CsvService csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, ILoggingService? logger = null, string? servicesFilePath = null)
+        public MainViewModel(CsvService csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, IDictionary<ServiceType, IEditServiceHandler> editHandlers, ILoggingService? logger = null, string? servicesFilePath = null)
         {
             _csvService = csvService;
             _networkService = networkService;
             _logger = logger;
             NetworkConfig = networkConfig;
+            _editHandlers = editHandlers;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceListModel.ResolveService = (type, name) =>
                 Services.FirstOrDefault(s =>
-                    s.ServiceType == type &&
+                    s.Type == type &&
                     s.DisplayName.Split(" - ").Last().Equals(name, StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrWhiteSpace(servicesFilePath))
             {
@@ -115,7 +117,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (target == null)
                 return;
 
-            EditRequested?.Invoke(target);
+            if (_editHandlers.TryGetValue(target.Type, out var handler))
+            {
+                handler.Edit(target);
+            }
+            else
+            {
+                _logger?.Log($"No edit handler registered for {target.Type}", LogLevel.Warning);
+            }
         }
 
         private void AddService()
@@ -129,7 +138,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             var typeName = serviceType.ToLegacyString();
             int index = 1;
-            foreach (var svc in Services.Where(s => s.ServiceType == serviceType))
+            foreach (var svc in Services.Where(s => s.Type == serviceType))
             {
                 var namePart = svc.DisplayName.Split(" - ").Last();
                 if (namePart.StartsWith(typeName) &&
@@ -148,7 +157,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _logger?.Log($"Removing service {SelectedService.DisplayName}", LogLevel.Debug);
                 var index = Services.IndexOf(SelectedService);
                 SelectedService.AddLog("Service removed", WpfBrushes.Red);
-                if (SelectedService.ServiceType != ServiceType.Csv)
+                if (SelectedService.Type != ServiceType.Csv)
                     _csvService.RemoveColumnsForService(SelectedService.DisplayName);
                 SelectedService.LogAdded -= OnServiceLogAdded;
                 SelectedService.ActiveChanged -= OnServiceActiveChanged;
@@ -167,15 +176,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 LogViewModel.RefreshLogs();
                 await SaveServicesAsync().ConfigureAwait(false);
                 _logger?.Log("Service removed", LogLevel.Debug);
-            }
-        }
-
-        public void EditSelectedService()
-        {
-            if (SelectedService != null)
-            {
-                SelectedService.IsActive = false;
-                EditRequested?.Invoke(SelectedService);
             }
         }
 
@@ -204,7 +204,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 var svc = new ServiceListModel
                 {
                     DisplayName = info.DisplayName,
-                    ServiceType = info.ServiceType,
+                    Type = info.ServiceType,
                     IsActive = info.IsActive,
                     Order = info.Order,
                     TcpOptions = info.TcpOptions,
@@ -219,7 +219,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 svc.SetColorsByType();
                 svc.LogAdded += OnServiceLogAdded;
                 svc.ActiveChanged += OnServiceActiveChanged;
-                if (svc.ServiceType != ServiceType.Csv)
+                if (svc.Type != ServiceType.Csv)
                     _csvService.EnsureColumnsForService(svc.DisplayName);
                 Services.Add(svc);
                 _logger?.Log($"Loaded service {svc.DisplayName}", LogLevel.Debug);
@@ -241,7 +241,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
                 if (Filters.TypeFilter != "All" &&
                     ServiceTypeExtensions.TryParse(Filters.TypeFilter, out var fType) &&
-                    svc.ServiceType != fType)
+                    svc.Type != fType)
                     return false;
 
                 if (Filters.StatusFilter == "Active" && !svc.IsActive)
@@ -257,7 +257,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void OnServiceLogAdded(ServiceListModel svc, LogEntry entry)
         {
             AllLogs.Insert(0, entry);
-            if (svc.ServiceType != ServiceType.Csv && Services.Any(s => s.ServiceType == ServiceType.Csv))
+            if (svc.Type != ServiceType.Csv && Services.Any(s => s.Type == ServiceType.Csv))
             {
                 try
                 {

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -14,7 +14,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     public class ServiceListModel : ViewModelBase
     {
         public string DisplayName { get; set; } = string.Empty;
-        public ServiceType ServiceType { get; set; }
+        public ServiceType Type { get; set; }
         [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 
@@ -227,7 +227,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void SetColorsByType()
         {
-            (BackgroundColor, BorderColor) = ServiceType switch
+            (BackgroundColor, BorderColor) = Type switch
             {
                 ServiceType.Tcp => (WpfBrushes.LightBlue, WpfBrushes.DarkBlue),
                 ServiceType.Http => (WpfBrushes.LightGreen, WpfBrushes.DarkGreen),

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -194,7 +194,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
             _options = service.TcpOptions ?? new TcpServiceOptions();
-            ServiceType = service.ServiceType;
+            ServiceType = service.Type;
             ServiceName = service.DisplayName.Split(" - ").Last();
             Script = string.IsNullOrWhiteSpace(_options.Script)
                 ? ScriptEditorViewModel.DefaultScript

--- a/DesktopApplicationTemplate.UI/Views/Ftp/FTPServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Ftp/FTPServiceView.xaml.cs
@@ -21,7 +21,7 @@ namespace DesktopApplicationTemplate.UI.Views.Ftp
 
         public void SetServiceContext(ServiceListModel service)
         {
-            LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
+            LogView.DataContext = new ServiceLogViewModel(service.Type, service.Logs);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Http/HttpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Http/HttpServiceView.xaml.cs
@@ -47,7 +47,7 @@ namespace DesktopApplicationTemplate.UI.Views.Http
 
         public void SetServiceContext(ServiceListModel service)
         {
-            LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
+            LogView.DataContext = new ServiceLogViewModel(service.Type, service.Logs);
         }
 
         private void Help_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -12,7 +12,6 @@ using DesktopApplicationTemplate.UI.Helpers;
 using System.Windows.Media;
 using System.Windows.Input;
 using System.Windows.Controls.Primitives;
-using DesktopApplicationTemplate.UI;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -27,21 +26,18 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         private readonly MainViewModel _viewModel;
         private readonly ILogger<MainView>? _logger;
-        private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
         private readonly IDictionary<ServiceType, IServiceFactory> _serviceFactories;
         private readonly IDictionary<ServiceType, INavigationHandler> _navigationHandlers;
         private readonly IDictionary<ServiceType, Func<Page>> _pageResolvers;
 
         public MainView(
             MainViewModel viewModel,
-            IDictionary<ServiceType, IEditServiceHandler> editHandlers,
             IDictionary<ServiceType, IServiceFactory> serviceFactories,
             IDictionary<ServiceType, INavigationHandler> navigationHandlers,
             IDictionary<ServiceType, Func<Page>> pageResolvers)
         {
             InitializeComponent();
             _viewModel = viewModel;
-            _editHandlers = editHandlers;
             _serviceFactories = serviceFactories;
             _navigationHandlers = navigationHandlers;
             _pageResolvers = pageResolvers;
@@ -50,7 +46,6 @@ namespace DesktopApplicationTemplate.UI.Views
                 _logger = factory.CreateLogger<MainView>();
             }
             DataContext = _viewModel;
-            _viewModel.EditRequested += OnEditRequested;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
@@ -95,7 +90,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public Page? GetOrCreateServicePage(ServiceListModel svc)
         {
-            if (svc.ServicePage == null && _pageResolvers.TryGetValue(svc.ServiceType, out var factory))
+            if (svc.ServicePage == null && _pageResolvers.TryGetValue(svc.Type, out var factory))
             {
                 svc.ServicePage = factory();
             }
@@ -104,7 +99,7 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 if (svc.ServicePage.DataContext is ILoggingViewModel vm && vm.Logger is not null)
                 {
-                    if (svc.ServiceType == ServiceType.Mqtt)
+                    if (svc.Type == ServiceType.Mqtt)
                     {
                         vm.Logger.LogAdded += entry => _viewModel.OnServiceLogAdded(svc, entry);
                     }
@@ -156,7 +151,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 var svc = new ServiceListModel
                 {
                     DisplayName = $"{type.ToLegacyString()} - {name}",
-                    ServiceType = type,
+                    Type = type,
                     IsActive = false
                 };
                 svc.SetColorsByType();
@@ -215,20 +210,6 @@ namespace DesktopApplicationTemplate.UI.Views
             await _viewModel.SaveServicesAsync();
             _logger?.LogDebug("AddService workflow completed");
         }
-
-    private void OnEditRequested(ServiceListModel service)
-    {
-        _logger?.LogDebug("Edit requested for {Name}", service.DisplayName);
-
-        if (_editHandlers.TryGetValue(service.ServiceType, out var handler))
-        {
-            handler.Edit(service);
-        }
-        else
-        {
-            _logger?.LogWarning("No edit handler registered for {ServiceType}", service.ServiceType);
-        }
-    }
 
 
         private void RemoveService_Click(object sender, RoutedEventArgs e)
@@ -300,9 +281,9 @@ namespace DesktopApplicationTemplate.UI.Views
                     var namePart = input.Contains(" - ") ? input.Split(" - ").Last() : input;
                     if (_viewModel.Services.Any(s => s != svc && s.DisplayName.Split(" - ").Last().Equals(namePart, StringComparison.OrdinalIgnoreCase)))
                     {
-                        namePart = _viewModel.GenerateServiceName(svc.ServiceType);
+                        namePart = _viewModel.GenerateServiceName(svc.Type);
                     }
-                    svc.DisplayName = $"{svc.ServiceType.ToLegacyString()} - {namePart}";
+                    svc.DisplayName = $"{svc.Type.ToLegacyString()} - {namePart}";
                     await _viewModel.SaveServicesAsync();
                 }
             }
@@ -319,7 +300,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     var color = dlg.ChosenColor;
                     var brush = new SolidColorBrush(color);
-                    foreach (var s in _viewModel.Services.Where(s => s.ServiceType == svc.ServiceType))
+                    foreach (var s in _viewModel.Services.Where(s => s.Type == svc.Type))
                     {
                         s.BackgroundColor = brush;
                         s.BorderColor = brush;

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml.cs
@@ -25,6 +25,6 @@ public partial class MqttTagSubscriptionsView : Page, IServiceLogHost
     /// <inheritdoc />
     public void SetServiceContext(ServiceListModel service)
     {
-        LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
+        LogView.DataContext = new ServiceLogViewModel(service.Type, service.Logs);
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml.cs
@@ -19,7 +19,7 @@ namespace DesktopApplicationTemplate.UI.Views.Tcp
 
         public void SetServiceContext(ServiceListModel service)
         {
-            LogView.DataContext = new ServiceLogViewModel(service.ServiceType, service.Logs);
+            LogView.DataContext = new ServiceLogViewModel(service.Type, service.Logs);
             if (DataContext is TcpServiceMessagesViewModel vm)
                 vm.SetService(service);
         }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Each service has an editor page where the parameters and test messages can be mo
 
 `ServiceType` is an enum that identifies each supported service category. It is serialized using short codes and still recognizes legacy names so existing configurations continue to load.
 
-Dictionary-based edit handlers are registered for each `ServiceType` and injected into the main window as a lookup. When a user edits a service, the window resolves the handler from that dictionary instead of relying on large switch statements, making it easy to plug in new handlers.
+Dictionary-based edit handlers are registered for each `ServiceType` and injected into the main view model as a lookup. When a user edits a service, the view model resolves the handler from that dictionary instead of relying on large switch statements, making it easy to plug in new handlers.
 
 Dynamic DI modules are enabled by `services.AddServiceModules()`, which scans assemblies for `IServiceModule` implementations and calls their `RegisterServices` methods. Dropping a new module into the application automatically registers its services without manual wiring.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Service persistence now stores `ServiceType` as short codes and reads legacy string names.
 - Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
 - `ServiceManager` loads default services from configuration using `ServiceType` short codes and accepts legacy names.
+- `ServiceListModel` now exposes a `Type` enum property, removing string-based service comparisons.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.
@@ -78,6 +79,7 @@
 - Removed `KeyboardHelper` and exit hooks; simulated key presses manage their own cleanup.
 - Removed `MainView` KeyDown handler; pressing Escape no longer returns to the home page.
 - Removed unused `HomePage` view and `PackUriSchemeInitializer`.
+- Main view model resolves edit requests through a DI-injected handler dictionary.
 - TCP create and edit views inline UDP and mode options, removing the separate advanced configuration view.
 - TCP create and edit view models remove string-based service type fields, using `ServiceType` enum for navigation.
 - TCP service messages view removes script editors and adds a test message input bound to view model.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -515,6 +515,8 @@ Related Commits/PRs:
 Latest Attempt: After reorganizing service views and view models into per-service subfolders, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally, so CI will verify.
 Newest Attempt: After adding service factory and navigation handler tests, the `dotnet` CLI remains missing and `dotnet test --settings tests.runsettings` cannot run; relying on CI.
 
+Latest Attempt: After moving edit handlers into the MainViewModel and switching ServiceListModel to a Type enum property, the `dotnet` command is still unavailable; restore, build, and test steps could not run locally so CI will verify.
+
 [2025-08-29 16:00] Topic: UI test removal
 Context: Removed DesktopApplicationTemplate.UI.Tests project and WPF UI tests that hung due to initialization issues.
 Observations: Deleting UI tests leaves only data-focused tests; solution no longer references the UI test project.


### PR DESCRIPTION
## Summary
- add ServiceListModel.Type enum property and remove string comparisons
- inject edit handlers into MainViewModel and invoke via dictionary
- document enum-based workflow and service editing changes

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4476044808326a062e54ff5ddbc59