### PR TITLE
docs: update agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 # Agent Instructions
 
-Detailed collaboration guidelines now reside in `Codex/AGENTS.md`.
+All collaboration guidelines now live in `Codex/AGENTS.md`.
 Review that file (and any nested `AGENTS.md` files) before starting work.

--- a/Codex/AGENTS.md
+++ b/Codex/AGENTS.md
@@ -1,14 +1,16 @@
 # Agent Instructions
 
+- Review this file and any nested `AGENTS.md` files before starting work.
 - Before beginning any task, review `Codex/CollaborationGuidelines.txt`, `Codex/docs/CHANGELOG.md`, `Codex/docs/CollaborationAndDebugTips.txt`, and any relevant `AGENTS.md` files to gather context and instructions.
 - `Codex/CollaborationGuidelines.txt` provides collaboration practices, while `Codex/docs/CollaborationAndDebugTips.txt` is a running log of what worked, what broke, and why.
 - Update those documents when your changes add context or new guidance.
-- After modifying code, attempt to run `dotnet test` with `tests.runsettings` and share the results; if the environment lacks Windows desktop support, note the limitation and rely on CI.
+- After modifying code, request that a collaborator run `dotnet test` with `tests.runsettings`, share the results, and document any environment limitations (for example, missing Windows desktop support) so the team can rely on CI when needed.
+
 ## Architecture & Coding Standards
 Summarized from the Codex Environment & Collaboration Guidelines:
 
 - **Dependency Injection:** Register services, ViewModels, and factories in `AppHost/ServiceCollection` via `IServiceCollection` extensions.
-- **Unit Tests:** Add xUnit tests for each new public method and edge cases; run `dotnet test` using `tests.runsettings`.
+- **Unit Tests:** Add xUnit tests for each new public method and edge cases; coordinate with collaborators to run `dotnet test` using `tests.runsettings` and share the results.
 - **Logging:** Use `Microsoft.Extensions.Logging` with structured logs, logging start/end and errors per Codex logging policy.
 - **Async/await:** Prefer async/await; avoid blocking and use `ConfigureAwait(false)` in libraries.
 - **MVVM:** Keep Views free of logic; ViewModels expose `ICommand` and observable state.


### PR DESCRIPTION
## Summary
- clarify that repository collaboration guidance now lives in `Codex/AGENTS.md`
- refresh Codex agent instructions with current document locations and testing expectations

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c861b05ab883268d4d540bdd6061d6