### PR TITLE
Add descriptor registration metadata to navigation handlers

### DIFF
--- a/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
@@ -19,7 +19,7 @@ public static class ServiceModuleExtensions
     /// </summary>
     /// <param name="services">The service collection to populate.</param>
     /// <param name="assemblies">Assemblies to scan. If none are provided, the current app domain assemblies are used.</param>
-    public static void AddServiceModules(this IServiceCollection services, params Assembly[] assemblies)
+    public static IServiceCatalog AddServiceModules(this IServiceCollection services, params Assembly[] assemblies)
     {
         assemblies ??= Array.Empty<Assembly>();
         if (assemblies.Length == 0)
@@ -43,9 +43,8 @@ public static class ServiceModuleExtensions
             descriptors.AddRange(moduleDescriptors);
         }
 
-        if (descriptors.Count > 0)
-        {
-            services.TryAddSingleton<IServiceCatalog>(_ => new ServiceCatalog(descriptors));
-        }
+        var catalog = new ServiceCatalog(descriptors);
+        services.TryAddSingleton<IServiceCatalog>(_ => catalog);
+        return catalog;
     }
 }

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -2,11 +2,17 @@ using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.Views;
 using Moq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows.Controls;
 using Xunit;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.EditHandlers;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Serialization;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -26,20 +32,30 @@ public class MainViewCreateNavigationTests
         var view = (MainView)RuntimeHelpers.GetUninitializedObject(typeof(MainView));
         typeof(MainView).GetField("ContentFrame")!.SetValue(view, new Frame());
         typeof(MainView).GetField("HomeContentGrid")!.SetValue(view, new Grid());
-        var handlerMocks = new Dictionary<ServiceType, Mock<INavigationHandler>>
+        var handlerMocks = new Dictionary<string, Mock<INavigationHandler>>
         {
-            { ServiceType.Mqtt, new Mock<INavigationHandler>() },
-            { ServiceType.Ftp, new Mock<INavigationHandler>() }
+            { ServiceDescriptorIds.Mqtt, new Mock<INavigationHandler>() },
+            { ServiceDescriptorIds.Ftp, new Mock<INavigationHandler>() }
         };
         foreach (var kvp in handlerMocks)
         {
-            kvp.Value.Setup(h => h.CreateView(kvp.Key.ToLegacyString())).Returns(new Page());
+            kvp.Value.SetupGet(h => h.DescriptorId).Returns(kvp.Key);
+            kvp.Value.Setup(h => h.CreateView(It.IsAny<string>())).Returns(new Page());
         }
         var expectedPage = new Page();
-        handlerMocks[type].Setup(h => h.CreateView(type.ToLegacyString())).Returns(expectedPage);
-        var dict = handlerMocks.ToDictionary(k => k.Key, v => v.Value.Object);
-        typeof(MainView).GetField("_navigationHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(view, dict);
+        var targetDescriptor = type == ServiceType.Mqtt ? ServiceDescriptorIds.Mqtt : ServiceDescriptorIds.Ftp;
+        handlerMocks[targetDescriptor].Setup(h => h.CreateView(type.ToLegacyString())).Returns(expectedPage);
+        var registry = new StubRegistry(
+            navigationHandlers: handlerMocks.ToDictionary(k => k.Key, v => new Func<INavigationHandler>(() => v.Value.Object)));
+        var catalog = new StubCatalog(new Dictionary<ServiceType, string>
+        {
+            { ServiceType.Mqtt, ServiceDescriptorIds.Mqtt },
+            { ServiceType.Ftp, ServiceDescriptorIds.Ftp }
+        });
+        typeof(MainView).GetField("_uiRegistry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, registry);
+        typeof(MainView).GetField("_catalog", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, catalog);
         typeof(MainView).GetField("_createServicePage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
             .SetValue(view, null);
         var method = typeof(MainView).GetMethod("NavigateTo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
@@ -70,8 +86,12 @@ public class MainViewCreateNavigationTests
         var view = (MainView)RuntimeHelpers.GetUninitializedObject(typeof(MainView));
         typeof(MainView).GetField("ContentFrame")!.SetValue(view, new Frame());
         typeof(MainView).GetField("HomeContentGrid")!.SetValue(view, new Grid());
-        typeof(MainView).GetField("_navigationHandlers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-            .SetValue(view, new Dictionary<ServiceType, INavigationHandler>());
+        var registry = new StubRegistry(navigationHandlers: new Dictionary<string, Func<INavigationHandler>>());
+        var catalog = new StubCatalog(new Dictionary<ServiceType, string>());
+        typeof(MainView).GetField("_uiRegistry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, registry);
+        typeof(MainView).GetField("_catalog", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .SetValue(view, catalog);
         var method = typeof(MainView).GetMethod("NavigateTo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
         // Act
@@ -80,5 +100,75 @@ public class MainViewCreateNavigationTests
         // Assert
         var frame = (Frame)typeof(MainView).GetField("ContentFrame")!.GetValue(view)!;
         Assert.Null(frame.Content);
+    }
+}
+
+internal sealed class StubRegistry : IServiceUiRegistry
+{
+    public StubRegistry(
+        IReadOnlyDictionary<string, Func<Page>>? servicePages = null,
+        IReadOnlyDictionary<string, Func<INavigationHandler>>? navigationHandlers = null,
+        IReadOnlyDictionary<string, Func<IServiceFactory>>? factories = null,
+        IReadOnlyDictionary<string, Func<IEditServiceHandler>>? editHandlers = null)
+    {
+        ServicePages = servicePages ?? new Dictionary<string, Func<Page>>();
+        NavigationHandlers = navigationHandlers ?? new Dictionary<string, Func<INavigationHandler>>();
+        Factories = factories ?? new Dictionary<string, Func<IServiceFactory>>();
+        EditHandlers = editHandlers ?? new Dictionary<string, Func<IEditServiceHandler>>();
+    }
+
+    public IReadOnlyDictionary<string, Func<Page>> ServicePages { get; }
+
+    public IReadOnlyDictionary<string, Func<INavigationHandler>> NavigationHandlers { get; }
+
+    public IReadOnlyDictionary<string, Func<IServiceFactory>> Factories { get; }
+
+    public IReadOnlyDictionary<string, Func<IEditServiceHandler>> EditHandlers { get; }
+}
+
+internal sealed class StubCatalog : IServiceCatalog
+{
+    private readonly Dictionary<string, IServiceDescriptor> _descriptorsById;
+    private readonly Dictionary<ServiceType, IServiceDescriptor> _descriptorsByType;
+
+    public StubCatalog(Dictionary<ServiceType, string> legacyMap)
+    {
+        LegacyMap = legacyMap;
+        _descriptorsById = legacyMap.ToDictionary(
+            kvp => kvp.Value,
+            kvp => (IServiceDescriptor)new StubDescriptor(kvp.Value, kvp.Key));
+        _descriptorsByType = _descriptorsById.Values.ToDictionary(d => d.LegacyType!.Value);
+        Descriptors = _descriptorsById.Values.ToArray();
+    }
+
+    public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
+
+    public IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
+
+    public bool TryGetById(string id, out IServiceDescriptor descriptor) => _descriptorsById.TryGetValue(id, out descriptor!);
+
+    public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) => _descriptorsByType.TryGetValue(legacyType, out descriptor!);
+
+    private sealed class StubDescriptor : IServiceDescriptor
+    {
+        public StubDescriptor(string id, ServiceType legacy)
+        {
+            Id = id;
+            LegacyType = legacy;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName => Id;
+
+        public string Category => "Test";
+
+        public string? Description => null;
+
+        public ServiceType? LegacyType { get; }
+
+        public IServiceOptionsSerializer? OptionsSerializer => null;
+
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
     }
 }

--- a/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
+++ b/DesktopApplicationTemplate.Tests/NavigationHandlerTests.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Http.Create;
 using DesktopApplicationTemplate.UI.ViewModels.Http.Advanced;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -26,7 +27,10 @@ public class NavigationHandlerTests
     {
         var provider = App.AppHost.Services;
         var mainView = provider.GetRequiredService<MainView>();
-        var handler = provider.GetKeyedService<INavigationHandler>(ServiceType.Http)!;
+        var catalog = provider.GetRequiredService<IServiceCatalog>();
+        var registry = provider.GetRequiredService<IServiceUiRegistry>();
+        var descriptorId = catalog.LegacyMap[ServiceType.Http];
+        var handler = registry.NavigationHandlers[descriptorId]();
         var createPage = handler.CreateView("svc");
         var vm = (HttpCreateServiceViewModel)createPage.DataContext!;
 
@@ -47,7 +51,10 @@ public class NavigationHandlerTests
     {
         var provider = App.AppHost.Services;
         var mainView = provider.GetRequiredService<MainView>();
-        var handler = provider.GetKeyedService<INavigationHandler>(ServiceType.Http)!;
+        var catalog = provider.GetRequiredService<IServiceCatalog>();
+        var registry = provider.GetRequiredService<IServiceUiRegistry>();
+        var descriptorId = catalog.LegacyMap[ServiceType.Http];
+        var handler = registry.NavigationHandlers[descriptorId]();
         var mainVm = (MainViewModel)typeof(MainView).GetField("_viewModel", BindingFlags.NonPublic | BindingFlags.Instance)!
             .GetValue(mainView)!;
         mainVm.Services.Clear();
@@ -62,7 +69,10 @@ public class NavigationHandlerTests
     {
         var provider = App.AppHost.Services;
         var mainView = provider.GetRequiredService<MainView>();
-        var handler = provider.GetKeyedService<INavigationHandler>(ServiceType.Http)!;
+        var catalog = provider.GetRequiredService<IServiceCatalog>();
+        var registry = provider.GetRequiredService<IServiceUiRegistry>();
+        var descriptorId = catalog.LegacyMap[ServiceType.Http];
+        var handler = registry.NavigationHandlers[descriptorId]();
         var createPage = handler.CreateView("svc");
         mainView.ShowPage(createPage);
         var vm = (HttpCreateServiceViewModel)createPage.DataContext!;
@@ -81,5 +91,18 @@ public class NavigationHandlerTests
         advVm = (HttpAdvancedConfigViewModel)advPage.DataContext!;
         advVm.SaveCommand.Execute(null);
         Assert.Same(createPage, frame.Content);
+    }
+
+    [WindowsFact]
+    public void CatalogDescriptorsProvideNavigationHandlers()
+    {
+        var provider = App.AppHost.Services;
+        var catalog = provider.GetRequiredService<IServiceCatalog>();
+        var registry = provider.GetRequiredService<IServiceUiRegistry>();
+
+        foreach (var descriptor in catalog.Descriptors)
+        {
+            Assert.True(registry.NavigationHandlers.ContainsKey(descriptor.Id));
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -1,82 +1,15 @@
-using DesktopApplicationTemplate.UI.Services;
-using DesktopApplicationTemplate.UI.EditHandlers;
-using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Core.Modules;
-using DesktopApplicationTemplate.UI.ViewModels;
-using DesktopApplicationTemplate.UI.ViewModels.Http;
-using DesktopApplicationTemplate.UI.ViewModels.Http.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Http.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Http.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.Tcp;
-using DesktopApplicationTemplate.UI.ViewModels.Tcp.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Tcp.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Hid;
-using DesktopApplicationTemplate.UI.ViewModels.Hid.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Hid.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Hid.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.Scp;
-using DesktopApplicationTemplate.UI.ViewModels.Scp.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Scp.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Scp.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.Csv;
-using DesktopApplicationTemplate.UI.ViewModels.Csv.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Csv.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.FileObserver;
-using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Create;
-using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.Heartbeat;
-using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
-using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Advanced;
-using DesktopApplicationTemplate.UI.ViewModels.Ftp;
-using DesktopApplicationTemplate.UI.ViewModels.Ftp.Create;
-using DesktopApplicationTemplate.UI.ViewModels.Ftp.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Ftp.Advanced;
-using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.UI.Views.Http;
-using DesktopApplicationTemplate.UI.Views.Http.Create;
-using DesktopApplicationTemplate.UI.Views.Http.Edit;
-using DesktopApplicationTemplate.UI.Views.Http.Advanced;
-using DesktopApplicationTemplate.UI.Views.Tcp;
-using DesktopApplicationTemplate.UI.Views.Tcp.Create;
-using DesktopApplicationTemplate.UI.Views.Tcp.Edit;
-using DesktopApplicationTemplate.UI.Views.Hid;
-using DesktopApplicationTemplate.UI.Views.Hid.Create;
-using DesktopApplicationTemplate.UI.Views.Hid.Edit;
-using DesktopApplicationTemplate.UI.Views.Hid.Advanced;
-using DesktopApplicationTemplate.UI.Views.Scp;
-using DesktopApplicationTemplate.UI.Views.Scp.Create;
-using DesktopApplicationTemplate.UI.Views.Scp.Edit;
-using DesktopApplicationTemplate.UI.Views.Scp.Advanced;
-using DesktopApplicationTemplate.UI.Views.Csv;
-using DesktopApplicationTemplate.UI.Views.Csv.Edit;
-using DesktopApplicationTemplate.UI.Views.Csv.Advanced;
-using DesktopApplicationTemplate.UI.Views.FileObserver;
-using DesktopApplicationTemplate.UI.Views.FileObserver.Create;
-using DesktopApplicationTemplate.UI.Views.FileObserver.Edit;
-using DesktopApplicationTemplate.UI.Views.FileObserver.Advanced;
-using DesktopApplicationTemplate.UI.Views.Heartbeat;
-using DesktopApplicationTemplate.UI.Views.Heartbeat.Create;
-using DesktopApplicationTemplate.UI.Views.Heartbeat.Edit;
-using DesktopApplicationTemplate.UI.Views.Heartbeat.Advanced;
-using DesktopApplicationTemplate.UI.Views.Mqtt;
-using DesktopApplicationTemplate.UI.Views.Mqtt.Create;
-using DesktopApplicationTemplate.UI.Views.Mqtt.Edit;
-using DesktopApplicationTemplate.UI.Views.Mqtt.Advanced;
-using DesktopApplicationTemplate.UI.Views.Ftp;
-using DesktopApplicationTemplate.UI.Views.Ftp.Create;
-using DesktopApplicationTemplate.UI.Views.Ftp.Edit;
-using DesktopApplicationTemplate.UI.Views.Ftp.Advanced;
 using DesktopApplicationTemplate.Core.Models;
-using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common;
+using DesktopApplicationTemplate.UI.Configuration;
 using DesktopApplicationTemplate.UI.Helpers;
-using Factories = DesktopApplicationTemplate.UI.Factories;
-// Qualify service-layer types explicitly to avoid name clashes with UI services
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Navigation;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -85,14 +18,15 @@ using MQTTnet;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System;
 using System.Windows.Threading;
 using System.Collections.Generic;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
-using DesktopApplicationTemplate.Services.Common;
+using System.Globalization;
 
 
 namespace DesktopApplicationTemplate.UI
@@ -125,29 +59,11 @@ namespace DesktopApplicationTemplate.UI
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            services.AddServiceModules();
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, (sp, _) => new MqttEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<MqttEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, (sp, _) => new HeartbeatEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HeartbeatEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, (sp, _) => new HidEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HidEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Csv, (sp, _) => new CsvEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<CsvEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.FileObserver, (sp, _) => new FileObserverEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<FileObserverEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Scp, (sp, _) => new ScpEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<ScpEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Tcp, (sp, _) => new TcpEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<TcpEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Http, (sp, _) => new HttpEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HttpEditServiceHandler>>()));
-            services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Ftp, (sp, _) => new FtpEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<FtpEditServiceHandler>>()));
-            services.AddSingleton<IDictionary<ServiceType, IEditServiceHandler>>(sp =>
-            {
-                var handlers = new Dictionary<ServiceType, IEditServiceHandler>();
-                foreach (ServiceType type in Enum.GetValues<ServiceType>())
-                {
-                    var handler = sp.GetKeyedService<IEditServiceHandler>(type);
-                    if (handler != null)
-                    {
-                        handlers[type] = handler;
-                    }
-                }
-                return handlers;
-            });
+            var catalog = services.AddServiceModules();
+            var registrations = InitializeServices(services, catalog);
+
+            services.AddSingleton<IServiceUiRegistry>(sp => ServiceUiRegistry.Create(sp, catalog, registrations));
+
             services.AddSingleton<MainView>();
             services.AddSingleton<IStartupService, StartupService>();
             services.AddSingleton<IProcessRunner, ProcessRunner>();
@@ -162,170 +78,16 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<ServiceMessageTableViewModel>();
-            services.AddSingleton<TcpServiceMessagesView>();
-            services.AddTransient<TcpServiceMessagesViewModel>();
             services.AddSingleton<DependencyChecker>();
-            services.AddSingleton<HttpServiceView>();
-            services.AddSingleton<HttpServiceViewModel>();
-            services.AddSingleton<FileObserverView>();
-            services.AddSingleton<FileObserverViewModel>();
-            services.AddSingleton<HeartbeatView>();
-            services.AddSingleton<HeartbeatViewModel>();
-            services.AddSingleton<SCPServiceView>();
-            services.AddSingleton<ScpServiceViewModel>();
-            services.AddSingleton<HidViewModel>();
-            services.AddSingleton<HidViews>();
-            services.AddSingleton<MqttService>();
-            services.AddSingleton<FTPServiceView>();
-            services.AddSingleton<FtpServiceViewModel>();
             services.AddFtpServer(builder => builder
                 .UseDotNetFileSystem()
                 .EnableAnonymousAuthentication());
             services.AddSingleton<IFtpServerService, DesktopApplicationTemplate.Service.Services.FtpServerService>();
-            services.AddSingleton<CsvViewerViewModel>();
-            services.AddSingleton<CsvService>();
-            services.AddSingleton<CsvServiceView>();
             services.AddSingleton<SettingsViewModel>();
-            services.AddKeyedTransient<Page>(ServiceType.Tcp, (sp, _) => sp.GetRequiredService<TcpServiceMessagesView>());
-            services.AddKeyedTransient<Page>(ServiceType.Http, (sp, _) => sp.GetRequiredService<HttpServiceView>());
-            services.AddKeyedTransient<Page>(ServiceType.FileObserver, (sp, _) => sp.GetRequiredService<FileObserverView>());
-            services.AddKeyedTransient<Page>(ServiceType.Hid, (sp, _) => sp.GetRequiredService<HidViews>());
-            services.AddKeyedTransient<Page>(ServiceType.Heartbeat, (sp, _) => sp.GetRequiredService<HeartbeatView>());
-            services.AddKeyedTransient<Page>(ServiceType.Scp, (sp, _) => sp.GetRequiredService<SCPServiceView>());
-            services.AddKeyedTransient<Page>(ServiceType.Mqtt, (sp, _) => sp.GetRequiredService<MqttTagSubscriptionsView>());
-            services.AddKeyedTransient<Page>(ServiceType.Ftp, (sp, _) => sp.GetRequiredService<FTPServiceView>());
-            services.AddKeyedTransient<Page>(ServiceType.Csv, (sp, _) => sp.GetRequiredService<CsvServiceView>());
-            services.AddSingleton<IDictionary<ServiceType, Func<Page>>>(sp => new Dictionary<ServiceType, Func<Page>>
-            {
-                [ServiceType.Tcp] = () => sp.GetKeyedService<Page>(ServiceType.Tcp)!,
-                [ServiceType.Http] = () => sp.GetKeyedService<Page>(ServiceType.Http)!,
-                [ServiceType.FileObserver] = () => sp.GetKeyedService<Page>(ServiceType.FileObserver)!,
-                [ServiceType.Hid] = () => sp.GetKeyedService<Page>(ServiceType.Hid)!,
-                [ServiceType.Heartbeat] = () => sp.GetKeyedService<Page>(ServiceType.Heartbeat)!,
-                [ServiceType.Scp] = () => sp.GetKeyedService<Page>(ServiceType.Scp)!,
-                [ServiceType.Mqtt] = () => sp.GetKeyedService<Page>(ServiceType.Mqtt)!,
-                [ServiceType.Ftp] = () => sp.GetKeyedService<Page>(ServiceType.Ftp)!,
-                [ServiceType.Csv] = () => sp.GetKeyedService<Page>(ServiceType.Csv)!,
-            });
             services.AddTransient<SplashWindow>();
             services.AddTransient<CreateServicePage>();
             services.AddTransient<CreateServiceViewModel>();
-            services.AddTransient<MqttCreateServiceView>();
-            services.AddTransient<MqttCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<MqttServiceOptions>, MqttCreateServiceViewModel>();
-            services.AddTransient<MqttEditServiceView>();
-            services.AddTransient<MqttEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<MqttServiceOptions>, MqttEditServiceViewModel>();
-            services.AddTransient<MqttAdvancedConfigView>();
-            services.AddTransient<MqttAdvancedConfigViewModel>();
-            services.AddTransient<TcpCreateServiceView>();
-            services.AddTransient<TcpCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<TcpServiceOptions>, TcpCreateServiceViewModel>();
-            services.AddTransient<TcpEditServiceView>();
-            services.AddTransient<TcpEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<TcpServiceOptions>, TcpEditServiceViewModel>();
-            services.AddTransient<FtpServerCreateView>();
-            services.AddTransient<FtpServerCreateViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<DesktopApplicationTemplate.UI.Services.FtpServerOptions>, FtpServerCreateViewModel>();
-            services.AddTransient<FtpServerAdvancedConfigView>();
-            services.AddTransient<FtpServerAdvancedConfigViewModel>();
-            services.AddTransient<FtpServerEditView>();
-            services.AddTransient<FtpServerEditViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<DesktopApplicationTemplate.UI.Services.FtpServerOptions>, FtpServerEditViewModel>();
-            services.AddTransient<HttpCreateServiceView>();
-            services.AddTransient<HttpCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<HttpServiceOptions>, HttpCreateServiceViewModel>();
-            services.AddTransient<HttpEditServiceView>();
-            services.AddTransient<HttpEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<HttpServiceOptions>, HttpEditServiceViewModel>();
-            services.AddTransient<HttpAdvancedConfigView>();
-            services.AddTransient<HttpAdvancedConfigViewModel>();
-            services.AddTransient<MqttEditConnectionView>();
-            services.AddTransient<MqttEditConnectionViewModel>();
-            services.AddTransient<MqttTagSubscriptionsView>();
-            services.AddTransient<MqttTagSubscriptionsViewModel>();
-            services.AddTransient<HidCreateServiceView>();
-            services.AddTransient<HidCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<HidServiceOptions>, HidCreateServiceViewModel>();
-            services.AddTransient<HidEditServiceView>();
-            services.AddTransient<HidEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<HidServiceOptions>, HidEditServiceViewModel>();
-            services.AddTransient<HidAdvancedConfigView>();
-            services.AddTransient<HidAdvancedConfigViewModel>();
-            services.AddTransient<HeartbeatCreateServiceView>();
-            services.AddTransient<HeartbeatCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<HeartbeatServiceOptions>, HeartbeatCreateServiceViewModel>();
-            services.AddTransient<HeartbeatEditServiceView>();
-            services.AddTransient<HeartbeatEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<HeartbeatServiceOptions>, HeartbeatEditServiceViewModel>();
-            services.AddTransient<HeartbeatAdvancedConfigView>();
-            services.AddTransient<HeartbeatAdvancedConfigViewModel>();
-            services.AddTransient<FileObserverCreateServiceView>();
-            services.AddTransient<FileObserverCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<FileObserverServiceOptions>, FileObserverCreateServiceViewModel>();
-            services.AddTransient<FileObserverEditServiceView>();
-            services.AddTransient<FileObserverEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<FileObserverServiceOptions>, FileObserverEditServiceViewModel>();
-            services.AddTransient<FileObserverAdvancedConfigView>();
-            services.AddTransient<FileObserverAdvancedConfigViewModel>();
-            services.AddTransient<CsvServiceEditorView>();
-            services.AddTransient<CsvServiceEditorViewModel>();
-            services.AddTransient<ServiceEditorViewModelBase<CsvServiceOptions>, CsvServiceEditorViewModel>();
-            services.AddTransient<CsvAdvancedConfigView>();
-            services.AddTransient<CsvAdvancedConfigViewModel>();
-            services.AddTransient<ScpCreateServiceView>();
-            services.AddTransient<ScpCreateServiceViewModel>();
-            services.AddTransient<ServiceCreateViewModelBase<ScpServiceOptions>, ScpCreateServiceViewModel>();
-            services.AddTransient<ScpEditServiceView>();
-            services.AddTransient<ScpEditServiceViewModel>();
-            services.AddTransient<ServiceEditViewModelBase<ScpServiceOptions>, ScpEditServiceViewModel>();
-            services.AddTransient<ScpAdvancedConfigView>();
-            services.AddTransient<ScpAdvancedConfigViewModel>();
             services.AddTransient<SettingsPage>();
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Mqtt, (sp, _) => new Navigation.MqttNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Ftp, (sp, _) => new Navigation.FtpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Http, (sp, _) => new Navigation.HttpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Tcp, (sp, _) => new Navigation.TcpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Hid, (sp, _) => new Navigation.HidNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Scp, (sp, _) => new Navigation.ScpNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Csv, (sp, _) => new Navigation.CsvNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.FileObserver, (sp, _) => new Navigation.FileObserverNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Navigation.INavigationHandler>(ServiceType.Heartbeat, (sp, _) => new Navigation.HeartbeatNavigationHandler(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddSingleton<IDictionary<ServiceType, Navigation.INavigationHandler>>(sp =>
-            {
-                var handlers = new Dictionary<ServiceType, Navigation.INavigationHandler>();
-                foreach (ServiceType type in Enum.GetValues<ServiceType>())
-                {
-                    var handler = sp.GetKeyedService<Navigation.INavigationHandler>(type);
-                    if (handler != null)
-                    {
-                        handlers[type] = handler;
-                    }
-                }
-                return handlers;
-            });
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Mqtt, (sp, _) => new Factories.MqttServiceFactory(sp, () => sp.GetRequiredService<MainView>(), sp.GetRequiredService<MainViewModel>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Ftp, (sp, _) => new Factories.FtpServiceFactory(sp, () => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Http, (sp, _) => new Factories.HttpServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Tcp, (sp, _) => new Factories.TcpServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Hid, (sp, _) => new Factories.HidServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Scp, (sp, _) => new Factories.ScpServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Csv, (sp, _) => new Factories.CsvServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.FileObserver, (sp, _) => new Factories.FileObserverServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddKeyedTransient<Factories.IServiceFactory>(ServiceType.Heartbeat, (sp, _) => new Factories.HeartbeatServiceFactory(() => sp.GetRequiredService<MainView>()));
-            services.AddSingleton<IDictionary<ServiceType, Factories.IServiceFactory>>(sp =>
-            {
-                var factories = new Dictionary<ServiceType, Factories.IServiceFactory>();
-                foreach (ServiceType type in Enum.GetValues<ServiceType>())
-                {
-                    var factory = sp.GetKeyedService<Factories.IServiceFactory>(type);
-                    if (factory != null)
-                    {
-                        factories[type] = factory;
-                    }
-                }
-                return factories;
-            });
 
 
             // Load strongly typed settings
@@ -339,6 +101,245 @@ namespace DesktopApplicationTemplate.UI
             services.AddOptions<FileObserverServiceOptions>();
             services.AddOptions<CsvServiceOptions>();
             services.AddOptions<ScpServiceOptions>();
+        }
+
+        private static IReadOnlyCollection<ServiceRegistrationInfo> InitializeServices(IServiceCollection services, IServiceCatalog catalog)
+        {
+            var descriptorIds = new HashSet<string>(catalog.Descriptors.Select(d => d.Id), StringComparer.Ordinal);
+            var registrations = new List<ServiceRegistrationInfo>();
+            var registeredTypes = new HashSet<Type>();
+            var registrationKeys = new HashSet<string>(StringComparer.Ordinal);
+            var assembly = typeof(App).Assembly;
+
+            foreach (var type in assembly.GetTypes())
+            {
+                var attributes = type.GetCustomAttributes<ServiceDescriptorRegistrationAttribute>(inherit: false);
+                foreach (var attribute in attributes)
+                {
+                    if (!descriptorIds.Contains(attribute.DescriptorId))
+                    {
+                        continue;
+                    }
+
+                    if (registrationKeys.Add(CreateRegistrationKey(attribute.DescriptorId, type, attribute.Kind)))
+                    {
+                        registrations.Add(new ServiceRegistrationInfo(attribute.DescriptorId, type, attribute.Kind, attribute.Lifetime));
+                    }
+
+                    if (registeredTypes.Add(type))
+                    {
+                        RegisterType(services, type, attribute.Lifetime);
+                    }
+                }
+            }
+
+            ApplyConventionRegistrations(services, catalog, registrations, registeredTypes, registrationKeys, assembly);
+
+            return registrations;
+        }
+
+        private static void RegisterType(IServiceCollection services, Type implementationType, ServiceLifetime lifetime)
+        {
+            switch (lifetime)
+            {
+                case ServiceLifetime.Singleton:
+                    services.AddSingleton(implementationType);
+                    break;
+                case ServiceLifetime.Scoped:
+                    services.AddScoped(implementationType);
+                    break;
+                default:
+                    services.AddTransient(implementationType);
+                    break;
+            }
+        }
+
+        private static void ApplyConventionRegistrations(
+            IServiceCollection services,
+            IServiceCatalog catalog,
+            ICollection<ServiceRegistrationInfo> registrations,
+            ISet<Type> registeredTypes,
+            ISet<string> registrationKeys,
+            Assembly assembly)
+        {
+            foreach (var descriptor in catalog.Descriptors)
+            {
+                if (!TryGetServicePrefix(descriptor, out var prefix))
+                {
+                    continue;
+                }
+
+                var matchingTypes = assembly.GetTypes()
+                    .Where(t => t.IsClass && !t.IsAbstract && t.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+                foreach (var type in matchingTypes)
+                {
+                    var kind = DetermineRegistrationKind(type);
+                    var lifetime = DetermineLifetime(type, prefix);
+
+                    if (registeredTypes.Add(type))
+                    {
+                        RegisterType(services, type, lifetime);
+                    }
+
+                    if (kind is ServiceRegistrationKind.NavigationHandler or ServiceRegistrationKind.EditHandler or ServiceRegistrationKind.ServiceFactory or ServiceRegistrationKind.ServicePage)
+                    {
+                        if (registrationKeys.Add(CreateRegistrationKey(descriptor.Id, type, kind.Value)))
+                        {
+                            registrations.Add(new ServiceRegistrationInfo(descriptor.Id, type, kind.Value, lifetime));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string CreateRegistrationKey(string descriptorId, Type implementationType, ServiceRegistrationKind kind)
+        {
+            var typeName = implementationType.FullName ?? implementationType.Name;
+            return FormattableString.Invariant($"{descriptorId}|{typeName}|{(int)kind}");
+        }
+
+        private static bool TryGetServicePrefix(IServiceDescriptor descriptor, out string prefix)
+        {
+            if (descriptor.LegacyType is { } legacy)
+            {
+                prefix = legacy.ToString();
+                return true;
+            }
+
+            prefix = descriptor.Id.Split('.').LastOrDefault() ?? descriptor.Id;
+            return true;
+        }
+
+        private static ServiceRegistrationKind? DetermineRegistrationKind(Type type)
+        {
+            if (typeof(INavigationHandler).IsAssignableFrom(type))
+            {
+                return ServiceRegistrationKind.NavigationHandler;
+            }
+
+            if (typeof(IEditServiceHandler).IsAssignableFrom(type))
+            {
+                return ServiceRegistrationKind.EditHandler;
+            }
+
+            if (typeof(IServiceFactory).IsAssignableFrom(type))
+            {
+                return ServiceRegistrationKind.ServiceFactory;
+            }
+
+            if (typeof(Page).IsAssignableFrom(type))
+            {
+                if (type.Name.Contains("Create", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ServiceRegistrationKind.CreateView;
+                }
+
+                if (type.Name.Contains("Edit", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ServiceRegistrationKind.EditView;
+                }
+
+                if (type.Name.Contains("Advanced", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ServiceRegistrationKind.AdvancedView;
+                }
+
+                return ServiceRegistrationKind.ServicePage;
+            }
+
+            if (IsViewModel(type))
+            {
+                if (InheritsFromGeneric(type, typeof(ServiceCreateViewModelBase<>)))
+                {
+                    return ServiceRegistrationKind.CreateViewModel;
+                }
+
+                if (InheritsFromGeneric(type, typeof(ServiceEditViewModelBase<>)))
+                {
+                    return ServiceRegistrationKind.EditViewModel;
+                }
+
+                if (InheritsFromGeneric(type, typeof(AdvancedConfigViewModelBase<>)))
+                {
+                    return ServiceRegistrationKind.AdvancedViewModel;
+                }
+
+                return ServiceRegistrationKind.ServicePageViewModel;
+            }
+
+            return null;
+        }
+
+        private static ServiceLifetime DetermineLifetime(Type type, string prefix)
+        {
+            if (typeof(IEditServiceHandler).IsAssignableFrom(type))
+            {
+                return ServiceLifetime.Singleton;
+            }
+
+            if (typeof(IServiceFactory).IsAssignableFrom(type) || typeof(INavigationHandler).IsAssignableFrom(type))
+            {
+                return ServiceLifetime.Transient;
+            }
+
+            if (typeof(Page).IsAssignableFrom(type))
+            {
+                if (type.Name.Contains("Create", StringComparison.OrdinalIgnoreCase) ||
+                    type.Name.Contains("Edit", StringComparison.OrdinalIgnoreCase) ||
+                    type.Name.Contains("Advanced", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ServiceLifetime.Transient;
+                }
+
+                return ServiceLifetime.Singleton;
+            }
+
+            if (IsViewModel(type))
+            {
+                if (type.Name.Contains("Create", StringComparison.OrdinalIgnoreCase) ||
+                    type.Name.Contains("Edit", StringComparison.OrdinalIgnoreCase) ||
+                    type.Name.Contains("Advanced", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ServiceLifetime.Transient;
+                }
+
+                if (type.Name.Contains("Service", StringComparison.OrdinalIgnoreCase) ||
+                    type.Name.Contains("Viewer", StringComparison.OrdinalIgnoreCase) ||
+                    type.Name.Equals($"{prefix}ViewModel", StringComparison.OrdinalIgnoreCase))
+                {
+                    return ServiceLifetime.Singleton;
+                }
+
+                return ServiceLifetime.Transient;
+            }
+
+            if (type.Namespace is { } serviceNamespace && serviceNamespace.Contains(".Services", StringComparison.Ordinal))
+            {
+                return ServiceLifetime.Singleton;
+            }
+
+            return ServiceLifetime.Transient;
+        }
+
+        private static bool IsViewModel(Type type) =>
+            type.Name.EndsWith("ViewModel", StringComparison.Ordinal) ||
+            typeof(ViewModelBase).IsAssignableFrom(type);
+
+        private static bool InheritsFromGeneric(Type type, Type genericDefinition)
+        {
+            var current = type;
+            while (current != null && current != typeof(object))
+            {
+                if (current.IsGenericType && current.GetGenericTypeDefinition() == genericDefinition)
+                {
+                    return true;
+                }
+
+                current = current.BaseType!;
+            }
+
+            return false;
         }
 
         internal void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)

--- a/DesktopApplicationTemplate.UI/Configuration/ServiceDescriptorRegistrationAttribute.cs
+++ b/DesktopApplicationTemplate.UI/Configuration/ServiceDescriptorRegistrationAttribute.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.UI.Configuration;
+
+/// <summary>
+/// Describes how a UI component participates in a service descriptor workflow.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class ServiceDescriptorRegistrationAttribute : Attribute
+{
+    public ServiceDescriptorRegistrationAttribute(string descriptorId, ServiceRegistrationKind kind, ServiceLifetime lifetime = ServiceLifetime.Transient)
+    {
+        DescriptorId = descriptorId ?? throw new ArgumentNullException(nameof(descriptorId));
+        Kind = kind;
+        Lifetime = lifetime;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the descriptor associated with the target type.
+    /// </summary>
+    public string DescriptorId { get; }
+
+    /// <summary>
+    /// Gets the registration category for the target type.
+    /// </summary>
+    public ServiceRegistrationKind Kind { get; }
+
+    /// <summary>
+    /// Gets the DI lifetime used when registering the target type.
+    /// </summary>
+    public ServiceLifetime Lifetime { get; }
+}
+
+/// <summary>
+/// Enumerates the kinds of UI registrations associated with a service descriptor.
+/// </summary>
+public enum ServiceRegistrationKind
+{
+    CreateView,
+    CreateViewModel,
+    EditView,
+    EditViewModel,
+    AdvancedView,
+    AdvancedViewModel,
+    SupplementalView,
+    SupplementalViewModel,
+    NavigationHandler,
+    EditHandler,
+    ServiceFactory,
+    ServicePage,
+    ServicePageViewModel
+}

--- a/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
+++ b/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
@@ -2,11 +2,12 @@ using System.Collections.Generic;
 using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Serialization;
-using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
+using DesktopApplicationTemplate.UI.Navigation;
+using System;
 
 namespace DesktopApplicationTemplate.UI.Modules;
 
@@ -23,99 +24,110 @@ public sealed class UiServiceModule : IServiceModule
             new JsonServiceOptionsSerializer<MqttServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Mqtt),
-                    MqttServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, MqttServiceDescriptor.DescriptorId),
+                        MqttServiceDescriptor.DescriptorId)
             });
 
         yield return new HttpServiceDescriptor(
             new JsonServiceOptionsSerializer<HttpServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Http),
-                    HttpServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, HttpServiceDescriptor.DescriptorId),
+                        HttpServiceDescriptor.DescriptorId)
             });
 
         yield return new FtpServiceDescriptor(
             new JsonServiceOptionsSerializer<FtpServerOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Ftp),
-                    FtpServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, FtpServiceDescriptor.DescriptorId),
+                        FtpServiceDescriptor.DescriptorId)
             });
 
         yield return new HidServiceDescriptor(
             new JsonServiceOptionsSerializer<HidServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Hid),
-                    HidServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, HidServiceDescriptor.DescriptorId),
+                        HidServiceDescriptor.DescriptorId)
             });
 
         yield return new CsvServiceDescriptor(
             new JsonServiceOptionsSerializer<CsvServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Csv),
-                    CsvServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, CsvServiceDescriptor.DescriptorId),
+                        CsvServiceDescriptor.DescriptorId)
             });
 
         yield return new FileObserverServiceDescriptor(
             new JsonServiceOptionsSerializer<FileObserverServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.FileObserver),
-                    FileObserverServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, FileObserverServiceDescriptor.DescriptorId),
+                        FileObserverServiceDescriptor.DescriptorId)
             });
 
         yield return new ScpServiceDescriptor(
             new JsonServiceOptionsSerializer<ScpServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Scp),
-                    ScpServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, ScpServiceDescriptor.DescriptorId),
+                        ScpServiceDescriptor.DescriptorId)
             });
 
         yield return new TcpServiceDescriptor(
             new JsonServiceOptionsSerializer<TcpServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Tcp),
-                    TcpServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, TcpServiceDescriptor.DescriptorId),
+                        TcpServiceDescriptor.DescriptorId)
             });
 
         yield return new HeartbeatServiceDescriptor(
             new JsonServiceOptionsSerializer<HeartbeatServiceOptions>(),
             new[]
             {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.UserInterface,
-                    typeof(IServiceFactory),
-                    sp => sp.GetRequiredKeyedService<IServiceFactory>(ServiceType.Heartbeat),
-                    HeartbeatServiceDescriptor.DescriptorId)
+                    ServiceFactoryBinding.Create(
+                        ServiceFactoryKind.UserInterface,
+                        typeof(IServiceFactory),
+                        sp => ResolveFactory(sp, HeartbeatServiceDescriptor.DescriptorId),
+                        HeartbeatServiceDescriptor.DescriptorId)
             });
+    }
+
+    private static object ResolveFactory(IServiceProvider services, string descriptorId)
+    {
+        var registry = services.GetRequiredService<IServiceUiRegistry>();
+        if (!registry.Factories.TryGetValue(descriptorId, out var factory))
+        {
+            throw new InvalidOperationException($"No UI factory registered for descriptor '{descriptorId}'.");
+        }
+
+        return factory();
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Csv.Advanced;
 using DesktopApplicationTemplate.UI.Views.Csv.Edit;
 using DesktopApplicationTemplate.UI.Views.Csv.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(CsvServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class CsvNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Csv;
+        public string DescriptorId => CsvServiceDescriptor.DescriptorId;
 
         public CsvNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -50,7 +52,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<CsvServiceOptions>(name, (CsvServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<CsvServiceOptions>(name, (CsvServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Advanced;
 using DesktopApplicationTemplate.UI.Views.FileObserver.Create;
 using DesktopApplicationTemplate.UI.Views.FileObserver.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(FileObserverServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class FileObserverNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.FileObserver;
+        public string DescriptorId => FileObserverServiceDescriptor.DescriptorId;
 
         public FileObserverNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -49,7 +51,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FileObserverServiceOptions>(name, (FileObserverServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<FileObserverServiceOptions>(name, (FileObserverServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Ftp.Advanced;
 using DesktopApplicationTemplate.UI.Views.Ftp.Create;
 using DesktopApplicationTemplate.UI.Views.Ftp.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(FtpServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class FtpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Ftp;
+        public string DescriptorId => FtpServiceDescriptor.DescriptorId;
 
         public FtpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -49,7 +51,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<FtpServerOptions>(name, (FtpServerOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<FtpServerOptions>(name, (FtpServerOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Advanced;
 using DesktopApplicationTemplate.UI.Views.Heartbeat.Create;
 using DesktopApplicationTemplate.UI.Views.Heartbeat.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(HeartbeatServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class HeartbeatNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Heartbeat;
+        public string DescriptorId => HeartbeatServiceDescriptor.DescriptorId;
 
         public HeartbeatNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -49,7 +51,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, (HeartbeatServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, (HeartbeatServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Hid.Advanced;
 using DesktopApplicationTemplate.UI.Views.Hid.Create;
 using DesktopApplicationTemplate.UI.Views.Hid.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(HidServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class HidNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Hid;
+        public string DescriptorId => HidServiceDescriptor.DescriptorId;
 
         public HidNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -49,7 +51,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HidServiceOptions>(name, (HidServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<HidServiceOptions>(name, (HidServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Http.Advanced;
 using DesktopApplicationTemplate.UI.Views.Http.Create;
 using DesktopApplicationTemplate.UI.Views.Http.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(HttpServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class HttpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Http;
+        public string DescriptorId => HttpServiceDescriptor.DescriptorId;
 
         public HttpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -49,7 +51,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<HttpServiceOptions>(name, (HttpServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<HttpServiceOptions>(name, (HttpServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/INavigationHandler.cs
@@ -1,12 +1,10 @@
 using System.Threading.Tasks;
 using System.Windows.Controls;
-using DesktopApplicationTemplate.Models;
-
 namespace DesktopApplicationTemplate.UI.Navigation
 {
     public interface INavigationHandler
     {
-        ServiceType ServiceType { get; }
+        string DescriptorId { get; }
         Page CreateView(string defaultName);
         Task AddServiceAsync(string name, object options);
     }

--- a/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Advanced;
 using DesktopApplicationTemplate.UI.Views.Mqtt.Create;
 using DesktopApplicationTemplate.UI.Views.Mqtt.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(MqttServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class MqttNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Mqtt;
+        public string DescriptorId => MqttServiceDescriptor.DescriptorId;
 
         public MqttNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -48,7 +50,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<MqttServiceOptions>(name, (MqttServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<MqttServiceOptions>(name, (MqttServiceOptions)options));
         }
 
     }

--- a/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
@@ -8,17 +8,19 @@ using DesktopApplicationTemplate.UI.ViewModels.Scp.Advanced;
 using DesktopApplicationTemplate.UI.Views.Scp.Create;
 using DesktopApplicationTemplate.UI.Views.Scp.Advanced;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(ScpServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class ScpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Scp;
+        public string DescriptorId => ScpServiceDescriptor.DescriptorId;
 
         public ScpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -49,7 +51,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<ScpServiceOptions>(name, (ScpServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<ScpServiceOptions>(name, (ScpServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/ServiceUiRegistry.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ServiceUiRegistry.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Configuration;
+using DesktopApplicationTemplate.UI.EditHandlers;
+using DesktopApplicationTemplate.UI.Factories;
+
+namespace DesktopApplicationTemplate.UI.Navigation;
+
+public interface IServiceUiRegistry
+{
+    IReadOnlyDictionary<string, Func<Page>> ServicePages { get; }
+    IReadOnlyDictionary<string, Func<INavigationHandler>> NavigationHandlers { get; }
+    IReadOnlyDictionary<string, Func<IServiceFactory>> Factories { get; }
+    IReadOnlyDictionary<string, Func<IEditServiceHandler>> EditHandlers { get; }
+}
+
+internal sealed class ServiceUiRegistry : IServiceUiRegistry
+{
+    private ServiceUiRegistry(
+        IReadOnlyDictionary<string, Func<Page>> servicePages,
+        IReadOnlyDictionary<string, Func<INavigationHandler>> navigationHandlers,
+        IReadOnlyDictionary<string, Func<IServiceFactory>> factories,
+        IReadOnlyDictionary<string, Func<IEditServiceHandler>> editHandlers)
+    {
+        ServicePages = servicePages;
+        NavigationHandlers = navigationHandlers;
+        Factories = factories;
+        EditHandlers = editHandlers;
+    }
+
+    public IReadOnlyDictionary<string, Func<Page>> ServicePages { get; }
+
+    public IReadOnlyDictionary<string, Func<INavigationHandler>> NavigationHandlers { get; }
+
+    public IReadOnlyDictionary<string, Func<IServiceFactory>> Factories { get; }
+
+    public IReadOnlyDictionary<string, Func<IEditServiceHandler>> EditHandlers { get; }
+
+    public static ServiceUiRegistry Create(IServiceProvider services, IServiceCatalog catalog, IReadOnlyCollection<ServiceRegistrationInfo> registrations)
+    {
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (catalog is null)
+        {
+            throw new ArgumentNullException(nameof(catalog));
+        }
+
+        if (registrations is null)
+        {
+            throw new ArgumentNullException(nameof(registrations));
+        }
+
+        var descriptorIds = new HashSet<string>(catalog.Descriptors.Select(d => d.Id), StringComparer.Ordinal);
+
+        var navigationHandlers = BuildFactoryDictionary<INavigationHandler>(services, registrations, descriptorIds, ServiceRegistrationKind.NavigationHandler);
+        var editHandlers = BuildFactoryDictionary<IEditServiceHandler>(services, registrations, descriptorIds, ServiceRegistrationKind.EditHandler);
+        var factories = BuildFactoryDictionary<IServiceFactory>(services, registrations, descriptorIds, ServiceRegistrationKind.ServiceFactory);
+        var pages = BuildFactoryDictionary<Page>(services, registrations, descriptorIds, ServiceRegistrationKind.ServicePage);
+
+        return new ServiceUiRegistry(pages, navigationHandlers, factories, editHandlers);
+    }
+
+    private static IReadOnlyDictionary<string, Func<TContract>> BuildFactoryDictionary<TContract>(
+        IServiceProvider services,
+        IEnumerable<ServiceRegistrationInfo> registrations,
+        HashSet<string> descriptorIds,
+        ServiceRegistrationKind kind)
+    {
+        var comparer = StringComparer.Ordinal;
+        var result = new Dictionary<string, Func<TContract>>(comparer);
+
+        foreach (var registration in registrations.Where(r => r.Kind == kind && descriptorIds.Contains(r.DescriptorId)))
+        {
+            if (result.ContainsKey(registration.DescriptorId))
+            {
+                continue;
+            }
+
+            result[registration.DescriptorId] = () => (TContract)services.GetRequiredService(registration.ImplementationType);
+        }
+
+        return result;
+    }
+}
+
+internal sealed record ServiceRegistrationInfo(
+    string DescriptorId,
+    Type ImplementationType,
+    ServiceRegistrationKind Kind,
+    Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime);

--- a/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
@@ -6,17 +6,19 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Create;
 using DesktopApplicationTemplate.UI.Views.Tcp.Create;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.UI.Configuration;
 
 namespace DesktopApplicationTemplate.UI.Navigation
 {
+    [ServiceDescriptorRegistration(TcpServiceDescriptor.DescriptorId, ServiceRegistrationKind.NavigationHandler)]
     public class TcpNavigationHandler : INavigationHandler
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
 
-        public ServiceType ServiceType => ServiceType.Tcp;
+        public string DescriptorId => TcpServiceDescriptor.DescriptorId;
 
         public TcpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
         {
@@ -38,7 +40,7 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(ServiceType, new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
+            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -16,6 +16,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI;
+using DesktopApplicationTemplate.UI.Navigation;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -57,17 +58,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly CsvService _csvService;
         private readonly ILoggingService? _logger;
         private readonly INetworkConfigurationService _networkService;
-        private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
+        private readonly IServiceUiRegistry _uiRegistry;
+        private readonly IServiceCatalog _catalog;
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
-        public MainViewModel(CsvService csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, IDictionary<ServiceType, IEditServiceHandler> editHandlers, ILoggingService? logger = null, string? servicesFilePath = null)
+        public MainViewModel(CsvService csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, IServiceUiRegistry uiRegistry, IServiceCatalog catalog, ILoggingService? logger = null, string? servicesFilePath = null)
         {
             _csvService = csvService;
             _networkService = networkService;
             _logger = logger;
             NetworkConfig = networkConfig;
-            _editHandlers = editHandlers;
+            _uiRegistry = uiRegistry;
+            _catalog = catalog;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceListModel.ResolveService = (type, name) =>
@@ -118,9 +121,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (target == null)
                 return;
 
-            if (_editHandlers.TryGetValue(target.Type, out var handler))
+            if (TryGetDescriptorId(target.Type, out var descriptorId) && _uiRegistry.EditHandlers.TryGetValue(descriptorId, out var handlerFactory))
             {
-                handler.Edit(target);
+                handlerFactory().Edit(target);
             }
             else
             {
@@ -282,6 +285,23 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             LogViewModel.ClearLogs();
             _logger?.Log("Logs cleared", LogLevel.Debug);
+        }
+
+        private bool TryGetDescriptorId(ServiceType serviceType, out string descriptorId)
+        {
+            if (_catalog.TryGetByLegacyType(serviceType, out var descriptor))
+            {
+                descriptorId = descriptor.Id;
+                return true;
+            }
+
+            if (_catalog.LegacyMap.TryGetValue(serviceType, out descriptorId))
+            {
+                return true;
+            }
+
+            descriptorId = serviceType.ToDescriptorId();
+            return false;
         }
 
         public void ExportDisplayedLogs(string filePath)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -3,8 +3,8 @@ using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
-using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,21 +25,18 @@ namespace DesktopApplicationTemplate.UI.Views
     {
         private readonly MainViewModel _viewModel;
         private readonly ILogger<MainView>? _logger;
-        private readonly IDictionary<ServiceType, IServiceFactory> _serviceFactories;
-        private readonly IDictionary<ServiceType, INavigationHandler> _navigationHandlers;
-        private readonly IDictionary<ServiceType, Func<Page>> _pageResolvers;
+        private readonly IServiceUiRegistry _uiRegistry;
+        private readonly IServiceCatalog _catalog;
 
         public MainView(
             MainViewModel viewModel,
-            IDictionary<ServiceType, IServiceFactory> serviceFactories,
-            IDictionary<ServiceType, INavigationHandler> navigationHandlers,
-            IDictionary<ServiceType, Func<Page>> pageResolvers)
+            IServiceUiRegistry uiRegistry,
+            IServiceCatalog catalog)
         {
             InitializeComponent();
             _viewModel = viewModel;
-            _serviceFactories = serviceFactories;
-            _navigationHandlers = navigationHandlers;
-            _pageResolvers = pageResolvers;
+            _uiRegistry = uiRegistry;
+            _catalog = catalog;
             if (App.AppHost.Services.GetService(typeof(ILoggerFactory)) is ILoggerFactory factory)
             {
                 _logger = factory.CreateLogger<MainView>();
@@ -89,7 +86,12 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public Page? GetOrCreateServicePage(ServiceListModel svc)
         {
-            if (svc.ServicePage == null && _pageResolvers.TryGetValue(svc.Type, out var factory))
+            if (!TryGetDescriptorId(svc.Type, out var descriptorId))
+            {
+                return svc.ServicePage;
+            }
+
+            if (svc.ServicePage == null && _uiRegistry.ServicePages.TryGetValue(descriptorId, out var factory))
             {
                 svc.ServicePage = factory();
             }
@@ -175,8 +177,14 @@ namespace DesktopApplicationTemplate.UI.Views
         private void NavigateTo(ServiceType serviceType)
         {
             var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType.ToLegacyString();
-            if (_navigationHandlers.TryGetValue(serviceType, out var handler))
+            if (!TryGetDescriptorId(serviceType, out var descriptorId))
             {
+                return;
+            }
+
+            if (_uiRegistry.NavigationHandlers.TryGetValue(descriptorId, out var handlerFactory))
+            {
+                var handler = handlerFactory();
                 var view = handler.CreateView(defaultName);
                 ShowPage(view);
             }
@@ -190,11 +198,14 @@ namespace DesktopApplicationTemplate.UI.Views
 
 
 
-        internal async Task AddServiceAsync(ServiceType type, object options)
+        internal async Task AddServiceAsync(string descriptorId, object options)
         {
-            if (!_serviceFactories.TryGetValue(type, out var factory))
+            if (!_uiRegistry.Factories.TryGetValue(descriptorId, out var factoryFactory))
+            {
                 return;
+            }
 
+            var factory = factoryFactory();
             var svc = factory.Create(options);
             svc.SetColorsByType();
             svc.LogAdded += _viewModel.OnServiceLogAdded;
@@ -208,6 +219,23 @@ namespace DesktopApplicationTemplate.UI.Views
                 ShowPage(svc.ServicePage);
             await _viewModel.SaveServicesAsync();
             _logger?.LogDebug("AddService workflow completed");
+        }
+
+        private bool TryGetDescriptorId(ServiceType serviceType, out string descriptorId)
+        {
+            if (_catalog.TryGetByLegacyType(serviceType, out var descriptor))
+            {
+                descriptorId = descriptor.Id;
+                return true;
+            }
+
+            if (_catalog.LegacyMap.TryGetValue(serviceType, out descriptorId))
+            {
+                return true;
+            }
+
+            descriptorId = serviceType.ToDescriptorId();
+            return false;
         }
 
 


### PR DESCRIPTION
## Summary
- de-duplicate descriptor-driven service registrations by tracking registration keys during bootstrap
- annotate each navigation handler with ServiceDescriptorRegistration metadata for descriptor-driven discovery

## Testing
- not run (Windows-only `dotnet test --settings tests.runsettings`)


------
https://chatgpt.com/codex/tasks/task_e_68dc1629552883269d49fcb647433918