### PR TITLE
Use Type property in service factories

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -76,15 +76,15 @@ namespace DesktopApplicationTemplate.UI
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
             services.AddServiceModules();
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, sp => new MqttEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<MqttEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, sp => new HeartbeatEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HeartbeatEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, sp => new HidEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HidEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Csv, sp => new CsvEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<CsvEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.FileObserver, sp => new FileObserverEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<FileObserverEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Scp, sp => new ScpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<ScpEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Tcp, sp => new TcpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<TcpEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Http, sp => new HttpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HttpEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Ftp, sp => new FtpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<FtpEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, (sp, _) => new MqttEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<MqttEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, (sp, _) => new HeartbeatEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HeartbeatEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, (sp, _) => new HidEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HidEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Csv, (sp, _) => new CsvEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<CsvEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.FileObserver, (sp, _) => new FileObserverEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<FileObserverEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Scp, (sp, _) => new ScpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<ScpEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Tcp, (sp, _) => new TcpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<TcpEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Http, (sp, _) => new HttpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HttpEditServiceHandler>>()));
+            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Ftp, (sp, _) => new FtpEditServiceHandler(sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<FtpEditServiceHandler>>()));
             services.AddSingleton<IDictionary<ServiceType, IEditServiceHandler>>(sp =>
             {
                 var handlers = new Dictionary<ServiceType, IEditServiceHandler>();
@@ -136,15 +136,15 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CsvService>();
             services.AddSingleton<CsvServiceView>();
             services.AddSingleton<SettingsViewModel>();
-            services.AddKeyedTransient<Page>(ServiceType.Tcp, sp => sp.GetRequiredService<TcpServiceMessagesView>());
-            services.AddKeyedTransient<Page>(ServiceType.Http, sp => sp.GetRequiredService<HttpServiceView>());
-            services.AddKeyedTransient<Page>(ServiceType.FileObserver, sp => sp.GetRequiredService<FileObserverView>());
-            services.AddKeyedTransient<Page>(ServiceType.Hid, sp => sp.GetRequiredService<HidViews>());
-            services.AddKeyedTransient<Page>(ServiceType.Heartbeat, sp => sp.GetRequiredService<HeartbeatView>());
-            services.AddKeyedTransient<Page>(ServiceType.Scp, sp => sp.GetRequiredService<SCPServiceView>());
-            services.AddKeyedTransient<Page>(ServiceType.Mqtt, sp => sp.GetRequiredService<MqttTagSubscriptionsView>());
-            services.AddKeyedTransient<Page>(ServiceType.Ftp, sp => sp.GetRequiredService<FTPServiceView>());
-            services.AddKeyedTransient<Page>(ServiceType.Csv, sp => sp.GetRequiredService<CsvServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.Tcp, (sp, _) => sp.GetRequiredService<TcpServiceMessagesView>());
+            services.AddKeyedTransient<Page>(ServiceType.Http, (sp, _) => sp.GetRequiredService<HttpServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.FileObserver, (sp, _) => sp.GetRequiredService<FileObserverView>());
+            services.AddKeyedTransient<Page>(ServiceType.Hid, (sp, _) => sp.GetRequiredService<HidViews>());
+            services.AddKeyedTransient<Page>(ServiceType.Heartbeat, (sp, _) => sp.GetRequiredService<HeartbeatView>());
+            services.AddKeyedTransient<Page>(ServiceType.Scp, (sp, _) => sp.GetRequiredService<SCPServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.Mqtt, (sp, _) => sp.GetRequiredService<MqttTagSubscriptionsView>());
+            services.AddKeyedTransient<Page>(ServiceType.Ftp, (sp, _) => sp.GetRequiredService<FTPServiceView>());
+            services.AddKeyedTransient<Page>(ServiceType.Csv, (sp, _) => sp.GetRequiredService<CsvServiceView>());
             services.AddSingleton<IDictionary<ServiceType, Func<Page>>>(sp => new Dictionary<ServiceType, Func<Page>>
             {
                 [ServiceType.Tcp] = () => sp.GetKeyedService<Page>(ServiceType.Tcp)!,
@@ -232,15 +232,15 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<ScpAdvancedConfigView>();
             services.AddTransient<ScpAdvancedConfigViewModel>();
             services.AddTransient<SettingsPage>();
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Mqtt, sp => new Navigation.MqttNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Ftp, sp => new Navigation.FtpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Http, sp => new Navigation.HttpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Tcp, sp => new Navigation.TcpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Hid, sp => new Navigation.HidNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Scp, sp => new Navigation.ScpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Csv, sp => new Navigation.CsvNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.FileObserver, sp => new Navigation.FileObserverNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Heartbeat, sp => new Navigation.HeartbeatNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Mqtt, (sp, _) => new Navigation.MqttNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Ftp, (sp, _) => new Navigation.FtpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Http, (sp, _) => new Navigation.HttpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Tcp, (sp, _) => new Navigation.TcpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Hid, (sp, _) => new Navigation.HidNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Scp, (sp, _) => new Navigation.ScpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Csv, (sp, _) => new Navigation.CsvNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.FileObserver, (sp, _) => new Navigation.FileObserverNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Heartbeat, (sp, _) => new Navigation.HeartbeatNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
             services.AddSingleton<IDictionary<ServiceType, Navigation.INavigationHandler>>(sp =>
             {
                 var handlers = new Dictionary<ServiceType, Navigation.INavigationHandler>();
@@ -254,15 +254,15 @@ namespace DesktopApplicationTemplate.UI
                 }
                 return handlers;
             });
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Mqtt, sp => new Factories.MqttServiceFactory(sp, () => sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Ftp, sp => new Factories.FtpServiceFactory(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Http, sp => new Factories.HttpServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Tcp, sp => new Factories.TcpServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Hid, sp => new Factories.HidServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Scp, sp => new Factories.ScpServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Csv, sp => new Factories.CsvServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.FileObserver, sp => new Factories.FileObserverServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Heartbeat, sp => new Factories.HeartbeatServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Mqtt, (sp, _) => new Factories.MqttServiceFactory(sp, () => sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Ftp, (sp, _) => new Factories.FtpServiceFactory(sp, () => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Http, (sp, _) => new Factories.HttpServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Tcp, (sp, _) => new Factories.TcpServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Hid, (sp, _) => new Factories.HidServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Scp, (sp, _) => new Factories.ScpServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Csv, (sp, _) => new Factories.CsvServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.FileObserver, (sp, _) => new Factories.FileObserverServiceFactory(() => sp.GetRequiredService<MainView>()));
+            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Heartbeat, (sp, _) => new Factories.HeartbeatServiceFactory(() => sp.GetRequiredService<MainView>()));
             services.AddSingleton<IDictionary<ServiceType, Factories.IServiceFactory>>(sp =>
             {
                 var factories = new Dictionary<ServiceType, Factories.IServiceFactory>();

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -4,7 +4,7 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.Views.Tcp;
 using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.Core.Models;
+using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.Csv.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.Csv,
+                Type = ServiceType.Csv,
                 IsActive = false,
                 CsvOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.FileObserver.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.FileObserver,
+                Type = ServiceType.FileObserver,
                 IsActive = false,
                 FileObserverOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
@@ -30,7 +30,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"FTP Server - {name}",
-                ServiceType = ServiceType.Ftp,
+                Type = ServiceType.Ftp,
                 IsActive = false,
                 FtpOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.Heartbeat.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.Heartbeat,
+                Type = ServiceType.Heartbeat,
                 IsActive = false,
                 HeartbeatOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.Hid.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.Hid,
+                Type = ServiceType.Hid,
                 IsActive = false,
                 HidOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.Http.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.Http,
+                Type = ServiceType.Http,
                 IsActive = false,
                 HttpOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
@@ -1,7 +1,9 @@
 using System;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.UI.Views.Mqtt;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using DesktopApplicationTemplate.Models;
@@ -32,7 +34,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var newService = new ServiceListModel
             {
                 DisplayName = $"MQTT - {name}",
-                ServiceType = ServiceType.Mqtt,
+                Type = ServiceType.Mqtt,
                 IsActive = false
             };
 

--- a/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.Scp.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.Scp,
+                Type = ServiceType.Scp,
                 IsActive = false,
                 ScpOptions = options
             };

--- a/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
@@ -26,7 +26,7 @@ namespace DesktopApplicationTemplate.UI.Factories
             var svc = new ServiceListModel
             {
                 DisplayName = $"{ServiceType.Tcp.ToLegacyString()} - {name}",
-                ServiceType = ServiceType.Tcp,
+                Type = ServiceType.Tcp,
                 IsActive = false,
                 TcpOptions = options
             };

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -12,6 +12,7 @@ using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Persistence;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -4,7 +4,7 @@ using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Factories;
-using DesktopApplicationTemplate.Core.Models;
+using DesktopApplicationTemplate.Models;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -275,7 +275,7 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (sender is MenuItem { DataContext: ServiceListModel svc })
             {
-                string input = Interaction.InputBox("Enter new service name:", "Rename Service", svc.DisplayName);
+                string input = Microsoft.VisualBasic.Interaction.InputBox("Enter new service name:", "Rename Service", svc.DisplayName);
                 if (!string.IsNullOrWhiteSpace(input))
                 {
                     var namePart = input.Contains(" - ") ? input.Split(" - ").Last() : input;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.
 - Removed unsupported `DisplayName` assignment from Windows service options to restore service build.
+- Service factories populate the `Type` property when creating service models.
 
 ### Navigation & UI
 #### Added

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -205,6 +205,7 @@ Latest Attempt: After injecting service factory and navigation handler dictionar
 Latest Attempt: After extracting edit workflows into dedicated handler classes, the `dotnet` command remains unavailable; restore, build, and test commands cannot run locally and CI will verify.
 Latest Attempt: After introducing a DI-based page resolver dictionary, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Latest Attempt: After removing service-specific references from MainView, the `dotnet` command is still missing; build and test commands cannot run locally and CI will verify.
+Latest Attempt: After updating service factories to set the `Type` property and installing the .NET SDK 8.0.404, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with compile errors in test projects, and `dotnet test --settings tests.runsettings` could not run due to the missing Microsoft.WindowsDesktop.App 8.0.0 runtime; relying on CI.
 Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.


### PR DESCRIPTION
## Summary
- populate ServiceListModel.Type in every IServiceFactory implementation
- register service factories and navigation handlers with explicit service type keys
- log test run limitations when WindowsDesktop runtime is missing

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: compile errors in test projects)*
- `dotnet test --settings tests.runsettings --no-build` *(fails: Microsoft.WindowsDesktop.App 8.0.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c44bcb3ea083268addef72fb4ef57f