### PR TITLE
Add UI namespace import for ServiceListModelTests

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -1,3 +1,4 @@
+using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Csv;
 using DesktopApplicationTemplate.UI.Services;


### PR DESCRIPTION
## Summary
- add the DesktopApplicationTemplate.UI namespace import used by ServiceListModelTests

## Testing
- `dotnet test --settings tests.runsettings` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c831c27170832692652812f2b52caf