### PR TITLE
Expose AddServiceAsync on navigation handlers

### DIFF
--- a/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
+++ b/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
@@ -39,6 +39,21 @@ public class NavigationHandlerTests
     }
 
     [WindowsFact]
+    public async Task AddServiceAsync_AddsService()
+    {
+        var provider = App.AppHost.Services;
+        var mainView = provider.GetRequiredService<MainView>();
+        var handler = provider.GetKeyedService<INavigationHandler>(ServiceType.Http)!;
+        var mainVm = (MainViewModel)typeof(MainView).GetField("_viewModel", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(mainView)!;
+        mainVm.Services.Clear();
+
+        await handler.AddServiceAsync("svc", new HttpServiceOptions { BaseUrl = "http://example" });
+
+        Assert.Single(mainVm.Services);
+    }
+
+    [WindowsFact]
     public void AdvancedConfig_ReturnsToCreateView()
     {
         var provider = App.AppHost.Services;

--- a/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Csv;
 using DesktopApplicationTemplate.UI.Views.Csv;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<CsvServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = _services.GetRequiredService<CsvServiceEditorView>();
             view.Initialize(vm);
@@ -42,6 +43,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<CsvServiceOptions>(name, (CsvServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.FileObserver;
 using DesktopApplicationTemplate.UI.Views.FileObserver;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<FileObserverCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FileObserverServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<FileObserverCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FileObserverServiceOptions>(name, (FileObserverServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Ftp;
 using DesktopApplicationTemplate.UI.Views.Ftp;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<FtpServerCreateViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FtpServerOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<FtpServerCreateView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FtpServerOptions>(name, (FtpServerOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Heartbeat;
 using DesktopApplicationTemplate.UI.Views.Heartbeat;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<HeartbeatCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<HeartbeatCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, (HeartbeatServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Hid;
 using DesktopApplicationTemplate.UI.Views.Hid;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<HidCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HidServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<HidCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HidServiceOptions>(name, (HidServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Http;
 using DesktopApplicationTemplate.UI.Views.Http;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<HttpCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HttpServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<HttpCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HttpServiceOptions>(name, (HttpServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
@@ -1,4 +1,4 @@
-using DesktopApplicationTemplate.UI.Views;
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.Models;
 
@@ -8,5 +8,6 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         ServiceType ServiceType { get; }
         Page CreateView(string defaultName);
+        Task AddServiceAsync(string name, object options);
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
 using DesktopApplicationTemplate.UI.Views.Mqtt;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<MqttCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<MqttServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,11 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<MqttServiceOptions>(name, (MqttServiceOptions)options));
         }
 
     }

--- a/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Scp;
 using DesktopApplicationTemplate.UI.Views.Scp;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<ScpCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<ScpServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<ScpCreateServiceView>(_services, vm);
             vm.AdvancedConfigRequested += opts =>
@@ -41,6 +42,12 @@ namespace DesktopApplicationTemplate.UI.Navigation
                 mainView.ShowPage(advView);
             };
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<ScpServiceOptions>(name, (ScpServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.Views.Tcp;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.Models;
+using System.Threading.Tasks;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
@@ -28,10 +29,16 @@ namespace DesktopApplicationTemplate.UI.Navigation
             var vm = _services.GetRequiredService<TcpCreateServiceViewModel>();
             vm.ServiceName = defaultName;
             var mainView = _getMainView();
-            vm.ServiceSaved += (name, options) => _ = mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<TcpServiceOptions>(name, options));
+            vm.ServiceSaved += (name, options) => _ = AddServiceAsync(name, options);
             vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
             var view = ActivatorUtilities.CreateInstance<TcpCreateServiceView>(_services, vm);
             return view;
+        }
+
+        public Task AddServiceAsync(string name, object options)
+        {
+            var mainView = _getMainView();
+            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,7 @@
 - ServiceMessageTableView limits height to keep the table compact.
 - Replaced main window navigation logo with a text header.
 - Centralized service navigation through `INavigationHandler` with DI-resolved handlers.
+- Navigation handlers expose `AddServiceAsync` to register services directly.
 - Script editor exposes the built-in script via `DefaultScript`, and TCP service messages view loads it when no script is provided.
 - Script editor raises an `OutputGenerated` event and TCP service messages view updates its output message when scripts run.
 - TcpServiceMessagesViewModel executes scripts asynchronously and awaits results when saving.


### PR DESCRIPTION
## Summary
- extend INavigationHandler with AddServiceAsync for service registration
- wire service-specific navigation handlers to AddServiceAsync
- cover AddServiceAsync in unit tests and changelog

## Testing
- `dotnet test --settings tests.runsettings` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c44a43b2bc83268bcfad499b33e682