### PR TITLE
Add Ftp namespace import for DI registration tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/FtpServerDiRegistrationTests.cs
+++ b/DesktopApplicationTemplate.Tests/FtpServerDiRegistrationTests.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels.Ftp;
 using DesktopApplicationTemplate.UI.ViewModels.Ftp.Create;
 using DesktopApplicationTemplate.UI.ViewModels.Ftp.Edit;
 using DesktopApplicationTemplate.UI.ViewModels.Ftp.Advanced;


### PR DESCRIPTION
## Summary
- include Ftp view model namespace in DI registration tests

## Testing
- `dotnet test --settings tests.runsettings` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c82cdc8ed88326a7f0a76afec73516