### PR TITLE
Qualify helpers namespace in MainWindow

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
-        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
+        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
 


### PR DESCRIPTION
## Summary
- include assembly qualifier for helpers namespace in MainWindow
- confirm NullToVisibilityConverter accessibility and namespace

## Testing
- `~/.dotnet/dotnet build DesktopApplicationTemplate.sln` *(fails: tag 'NullToVisibilityConverter' does not exist in XML namespace `clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI`)*
- `~/.dotnet/dotnet test --settings tests.runsettings --no-build` *(DesktopApplicationTemplate.Core.Tests passed; DesktopApplicationTemplate.Tests could not run: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68c81405e1108326afd9c7513a500009