### PR TITLE
Document Codex documentation migration

### DIFF
--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -298,14 +298,13 @@
 - `/test` comment workflow to run CI on demand.
 - `TestCommon` library providing shared test helpers and fixtures referenced by all test projects.
 - `TestHelpers.CreateService` simplifies creating `ServiceListModel` instances in tests to reduce duplication.
-- Test-only composite service demonstrates reuse of `ServiceRule` and `ServiceScreen` in unit tests.
-- Comparison tests ensure composed sample service matches original implementation results and log formatting.
 - Collaboration tips note that WPF projects require Windows or the WindowsDesktop runtime and fail with `InitializeComponent` and `NETSDK1100` errors if missing.
 - Guide on creating custom services and registering dependencies via `IServiceModule`.
 - README now explains `ServiceType`, dictionary-based edit handlers, and dynamic DI modules with a sample for adding a new service.
 - Tests verify service factories create pages and navigation handlers wire events.
 
 #### Changed
+- Moved `docs/CHANGELOG.md` and supporting tools into `Codex/docs/` and `Codex/tools/`, updating documentation references to the new paths.
 - Consolidated GitHub Actions into a single `CI` workflow with collaboration instructions in `AGENTS.md`.
 - CI workflow runs on pushes to `feature/**` and `bugfix/**` branches, supports manual triggers, and skips checks for pull requests targeting `dev`.
 - Updated GitHub workflows to install the WPF workload instead of the deprecated `windowsdesktop` workload.

--- a/Codex/tools/add-tip.ps1
+++ b/Codex/tools/add-tip.ps1
@@ -19,7 +19,9 @@ param(
   [string]$Actions = "",
   [string]$Refs = ""
 )
-$path = Join-Path $PSScriptRoot "..\docs\CollaborationAndDebugTips.txt"
+$codexRoot = Split-Path $PSScriptRoot -Parent
+$docsRoot = Join-Path $codexRoot "docs"
+$path = Join-Path $docsRoot "CollaborationAndDebugTips.txt"
 $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm"
 $block = @"
 [$timestamp] Topic: $Topic


### PR DESCRIPTION
## Summary
- update the Codex add-tip tool to resolve the documentation path from the Codex directory
- note the relocation of docs and tooling in the changelog and drop obsolete composite service notes

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c86718d5dc83269a9781bc17d1c384