### PR TITLE
Clarify documentation for CI-first collaboration flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contributing
 
+- Review `Codex/CollaborationGuidelines.txt` for detailed collaboration standards before starting any task.
 - Use feature or bugfix branches and open pull requests against `main` or `dev`.
-- Codex MUST NOT run tests locally. All validation occurs via GitHub Actions.
+- GitHub Actions runs the full validation suite; do not attempt to execute it from the Codex container. Capture CI outcomes (or maintainer-provided summaries) when discussing verification.
 - Ensure the CI workflow is green before requesting a review.

--- a/Codex/AGENTS.md
+++ b/Codex/AGENTS.md
@@ -4,13 +4,13 @@
 - Before beginning any task, review `Codex/CollaborationGuidelines.txt`, `Codex/docs/CHANGELOG.md`, `Codex/docs/CollaborationAndDebugTips.txt`, and any relevant `AGENTS.md` files to gather context and instructions.
 - `Codex/CollaborationGuidelines.txt` provides collaboration practices, while `Codex/docs/CollaborationAndDebugTips.txt` is a running log of what worked, what broke, and why.
 - Update those documents when your changes add context or new guidance.
-- After modifying code, request that a collaborator run `dotnet test` with `tests.runsettings`, share the results, and document any environment limitations (for example, missing Windows desktop support) so the team can rely on CI when needed.
+- After modifying code, rely on GitHub Actions to run `dotnet test` with `tests.runsettings`. Document the CI results and any environment limitations (for example, missing Windows desktop support) so the team can troubleshoot when needed.
 
 ## Architecture & Coding Standards
 Summarized from the Codex Environment & Collaboration Guidelines:
 
 - **Dependency Injection:** Register services, ViewModels, and factories in `AppHost/ServiceCollection` via `IServiceCollection` extensions.
-- **Unit Tests:** Add xUnit tests for each new public method and edge cases; coordinate with collaborators to run `dotnet test` using `tests.runsettings` and share the results.
+- **Unit Tests:** Add xUnit tests for each new public method and edge cases; GitHub Actions executes `dotnet test` using `tests.runsettings`, so reference the CI output instead of attempting local runs.
 - **Logging:** Use `Microsoft.Extensions.Logging` with structured logs, logging start/end and errors per Codex logging policy.
 - **Async/await:** Prefer async/await; avoid blocking and use `ConfigureAwait(false)` in libraries.
 - **MVVM:** Keep Views free of logic; ViewModels expose `ICommand` and observable state.

--- a/Codex/CollaborationGuidelines.txt
+++ b/Codex/CollaborationGuidelines.txt
@@ -5,31 +5,31 @@ Environment Setup
 -----------------
 - Install the .NET SDK version `8.0.404` (pinned via `global.json`).
 - On Windows, the .NET SDK includes WPF by default; no additional workload installation is needed.
-- Ask a Windows collaborator to run the solution build and test workflow and share their logs. Codex cannot execute these commands in the Linux container and summarizes collaborator-provided results in `Codex/docs/CollaborationAndDebugTips.txt`.
+- Monitor GitHub Actions for the solution build and test workflow. Codex cannot execute these commands in the Linux container, so capture CI logs (or maintainer-provided summaries) in `Codex/docs/CollaborationAndDebugTips.txt`.
 
 Effective Collaboration Techniques
 ----------------------------------
 - Provide clear goals, file paths, and context for each task.
 - Prefer small, incremental changes that compile and test quickly.
-- Ask Windows collaborators to run programmatic checks after modifications and share their output. Codex summarizes the results in `Codex/docs/CollaborationAndDebugTips.txt` instead of running the commands directly.
+- Review GitHub Actions results after modifications and summarize the output in `Codex/docs/CollaborationAndDebugTips.txt`. Coordinate with Windows collaborators only when a CI issue requires additional diagnostics.
 - Use `rg` or targeted `find` commands instead of recursive `ls` or `grep`.
 
 Reference Documents
 -------------------
 - Review `Codex/docs/CHANGELOG.md` for release-level summaries that describe why notable changes shipped.
-- Capture troubleshooting details and collaborator-provided build/test outcomes in `Codex/docs/CollaborationAndDebugTips.txt`.
+- Capture troubleshooting details and CI build/test outcomes (plus any collaborator-provided diagnostics) in `Codex/docs/CollaborationAndDebugTips.txt`.
 - When updating either document, extend the relevant entry when applicable or start a new timestamped section only when introducing a distinct topic.
 
 GitHub Workflow Notes
 ---------------------
 - Keep changes on the main branch and make atomic commits with descriptive messages.
-- After code updates, request that a Windows collaborator run `dotnet test --settings tests.runsettings` (or the relevant checks) and forward their output. Cite the collaborator's results when drafting the PR instead of running the commands locally.
+- After code updates, rely on GitHub Actions to run `dotnet test --settings tests.runsettings` (and other checks). Reference the CI results when drafting the PR, noting any limitations that prevented completion.
 - Only committed code is evaluated, so ensure the working tree is clean before calling `make_pr`.
 
 Documentation Style
 -------------------
 - Cross-link new instructions to the appropriate sections in this document, `Codex/docs/CHANGELOG.md`, or `Codex/docs/CollaborationAndDebugTips.txt` so contributors can find them later.
-- Summaries of collaborator test runs belong in `Codex/docs/CollaborationAndDebugTips.txt`, not inline in pull request descriptions.
+- Summaries of CI test runs (and any collaborator follow-up diagnostics) belong in `Codex/docs/CollaborationAndDebugTips.txt`, not inline in pull request descriptions.
 
 Draw.io Integration
 -------------------
@@ -42,7 +42,7 @@ Unit Testing Insights
 - Tests use xUnit with Moq for mocking and reside in `DesktopApplicationTemplate.Tests`.
 - Prefer isolated tests that validate one behavior and use expressive method names.
 - Configure dependencies through DI to keep tests focused and deterministic.
-- Coordinate with Windows collaborators to execute the `dotnet test` runs and share their logs; summarize collaborator-provided outcomes in `Codex/docs/CollaborationAndDebugTips.txt` since the container cannot run them directly.
+- Monitor GitHub Actions for the `dotnet test` run and summarize the CI outcome in `Codex/docs/CollaborationAndDebugTips.txt`. If CI cannot complete, coordinate with a Windows collaborator for follow-up diagnostics.
 
 Miscellaneous Tips
 ------------------

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ repository root will automatically respect this setting.
 
 After cloning the repository:
 
-- Coordinate with a Windows collaborator to run the standard `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` commands documented below. Codex runs inside a Linux container without the WindowsDesktop runtime, so it depends on collaborators to share build and test results.
+- Rely on GitHub Actions to run the standard `dotnet restore`, `dotnet build DesktopApplicationTemplate.sln`, and `dotnet test --settings tests.runsettings` commands documented below. Codex runs inside a Linux container without the WindowsDesktop runtime, so capture the CI logs (or maintainer summaries) when documenting build and test results.
 - Run the setup script to configure the Git hooks and [Git LFS](https://git-lfs.com/):
 
   ```bash
@@ -46,7 +46,7 @@ Run the script any time the project dependencies or hooks need to be refreshed.
 
 ## Build the solution
 
-> **Note:** The Codex container lacks the WindowsDesktop runtime and cannot execute these commands. Windows collaborators should run them locally and provide the results for review.
+> **Note:** The Codex container lacks the WindowsDesktop runtime and cannot execute these commands. GitHub Actions performs the authoritative build; Windows collaborators only need to re-run the steps locally when diagnosing CI issues.
 
 Restore NuGet packages and build all projects:
 
@@ -93,7 +93,7 @@ dotnet run --project DesktopApplicationTemplate.Service/DesktopApplicationTempla
 
 ## Execute unit tests
 
-> **Note:** Codex cannot run WPF tests in the container environment. Collaborators on Windows should execute the command below and share the outcome.
+> **Note:** Codex cannot run WPF tests in the container environment. GitHub Actions runs the command below; review the CI logs for the outcome and only request a Windows collaborator's help if additional diagnostics are required.
 
 Use `dotnet test` to run the xUnit tests. The repository includes a
 `tests.runsettings` file that ensures the entire test suite runs even


### PR DESCRIPTION
## Summary
- add an explicit reminder in CONTRIBUTING.md to review Codex/CollaborationGuidelines.txt before starting work
- update Codex/AGENTS.md and Codex/CollaborationGuidelines.txt to emphasize that GitHub Actions runs dotnet test and captures the authoritative results
- refresh README.md notes so contributors rely on CI for build/test verification and only run commands locally when debugging

## Testing
- not run (documentation-only changes; CI is the source of truth)


------
https://chatgpt.com/codex/tasks/task_e_68c869babf908326a21c17b6d87cb452