### PR TITLE
refactor: centralize create view model events

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverCreateServiceViewModel.cs
@@ -18,7 +18,7 @@ public class FileObserverCreateServiceViewModel : ServiceCreateViewModelBase<Fil
     /// Initializes a new instance of the <see cref="FileObserverCreateServiceViewModel"/> class.
     /// </summary>
     public FileObserverCreateServiceViewModel(IServiceRule rule, IFileDialogService fileDialog, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
         _fileDialog = fileDialog ?? throw new ArgumentNullException(nameof(fileDialog));
         BrowseCommand = new RelayCommand(BrowseFolder);
@@ -47,38 +47,10 @@ public class FileObserverCreateServiceViewModel : ServiceCreateViewModelBase<Fil
     /// </summary>
     public ICommand BrowseCommand { get; }
 
-    /// <summary>
-    /// Current configuration options.
-    /// </summary>
-    public FileObserverServiceOptions Options { get; } = new();
-
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(FileObserverServiceOptions options)
     {
-        if (HasErrors)
-        {
-            Logger?.Log("FileObserver create validation failed", LogLevel.Warning);
-            return;
-        }
-        Logger?.Log("FileObserver create options start", LogLevel.Debug);
-        Options.FilePath = FilePath;
-        Logger?.Log("FileObserver create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("FileObserver create cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Logger?.Log("Opening FileObserver advanced config", LogLevel.Debug);
-        Options.FilePath = FilePath;
-        RaiseAdvancedConfigRequested(Options);
+        options.FilePath = FilePath;
     }
 
     private void BrowseFolder()

--- a/DesktopApplicationTemplate.UI/ViewModels/Ftp/FtpServerCreateViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Ftp/FtpServerCreateViewModel.cs
@@ -9,7 +9,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Ftp;
 /// </summary>
 public class FtpServerCreateViewModel : ServiceCreateViewModelBase<FtpServerOptions>
 {
-    private readonly IServiceScreen<FtpServerOptions> _screen;
     private int _port = 21;
     private string _rootPath = string.Empty;
 
@@ -17,19 +16,9 @@ public class FtpServerCreateViewModel : ServiceCreateViewModelBase<FtpServerOpti
     /// Initializes a new instance of the <see cref="FtpServerCreateViewModel"/> class.
     /// </summary>
     public FtpServerCreateViewModel(IServiceRule rule, IServiceScreen<FtpServerOptions> screen, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, screen, logger)
     {
-        _screen = screen ?? throw new ArgumentNullException(nameof(screen));
-
-        _screen.ServiceSaved += (_, o) => RaiseServiceSaved(o);
-        _screen.EditCancelled += () => RaiseEditCancelled();
-        _screen.AdvancedConfigRequested += o => RaiseAdvancedConfigRequested(o);
     }
-
-    /// <summary>
-    /// Current advanced options.
-    /// </summary>
-    public FtpServerOptions Options { get; } = new();
 
     /// <summary>
     /// Port to listen on.
@@ -68,23 +57,9 @@ public class FtpServerCreateViewModel : ServiceCreateViewModelBase<FtpServerOpti
     }
 
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(FtpServerOptions options)
     {
-        if (HasErrors)
-            return;
-        Options.Port = Port;
-        Options.RootPath = RootPath;
-        _screen.Save(ServiceName, Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel() => _screen.Cancel();
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Options.Port = Port;
-        Options.RootPath = RootPath;
-        _screen.OpenAdvanced(Options);
+        options.Port = Port;
+        options.RootPath = RootPath;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Heartbeat/HeartbeatCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Heartbeat/HeartbeatCreateServiceViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -15,7 +14,7 @@ public class HeartbeatCreateServiceViewModel : ServiceCreateViewModelBase<Heartb
     /// Initializes a new instance of the <see cref="HeartbeatCreateServiceViewModel"/> class.
     /// </summary>
     public HeartbeatCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
     }
 
@@ -28,32 +27,9 @@ public class HeartbeatCreateServiceViewModel : ServiceCreateViewModelBase<Heartb
         set { _baseMessage = value; OnPropertyChanged(); }
     }
 
-    /// <summary>
-    /// Current configuration options.
-    /// </summary>
-    public HeartbeatServiceOptions Options { get; } = new();
-
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(HeartbeatServiceOptions options)
     {
-        Logger?.Log("Heartbeat create options start", LogLevel.Debug);
-        Options.BaseMessage = BaseMessage;
-        Logger?.Log("Heartbeat create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("Heartbeat create cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Logger?.Log("Heartbeat advanced config requested", LogLevel.Debug);
-        Options.BaseMessage = BaseMessage;
-        RaiseAdvancedConfigRequested(Options);
+        options.BaseMessage = BaseMessage;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Hid/HidCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Hid/HidCreateServiceViewModel.cs
@@ -18,7 +18,7 @@ public class HidCreateServiceViewModel : ServiceCreateViewModelBase<HidServiceOp
     /// Initializes a new instance of the <see cref="HidCreateServiceViewModel"/> class.
     /// </summary>
     public HidCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
         UsbProtocols = new[] { "2.0", "3.0" };
     }
@@ -55,36 +55,11 @@ public class HidCreateServiceViewModel : ServiceCreateViewModelBase<HidServiceOp
         set { _attachedService = value; OnPropertyChanged(); }
     }
 
-    /// <summary>
-    /// Current configuration options.
-    /// </summary>
-    public HidServiceOptions Options { get; } = new();
-    
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(HidServiceOptions options)
     {
-        Logger?.Log("HID create options start", LogLevel.Debug);
-        Options.MessageTemplate = MessageTemplate;
-        Options.UsbProtocol = SelectedUsbProtocol;
-        Options.AttachedService = AttachedService;
-        Logger?.Log("HID create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("HID create cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Logger?.Log("Opening HID advanced config", LogLevel.Debug);
-        Options.MessageTemplate = MessageTemplate;
-        Options.UsbProtocol = SelectedUsbProtocol;
-        Options.AttachedService = AttachedService;
-        RaiseAdvancedConfigRequested(Options);
+        options.MessageTemplate = MessageTemplate;
+        options.UsbProtocol = SelectedUsbProtocol;
+        options.AttachedService = AttachedService;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Http/HttpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Http/HttpCreateServiceViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -15,7 +14,7 @@ public class HttpCreateServiceViewModel : ServiceCreateViewModelBase<HttpService
     /// Initializes a new instance of the <see cref="HttpCreateServiceViewModel"/> class.
     /// </summary>
     public HttpCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
     }
 
@@ -28,32 +27,9 @@ public class HttpCreateServiceViewModel : ServiceCreateViewModelBase<HttpService
         set { _baseUrl = value; OnPropertyChanged(); }
     }
 
-    /// <summary>
-    /// Current configuration options.
-    /// </summary>
-    public HttpServiceOptions Options { get; } = new();
-
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(HttpServiceOptions options)
     {
-        Logger?.Log("HTTP create options start", LogLevel.Debug);
-        Options.BaseUrl = BaseUrl;
-        Logger?.Log("HTTP create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("HTTP create cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Logger?.Log("Opening HTTP advanced config", LogLevel.Debug);
-        Options.BaseUrl = BaseUrl;
-        RaiseAdvancedConfigRequested(Options);
+        options.BaseUrl = BaseUrl;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttCreateServiceViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -19,7 +18,7 @@ public class MqttCreateServiceViewModel : ServiceCreateViewModelBase<MqttService
     /// Initializes a new instance of the <see cref="MqttCreateServiceViewModel"/> class.
     /// </summary>
     public MqttCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
     }
 
@@ -95,49 +94,15 @@ public class MqttCreateServiceViewModel : ServiceCreateViewModelBase<MqttService
         set { _password = value; OnPropertyChanged(); }
     }
 
-    /// <summary>
-    /// Current configuration options including advanced settings.
-    /// </summary>
-    public MqttServiceOptions Options { get; } = new();
-
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(MqttServiceOptions options)
     {
-        if (HasErrors)
-        {
-            Logger?.Log("MQTT create validation failed", LogLevel.Warning);
-            return;
-        }
-        Logger?.Log("MQTT create options start", LogLevel.Debug);
-        Options.Host = Host;
-        Options.Port = Port;
-        Options.ClientId = ClientId;
-        Options.Username = string.IsNullOrWhiteSpace(Username) ? null : Username;
-        Options.Password = string.IsNullOrWhiteSpace(Password) ? null : Password;
-        Options.WillTopic = string.IsNullOrWhiteSpace(Options.WillTopic) ? null : Options.WillTopic;
-        Options.WillPayload = string.IsNullOrWhiteSpace(Options.WillPayload) ? null : Options.WillPayload;
-        Logger?.Log("MQTT create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("MQTT create options cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Logger?.Log("Opening MQTT advanced config", LogLevel.Debug);
-        Options.Host = Host;
-        Options.Port = Port;
-        Options.ClientId = ClientId;
-        Options.Username = string.IsNullOrWhiteSpace(Username) ? null : Username;
-        Options.Password = string.IsNullOrWhiteSpace(Password) ? null : Password;
-        Options.WillTopic = string.IsNullOrWhiteSpace(Options.WillTopic) ? null : Options.WillTopic;
-        Options.WillPayload = string.IsNullOrWhiteSpace(Options.WillPayload) ? null : Options.WillPayload;
-        RaiseAdvancedConfigRequested(Options);
+        options.Host = Host;
+        options.Port = Port;
+        options.ClientId = ClientId;
+        options.Username = string.IsNullOrWhiteSpace(Username) ? null : Username;
+        options.Password = string.IsNullOrWhiteSpace(Password) ? null : Password;
+        options.WillTopic = string.IsNullOrWhiteSpace(options.WillTopic) ? null : options.WillTopic;
+        options.WillPayload = string.IsNullOrWhiteSpace(options.WillPayload) ? null : options.WillPayload;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Scp/ScpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Scp/ScpCreateServiceViewModel.cs
@@ -18,7 +18,7 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
     /// Initializes a new instance of the <see cref="ScpCreateServiceViewModel"/> class.
     /// </summary>
     public ScpCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
     }
 
@@ -123,45 +123,13 @@ public class ScpCreateServiceViewModel : ServiceCreateViewModelBase<ScpServiceOp
         }
     }
 
-    /// <summary>
-    /// Current configuration options.
-    /// </summary>
-    public ScpServiceOptions Options { get; } = new();
-
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(ScpServiceOptions options)
     {
-        if (HasErrors)
-        {
-            Logger?.Log("SCP create validation failed", LogLevel.Warning);
-            return;
-        }
-        Logger?.Log("SCP create options start", LogLevel.Debug);
-        Options.Host = Host;
+        options.Host = Host;
         if (int.TryParse(Port, out var port))
-            Options.Port = port;
-        Options.Username = Username;
-        Options.Password = Password;
-        Logger?.Log("SCP create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("SCP create cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        Logger?.Log("Opening SCP advanced config", LogLevel.Debug);
-        Options.Host = Host;
-        if (int.TryParse(Port, out var port))
-            Options.Port = port;
-        Options.Username = Username;
-        Options.Password = Password;
-        RaiseAdvancedConfigRequested(Options);
+            options.Port = port;
+        options.Username = Username;
+        options.Password = Password;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceCreateViewModelBase.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceCreateViewModelBase.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 
@@ -9,17 +10,68 @@ namespace DesktopApplicationTemplate.UI.ViewModels;
 /// <typeparam name="TOptions">Type of options managed by the service.</typeparam>
 public abstract class ServiceCreateViewModelBase<TOptions> : ServiceEditorViewModelBase<TOptions>
 {
+    private readonly IServiceScreen<TOptions>? _screen;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ServiceCreateViewModelBase{TOptions}"/> class.
     /// </summary>
-    protected ServiceCreateViewModelBase(IServiceRule rule, ILoggingService? logger = null)
+    protected ServiceCreateViewModelBase(IServiceRule rule, IServiceScreen<TOptions>? screen = null, ILoggingService? logger = null)
         : base(rule, logger)
     {
+        _screen = screen;
         SaveButtonText = "Create";
+        if (_screen is not null)
+        {
+            _screen.ServiceSaved += (_, o) => RaiseServiceSaved(o);
+            _screen.EditCancelled += () => RaiseEditCancelled();
+            _screen.AdvancedConfigRequested += o => RaiseAdvancedConfigRequested(o);
+        }
     }
+
+    /// <summary>
+    /// Current configuration options.
+    /// </summary>
+    public TOptions Options { get; } = new();
 
     /// <summary>
     /// Alias for <see cref="ServiceEditorViewModelBase{TOptions}.SaveCommand"/> used by XAML bindings.
     /// </summary>
     public ICommand CreateCommand => SaveCommand;
+
+    /// <inheritdoc />
+    protected override void OnSave()
+    {
+        if (HasErrors)
+            return;
+        ApplyOptions(Options);
+        if (_screen is not null)
+            _screen.Save(ServiceName, Options);
+        else
+            RaiseServiceSaved(Options);
+    }
+
+    /// <inheritdoc />
+    protected override void OnCancel()
+    {
+        if (_screen is not null)
+            _screen.Cancel();
+        else
+            RaiseEditCancelled();
+    }
+
+    /// <inheritdoc />
+    protected override void OnAdvancedConfig()
+    {
+        ApplyOptions(Options);
+        if (_screen is not null)
+            _screen.OpenAdvanced(Options);
+        else
+            RaiseAdvancedConfigRequested(Options);
+    }
+
+    /// <summary>
+    /// Copies view model properties into the provided options instance.
+    /// </summary>
+    /// <param name="options">Options instance to populate.</param>
+    protected abstract void ApplyOptions(TOptions options);
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpCreateServiceViewModel.cs
@@ -15,15 +15,10 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private TcpServiceMode _mode;
 
     /// <summary>
-    /// Current options.
-    /// </summary>
-    public TcpServiceOptions Options { get; } = new();
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="TcpCreateServiceViewModel"/> class.
     /// </summary>
     public TcpCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
-        : base(rule, logger)
+        : base(rule, logger: logger)
     {
     }
 
@@ -87,32 +82,11 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
     /// <inheritdoc />
-    protected override void OnSave()
+    protected override void ApplyOptions(TcpServiceOptions options)
     {
-        if (HasErrors)
-        {
-            Logger?.Log("TCP create validation failed", LogLevel.Warning);
-            return;
-        }
-        Logger?.Log("TCP create options start", LogLevel.Debug);
-        Options.Host = Host;
-        Options.Port = Port;
-        Options.UseUdp = UseUdp;
-        Options.Mode = Mode;
-        Logger?.Log("TCP create options finished", LogLevel.Debug);
-        RaiseServiceSaved(Options);
-    }
-
-    /// <inheritdoc />
-    protected override void OnCancel()
-    {
-        Logger?.Log("TCP create options cancelled", LogLevel.Debug);
-        RaiseEditCancelled();
-    }
-
-    /// <inheritdoc />
-    protected override void OnAdvancedConfig()
-    {
-        // Advanced configuration removed.
+        options.Host = Host;
+        options.Port = Port;
+        options.UseUdp = UseUdp;
+        options.Mode = Mode;
     }
 }


### PR DESCRIPTION
## Summary
- centralize common create view model logic in `ServiceCreateViewModelBase`
- simplify concrete create view models to only map properties to options

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c44ee750908326aeffa5009f6f6a9b