### PR TITLE
Add ServiceType enum and reference in main window

### DIFF
--- a/DesktopApplicationTemplate.Core/ServiceType.cs
+++ b/DesktopApplicationTemplate.Core/ServiceType.cs
@@ -1,0 +1,18 @@
+namespace DesktopApplicationTemplate.Core
+{
+    /// <summary>
+    /// Represents the supported service types within the application.
+    /// </summary>
+    public enum ServiceType
+    {
+        Mqtt,
+        Http,
+        Ftp,
+        Hid,
+        Csv,
+        FileObserver,
+        Scp,
+        Tcp,
+        Heartbeat
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -4,7 +4,7 @@ using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Factories;
-using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
## Summary
- add ServiceType enum to DesktopApplicationTemplate.Core
- reference core namespace in MainWindow

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found)*
- `dotnet test --settings tests.runsettings --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c46404786883269dddf724eb7dfede