### PR TITLE
Add UI namespace import to service factory tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServiceFactoryTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceFactoryTests.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;


### PR DESCRIPTION
## Summary
- add the DesktopApplicationTemplate.UI namespace import to ServiceFactoryTests so the App type resolves

## Testing
- dotnet test --settings tests.runsettings *(fails: command not found: dotnet in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c834749d508326ac0c550ef19c6ce5