### PR TITLE
Remove redundant ViewModels compile entry

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -53,8 +53,4 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="ViewModels/**/**/*.cs" />
-  </ItemGroup>
-
-  </Project>
+</Project>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -316,6 +316,7 @@
 - Core unit test project targets cross-platform `net8.0` for broader compatibility.
 - Removed WPF workload installation steps; WPF ships with the Windows .NET SDK.
 - Removed `DesktopApplicationTemplate.UI.Tests` project and WPF-specific unit tests.
+- Removed redundant `ViewModels` compile includes from the UI project, relying on default wildcard items.
 
 #### Fixed
 - Added missing `FluentAssertions` package reference to the test project and documented dependency checks to avoid build failures.

--- a/docs/CollaborationAndDebugTips.txt
+++ b/docs/CollaborationAndDebugTips.txt
@@ -206,7 +206,8 @@ Latest Attempt: After extracting edit workflows into dedicated handler classes, 
 Latest Attempt: After introducing a DI-based page resolver dictionary, the `dotnet` command remains unavailable; restore, build, and test commands could not run locally and CI will verify.
 Latest Attempt: After removing service-specific references from MainView, the `dotnet` command is still missing; build and test commands cannot run locally and CI will verify.
 Latest Attempt: After updating service factories to set the `Type` property and installing the .NET SDK 8.0.404, `dotnet restore` succeeded but `dotnet build DesktopApplicationTemplate.sln` failed with compile errors in test projects, and `dotnet test --settings tests.runsettings` could not run due to the missing Microsoft.WindowsDesktop.App 8.0.0 runtime; relying on CI.
-Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e
+Latest Attempt: After removing redundant ViewModels compile includes from the UI project, the `dotnet` CLI remains unavailable; `dotnet clean` and `dotnet build` could not run locally, so CI will verify.
+Related Commits/PRs: 8517691, 4c0dbb5, 1b5b0ec, 739abbe, 4f74a36, ff70210, 272560a, 26960dc, 7e9096b, 6454680, a70fb18, f1e064e, 8f72dc1
 [2025-08-27 04:25] Topic: Logging interface restoration
 Context: Introduced core logging abstractions and refactored edit view models to support DI.
 Observations: Added ILoggingService, LogLevel enum, moved LogEntry to core, and implemented Load methods on TCP and SCP edit view models.


### PR DESCRIPTION
## Summary
- rely on default SDK wildcard includes for ViewModels in the UI project
- document build-tool limitation when cleaning up compile items
- record change in the changelog

## Testing
- `dotnet clean && dotnet build` *(fails: command not found)*
- `dotnet test --settings tests.runsettings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c482f1a27483268a2656561c912aed