### PR TITLE
Use RuntimeHelpers for MainView navigation tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -4,7 +4,7 @@ using DesktopApplicationTemplate.UI.Views;
 using Moq;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using Xunit;
 
@@ -23,7 +23,7 @@ public class MainViewCreateNavigationTests
     public void NavigateTo_InvokesCorrectHandler(ServiceType type)
     {
         // Arrange
-        var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
+        var view = (MainView)RuntimeHelpers.GetUninitializedObject(typeof(MainView));
         typeof(MainView).GetField("ContentFrame")!.SetValue(view, new Frame());
         typeof(MainView).GetField("HomeContentGrid")!.SetValue(view, new Grid());
         var handlerMocks = new Dictionary<ServiceType, Mock<INavigationHandler>>
@@ -67,7 +67,7 @@ public class MainViewCreateNavigationTests
     public void NavigateTo_NoHandler_DoesNothing()
     {
         // Arrange
-        var view = (MainView)FormatterServices.GetUninitializedObject(typeof(MainView));
+        var view = (MainView)RuntimeHelpers.GetUninitializedObject(typeof(MainView));
         typeof(MainView).GetField("ContentFrame")!.SetValue(view, new Frame());
         typeof(MainView).GetField("HomeContentGrid")!.SetValue(view, new Grid());
         typeof(MainView).GetField("_navigationHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!


### PR DESCRIPTION
## Summary
- replace FormatterServices usage in MainViewCreateNavigationTests with RuntimeHelpers
- update the corresponding using directive to System.Runtime.CompilerServices

## Testing
- dotnet test --settings tests.runsettings *(fails: dotnet CLI is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c82f80a53c832699ac341e374af7af