### PR TITLE
Add service descriptor catalog and registration

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
+++ b/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
+    <ProjectReference Include="..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\TestCommon\TestCommon.csproj" />
   </ItemGroup>
 </Project>

--- a/DesktopApplicationTemplate.Core.Tests/ServiceCatalogTests.cs
+++ b/DesktopApplicationTemplate.Core.Tests/ServiceCatalogTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Core.Tests;
+
+public class ServiceCatalogTests
+{
+    [Fact]
+    public void AddServiceModules_RegistersCatalogWithDescriptors()
+    {
+        var services = new ServiceCollection();
+        services.AddServiceModules(typeof(CommonServicesModule).Assembly);
+
+        using var provider = services.BuildServiceProvider();
+        var catalog = provider.GetService<IServiceCatalog>();
+
+        catalog.Should().NotBeNull();
+        catalog!.Descriptors.Should().HaveCountGreaterThan(0);
+        catalog.TryGetById(ServiceDescriptorIds.Tcp, out var tcpDescriptor).Should().BeTrue();
+        tcpDescriptor!.LegacyType.Should().Be(ServiceType.Tcp);
+        catalog.LegacyMap.Should().ContainKey(ServiceType.Tcp).WhoseValue.Should().Be(ServiceDescriptorIds.Tcp);
+    }
+
+    [Fact]
+    public void AddServiceModules_DetectsMetadataConflicts()
+    {
+        var services = new ServiceCollection();
+
+        Action act = () => services.AddServiceModules(typeof(ConflictingDescriptorModule).Assembly);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private sealed class ConflictingDescriptorModule : IServiceModule
+    {
+        public void RegisterServices(IServiceCollection services)
+        {
+        }
+
+        public IEnumerable<IServiceDescriptor> DescribeServices()
+        {
+            yield return new SimpleDescriptor("test.service", "One");
+            yield return new SimpleDescriptor("test.service", "Two");
+        }
+    }
+
+    private sealed class SimpleDescriptor : IServiceDescriptor
+    {
+        public SimpleDescriptor(string id, string displayName)
+        {
+            Id = id;
+            DisplayName = displayName;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public string Category => "Test";
+
+        public string? Description => null;
+
+        public ServiceType? LegacyType => null;
+
+        public IServiceOptionsSerializer? OptionsSerializer => null;
+
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+    }
+}

--- a/DesktopApplicationTemplate.Core.Tests/ServiceTypeExtensionsTests.cs
+++ b/DesktopApplicationTemplate.Core.Tests/ServiceTypeExtensionsTests.cs
@@ -1,3 +1,4 @@
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using FluentAssertions;
 using Xunit;
@@ -30,6 +31,14 @@ public class ServiceTypeExtensionsTests
     public void ToLegacyString_ReturnsFriendlyName(ServiceType type, string expected)
     {
         type.ToLegacyString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(ServiceType.Tcp, ServiceDescriptorIds.Tcp)]
+    [InlineData(ServiceType.Http, ServiceDescriptorIds.Http)]
+    public void ToDescriptorId_ReturnsStableIdentifier(ServiceType type, string expected)
+    {
+        type.ToDescriptorId().Should().Be(expected);
     }
 }
 

--- a/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
 
 namespace DesktopApplicationTemplate.Models;
 
@@ -20,6 +21,19 @@ public static class ServiceTypeExtensions
         { ServiceType.Scp, "SC" },
         { ServiceType.Tcp, "TC" },
         { ServiceType.Heartbeat, "HB" }
+    };
+
+    private static readonly Dictionary<ServiceType, string> DescriptorMap = new()
+    {
+        { ServiceType.Mqtt, ServiceDescriptorIds.Mqtt },
+        { ServiceType.Http, ServiceDescriptorIds.Http },
+        { ServiceType.Ftp, ServiceDescriptorIds.Ftp },
+        { ServiceType.Hid, ServiceDescriptorIds.Hid },
+        { ServiceType.Csv, ServiceDescriptorIds.Csv },
+        { ServiceType.FileObserver, ServiceDescriptorIds.FileObserver },
+        { ServiceType.Scp, ServiceDescriptorIds.Scp },
+        { ServiceType.Tcp, ServiceDescriptorIds.Tcp },
+        { ServiceType.Heartbeat, ServiceDescriptorIds.Heartbeat }
     };
 
     private static readonly Dictionary<string, ServiceType> LegacyMap = new(StringComparer.OrdinalIgnoreCase)
@@ -83,5 +97,11 @@ public static class ServiceTypeExtensions
             ServiceType.Heartbeat => "Heartbeat",
             _ => type.ToCode()
         };
+
+    /// <summary>
+    /// Gets the stable descriptor identifier for the service type.
+    /// </summary>
+    public static string ToDescriptorId(this ServiceType type) =>
+        DescriptorMap.TryGetValue(type, out var id) ? id : type.ToString();
 }
 

--- a/DesktopApplicationTemplate.Core/Modules/IServiceModule.cs
+++ b/DesktopApplicationTemplate.Core/Modules/IServiceModule.cs
@@ -1,4 +1,5 @@
-using DesktopApplicationTemplate.Models;
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.Core.Modules;
@@ -9,13 +10,13 @@ namespace DesktopApplicationTemplate.Core.Modules;
 public interface IServiceModule
 {
     /// <summary>
-    /// Gets the service type represented by this module.
-    /// </summary>
-    ServiceType Type { get; }
-
-    /// <summary>
     /// Registers services with the provided service collection.
     /// </summary>
     /// <param name="services">The service collection to register with.</param>
     void RegisterServices(IServiceCollection services);
+
+    /// <summary>
+    /// Describes the services provided by this module for catalog registration.
+    /// </summary>
+    IEnumerable<IServiceDescriptor> DescribeServices();
 }

--- a/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace DesktopApplicationTemplate.Core.Modules;
 
@@ -29,11 +32,20 @@ public static class ServiceModuleExtensions
             .SelectMany(a => a.GetTypes())
             .Where(t => moduleType.IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
             .Select(t => Activator.CreateInstance(t))
-            .OfType<IServiceModule>();
+            .OfType<IServiceModule>()
+            .ToList();
 
+        var descriptors = new List<IServiceDescriptor>();
         foreach (var module in modules)
         {
             module.RegisterServices(services);
+            var moduleDescriptors = module.DescribeServices() ?? Enumerable.Empty<IServiceDescriptor>();
+            descriptors.AddRange(moduleDescriptors);
+        }
+
+        if (descriptors.Count > 0)
+        {
+            services.TryAddSingleton<IServiceCatalog>(_ => new ServiceCatalog(descriptors));
         }
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/IServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceCatalog.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Provides lookup access to registered <see cref="IServiceDescriptor"/> instances.
+/// </summary>
+public interface IServiceCatalog
+{
+    /// <summary>
+    /// Gets the descriptors registered with the catalog.
+    /// </summary>
+    IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
+
+    /// <summary>
+    /// Gets a mapping of legacy <see cref="ServiceType"/> values to descriptor identifiers.
+    /// </summary>
+    IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
+
+    /// <summary>
+    /// Attempts to retrieve a descriptor by its unique identifier.
+    /// </summary>
+    bool TryGetById(string id, out IServiceDescriptor descriptor);
+
+    /// <summary>
+    /// Attempts to retrieve a descriptor from a legacy <see cref="ServiceType"/>.
+    /// </summary>
+    bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor);
+}

--- a/DesktopApplicationTemplate.Core/Services/IServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceDescriptor.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Describes a service feature exposed by the platform.
+/// </summary>
+public interface IServiceDescriptor
+{
+    /// <summary>
+    /// Gets the stable identifier for the service.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the human readable display name.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the category used for grouping similar services.
+    /// </summary>
+    string Category { get; }
+
+    /// <summary>
+    /// Gets an optional description for the service.
+    /// </summary>
+    string? Description { get; }
+
+    /// <summary>
+    /// Gets the legacy <see cref="ServiceType"/> associated with the service, if any.
+    /// </summary>
+    ServiceType? LegacyType { get; }
+
+    /// <summary>
+    /// Gets the serializer used to persist service options, if available.
+    /// </summary>
+    IServiceOptionsSerializer? OptionsSerializer { get; }
+
+    /// <summary>
+    /// Gets registered factory bindings for integrating the service.
+    /// </summary>
+    IReadOnlyCollection<ServiceFactoryBinding> Factories { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/IServiceOptionsSerializer.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceOptionsSerializer.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Text.Json;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Provides helpers for serializing and deserializing service option payloads.
+/// </summary>
+public interface IServiceOptionsSerializer
+{
+    /// <summary>
+    /// Gets the concrete options type handled by the serializer.
+    /// </summary>
+    Type OptionsType { get; }
+
+    /// <summary>
+    /// Creates a default instance of the options type.
+    /// </summary>
+    object CreateDefaultOptions();
+
+    /// <summary>
+    /// Deserializes the provided JSON payload into the options type.
+    /// </summary>
+    object Deserialize(string json);
+
+    /// <summary>
+    /// Deserializes the provided JSON element into the options type.
+    /// </summary>
+    object Deserialize(JsonElement element);
+
+    /// <summary>
+    /// Serializes the supplied options instance to a JSON payload.
+    /// </summary>
+    string Serialize(object options);
+
+    /// <summary>
+    /// Writes the supplied options instance to the provided JSON writer.
+    /// </summary>
+    void Serialize(Utf8JsonWriter writer, object options);
+}
+
+/// <summary>
+/// Strongly typed serializer contract for service options.
+/// </summary>
+/// <typeparam name="TOptions">Options type.</typeparam>
+public interface IServiceOptionsSerializer<TOptions> : IServiceOptionsSerializer
+{
+    /// <summary>
+    /// Creates a default instance of the options type.
+    /// </summary>
+    new TOptions CreateDefaultOptions();
+
+    /// <summary>
+    /// Deserializes the provided JSON payload into the options type.
+    /// </summary>
+    new TOptions Deserialize(string json);
+
+    /// <summary>
+    /// Deserializes the provided JSON element into the options type.
+    /// </summary>
+    new TOptions Deserialize(JsonElement element);
+
+    /// <summary>
+    /// Serializes the supplied options instance to a JSON payload.
+    /// </summary>
+    string Serialize(TOptions options);
+
+    /// <summary>
+    /// Writes the supplied options instance to the provided JSON writer.
+    /// </summary>
+    void Serialize(Utf8JsonWriter writer, TOptions options);
+}

--- a/DesktopApplicationTemplate.Core/Services/Serialization/JsonServiceOptionsSerializer.cs
+++ b/DesktopApplicationTemplate.Core/Services/Serialization/JsonServiceOptionsSerializer.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Text.Json;
+
+namespace DesktopApplicationTemplate.Core.Services.Serialization;
+
+/// <summary>
+/// Serializes service options using <see cref="JsonSerializer"/>.
+/// </summary>
+/// <typeparam name="TOptions">Options type.</typeparam>
+public sealed class JsonServiceOptionsSerializer<TOptions> : IServiceOptionsSerializer<TOptions>
+    where TOptions : class
+{
+    private readonly JsonSerializerOptions _options;
+    private readonly Func<TOptions> _factory;
+
+    public JsonServiceOptionsSerializer(Func<TOptions>? factory = null, JsonSerializerOptions? options = null)
+    {
+        _factory = factory ?? CreateDefaultFactory();
+        _options = options ?? new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = false
+        };
+    }
+
+    public Type OptionsType => typeof(TOptions);
+
+    public TOptions CreateDefaultOptions() => _factory();
+
+    object IServiceOptionsSerializer.CreateDefaultOptions() => CreateDefaultOptions();
+
+    public TOptions Deserialize(string json) =>
+        JsonSerializer.Deserialize(json, OptionsType, _options) as TOptions
+        ?? throw new InvalidOperationException($"Unable to deserialize {OptionsType.Name} from payload.");
+
+    object IServiceOptionsSerializer.Deserialize(string json) => Deserialize(json);
+
+    public TOptions Deserialize(JsonElement element) =>
+        element.Deserialize<TOptions>(_options)
+        ?? throw new InvalidOperationException($"Unable to deserialize {OptionsType.Name} from element.");
+
+    object IServiceOptionsSerializer.Deserialize(JsonElement element) => Deserialize(element);
+
+    public string Serialize(TOptions options) => JsonSerializer.Serialize(options, _options);
+
+    string IServiceOptionsSerializer.Serialize(object options) => Serialize((TOptions)options);
+
+    public void Serialize(Utf8JsonWriter writer, TOptions options)
+    {
+        JsonSerializer.Serialize(writer, options, _options);
+    }
+
+    void IServiceOptionsSerializer.Serialize(Utf8JsonWriter writer, object options) => Serialize(writer, (TOptions)options);
+
+    private static Func<TOptions> CreateDefaultFactory()
+    {
+        if (typeof(TOptions).GetConstructor(Type.EmptyTypes) == null)
+        {
+            throw new InvalidOperationException($"Options type {typeof(TOptions).Name} must provide a parameterless constructor or a factory.");
+        }
+
+        return Activator.CreateInstance<TOptions>;
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Aggregates <see cref="IServiceDescriptor"/> instances discovered from service modules.
+/// </summary>
+public sealed class ServiceCatalog : IServiceCatalog
+{
+    private readonly IReadOnlyDictionary<string, IServiceDescriptor> _descriptorsById;
+    private readonly IReadOnlyDictionary<ServiceType, IServiceDescriptor> _descriptorsByLegacy;
+    private readonly IReadOnlyDictionary<ServiceType, string> _legacyMap;
+
+    public ServiceCatalog(IEnumerable<IServiceDescriptor> descriptors)
+    {
+        if (descriptors is null)
+        {
+            throw new ArgumentNullException(nameof(descriptors));
+        }
+
+        var builders = new Dictionary<string, ServiceDescriptorBuilder>(StringComparer.Ordinal);
+        foreach (var descriptor in descriptors)
+        {
+            if (!builders.TryGetValue(descriptor.Id, out var builder))
+            {
+                builder = new ServiceDescriptorBuilder(descriptor.Id);
+                builders.Add(descriptor.Id, builder);
+            }
+
+            builder.Merge(descriptor);
+        }
+
+        var snapshots = builders.Values.Select(b => b.Build()).ToList();
+
+        _descriptorsById = snapshots.ToDictionary(d => d.Id, d => (IServiceDescriptor)d, StringComparer.Ordinal);
+        var legacyLookup = new Dictionary<ServiceType, IServiceDescriptor>();
+        foreach (var descriptor in snapshots)
+        {
+            if (descriptor.LegacyType is { } legacy)
+            {
+                if (!legacyLookup.TryAdd(legacy, descriptor))
+                {
+                    throw new InvalidOperationException($"Legacy service type '{legacy}' is already mapped to descriptor '{legacyLookup[legacy].Id}'.");
+                }
+            }
+        }
+
+        _descriptorsByLegacy = legacyLookup;
+        _legacyMap = legacyLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id, StringComparer.Ordinal);
+        Descriptors = snapshots;
+    }
+
+    public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
+
+    public IReadOnlyDictionary<ServiceType, string> LegacyMap => _legacyMap;
+
+    public bool TryGetById(string id, out IServiceDescriptor descriptor) =>
+        _descriptorsById.TryGetValue(id, out descriptor!);
+
+    public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) =>
+        _descriptorsByLegacy.TryGetValue(legacyType, out descriptor!);
+
+    private sealed class ServiceDescriptorBuilder
+    {
+        private readonly string _id;
+        private string? _displayName;
+        private string? _category;
+        private string? _description;
+        private ServiceType? _legacyType;
+        private IServiceOptionsSerializer? _serializer;
+        private readonly Dictionary<(ServiceFactoryKind Kind, Type ContractType, string? Key), ServiceFactoryBinding> _factories = new();
+
+        public ServiceDescriptorBuilder(string id)
+        {
+            _id = id;
+        }
+
+        public void Merge(IServiceDescriptor descriptor)
+        {
+            if (!string.Equals(_id, descriptor.Id, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Descriptor id mismatch. Expected '{_id}', received '{descriptor.Id}'.");
+            }
+
+            _displayName = AssignOrValidate(_displayName, descriptor.DisplayName, nameof(descriptor.DisplayName));
+            _category = AssignOrValidate(_category, descriptor.Category, nameof(descriptor.Category));
+            _description = AssignOrValidate(_description, descriptor.Description, nameof(descriptor.Description), allowNull: true);
+
+            if (descriptor.LegacyType is { } legacy)
+            {
+                if (_legacyType is null)
+                {
+                    _legacyType = legacy;
+                }
+                else if (_legacyType.Value != legacy)
+                {
+                    throw new InvalidOperationException($"Conflicting legacy type assignments for descriptor '{_id}'.");
+                }
+            }
+
+            if (descriptor.OptionsSerializer is { } serializer)
+            {
+                if (_serializer is null)
+                {
+                    _serializer = serializer;
+                }
+                else if (_serializer.GetType() != serializer.GetType())
+                {
+                    throw new InvalidOperationException($"Conflicting serializer registrations for descriptor '{_id}'.");
+                }
+            }
+
+            foreach (var binding in descriptor.Factories ?? Array.Empty<ServiceFactoryBinding>())
+            {
+                var key = (binding.Kind, binding.ContractType, binding.Key);
+                _factories[key] = binding;
+            }
+        }
+
+        public IServiceDescriptor Build()
+        {
+            if (string.IsNullOrWhiteSpace(_displayName))
+            {
+                throw new InvalidOperationException($"Descriptor '{_id}' must specify a display name.");
+            }
+
+            if (string.IsNullOrWhiteSpace(_category))
+            {
+                throw new InvalidOperationException($"Descriptor '{_id}' must specify a category.");
+            }
+
+            var factories = _factories.Values.ToList();
+            return new Snapshot(_id, _displayName!, _category!, _description, _legacyType, _serializer, factories);
+        }
+
+        private static string? AssignOrValidate(string? current, string? incoming, string propertyName, bool allowNull = false)
+        {
+            if (string.IsNullOrWhiteSpace(incoming))
+            {
+                return allowNull ? current : current ?? throw new InvalidOperationException($"Descriptor must provide a value for '{propertyName}'.");
+            }
+
+            if (current is null)
+            {
+                return incoming;
+            }
+
+            if (!string.Equals(current, incoming, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Conflicting values for '{propertyName}'.");
+            }
+
+            return current;
+        }
+    }
+
+    private sealed class Snapshot : IServiceDescriptor
+    {
+        public Snapshot(
+            string id,
+            string displayName,
+            string category,
+            string? description,
+            ServiceType? legacyType,
+            IServiceOptionsSerializer? serializer,
+            IReadOnlyCollection<ServiceFactoryBinding> factories)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Category = category;
+            Description = description;
+            LegacyType = legacyType;
+            OptionsSerializer = serializer;
+            Factories = factories;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public string Category { get; }
+
+        public string? Description { get; }
+
+        public ServiceType? LegacyType { get; }
+
+        public IServiceOptionsSerializer? OptionsSerializer { get; }
+
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories { get; }
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/ServiceDescriptorIds.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceDescriptorIds.cs
@@ -1,0 +1,17 @@
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Provides stable identifiers for built-in service descriptors.
+/// </summary>
+public static class ServiceDescriptorIds
+{
+    public const string Mqtt = "service.mqtt";
+    public const string Http = "service.http";
+    public const string Ftp = "service.ftp";
+    public const string Hid = "service.hid";
+    public const string Csv = "service.csv";
+    public const string FileObserver = "service.fileobserver";
+    public const string Scp = "service.scp";
+    public const string Tcp = "service.tcp";
+    public const string Heartbeat = "service.heartbeat";
+}

--- a/DesktopApplicationTemplate.Core/Services/ServiceFactoryBinding.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceFactoryBinding.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Describes how to obtain a factory for integrating a service in a specific context.
+/// </summary>
+public sealed record ServiceFactoryBinding(
+    ServiceFactoryKind Kind,
+    Type ContractType,
+    Func<IServiceProvider, object?> Resolver,
+    string? Key = null)
+{
+    public static ServiceFactoryBinding Create(ServiceFactoryKind kind, Type contractType, Func<IServiceProvider, object?> resolver, string? key = null)
+        => new(kind, contractType, resolver, key);
+}

--- a/DesktopApplicationTemplate.Core/Services/ServiceFactoryKind.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceFactoryKind.cs
@@ -1,0 +1,17 @@
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Identifies the integration point for a service factory binding.
+/// </summary>
+public enum ServiceFactoryKind
+{
+    /// <summary>
+    /// Factory used to integrate with user interface workflows.
+    /// </summary>
+    UserInterface,
+
+    /// <summary>
+    /// Factory used to provision runtime/background services.
+    /// </summary>
+    Runtime
+}

--- a/DesktopApplicationTemplate.Services.Common/CommonServicesModule.cs
+++ b/DesktopApplicationTemplate.Services.Common/CommonServicesModule.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.Services.Common;
+
+/// <summary>
+/// Registers shared service descriptors.
+/// </summary>
+public sealed class CommonServicesModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+        // Shared services are registered through extension methods elsewhere.
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new MqttServiceDescriptor();
+        yield return new HttpServiceDescriptor();
+        yield return new FtpServiceDescriptor();
+        yield return new HidServiceDescriptor();
+        yield return new CsvServiceDescriptor();
+        yield return new FileObserverServiceDescriptor();
+        yield return new ScpServiceDescriptor();
+        yield return new TcpServiceDescriptor();
+        yield return new HeartbeatServiceDescriptor();
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/CsvServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/CsvServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class CsvServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Csv;
+
+    public CsvServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "CSV Creator",
+            "File",
+            "Generate CSV output from message payloads.",
+            ServiceType.Csv,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/FileObserverServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/FileObserverServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class FileObserverServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.FileObserver;
+
+    public FileObserverServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "File Observer",
+            "File",
+            "Monitor directories for changes and trigger automation flows.",
+            ServiceType.FileObserver,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/FtpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/FtpServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class FtpServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Ftp;
+
+    public FtpServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "FTP",
+            "Networking",
+            "Transfer files to remote hosts using the FTP protocol.",
+            ServiceType.Ftp,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/HeartbeatServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/HeartbeatServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class HeartbeatServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Heartbeat;
+
+    public HeartbeatServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "Heartbeat",
+            "Monitoring",
+            "Emit periodic heartbeat messages for monitoring integrations.",
+            ServiceType.Heartbeat,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/HidServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/HidServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class HidServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Hid;
+
+    public HidServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "HID",
+            "Hardware",
+            "Interact with Human Interface Devices for automation scenarios.",
+            ServiceType.Hid,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/HttpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/HttpServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class HttpServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Http;
+
+    public HttpServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "HTTP",
+            "Networking",
+            "Interact with HTTP endpoints for automation workflows.",
+            ServiceType.Http,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/MqttServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/MqttServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class MqttServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Mqtt;
+
+    public MqttServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "MQTT",
+            "Messaging",
+            "Connect to MQTT brokers and manage topic subscriptions.",
+            ServiceType.Mqtt,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/ScpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/ScpServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class ScpServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Scp;
+
+    public ScpServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "SCP",
+            "Networking",
+            "Transfer files securely using the SCP protocol.",
+            ServiceType.Scp,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/ServiceDescriptorBase.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/ServiceDescriptorBase.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+/// <summary>
+/// Provides a reusable base implementation for service descriptors.
+/// </summary>
+public abstract class ServiceDescriptorBase : IServiceDescriptor
+{
+    protected ServiceDescriptorBase(
+        string id,
+        string displayName,
+        string category,
+        string? description,
+        ServiceType legacyType,
+        IServiceOptionsSerializer? optionsSerializer,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories)
+    {
+        Id = id;
+        DisplayName = displayName;
+        Category = category;
+        Description = description;
+        LegacyType = legacyType;
+        OptionsSerializer = optionsSerializer;
+        Factories = factories?.ToArray() ?? Array.Empty<ServiceFactoryBinding>();
+    }
+
+    public string Id { get; }
+
+    public string DisplayName { get; }
+
+    public string Category { get; }
+
+    public string? Description { get; }
+
+    public ServiceType? LegacyType { get; }
+
+    public IServiceOptionsSerializer? OptionsSerializer { get; }
+
+    public IReadOnlyCollection<ServiceFactoryBinding> Factories { get; }
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/TcpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/TcpServiceDescriptor.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Services.Common.Descriptors;
+
+public sealed class TcpServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = ServiceDescriptorIds.Tcp;
+
+    public TcpServiceDescriptor(
+        IServiceOptionsSerializer? optionsSerializer = null,
+        IReadOnlyCollection<ServiceFactoryBinding>? factories = null)
+        : base(
+            DescriptorId,
+            "TCP",
+            "Networking",
+            "Send and receive messages over TCP or UDP.",
+            ServiceType.Tcp,
+            optionsSerializer,
+            factories)
+    {
+    }
+}

--- a/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
+++ b/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Serialization;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.UI.Modules;
+
+public sealed class UiServiceModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+        // UI service registrations remain in App.xaml configuration for now.
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new MqttServiceDescriptor(
+            new JsonServiceOptionsSerializer<MqttServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Mqtt),
+                    MqttServiceDescriptor.DescriptorId)
+            });
+
+        yield return new HttpServiceDescriptor(
+            new JsonServiceOptionsSerializer<HttpServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Http),
+                    HttpServiceDescriptor.DescriptorId)
+            });
+
+        yield return new FtpServiceDescriptor(
+            new JsonServiceOptionsSerializer<FtpServerOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Ftp),
+                    FtpServiceDescriptor.DescriptorId)
+            });
+
+        yield return new HidServiceDescriptor(
+            new JsonServiceOptionsSerializer<HidServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Hid),
+                    HidServiceDescriptor.DescriptorId)
+            });
+
+        yield return new CsvServiceDescriptor(
+            new JsonServiceOptionsSerializer<CsvServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Csv),
+                    CsvServiceDescriptor.DescriptorId)
+            });
+
+        yield return new FileObserverServiceDescriptor(
+            new JsonServiceOptionsSerializer<FileObserverServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.FileObserver),
+                    FileObserverServiceDescriptor.DescriptorId)
+            });
+
+        yield return new ScpServiceDescriptor(
+            new JsonServiceOptionsSerializer<ScpServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Scp),
+                    ScpServiceDescriptor.DescriptorId)
+            });
+
+        yield return new TcpServiceDescriptor(
+            new JsonServiceOptionsSerializer<TcpServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Tcp),
+                    TcpServiceDescriptor.DescriptorId)
+            });
+
+        yield return new HeartbeatServiceDescriptor(
+            new JsonServiceOptionsSerializer<HeartbeatServiceOptions>(),
+            new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.UserInterface,
+                    typeof(IServiceFactory),
+                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Heartbeat),
+                    HeartbeatServiceDescriptor.DescriptorId)
+            });
+    }
+}


### PR DESCRIPTION
## Summary
- add service descriptor contracts, catalog implementation, and JSON option serializer helpers
- update service module discovery to collect descriptors and publish a shared catalog
- register built-in service descriptors in common and UI assemblies and expose descriptor ids on ServiceType
- add catalog and descriptor id unit tests for validation

## Testing
- `dotnet build DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj` *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc11c29bc08326b8570ace83334197