### PR TITLE
Adjust ListLogger LogAdded event

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -352,7 +352,11 @@ namespace DesktopApplicationTemplate.Tests
         {
             public List<string> Messages { get; } = new();
             public LogLevel MinimumLevel { get; set; }
-            public event Action<LogEntry>? LogAdded;
+            public event Action<LogEntry> LogAdded
+            {
+                add { }
+                remove { }
+            }
             public void Log(string message, LogLevel level)
             {
                 Messages.Add(message);


### PR DESCRIPTION
## Summary
- replace the ListLogger LogAdded event declaration with an explicit add/remove accessor so it no longer raises nullable warnings

## Testing
- `dotnet test --settings tests.runsettings` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c83507a9b08326976cbfdb27535128