### PR TITLE
Add UI namespace import to navigation handler tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
+++ b/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;


### PR DESCRIPTION
## Summary
- add the DesktopApplicationTemplate.UI namespace import to NavigationHandlerTests

## Testing
- dotnet test --settings tests.runsettings *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8322bb64c8326b246e22f01903839