### PR TITLE
Include Tcp namespace in DI container tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/DiContainerTests.cs
+++ b/DesktopApplicationTemplate.Tests/DiContainerTests.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Create;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Edit;
 using DesktopApplicationTemplate.Services.Common;


### PR DESCRIPTION
## Summary
- add Tcp ViewModels namespace to DiContainerTests

## Testing
- `dotnet test --settings tests.runsettings` *(fails: The tag 'NullToVisibilityConverter' does not exist in XML namespace 'clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI')*

------
https://chatgpt.com/codex/tasks/task_e_68c8245287ec83268425b8ef1b82cf12