### PR TITLE
Update logging service to use AppData log file

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -28,10 +28,21 @@ namespace DesktopApplicationTemplate.UI.Services
 
         public event Action<LogEntry>? LogAdded;
 
-        public LoggingService(IRichTextLogger richTextLogger, string logFilePath = "app.log")
+        public LoggingService(IRichTextLogger richTextLogger, string? logFilePath = null)
         {
             _richTextLogger = richTextLogger;
-            _logFilePath = logFilePath;
+            var resolvedLogFilePath = logFilePath ?? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "DesktopApplicationTemplate",
+                "app.log");
+
+            var directoryPath = Path.GetDirectoryName(resolvedLogFilePath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            _logFilePath = resolvedLogFilePath;
             Reload();
         }
 


### PR DESCRIPTION
## Summary
- resolve the logging file path to %AppData%/DesktopApplicationTemplate/app.log by default
- ensure the log directory exists before writing entries

## Testing
- dotnet test --settings tests.runsettings *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c840ef0dc08326ac3188bfbd54fa20