### PR TITLE
Update logging file path for AppData directory

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -31,19 +31,31 @@ namespace DesktopApplicationTemplate.UI.Services
         public LoggingService(IRichTextLogger richTextLogger, string? logFilePath = null)
         {
             _richTextLogger = richTextLogger;
-            var resolvedLogFilePath = logFilePath ?? Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "DesktopApplicationTemplate",
-                "app.log");
 
+            var resolvedLogFilePath = logFilePath ?? GetDefaultLogFilePath();
+            EnsureDirectoryExists(resolvedLogFilePath);
+
+            _logFilePath = resolvedLogFilePath;
+            Reload();
+        }
+
+        private static string GetDefaultLogFilePath()
+        {
+            var logDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "DesktopApplicationTemplate");
+
+            return Path.Combine(logDirectory, "app.log");
+        }
+
+        private static void EnsureDirectoryExists(string resolvedLogFilePath)
+        {
             var directoryPath = Path.GetDirectoryName(resolvedLogFilePath);
+
             if (!string.IsNullOrEmpty(directoryPath))
             {
                 Directory.CreateDirectory(directoryPath);
             }
-
-            _logFilePath = resolvedLogFilePath;
-            Reload();
         }
 
         public void Log(string message, LogLevel level)


### PR DESCRIPTION
## Summary
- default the UI logging service log file to %AppData%/DesktopApplicationTemplate/app.log
- ensure the log directory exists before writing so logging errors do not interrupt execution

## Testing
- dotnet test --settings tests.runsettings *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84d9982508326a37dcd427afa66f4