### PR TITLE
Add presentation metadata to service descriptors

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/ServiceCatalogTests.cs
+++ b/DesktopApplicationTemplate.Core.Tests/ServiceCatalogTests.cs
@@ -26,6 +26,12 @@ public class ServiceCatalogTests
         catalog.TryGetById(ServiceDescriptorIds.Tcp, out var tcpDescriptor).Should().BeTrue();
         tcpDescriptor!.LegacyType.Should().Be(ServiceType.Tcp);
         catalog.LegacyMap.Should().ContainKey(ServiceType.Tcp).WhoseValue.Should().Be(ServiceDescriptorIds.Tcp);
+        tcpDescriptor.Presentation.IconGlyph.Should().Be("🔗");
+        tcpDescriptor.Presentation.PrimaryAccentColor.Should().Be("#FFADD8E6");
+        tcpDescriptor.Presentation.SecondaryAccentColor.Should().Be("#FF00008B");
+        tcpDescriptor.Presentation.DisplayLabel.Should().Be("TCP");
+        tcpDescriptor.HasPayloadDescription.Should().BeFalse();
+        tcpDescriptor.DescribePayload(null).Should().BeNull();
     }
 
     [Fact]
@@ -72,5 +78,11 @@ public class ServiceCatalogTests
         public IServiceOptionsSerializer? OptionsSerializer => null;
 
         public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+
+        public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;
+
+        public bool HasPayloadDescription => false;
+
+        public string? DescribePayload(object? payload) => null;
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/IServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceDescriptor.cs
@@ -42,4 +42,21 @@ public interface IServiceDescriptor
     /// Gets registered factory bindings for integrating the service.
     /// </summary>
     IReadOnlyCollection<ServiceFactoryBinding> Factories { get; }
+
+    /// <summary>
+    /// Gets UI presentation metadata that can be used to render the service.
+    /// </summary>
+    ServicePresentationMetadata Presentation { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="DescribePayload(object?)"/> provides custom payload details.
+    /// </summary>
+    bool HasPayloadDescription { get; }
+
+    /// <summary>
+    /// Provides a user-friendly description for a persisted payload, if available.
+    /// </summary>
+    /// <param name="payload">The payload to describe.</param>
+    /// <returns>The description, or <c>null</c> when not available.</returns>
+    string? DescribePayload(object? payload);
 }

--- a/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
@@ -72,6 +72,9 @@ public sealed class ServiceCatalog : IServiceCatalog
         private ServiceType? _legacyType;
         private IServiceOptionsSerializer? _serializer;
         private readonly Dictionary<(ServiceFactoryKind Kind, Type ContractType, string? Key), ServiceFactoryBinding> _factories = new();
+        private ServicePresentationMetadata? _presentation;
+        private bool _hasPayloadDescriptor;
+        private Func<object?, string?> _payloadDescriptor = static _ => null;
 
         public ServiceDescriptorBuilder(string id)
         {
@@ -88,6 +91,31 @@ public sealed class ServiceCatalog : IServiceCatalog
             _displayName = AssignOrValidate(_displayName, descriptor.DisplayName, nameof(descriptor.DisplayName));
             _category = AssignOrValidate(_category, descriptor.Category, nameof(descriptor.Category));
             _description = AssignOrValidate(_description, descriptor.Description, nameof(descriptor.Description), allowNull: true);
+
+            if (!descriptor.Presentation.IsEmpty)
+            {
+                if (_presentation is null)
+                {
+                    _presentation = descriptor.Presentation;
+                }
+                else if (_presentation != descriptor.Presentation)
+                {
+                    throw new InvalidOperationException($"Conflicting presentation metadata for descriptor '{_id}'.");
+                }
+            }
+
+            if (descriptor.HasPayloadDescription)
+            {
+                if (!_hasPayloadDescriptor)
+                {
+                    _payloadDescriptor = descriptor.DescribePayload;
+                    _hasPayloadDescriptor = true;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Conflicting payload description handlers for descriptor '{_id}'.");
+                }
+            }
 
             if (descriptor.LegacyType is { } legacy)
             {
@@ -133,7 +161,18 @@ public sealed class ServiceCatalog : IServiceCatalog
             }
 
             var factories = _factories.Values.ToList();
-            return new Snapshot(_id, _displayName!, _category!, _description, _legacyType, _serializer, factories);
+            var presentation = ServicePresentationMetadata.Normalize(_presentation);
+            return new Snapshot(
+                _id,
+                _displayName!,
+                _category!,
+                _description,
+                _legacyType,
+                _serializer,
+                factories,
+                presentation,
+                _hasPayloadDescriptor,
+                _payloadDescriptor);
         }
 
         private static string? AssignOrValidate(string? current, string? incoming, string propertyName, bool allowNull = false)
@@ -166,7 +205,10 @@ public sealed class ServiceCatalog : IServiceCatalog
             string? description,
             ServiceType? legacyType,
             IServiceOptionsSerializer? serializer,
-            IReadOnlyCollection<ServiceFactoryBinding> factories)
+            IReadOnlyCollection<ServiceFactoryBinding> factories,
+            ServicePresentationMetadata presentation,
+            bool hasPayloadDescription,
+            Func<object?, string?> payloadDescriptor)
         {
             Id = id;
             DisplayName = displayName;
@@ -175,6 +217,9 @@ public sealed class ServiceCatalog : IServiceCatalog
             LegacyType = legacyType;
             OptionsSerializer = serializer;
             Factories = factories;
+            Presentation = presentation;
+            HasPayloadDescription = hasPayloadDescription;
+            _payloadDescriptor = payloadDescriptor;
         }
 
         public string Id { get; }
@@ -190,5 +235,13 @@ public sealed class ServiceCatalog : IServiceCatalog
         public IServiceOptionsSerializer? OptionsSerializer { get; }
 
         public IReadOnlyCollection<ServiceFactoryBinding> Factories { get; }
+
+        public ServicePresentationMetadata Presentation { get; }
+
+        public bool HasPayloadDescription { get; }
+
+        public string? DescribePayload(object? payload) => _payloadDescriptor(payload);
+
+        private readonly Func<object?, string?> _payloadDescriptor;
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/ServicePresentationMetadata.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServicePresentationMetadata.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Provides UI presentation guidance for a service descriptor that can be consumed without referencing UI assemblies.
+/// </summary>
+public sealed record ServicePresentationMetadata(
+    string? IconGlyph,
+    string? PrimaryAccentColor,
+    string? SecondaryAccentColor,
+    string? DisplayLabel)
+{
+    /// <summary>
+    /// Gets an empty metadata instance used when no presentation hints are provided.
+    /// </summary>
+    public static ServicePresentationMetadata Empty { get; } = new(null, null, null, null);
+
+    /// <summary>
+    /// Gets a value indicating whether the metadata contains any presentation hints.
+    /// </summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(IconGlyph)
+        && string.IsNullOrWhiteSpace(PrimaryAccentColor)
+        && string.IsNullOrWhiteSpace(SecondaryAccentColor)
+        && string.IsNullOrWhiteSpace(DisplayLabel);
+
+    /// <summary>
+    /// Normalizes the provided metadata by returning <see cref="Empty"/> when <paramref name="metadata"/> is <c>null</c>.
+    /// </summary>
+    /// <param name="metadata">The metadata instance to normalize.</param>
+    /// <returns>The normalized metadata.</returns>
+    public static ServicePresentationMetadata Normalize(ServicePresentationMetadata? metadata) => metadata ?? Empty;
+}

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/CsvServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/CsvServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class CsvServiceDescriptor : ServiceDescriptorBase
             "Generate CSV output from message payloads.",
             ServiceType.Csv,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                "📄",
+                "#FFD3D3D3",
+                "#FF808080",
+                "CSV Creator"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/FileObserverServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/FileObserverServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class FileObserverServiceDescriptor : ServiceDescriptorBase
             "Monitor directories for changes and trigger automation flows.",
             ServiceType.FileObserver,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                null,
+                "#FFFFA07A",
+                "#FFE9967A",
+                "File Observer"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/FtpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/FtpServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class FtpServiceDescriptor : ServiceDescriptorBase
             "Transfer files to remote hosts using the FTP protocol.",
             ServiceType.Ftp,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                "🖥️",
+                "#FFB0C4DE",
+                "#FF4682B4",
+                "FTP Server"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/HeartbeatServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/HeartbeatServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class HeartbeatServiceDescriptor : ServiceDescriptorBase
             "Emit periodic heartbeat messages for monitoring integrations.",
             ServiceType.Heartbeat,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                null,
+                "#FFFFB6C1",
+                "#FFFF1493",
+                "Heartbeat"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/HidServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/HidServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class HidServiceDescriptor : ServiceDescriptorBase
             "Interact with Human Interface Devices for automation scenarios.",
             ServiceType.Hid,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                null,
+                "#FFFFFFE0",
+                "#FFDAA520",
+                "HID"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/HttpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/HttpServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class HttpServiceDescriptor : ServiceDescriptorBase
             "Interact with HTTP endpoints for automation workflows.",
             ServiceType.Http,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                "🌐",
+                "#FF90EE90",
+                "#FF006400",
+                "HTTP"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/MqttServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/MqttServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class MqttServiceDescriptor : ServiceDescriptorBase
             "Connect to MQTT brokers and manage topic subscriptions.",
             ServiceType.Mqtt,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                "📡",
+                "#FFFAFAD2",
+                "#FFDAA520",
+                "MQTT"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/ScpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/ScpServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class ScpServiceDescriptor : ServiceDescriptorBase
             "Transfer files securely using the SCP protocol.",
             ServiceType.Scp,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                "📦",
+                "#FFE0FFFF",
+                "#FF5F9EA0",
+                "SCP"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/ServiceDescriptorBase.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/ServiceDescriptorBase.cs
@@ -11,6 +11,10 @@ namespace DesktopApplicationTemplate.Services.Common.Descriptors;
 /// </summary>
 public abstract class ServiceDescriptorBase : IServiceDescriptor
 {
+    private static readonly Func<object?, string?> DefaultPayloadDescriptor = static _ => null;
+
+    private readonly Func<object?, string?> _payloadDescriptor;
+
     protected ServiceDescriptorBase(
         string id,
         string displayName,
@@ -18,7 +22,9 @@ public abstract class ServiceDescriptorBase : IServiceDescriptor
         string? description,
         ServiceType legacyType,
         IServiceOptionsSerializer? optionsSerializer,
-        IReadOnlyCollection<ServiceFactoryBinding>? factories)
+        IReadOnlyCollection<ServiceFactoryBinding>? factories,
+        ServicePresentationMetadata? presentation = null,
+        Func<object?, string?>? payloadDescription = null)
     {
         Id = id;
         DisplayName = displayName;
@@ -27,6 +33,9 @@ public abstract class ServiceDescriptorBase : IServiceDescriptor
         LegacyType = legacyType;
         OptionsSerializer = optionsSerializer;
         Factories = factories?.ToArray() ?? Array.Empty<ServiceFactoryBinding>();
+        Presentation = ServicePresentationMetadata.Normalize(presentation);
+        _payloadDescriptor = payloadDescription ?? DefaultPayloadDescriptor;
+        HasPayloadDescription = payloadDescription is not null;
     }
 
     public string Id { get; }
@@ -42,4 +51,10 @@ public abstract class ServiceDescriptorBase : IServiceDescriptor
     public IServiceOptionsSerializer? OptionsSerializer { get; }
 
     public IReadOnlyCollection<ServiceFactoryBinding> Factories { get; }
+
+    public ServicePresentationMetadata Presentation { get; }
+
+    public bool HasPayloadDescription { get; }
+
+    public virtual string? DescribePayload(object? payload) => _payloadDescriptor(payload);
 }

--- a/DesktopApplicationTemplate.Services.Common/Descriptors/TcpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Services.Common/Descriptors/TcpServiceDescriptor.cs
@@ -18,7 +18,12 @@ public sealed class TcpServiceDescriptor : ServiceDescriptorBase
             "Send and receive messages over TCP or UDP.",
             ServiceType.Tcp,
             optionsSerializer,
-            factories)
+            factories,
+            new ServicePresentationMetadata(
+                "🔗",
+                "#FFADD8E6",
+                "#FF00008B",
+                "TCP"))
     {
     }
 }

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -170,5 +170,11 @@ internal sealed class StubCatalog : IServiceCatalog
         public IServiceOptionsSerializer? OptionsSerializer => null;
 
         public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+
+        public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;
+
+        public bool HasPayloadDescription => false;
+
+        public string? DescribePayload(object? payload) => null;
     }
 }


### PR DESCRIPTION
## Summary
- introduce a shared `ServicePresentationMetadata` contract and extend `IServiceDescriptor` with presentation and payload description hooks
- propagate metadata and payload describers through `ServiceCatalog`
- populate the common service descriptors with icon, color, and label metadata and extend catalog tests to cover the new surface

## Testing
- Not run (CI will cover)


------
https://chatgpt.com/codex/tasks/task_e_68dc32d5e1148326a9f580dbe20bb487