### PR TITLE
Ensure theme resource dictionaries compile as pages

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -33,18 +33,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Themes\" />
-    <Resource Include="Themes/BubblyWindow.xaml" />
-    <Resource Include="Themes/LightTheme.xaml" />
-    <Resource Include="Themes/DarkTheme.xaml" />
-    <Resource Include="Themes/ToggleSwitch.xaml" />
-    <Resource Include="Themes/MqttTagSubscriptionsView.xaml" />
-    <Resource Include="Themes/DataFlowDiagram.xaml" />
-  </ItemGroup>
-
-
-  <ItemGroup>
     <Page Update="Views/**/*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Update="Themes/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>


### PR DESCRIPTION
## Summary
- ensure all theme resource dictionaries are included as WPF pages so every XAML file participates in the build
- rely on wildcard metadata so new theme XAML files automatically use the correct MSBuild generator

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: dotnet CLI is not available in the container)*
- `dotnet test --settings tests.runsettings` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c85269999c83268aad80c9d3416ddd