### PR TITLE
Fix duplicate members in SettingsViewModel

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -9,8 +9,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class SettingsViewModel : ViewModelBase
     {
-        private readonly ILoggingService? _logger;
-
         internal static string FilePath { get; set; } =
             Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
         private readonly ILoggingService? _logger;
@@ -24,11 +22,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private static bool _suppressSaveConfirmation;
         private static bool _suppressCloseConfirmation;
         private bool _dirty;
-
-        public SettingsViewModel(ILoggingService? logger = null)
-        {
-            _logger = logger;
-        }
 
         public static bool TcpLoggingEnabled { get; private set; } = true;
         public static bool SaveConfirmationSuppressed


### PR DESCRIPTION
## Summary
- remove the duplicate `_logger` field declaration from `SettingsViewModel`
- collapse redundant constructors so the parameterless overload delegates to the injectable constructor

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c822f3908c83269c4b4e398717ceea