### PR TITLE
Clarify documentation for Windows collaborator build/test workflow

### DIFF
--- a/Codex/CollaborationGuidelines.txt
+++ b/Codex/CollaborationGuidelines.txt
@@ -5,8 +5,7 @@ Environment Setup
 -----------------
 - Install the .NET SDK version `8.0.404` (pinned via `global.json`).
 - On Windows, the .NET SDK includes WPF by default; no additional workload installation is needed.
-
-- Standard commands for builds and tests:
+- Windows collaborators run the standard build and test commands below and share the results. Codex cannot execute them inside the Linux container and relies on collaborator-provided logs.
 
   ```bash
   dotnet restore
@@ -14,17 +13,19 @@ Environment Setup
   dotnet test --settings tests.runsettings
   ```
 
+  Record a brief summary of the shared output in `Codex/docs/CollaborationAndDebugTips.txt` so future work understands the latest build state.
+
 Effective Collaboration Techniques
 ----------------------------------
 - Provide clear goals, file paths, and context for each task.
 - Prefer small, incremental changes that compile and test quickly.
-- Run programmatic checks after modifications and share their output.
+- Ask Windows collaborators to run programmatic checks after modifications and share their output. Codex summarizes the results in `Codex/docs/CollaborationAndDebugTips.txt` instead of running the commands directly.
 - Use `rg` or targeted `find` commands instead of recursive `ls` or `grep`.
 
 GitHub Workflow Notes
 ---------------------
 - Keep changes on the main branch and make atomic commits with descriptive messages.
-- After all code updates, run `dotnet test` and include the output in the pull request.
+- After code updates, ensure a Windows collaborator runs `dotnet test --settings tests.runsettings` and share their output in the pull request summary. Codex references their results when drafting the PR.
 - Only committed code is evaluated, so ensure the working tree is clean before calling `make_pr`.
 
 Documentation Style
@@ -43,7 +44,7 @@ Unit Testing Insights
 - Tests use xUnit with Moq for mocking and reside in `DesktopApplicationTemplate.Tests`.
 - Prefer isolated tests that validate one behavior and use expressive method names.
 - Configure dependencies through DI to keep tests focused and deterministic.
-- Run tests with `dotnet test` to ensure stability across platforms and CI environments.
+- Coordinate with Windows collaborators to run `dotnet test` so results cover the full Windows-only surface area.
 
 Miscellaneous Tips
 ------------------

--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.
-- Renamed root `CollaborationAndDebugTips.txt` to `CollaborationGuidelines.txt` and clarified distinction from `Codex/docs/CollaborationAndDebugTips.txt`.
+- Moved the collaboration guide into `Codex/CollaborationGuidelines.txt` and clarified distinction from `Codex/docs/CollaborationAndDebugTips.txt`.
 - Updated `global.json` to require the .NET 8 SDK version `8.0.404`.
 - Disabled default `AutoStart` and set environment configuration files to `"AutoStart": false`.
 - Core library targets `net8.0` to avoid Windows targeting pack restore errors.

--- a/Codex/docs/CollaborationAndDebugTips.txt
+++ b/Codex/docs/CollaborationAndDebugTips.txt
@@ -7,6 +7,7 @@ Purpose: Running log of what worked, what broke, and why.
 - Append commit hashes or PR numbers to the **Related Commits/PRs** line as work continues.
 - Use `Codex/tools/add-tip.ps1` with the same `-Topic` value to generate a block, then merge it into the existing entry.
 - Always record environment limitations (e.g., missing dotnet runtime).
+- When Windows collaborators run builds or tests, capture the commands and summarize their results so Codex can reference them.
 
 [2025-08-27 04:05] Topic: Documentation restructuring
 Context: Grouped changelog entries under feature headings and clarified topic-based logging.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,7 @@ repository root will automatically respect this setting.
 
 After cloning the repository:
 
-- Run a full build and test cycle:
-
-  ```bash
-  dotnet restore
-  dotnet build DesktopApplicationTemplate.sln
-  dotnet test --settings tests.runsettings
-  ```
-
+- Coordinate with a Windows collaborator to run the standard `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` commands documented below. Codex runs inside a Linux container without the WindowsDesktop runtime, so it depends on collaborators to share build and test results.
 - Run the setup script to configure the Git hooks and [Git LFS](https://git-lfs.com/):
 
   ```bash
@@ -52,6 +45,8 @@ After cloning the repository:
 Run the script any time the project dependencies or hooks need to be refreshed.
 
 ## Build the solution
+
+> **Note:** The Codex container lacks the WindowsDesktop runtime and cannot execute these commands. Windows collaborators should run them locally and provide the results for review.
 
 Restore NuGet packages and build all projects:
 
@@ -97,6 +92,8 @@ dotnet run --project DesktopApplicationTemplate.Service/DesktopApplicationTempla
 ```
 
 ## Execute unit tests
+
+> **Note:** Codex cannot run WPF tests in the container environment. Collaborators on Windows should execute the command below and share the outcome.
 
 Use `dotnet test` to run the xUnit tests. The repository includes a
 `tests.runsettings` file that ensures the entire test suite runs even


### PR DESCRIPTION
## Summary
- update README to reference Codex-based workflow and remove the mandatory build/test step
- clarify in Codex collaboration guidelines that Windows collaborators run dotnet restore/build/test and share results
- note in collaboration log instructions that collaborator-provided build outputs should be summarized, and update the changelog to match the new file paths

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c8602f9bc88326b3a50273923ad41a