### PR TITLE
Qualify shared namespace in MainWindow

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
 
-        xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
+        xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
         mc:Ignorable="d"
         Title="MainView"
         MinWidth="800" MinHeight="600" Height="600"


### PR DESCRIPTION
## Summary
- qualify `shared` namespace in `MainWindow.xaml` with `DesktopApplicationTemplate.UI` assembly so shared views resolve correctly
- confirm `ServiceLogView` declares the expected class name and is compiled as a `Page`

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: The tag 'NullToVisibilityConverter' does not exist in XML namespace 'clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI')*
- `dotnet test --settings tests.runsettings --no-build` *(partial pass: core tests passed; test runner could not handle `DesktopApplicationTemplate.Tests.dll` argument)*

------
https://chatgpt.com/codex/tasks/task_e_68c817acd1508326827b58e3e45a94b4