### PR TITLE
chore: qualify main window views namespace

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
+        xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"


### PR DESCRIPTION
## Summary
- add assembly qualifier to `local` namespace in `MainWindow.xaml` so designer can resolve `FilterPanel`
- verify `FilterPanel.xaml` is defined with proper `x:Class` and compiled as a `Page`

## Testing
- `dotnet restore`
- `dotnet build DesktopApplicationTemplate.sln` *(fails: The tag 'NullToVisibilityConverter' does not exist in XML namespace 'clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI')*
- `dotnet test --settings tests.runsettings --no-build` *(partial: DesktopApplicationTemplate.Core.Tests passed; other test assembly produced invalid argument error)*

------
https://chatgpt.com/codex/tasks/task_e_68c8162b29d08326ac0e2a97f499b2b0