### PR TITLE
Ensure main window controls application shutdown

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -378,6 +378,7 @@ namespace DesktopApplicationTemplate.UI
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Startup event")]
         protected override async void OnStartup(StartupEventArgs e)
         {
+            ShutdownMode = ShutdownMode.OnExplicitShutdown;
             await AppHost.StartAsync();
 
             var settings = AppHost.Services.GetRequiredService<SettingsViewModel>();
@@ -409,7 +410,9 @@ namespace DesktopApplicationTemplate.UI
             }
             else
             {
-                mainWindow.Show();
+                MainWindow = mainWindow;
+                MainWindow.Show();
+                ShutdownMode = ShutdownMode.OnMainWindowClose;
             }
 
             base.OnStartup(e);


### PR DESCRIPTION
## Summary
- set the application's shutdown mode to explicit at startup to avoid premature shutdown before the main window loads
- assign the resolved `MainView` instance to `MainWindow`, display it, and restore the normal shutdown mode once the UI is shown

## Testing
- dotnet test --settings tests.runsettings *(fails: `dotnet` command is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c837e942888326988e7fe79b18f0ae