### PR TITLE
Add UI namespace to MainViewModelFilterTests

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
@@ -1,3 +1,4 @@
+using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;


### PR DESCRIPTION
## Summary
- add the DesktopApplicationTemplate.UI namespace import to MainViewModelFilterTests to match updated dependencies

## Testing
- dotnet test --settings tests.runsettings *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c830012eec8326bde795f4b95c3a97