### PR TITLE
Specify behaviors assembly in MainWindow

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
-        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
+        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
 
         xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
         mc:Ignorable="d"


### PR DESCRIPTION
## Summary
- include explicit assembly name for TextBoxHintBehavior in MainWindow

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: property 'TextBoxHintBehavior.AutoToolTip' does not exist)*
- `dotnet test --settings tests.runsettings` *(fails: property 'TextBoxHintBehavior.AutoToolTip' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c811d5d95483268ecf16a559ca10d0