### PR TITLE
Adopt descriptor-driven service persistence

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -4,6 +4,8 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Serialization;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -27,16 +29,19 @@ namespace DesktopApplicationTemplate.Tests
             ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
             try
             {
-                var services = new List<ServiceListModel>
-                {
-                    new ServiceListModel{DisplayName="A", Type=ServiceType.Heartbeat, IsActive=true, Order=0},
-                    new ServiceListModel{DisplayName="B", Type=ServiceType.Tcp, IsActive=false, Order=1}
-                };
+                var catalog = CreateCatalog();
+                var serviceA = TestHelpers.CreateService(ServiceType.Heartbeat, "A");
+                serviceA.IsActive = true;
+                serviceA.Order = 0;
+                var serviceB = TestHelpers.CreateService(ServiceType.Tcp, "B");
+                serviceB.IsActive = false;
+                serviceB.Order = 1;
+                var services = new List<ServiceListModel> { serviceA, serviceB };
                 services[0].AssociatedServices.Add("B");
                 services[1].AssociatedServices.Add("A");
 
-                ServicePersistence.Save(services);
-                var loaded = ServicePersistence.Load();
+                ServicePersistence.Save(services, catalog);
+                var loaded = ServicePersistence.Load(catalog);
                 Assert.Equal(2, loaded.Count);
                 Assert.Equal("A", loaded[0].DisplayName);
                 Assert.Contains("B", loaded[0].AssociatedServices);
@@ -60,13 +65,14 @@ namespace DesktopApplicationTemplate.Tests
             ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
             try
             {
-                var a = new ServiceListModel { DisplayName = "A", Type = ServiceType.Tcp };
-                var b = new ServiceListModel { DisplayName = "B", Type = ServiceType.Tcp };
+                var catalog = CreateCatalog();
+                var a = new ServiceListModel { DisplayName = "A", Type = ServiceType.Tcp, DescriptorId = ServiceType.Tcp.ToDescriptorId() };
+                var b = new ServiceListModel { DisplayName = "B", Type = ServiceType.Tcp, DescriptorId = ServiceType.Tcp.ToDescriptorId() };
                 a.AssociatedServices.Add("B");
                 b.AssociatedServices.Add("A");
                 var services = new List<ServiceListModel> { a, b };
 
-                ServicePersistence.Save(services);
+                ServicePersistence.Save(services, catalog);
 
                 Assert.True(File.Exists(ServicePersistence.FilePath));
             }
@@ -97,12 +103,13 @@ namespace DesktopApplicationTemplate.Tests
 
             try
             {
+                var catalog = CreateCatalog();
                 var opt = host.Services.GetRequiredService<IOptions<TcpServiceOptions>>().Value;
 
                 var serviceInfo = TestHelpers.CreateService(type, name);
                 serviceInfo.IsActive = false;
                 serviceInfo.Order = 0;
-                serviceInfo.TcpOptions = new TcpServiceOptions
+                serviceInfo.SetPayload(new TcpServiceOptions
                 {
                     Host = "h",
                     Port = 42,
@@ -112,11 +119,11 @@ namespace DesktopApplicationTemplate.Tests
                     Script = "return message;",
                     OutputMessage = "out",
                     LastTestMessage = "last"
-                };
+                });
 
                 var services = new List<ServiceListModel> { serviceInfo };
 
-                ServicePersistence.Save(services);
+                ServicePersistence.Save(services, catalog);
 
                 // mutate options to verify load restores
                 opt.Host = "changed";
@@ -128,17 +135,17 @@ namespace DesktopApplicationTemplate.Tests
                 opt.OutputMessage = "changed";
                 opt.LastTestMessage = "changed";
 
-                var loaded = ServicePersistence.Load();
+                var loaded = ServicePersistence.Load(catalog);
                 var info = Assert.Single(loaded);
-                Assert.NotNull(info.TcpOptions);
-                Assert.Equal("h", info.TcpOptions!.Host);
-                Assert.Equal(42, info.TcpOptions.Port);
-                Assert.True(info.TcpOptions.UseUdp);
-                Assert.Equal(TcpServiceMode.Sending, info.TcpOptions.Mode);
-                Assert.Equal("in", info.TcpOptions.InputMessage);
-                Assert.Equal("return message;", info.TcpOptions.Script);
-                Assert.Equal("out", info.TcpOptions.OutputMessage);
-                Assert.Equal("last", info.TcpOptions.LastTestMessage);
+                var payload = Assert.IsType<TcpServiceOptions>(info.Payload);
+                Assert.Equal("h", payload.Host);
+                Assert.Equal(42, payload.Port);
+                Assert.True(payload.UseUdp);
+                Assert.Equal(TcpServiceMode.Sending, payload.Mode);
+                Assert.Equal("in", payload.InputMessage);
+                Assert.Equal("return message;", payload.Script);
+                Assert.Equal("out", payload.OutputMessage);
+                Assert.Equal("last", payload.LastTestMessage);
 
                 // global options restored
                 var restored = host.Services.GetRequiredService<IOptions<TcpServiceOptions>>().Value;
@@ -179,22 +186,23 @@ namespace DesktopApplicationTemplate.Tests
 
             try
             {
+                var catalog = CreateCatalog();
                 var opt = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
 
                 var serviceInfo = TestHelpers.CreateService(ServiceType.Ftp, "One");
                 serviceInfo.IsActive = false;
                 serviceInfo.Order = 0;
-                serviceInfo.FtpOptions = new FtpServerOptions
+                serviceInfo.SetPayload(new FtpServerOptions
                 {
                     Port = 21,
                     RootPath = "/srv",
                     AllowAnonymous = true,
                     Username = "u",
                     Password = "p"
-                };
+                });
                 var services = new List<ServiceListModel> { serviceInfo };
 
-                ServicePersistence.Save(services);
+                ServicePersistence.Save(services, catalog);
 
                 // mutate options to verify load restores
                 opt.Port = 100;
@@ -203,14 +211,14 @@ namespace DesktopApplicationTemplate.Tests
                 opt.Username = null;
                 opt.Password = null;
 
-                var loaded = ServicePersistence.Load();
+                var loaded = ServicePersistence.Load(catalog);
                 var info = Assert.Single(loaded);
-                Assert.NotNull(info.FtpOptions);
-                Assert.Equal(21, info.FtpOptions!.Port);
-                Assert.Equal("/srv", info.FtpOptions.RootPath);
-                Assert.True(info.FtpOptions.AllowAnonymous);
-                Assert.Equal("u", info.FtpOptions.Username);
-                Assert.Equal("p", info.FtpOptions.Password);
+                var payload = Assert.IsType<FtpServerOptions>(info.Payload);
+                Assert.Equal(21, payload.Port);
+                Assert.Equal("/srv", payload.RootPath);
+                Assert.True(payload.AllowAnonymous);
+                Assert.Equal("u", payload.Username);
+                Assert.Equal("p", payload.Password);
 
                 // global options restored
                 var restoredFtp = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
@@ -232,7 +240,7 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
-        public void SaveAndLoad_PreservesLegacyFtpOptions()
+        public void Load_PreservesLegacyFtpOptions()
         {
             var host = Host.CreateDefaultBuilder()
                 .ConfigureServices(s => s.Configure<FtpServerOptions>(_ => { }))
@@ -248,46 +256,62 @@ namespace DesktopApplicationTemplate.Tests
 
             try
             {
-                var opt = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
+                var catalog = CreateCatalog();
+                var options = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
 
-                var serviceInfo = TestHelpers.CreateService(ServiceType.Ftp, "One");
-                serviceInfo.IsActive = false;
-                serviceInfo.Order = 0;
-                serviceInfo.FtpOptions = new FtpServerOptions
-                {
-                    Port = 21,
-                    RootPath = "/srv",
-                    AllowAnonymous = true,
-                    Username = "u",
-                    Password = "p"
-                };
-                var services = new List<ServiceListModel> { serviceInfo };
+                var legacyJson = @"[
+    {
+        ""DisplayName"": ""Legacy Ftp"",
+        ""ServiceType"": ""FTP"",
+        ""IsActive"": true,
+        ""Created"": ""2024-01-01T00:00:00"",
+        ""Order"": 4,
+        ""AssociatedServices"": [""Tcp1""],
+        ""TotalExecutionTimeMs"": 123.0,
+        ""ExecutionCount"": 10,
+        ""FtpOptions"": {
+            ""Port"": 21,
+            ""RootPath"": ""/srv"",
+            ""AllowAnonymous"": true,
+            ""Username"": ""legacy-user"",
+            ""Password"": ""legacy-pass""
+        }
+    }
+]";
 
-                ServicePersistence.Save(services);
+                File.WriteAllText(ServicePersistence.FilePath, legacyJson);
 
                 // mutate options to verify load restores
-                opt.Port = 100;
-                opt.RootPath = "changed";
-                opt.AllowAnonymous = false;
-                opt.Username = null;
-                opt.Password = null;
+                options.Port = 100;
+                options.RootPath = "changed";
+                options.AllowAnonymous = false;
+                options.Username = null;
+                options.Password = null;
 
-                var loaded = ServicePersistence.Load();
+                var loaded = ServicePersistence.Load(catalog);
                 var info = Assert.Single(loaded);
-                Assert.NotNull(info.FtpOptions);
-                Assert.Equal(21, info.FtpOptions!.Port);
-                Assert.Equal("/srv", info.FtpOptions.RootPath);
-                Assert.True(info.FtpOptions.AllowAnonymous);
-                Assert.Equal("u", info.FtpOptions.Username);
-                Assert.Equal("p", info.FtpOptions.Password);
+                Assert.Equal(ServiceDescriptorIds.Ftp, info.DescriptorId);
+                Assert.Equal(ServiceType.Ftp, info.ServiceType);
+                Assert.True(info.IsActive);
+                Assert.Equal(4, info.Order);
+                Assert.Contains("Tcp1", info.AssociatedServices);
+                Assert.Equal(123.0, info.TotalExecutionTimeMs);
+                Assert.Equal(10, info.ExecutionCount);
+
+                var payload = Assert.IsType<FtpServerOptions>(info.Payload);
+                Assert.Equal(21, payload.Port);
+                Assert.Equal("/srv", payload.RootPath);
+                Assert.True(payload.AllowAnonymous);
+                Assert.Equal("legacy-user", payload.Username);
+                Assert.Equal("legacy-pass", payload.Password);
 
                 // global options restored
-                var restoredLegacy = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
-                Assert.Equal(21, restoredLegacy.Port);
-                Assert.Equal("/srv", restoredLegacy.RootPath);
-                Assert.True(restoredLegacy.AllowAnonymous);
-                Assert.Equal("u", restoredLegacy.Username);
-                Assert.Equal("p", restoredLegacy.Password);
+                var restored = host.Services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
+                Assert.Equal(21, restored.Port);
+                Assert.Equal("/srv", restored.RootPath);
+                Assert.True(restored.AllowAnonymous);
+                Assert.Equal("legacy-user", restored.Username);
+                Assert.Equal("legacy-pass", restored.Password);
             }
             finally
             {
@@ -311,7 +335,7 @@ namespace DesktopApplicationTemplate.Tests
             {
                 File.WriteAllText(ServicePersistence.FilePath, "[{'DisplayName':'Svc','ServiceType':'FTP Server'}]".Replace("'", "\""));
                 var logger = new ListLogger();
-                var loaded = ServicePersistence.Load(logger);
+                var loaded = ServicePersistence.Load(CreateCatalog(), logger);
                 var info = Assert.Single(loaded);
                 Assert.Equal(ServiceType.Ftp, info.ServiceType);
             }
@@ -335,7 +359,7 @@ namespace DesktopApplicationTemplate.Tests
             {
                 File.WriteAllText(ServicePersistence.FilePath, "[{'DisplayName':'Svc','ServiceType':'Unknown'}]".Replace("'", "\""));
                 var logger = new ListLogger();
-                var loaded = ServicePersistence.Load(logger);
+                var loaded = ServicePersistence.Load(CreateCatalog(), logger);
                 Assert.Empty(loaded);
                 Assert.Contains(logger.Messages, m => m.Contains("Unknown"));
             }
@@ -346,6 +370,24 @@ namespace DesktopApplicationTemplate.Tests
             }
 
             ConsoleTestLogger.LogPass();
+        }
+
+        private static IServiceCatalog CreateCatalog()
+        {
+            var descriptors = new IServiceDescriptor[]
+            {
+                new TcpServiceDescriptor(new JsonServiceOptionsSerializer<TcpServiceOptions>()),
+                new FtpServiceDescriptor(new JsonServiceOptionsSerializer<FtpServerOptions>()),
+                new HttpServiceDescriptor(new JsonServiceOptionsSerializer<HttpServiceOptions>()),
+                new CsvServiceDescriptor(new JsonServiceOptionsSerializer<CsvServiceOptions>()),
+                new FileObserverServiceDescriptor(new JsonServiceOptionsSerializer<FileObserverServiceOptions>()),
+                new ScpServiceDescriptor(new JsonServiceOptionsSerializer<ScpServiceOptions>()),
+                new HidServiceDescriptor(new JsonServiceOptionsSerializer<HidServiceOptions>()),
+                new HeartbeatServiceDescriptor(new JsonServiceOptionsSerializer<HeartbeatServiceOptions>()),
+                new MqttServiceDescriptor(new JsonServiceOptionsSerializer<MqttServiceOptions>())
+            };
+
+            return new ServiceCatalog(descriptors);
         }
 
         private sealed class ListLogger : ILoggingService

--- a/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/TcpServiceMessagesViewModelTests.cs
@@ -97,7 +97,7 @@ public class TcpServiceMessagesViewModelTests
     public void ServiceName_NoPriorMessage_UsesDefault()
     {
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = new TcpServiceOptions();
+        service.SetPayload(new TcpServiceOptions());
         var routing = new MessageRoutingService();
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing);
         vm.SetService(service);
@@ -111,7 +111,7 @@ public class TcpServiceMessagesViewModelTests
     public void ServiceName_NoPriorMessage_UsesRoutingMessage()
     {
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = new TcpServiceOptions();
+        service.SetPayload(new TcpServiceOptions());
         var routing = new MessageRoutingService();
         routing.UpdateMessage(ServiceType.Tcp, "svc", "last");
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing);
@@ -125,7 +125,7 @@ public class TcpServiceMessagesViewModelTests
     public void ServiceName_WithPriorMessage_UsesStored()
     {
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = new TcpServiceOptions { LastTestMessage = "hello" };
+        service.SetPayload(new TcpServiceOptions { LastTestMessage = "hello" });
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         vm.SetService(service);
 
@@ -137,7 +137,7 @@ public class TcpServiceMessagesViewModelTests
     {
         var options = new TcpServiceOptions();
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = options;
+        service.SetPayload(options);
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         vm.SetService(service);
         vm.TestMessage = "test";
@@ -152,7 +152,7 @@ public class TcpServiceMessagesViewModelTests
     {
         var options = new TcpServiceOptions();
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = options;
+        service.SetPayload(options);
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         vm.SetService(service);
         vm.Script = "return message;";
@@ -167,7 +167,7 @@ public class TcpServiceMessagesViewModelTests
     {
         var options = new TcpServiceOptions();
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = options;
+        service.SetPayload(options);
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         vm.SetService(service);
         vm.Script = "string Process(string message) => message + \"!\";";
@@ -183,7 +183,7 @@ public class TcpServiceMessagesViewModelTests
     public void SetService_LoadsScript()
     {
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = new TcpServiceOptions { Script = "return message;" };
+        service.SetPayload(new TcpServiceOptions { Script = "return message;" });
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
 
         vm.SetService(service);
@@ -195,7 +195,7 @@ public class TcpServiceMessagesViewModelTests
     public void SetService_NoScript_UsesDefault()
     {
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = new TcpServiceOptions();
+        service.SetPayload(new TcpServiceOptions());
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
 
         vm.SetService(service);
@@ -208,7 +208,7 @@ public class TcpServiceMessagesViewModelTests
     {
         var options = new TcpServiceOptions();
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = options;
+        service.SetPayload(options);
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         vm.SetService(service);
         vm.TestMessage = "ping";
@@ -225,7 +225,7 @@ public class TcpServiceMessagesViewModelTests
     {
         var options = new TcpServiceOptions();
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = options;
+        service.SetPayload(options);
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), new MessageRoutingService());
         vm.SetService(service);
         vm.TestMessage = "ping";
@@ -285,7 +285,7 @@ public class TcpServiceMessagesViewModelTests
     {
         var options = new TcpServiceOptions();
         var service = TestHelpers.CreateService(ServiceType.Tcp, "svc");
-        service.TcpOptions = options;
+        service.SetPayload(options);
         var routing = new MessageRoutingService();
         var vm = new TcpServiceMessagesViewModel(new ServiceMessageTableViewModel(), routing);
         vm.SetService(service);

--- a/DesktopApplicationTemplate.Tests/TestHelpers.cs
+++ b/DesktopApplicationTemplate.Tests/TestHelpers.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate.Tests;
@@ -8,6 +9,7 @@ public static class TestHelpers
     public static ServiceListModel CreateService(ServiceType type, string name) => new ServiceListModel
     {
         Type = type,
+        DescriptorId = type.ToDescriptorId(),
         DisplayName = $"{type.ToLegacyString()} - {name}"
     };
 }

--- a/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
@@ -6,6 +6,8 @@ using DesktopApplicationTemplate.UI.ViewModels.Csv.Advanced;
 using DesktopApplicationTemplate.UI.Views.Csv.Edit;
 using DesktopApplicationTemplate.UI.Views.Csv.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -31,15 +33,24 @@ public class CsvEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var csvPage = mainView.GetOrCreateServicePage(service);
-        var options = service.CsvOptions ?? new CsvServiceOptions();
+        var payload = service.GetPayload<CsvServiceOptions>();
+        if (payload is null)
+        {
+            payload = new CsvServiceOptions();
+            service.SetPayload(payload);
+        }
+
+        var options = payload;
         var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
         vm.Load(service.DisplayName.Split(" - ").Last(), options);
         var editView = _services.GetRequiredService<CsvServiceEditorView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"CSV Creator - {name}";
-            service.CsvOptions = opts;
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
             if (csvPage != null)
                 mainView.ShowPage(csvPage);
             _ = mainViewModel.SaveServicesAsync();
@@ -60,6 +71,26 @@ public class CsvEditServiceHandler : IEditServiceHandler
         };
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
+}
+
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
     }
 }
 

--- a/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
@@ -6,6 +6,8 @@ using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Advanced;
 using DesktopApplicationTemplate.UI.Views.FileObserver.Edit;
 using DesktopApplicationTemplate.UI.Views.FileObserver.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -30,23 +32,36 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
     {
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
-        var foPage = mainView.GetOrCreateServicePage(service);
-        var options = service.FileObserverOptions ?? new FileObserverServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var observerPage = mainView.GetOrCreateServicePage(service);
+        var payload = service.GetPayload<FileObserverServiceOptions>();
+        if (payload is null)
+        {
+            payload = new FileObserverServiceOptions();
+            service.SetPayload(payload);
+        }
+
+        var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), payload);
         var editView = _services.GetRequiredService<FileObserverEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"File Observer - {name}";
-            service.FileObserverOptions = opts;
-            if (foPage != null)
-                mainView.ShowPage(foPage);
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
+            if (observerPage != null)
+            {
+                mainView.ShowPage(observerPage);
+            }
+
             _ = mainViewModel.SaveServicesAsync();
         };
         vm.EditCancelled += () =>
         {
-            if (foPage != null)
-                mainView.ShowPage(foPage);
+            if (observerPage != null)
+            {
+                mainView.ShowPage(observerPage);
+            }
         };
         vm.AdvancedConfigRequested += opts =>
         {
@@ -60,5 +75,24 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
-}
 
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
+    }
+}

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -6,6 +6,8 @@ using DesktopApplicationTemplate.UI.ViewModels.Ftp.Advanced;
 using DesktopApplicationTemplate.UI.Views.Ftp.Edit;
 using DesktopApplicationTemplate.UI.Views.Ftp.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -32,13 +34,22 @@ public class FtpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var ftpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.FtpOptions ?? new FtpServerOptions();
+        var payload = service.GetPayload<FtpServerOptions>();
+        if (payload is null)
+        {
+            payload = new FtpServerOptions();
+            service.SetPayload(payload);
+        }
+
+        var options = payload;
         var vm = ActivatorUtilities.CreateInstance<FtpServerEditViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
         var editView = ActivatorUtilities.CreateInstance<FtpServerEditView>(_services, vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"FTP Server - {name}";
-            service.FtpOptions = opts;
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
             var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
             opt.Port = opts.Port;
             opt.RootPath = opts.RootPath;
@@ -65,6 +76,26 @@ public class FtpEditServiceHandler : IEditServiceHandler
         };
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
+}
+
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
     }
 }
 

--- a/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
@@ -2,10 +2,10 @@ using System;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Edit;
-using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Advanced;
 using DesktopApplicationTemplate.UI.Views.Heartbeat.Edit;
-using DesktopApplicationTemplate.UI.Views.Heartbeat.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -30,35 +30,58 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
     {
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
-        var hbPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HeartbeatOptions ?? new HeartbeatServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<HeartbeatEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var heartbeatPage = mainView.GetOrCreateServicePage(service);
+        var payload = service.GetPayload<HeartbeatServiceOptions>();
+        if (payload is null)
+        {
+            payload = new HeartbeatServiceOptions();
+            service.SetPayload(payload);
+        }
+
+        var vm = ActivatorUtilities.CreateInstance<HeartbeatEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), payload);
         var editView = _services.GetRequiredService<HeartbeatEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"Heartbeat - {name}";
-            service.HeartbeatOptions = opts;
-            if (hbPage != null)
-                mainView.ShowPage(hbPage);
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
+            if (heartbeatPage != null)
+            {
+                mainView.ShowPage(heartbeatPage);
+            }
+
             _ = mainViewModel.SaveServicesAsync();
         };
         vm.EditCancelled += () =>
         {
-            if (hbPage != null)
-                mainView.ShowPage(hbPage);
-        };
-        vm.AdvancedConfigRequested += opts =>
-        {
-            var advVm = ActivatorUtilities.CreateInstance<HeartbeatAdvancedConfigViewModel>(_services, opts);
-            var advView = _services.GetRequiredService<HeartbeatAdvancedConfigView>();
-            advView.Initialize(advVm);
-            advVm.Saved += _ => mainView.ShowPage(editView);
-            advVm.BackRequested += () => mainView.ShowPage(editView);
-            mainView.ShowPage(advView);
+            if (heartbeatPage != null)
+            {
+                mainView.ShowPage(heartbeatPage);
+            }
         };
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
-}
 
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
+    }
+}

--- a/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
@@ -6,6 +6,8 @@ using DesktopApplicationTemplate.UI.ViewModels.Hid.Advanced;
 using DesktopApplicationTemplate.UI.Views.Hid.Edit;
 using DesktopApplicationTemplate.UI.Views.Hid.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -31,22 +33,35 @@ public class HidEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var hidPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HidOptions ?? new HidServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<HidEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var payload = service.GetPayload<HidServiceOptions>();
+        if (payload is null)
+        {
+            payload = new HidServiceOptions();
+            service.SetPayload(payload);
+        }
+
+        var vm = ActivatorUtilities.CreateInstance<HidEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), payload);
         var editView = _services.GetRequiredService<HidEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"HID - {name}";
-            service.HidOptions = opts;
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
             if (hidPage != null)
+            {
                 mainView.ShowPage(hidPage);
+            }
+
             _ = mainViewModel.SaveServicesAsync();
         };
         vm.EditCancelled += () =>
         {
             if (hidPage != null)
+            {
                 mainView.ShowPage(hidPage);
+            }
         };
         vm.AdvancedConfigRequested += opts =>
         {
@@ -60,5 +75,24 @@ public class HidEditServiceHandler : IEditServiceHandler
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
-}
 
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
+    }
+}

--- a/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
@@ -6,6 +6,8 @@ using DesktopApplicationTemplate.UI.ViewModels.Http.Advanced;
 using DesktopApplicationTemplate.UI.Views.Http.Edit;
 using DesktopApplicationTemplate.UI.Views.Http.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -31,14 +33,23 @@ public class HttpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var httpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HttpOptions ?? new HttpServiceOptions();
+        var payload = service.GetPayload<HttpServiceOptions>();
+        if (payload is null)
+        {
+            payload = new HttpServiceOptions();
+            service.SetPayload(payload);
+        }
+
+        var options = payload;
         var vm = ActivatorUtilities.CreateInstance<HttpEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
         var editView = _services.GetRequiredService<HttpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"HTTP - {name}";
-            service.HttpOptions = opts;
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
             if (httpPage != null)
                 mainView.ShowPage(httpPage);
             _ = mainViewModel.SaveServicesAsync();
@@ -59,6 +70,26 @@ public class HttpEditServiceHandler : IEditServiceHandler
         };
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
+    }
+
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
     }
 }
 

--- a/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
@@ -6,6 +6,8 @@ using DesktopApplicationTemplate.UI.ViewModels.Scp.Advanced;
 using DesktopApplicationTemplate.UI.Views.Scp.Edit;
 using DesktopApplicationTemplate.UI.Views.Scp.Advanced;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -31,28 +33,39 @@ public class ScpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var scpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.ScpOptions ?? new ScpServiceOptions();
-        var vm = _services.GetRequiredService<ScpEditServiceViewModel>();
-        vm.Load(service.DisplayName.Split(" - ").Last(), options);
+        var payload = service.GetPayload<ScpServiceOptions>();
+        if (payload is null)
+        {
+            payload = new ScpServiceOptions();
+            service.SetPayload(payload);
+        }
+
+        var vm = ActivatorUtilities.CreateInstance<ScpEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), payload);
         var editView = _services.GetRequiredService<ScpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"SCP - {name}";
-            service.ScpOptions = opts;
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, service.Type);
+            service.ApplyDescriptor(descriptor, name);
+            service.SetPayload(opts);
             if (scpPage != null)
+            {
                 mainView.ShowPage(scpPage);
+            }
+
             _ = mainViewModel.SaveServicesAsync();
         };
         vm.EditCancelled += () =>
         {
             if (scpPage != null)
+            {
                 mainView.ShowPage(scpPage);
+            }
         };
         vm.AdvancedConfigRequested += opts =>
         {
-            var advVm = _services.GetRequiredService<ScpAdvancedConfigViewModel>();
-            advVm.Load(opts);
+            var advVm = ActivatorUtilities.CreateInstance<ScpAdvancedConfigViewModel>(_services, opts);
             var advView = _services.GetRequiredService<ScpAdvancedConfigView>();
             advView.Initialize(advVm);
             advVm.Saved += _ => mainView.ShowPage(editView);
@@ -62,5 +75,24 @@ public class ScpEditServiceHandler : IEditServiceHandler
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
-}
 
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
+    }
+}

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -5,6 +5,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Tcp.Edit;
 using DesktopApplicationTemplate.UI.Views.Tcp.Edit;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -30,7 +31,7 @@ public class TcpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var tcpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.TcpOptions ?? new TcpServiceOptions();
+        var options = service.GetPayload<TcpServiceOptions>() ?? new TcpServiceOptions();
         var vm = _services.GetRequiredService<TcpEditServiceViewModel>();
         vm.ServiceType = service.Type;
         vm.Load(service.DisplayName.Split(" - ").Last(), options);
@@ -38,9 +39,12 @@ public class TcpEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
-            service.Type = vm.ServiceType;
-            service.TcpOptions = opts;
+            var catalog = _services.GetRequiredService<IServiceCatalog>();
+            var descriptor = ResolveDescriptor(catalog, service.DescriptorId, vm.ServiceType);
+            service.Type = descriptor?.LegacyType ?? vm.ServiceType;
+            service.ApplyDescriptor(descriptor, name);
+
+            service.SetPayload(opts);
             if (tcpPage != null)
                 mainView.ShowPage(tcpPage);
             _ = mainViewModel.SaveServicesAsync();
@@ -53,5 +57,25 @@ public class TcpEditServiceHandler : IEditServiceHandler
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);
     }
+    private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string descriptorId, ServiceType serviceType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var byId))
+        {
+            return byId;
+        }
+
+        if (catalog.TryGetByLegacyType(serviceType, out var legacy))
+        {
+            return legacy;
+        }
+
+        if (catalog.LegacyMap.TryGetValue(serviceType, out var fallbackId) && catalog.TryGetById(fallbackId, out var fallback))
+        {
+            return fallback;
+        }
+
+        return null;
+    }
+
 }
 

--- a/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -20,16 +21,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<CsvServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.Csv.ToLegacyString()} - {name}",
                 Type = ServiceType.Csv,
-                IsActive = false,
-                CsvOptions = options
+                DescriptorId = CsvServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -20,16 +21,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<FileObserverServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.FileObserver.ToLegacyString()} - {name}",
                 Type = ServiceType.FileObserver,
-                IsActive = false,
-                FileObserverOptions = options
+                DescriptorId = FileObserverServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
@@ -5,6 +5,7 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -24,16 +25,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<FtpServerOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"FTP Server - {name}",
                 Type = ServiceType.Ftp,
-                IsActive = false,
-                FtpOptions = options
+                DescriptorId = FtpServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -20,16 +21,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<HeartbeatServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.Heartbeat.ToLegacyString()} - {name}",
                 Type = ServiceType.Heartbeat,
-                IsActive = false,
-                HeartbeatOptions = options
+                DescriptorId = HeartbeatServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -20,16 +21,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<HidServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.Hid.ToLegacyString()} - {name}",
                 Type = ServiceType.Hid,
-                IsActive = false,
-                HidOptions = options
+                DescriptorId = HidServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -20,16 +21,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<HttpServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.Http.ToLegacyString()} - {name}",
                 Type = ServiceType.Http,
-                IsActive = false,
-                HttpOptions = options
+                DescriptorId = HttpServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Mqtt.Edit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -30,15 +31,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<MqttServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var newService = new ServiceListModel
             {
-                DisplayName = $"MQTT - {name}",
                 Type = ServiceType.Mqtt,
+                DescriptorId = MqttServiceDescriptor.DescriptorId,
                 IsActive = false
             };
+
+            newService.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(newService);
 

--- a/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -20,16 +21,16 @@ namespace DesktopApplicationTemplate.UI.Factories
         public ServiceListModel Create(object optionsObj)
         {
             var ctx = (ServiceFactoryOptions<TcpServiceOptions>)optionsObj;
-            var name = ctx.Name;
             var options = ctx.Options;
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.Tcp.ToLegacyString()} - {name}",
                 Type = ServiceType.Tcp,
-                IsActive = false,
-                TcpOptions = options
+                DescriptorId = TcpServiceDescriptor.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -1,138 +1,65 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Services;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.UI;
+using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.Persistence
 {
     public static class ServicePersistence
     {
+        private static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
         public static string FilePath { get; set; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
 
-        public static void Save(IEnumerable<ServiceListModel> services, ILoggingService? logger = null)
+        public static void Save(IEnumerable<ServiceListModel> services, IServiceCatalog catalog, ILoggingService? logger = null)
         {
-            var data = new List<ServiceInfo>();
+            var records = new List<PersistedServiceRecord>();
             var index = 0;
-            foreach (var s in services)
+            foreach (var service in services)
             {
-                TcpServiceOptions? tcp = null;
-                CsvServiceOptions? csv = null;
-                FtpServerOptions? ftp = null;
-                HttpServiceOptions? http = null;
-                if (s.Type == ServiceType.Tcp && s.TcpOptions != null)
+                var descriptor = ResolveDescriptor(service.DescriptorId, service.Type, catalog);
+                var payload = CreatePayloadElement(service.DescriptorPayload, descriptor?.OptionsSerializer);
+                records.Add(new PersistedServiceRecord
                 {
-                    tcp = new TcpServiceOptions
-                    {
-                        Host = s.TcpOptions.Host,
-                        Port = s.TcpOptions.Port,
-                        UseUdp = s.TcpOptions.UseUdp,
-                        Mode = s.TcpOptions.Mode,
-                        InputMessage = s.TcpOptions.InputMessage,
-                        Script = s.TcpOptions.Script,
-                        OutputMessage = s.TcpOptions.OutputMessage,
-                        LastTestMessage = s.TcpOptions.LastTestMessage
-                    };
-                }
-
-                if (s.Type == ServiceType.Ftp && s.FtpOptions != null)
-                {
-                    ftp = new FtpServerOptions
-                    {
-                        Port = s.FtpOptions.Port,
-                        RootPath = s.FtpOptions.RootPath,
-                        AllowAnonymous = s.FtpOptions.AllowAnonymous,
-                        Username = s.FtpOptions.Username,
-                        Password = s.FtpOptions.Password
-                    };
-                }
-
-                if (s.Type == ServiceType.Http && s.HttpOptions != null)
-                {
-                    http = new HttpServiceOptions
-                    {
-                        BaseUrl = s.HttpOptions.BaseUrl,
-                        Username = s.HttpOptions.Username,
-                        Password = s.HttpOptions.Password,
-                        ClientCertificatePath = s.HttpOptions.ClientCertificatePath
-                    };
-                }
-                if (s.Type == ServiceType.Csv && s.CsvOptions != null)
-                {
-                    csv = new CsvServiceOptions
-                    {
-                        OutputPath = s.CsvOptions?.OutputPath ?? string.Empty,
-                        Delimiter = s.CsvOptions?.Delimiter ?? ",",
-                        IncludeHeaders = s.CsvOptions?.IncludeHeaders ?? true
-                    };
-                }
-
-                data.Add(new ServiceInfo
-                {
-                    DisplayName = s.DisplayName,
-                    ServiceType = s.Type,
-                    IsActive = s.IsActive,
+                    DisplayName = service.DisplayName,
+                    DescriptorId = descriptor?.Id ?? ResolveDescriptorId(service),
+                    LegacyType = service.Type,
+                    LegacyTypeName = service.Type.ToString(),
+                    IsActive = service.IsActive,
                     Created = DateTime.Now,
                     Order = index++,
-                    AssociatedServices = new List<string>(s.AssociatedServices),
-                    TcpOptions = tcp,
-                    FtpOptions = ftp,
-                    HttpOptions = http,
-                    CsvOptions = csv,
-                    TotalExecutionTimeMs = s.TotalExecutionTimeMs,
-                    ExecutionCount = s.ExecutionCount
+                    AssociatedServices = new List<string>(service.AssociatedServices),
+                    Payload = payload,
+                    TotalExecutionTimeMs = service.TotalExecutionTimeMs,
+                    ExecutionCount = service.ExecutionCount
                 });
             }
 
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                ReferenceHandler = ReferenceHandler.IgnoreCycles,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            };
-
-            try
-            {
-                var json = JsonSerializer.Serialize(data, options);
-                logger?.Log($"Persisting services to {FilePath}", LogLevel.Debug);
-                var directory = Path.GetDirectoryName(FilePath);
-                if (!string.IsNullOrEmpty(directory))
-                {
-                    Directory.CreateDirectory(directory);
-                }
-                using var fs = new FileStream(FilePath, FileMode.Create, FileAccess.Write, FileShare.None);
-                using var sw = new StreamWriter(fs);
-                sw.Write(json);
-                logger?.Log($"Saved {data.Count} services to {FilePath}", LogLevel.Debug);
-            }
-            catch (StackOverflowException)
-            {
-                var dumpOptions = new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    ReferenceHandler = ReferenceHandler.Preserve
-                };
-                var dump = JsonSerializer.Serialize(data, dumpOptions);
-                var temp = Path.Combine(Path.GetTempPath(), "services_dump.json");
-                File.WriteAllText(temp, dump);
-                Environment.FailFast($"Stack overflow while saving services. Dump written to {temp}");
-            }
+            WriteRecords(records, logger);
         }
 
-        public static List<ServiceInfo> Load(ILoggingService? logger = null)
+        public static List<ServiceInfo> Load(IServiceCatalog catalog, ILoggingService? logger = null)
         {
             if (!File.Exists(FilePath))
             {
                 logger?.Log("Services file not found", LogLevel.Warning);
                 return new List<ServiceInfo>();
             }
+
             string json;
             try
             {
@@ -143,83 +70,255 @@ namespace DesktopApplicationTemplate.Persistence
                 logger?.Log("Services file not found", LogLevel.Warning);
                 return new List<ServiceInfo>();
             }
+
             try
             {
-                var legacy = JsonSerializer.Deserialize<List<LegacyServiceInfo>>(json) ?? new List<LegacyServiceInfo>();
-                var result = new List<ServiceInfo>();
-                foreach (var info in legacy)
+                var records = JsonSerializer.Deserialize<List<PersistedServiceRecord>>(json, SerializerOptions) ?? new();
+                return MapRecords(records, catalog, logger);
+            }
+            catch (JsonException)
+            {
+                // fall back to legacy payload shape
+            }
+            catch (NotSupportedException)
+            {
+                // fall back to legacy payload shape
+            }
+
+            var legacy = JsonSerializer.Deserialize<List<LegacyServiceInfo>>(json, SerializerOptions) ?? new List<LegacyServiceInfo>();
+            return MapLegacyRecords(legacy, catalog, logger);
+        }
+
+        private static void WriteRecords(IReadOnlyCollection<PersistedServiceRecord> records, ILoggingService? logger)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(records, SerializerOptions);
+                logger?.Log($"Persisting services to {FilePath}", LogLevel.Debug);
+                var directory = Path.GetDirectoryName(FilePath);
+                if (!string.IsNullOrEmpty(directory))
                 {
-                    if (ServiceTypeExtensions.TryParse(info.ServiceType, out var type))
-                    {
-                        result.Add(new ServiceInfo
-                        {
-                            DisplayName = info.DisplayName,
-                            ServiceType = type,
-                            IsActive = info.IsActive,
-                            Created = info.Created,
-                            Order = info.Order,
-                            AssociatedServices = info.AssociatedServices ?? new List<string>(),
-                            TcpOptions = info.TcpOptions,
-                            FtpOptions = info.FtpOptions,
-                            HttpOptions = info.HttpOptions,
-                            CsvOptions = info.CsvOptions,
-                            TotalExecutionTimeMs = info.TotalExecutionTimeMs,
-                            ExecutionCount = info.ExecutionCount
-                        });
-                    }
-                    else
-                    {
-                        logger?.Log($"Unmapped service type '{info.ServiceType}' for '{info.DisplayName}'", LogLevel.Warning);
-                    }
+                    Directory.CreateDirectory(directory);
                 }
 
-                foreach (var info in result)
+                File.WriteAllText(FilePath, json);
+                logger?.Log($"Saved {records.Count} services to {FilePath}", LogLevel.Debug);
+            }
+            catch (StackOverflowException)
+            {
+                var dumpOptions = new JsonSerializerOptions
                 {
-                    if (info.ServiceType == ServiceType.Tcp && info.TcpOptions != null)
-                    {
-                        var opt = App.AppHost?.Services.GetService<IOptions<TcpServiceOptions>>();
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            value.Host = info.TcpOptions.Host;
-                            value.Port = info.TcpOptions.Port;
-                            value.UseUdp = info.TcpOptions.UseUdp;
-                            value.Mode = info.TcpOptions.Mode;
-                            value.InputMessage = info.TcpOptions.InputMessage;
-                            value.Script = info.TcpOptions.Script;
-                            value.OutputMessage = info.TcpOptions.OutputMessage;
-                            value.LastTestMessage = info.TcpOptions.LastTestMessage;
-                        }
-                    }
-                    if (info.ServiceType == ServiceType.Ftp && info.FtpOptions != null)
-                    {
-                        try
-                        {
-                            var opt = App.AppHost?.Services.GetService<IOptions<FtpServerOptions>>();
-                            if (opt != null)
-                            {
-                                var value = opt.Value;
-                                value.Port = info.FtpOptions.Port;
-                                value.RootPath = info.FtpOptions.RootPath;
-                                value.AllowAnonymous = info.FtpOptions.AllowAnonymous;
-                                value.Username = info.FtpOptions.Username;
-                                value.Password = info.FtpOptions.Password;
-                            }
-                        }
-                        catch
-                        {
-                            // ignore missing options during tests or early startup
-                        }
-                    }
+                    WriteIndented = true,
+                    ReferenceHandler = ReferenceHandler.Preserve
+                };
+                var dump = JsonSerializer.Serialize(records, dumpOptions);
+                var temp = Path.Combine(Path.GetTempPath(), "services_dump.json");
+                File.WriteAllText(temp, dump);
+                Environment.FailFast($"Stack overflow while saving services. Dump written to {temp}");
+            }
+        }
+
+        private static List<ServiceInfo> MapRecords(IEnumerable<PersistedServiceRecord> records, IServiceCatalog catalog, ILoggingService? logger)
+        {
+            var result = new List<ServiceInfo>();
+            foreach (var record in records.OrderBy(r => r.Order))
+            {
+                var descriptor = ResolveDescriptor(record.DescriptorId, record.LegacyType ?? ParseLegacyType(record.LegacyTypeName), catalog);
+                var payload = DeserializePayload(record.Payload, descriptor?.OptionsSerializer);
+
+                var info = new ServiceInfo
+                {
+                    DisplayName = record.DisplayName,
+                    DescriptorId = descriptor?.Id ?? record.DescriptorId,
+                    ServiceType = descriptor?.LegacyType ?? record.LegacyType ?? ParseLegacyType(record.LegacyTypeName),
+                    IsActive = record.IsActive,
+                    Created = record.Created,
+                    Order = record.Order,
+                    AssociatedServices = record.AssociatedServices ?? new List<string>(),
+                    Payload = payload,
+                    TotalExecutionTimeMs = record.TotalExecutionTimeMs,
+                    ExecutionCount = record.ExecutionCount
+                };
+
+                result.Add(info);
+                TryRestoreGlobalOptions(descriptor, payload);
+            }
+
+            logger?.Log($"Loaded {result.Count} services", LogLevel.Debug);
+            return result;
+        }
+
+        private static List<ServiceInfo> MapLegacyRecords(IEnumerable<LegacyServiceInfo> legacy, IServiceCatalog catalog, ILoggingService? logger)
+        {
+            var result = new List<ServiceInfo>();
+            foreach (var record in legacy)
+            {
+                if (!ServiceTypeExtensions.TryParse(record.ServiceType, out var type))
+                {
+                    logger?.Log($"Unmapped service type '{record.ServiceType}' for '{record.DisplayName}'", LogLevel.Warning);
+                    continue;
                 }
 
-                logger?.Log($"Loaded {result.Count} services", LogLevel.Debug);
+                var descriptor = ResolveDescriptor(record.DescriptorId, type, catalog) ?? ResolveDescriptor(type.ToDescriptorId(), type, catalog);
+                var payload = ResolveLegacyPayload(type, record);
+
+                var info = new ServiceInfo
+                {
+                    DisplayName = record.DisplayName,
+                    DescriptorId = descriptor?.Id ?? record.DescriptorId ?? type.ToDescriptorId(),
+                    ServiceType = descriptor?.LegacyType ?? type,
+                    IsActive = record.IsActive,
+                    Created = record.Created,
+                    Order = record.Order,
+                    AssociatedServices = record.AssociatedServices ?? new List<string>(),
+                    Payload = payload,
+                    TotalExecutionTimeMs = record.TotalExecutionTimeMs,
+                    ExecutionCount = record.ExecutionCount
+                };
+
+                result.Add(info);
+                TryRestoreGlobalOptions(descriptor, payload);
+            }
+
+            logger?.Log($"Loaded {result.Count} services", LogLevel.Debug);
+            return result;
+        }
+
+        private static object? ResolveLegacyPayload(ServiceType type, LegacyServiceInfo record) => type switch
+        {
+            ServiceType.Tcp => record.TcpOptions,
+            ServiceType.Ftp => record.FtpOptions,
+            ServiceType.Http => record.HttpOptions,
+            ServiceType.Csv => record.CsvOptions,
+            _ => null
+        };
+
+        private static IServiceDescriptor? ResolveDescriptor(string? descriptorId, ServiceType? legacyType, IServiceCatalog catalog)
+        {
+            if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId!, out var descriptor))
+            {
+                return descriptor;
+            }
+
+            if (legacyType.HasValue && catalog.TryGetByLegacyType(legacyType.Value, out descriptor))
+            {
+                return descriptor;
+            }
+
+            return null;
+        }
+
+        private static string ResolveDescriptorId(ServiceListModel service)
+        {
+            if (!string.IsNullOrWhiteSpace(service.DescriptorId))
+            {
+                return service.DescriptorId;
+            }
+
+            if (service.Type != default)
+            {
+                return service.Type.ToDescriptorId();
+            }
+
+            return service.DisplayName;
+        }
+
+        private static JsonElement? CreatePayloadElement(object? payload, IServiceOptionsSerializer? serializer)
+        {
+            if (payload is null)
+            {
+                return null;
+            }
+
+            if (payload is JsonElement element)
+            {
+                return element.Clone();
+            }
+
+            if (payload is JsonDocument document)
+            {
+                return document.RootElement.Clone();
+            }
+
+            if (serializer is not null)
+            {
+                using var stream = new MemoryStream();
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    serializer.Serialize(writer, payload);
+                }
+
+                stream.Position = 0;
+                using var doc = JsonDocument.Parse(stream);
+                return doc.RootElement.Clone();
+            }
+
+            return JsonSerializer.SerializeToElement(payload, payload.GetType(), SerializerOptions);
+        }
+
+        private static object? DeserializePayload(JsonElement? element, IServiceOptionsSerializer? serializer)
+        {
+            if (!element.HasValue)
+            {
+                return null;
+            }
+
+            var value = element.Value;
+            if (value.ValueKind == JsonValueKind.Null || value.ValueKind == JsonValueKind.Undefined)
+            {
+                return null;
+            }
+
+            if (serializer is not null)
+            {
+                return serializer.Deserialize(value);
+            }
+
+            return value.Deserialize<object>(SerializerOptions);
+        }
+
+        private static ServiceType? ParseLegacyType(string? value)
+        {
+            if (ServiceTypeExtensions.TryParse(value, out var result))
+            {
                 return result;
             }
-            catch
+
+            return null;
+        }
+
+        private static void TryRestoreGlobalOptions(IServiceDescriptor? descriptor, object? payload)
+        {
+            if (descriptor?.OptionsSerializer is null || payload is null || App.AppHost?.Services is null)
             {
-                logger?.Log("Failed to parse services file", LogLevel.Error);
-                return new List<ServiceInfo>();
+                return;
+            }
+
+            var optionsType = descriptor.OptionsSerializer.OptionsType;
+            if (!optionsType.IsInstanceOfType(payload))
+            {
+                return;
+            }
+
+            var serviceProvider = App.AppHost.Services;
+            var optionsTypeGeneric = typeof(IOptions<>).MakeGenericType(optionsType);
+            var optionsInstance = serviceProvider.GetService(optionsTypeGeneric);
+            if (optionsInstance is null)
+            {
+                return;
+            }
+
+            var valueProperty = optionsTypeGeneric.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public);
+            if (valueProperty?.GetValue(optionsInstance) is not object target)
+            {
+                return;
+            }
+
+            foreach (var property in optionsType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                         .Where(p => p.CanRead && p.CanWrite))
+            {
+                var value = property.GetValue(payload);
+                property.SetValue(target, value);
             }
         }
     }
@@ -227,15 +326,28 @@ namespace DesktopApplicationTemplate.Persistence
     public class ServiceInfo
     {
         public string DisplayName { get; set; } = string.Empty;
+        public string DescriptorId { get; set; } = string.Empty;
         public ServiceType ServiceType { get; set; }
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
         public int Order { get; set; }
         public List<string> AssociatedServices { get; set; } = new();
-        public TcpServiceOptions? TcpOptions { get; set; }
-        public FtpServerOptions? FtpOptions { get; set; }
-        public HttpServiceOptions? HttpOptions { get; set; }
-        public CsvServiceOptions? CsvOptions { get; set; }
+        public object? Payload { get; set; }
+        public double TotalExecutionTimeMs { get; set; }
+        public int ExecutionCount { get; set; }
+    }
+
+    internal class PersistedServiceRecord
+    {
+        public string DisplayName { get; set; } = string.Empty;
+        public string DescriptorId { get; set; } = string.Empty;
+        public ServiceType? LegacyType { get; set; }
+        public string? LegacyTypeName { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime Created { get; set; }
+        public int Order { get; set; }
+        public List<string>? AssociatedServices { get; set; }
+        public JsonElement? Payload { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
     }
@@ -244,10 +356,11 @@ namespace DesktopApplicationTemplate.Persistence
     {
         public string DisplayName { get; set; } = string.Empty;
         public string ServiceType { get; set; } = string.Empty;
+        public string? DescriptorId { get; set; }
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
         public int Order { get; set; }
-        public List<string> AssociatedServices { get; set; } = new();
+        public List<string>? AssociatedServices { get; set; }
         public TcpServiceOptions? TcpOptions { get; set; }
         public FtpServerOptions? FtpOptions { get; set; }
         public HttpServiceOptions? HttpOptions { get; set; }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -140,7 +140,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         internal string GenerateServiceName(ServiceType serviceType)
         {
-            var typeName = serviceType.ToLegacyString();
+            var typeName = GetDisplayPrefix(serviceType);
             int index = 1;
             foreach (var svc in Services.Where(s => s.Type == serviceType))
             {
@@ -197,34 +197,40 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     await tcpVm.SaveAsync().ConfigureAwait(false);
                 }
             }
-            ServicePersistence.Save(Services);
+            ServicePersistence.Save(Services, _catalog, _logger);
         }
 
         private void LoadServices()
         {
-            var existing = ServicePersistence.Load(_logger);
+            var existing = ServicePersistence.Load(_catalog, _logger);
             foreach (var info in existing.OrderBy(i => i.Order))
             {
+                var descriptor = ResolveDescriptor(info.DescriptorId, info.ServiceType);
+                var serviceType = descriptor?.LegacyType ?? info.ServiceType;
                 var svc = new ServiceListModel
                 {
                     DisplayName = info.DisplayName,
-                    Type = info.ServiceType,
+                    Type = serviceType,
+                    DescriptorId = descriptor?.Id ?? info.DescriptorId,
+                    DescriptorPayload = info.Payload,
                     IsActive = info.IsActive,
                     Order = info.Order,
-                    TcpOptions = info.TcpOptions,
-                    FtpOptions = info.FtpOptions,
-                    HttpOptions = info.HttpOptions,
-                    CsvOptions = info.CsvOptions,
                     TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                     ExecutionCount = info.ExecutionCount
                 };
                 foreach (var a in info.AssociatedServices ?? new List<string>())
+                {
                     svc.AssociatedServices.Add(a);
-                svc.SetColorsByType();
+                }
+
+                svc.ApplyDescriptor(descriptor);
                 svc.LogAdded += OnServiceLogAdded;
                 svc.ActiveChanged += OnServiceActiveChanged;
                 if (svc.Type != ServiceType.Csv)
+                {
                     _csvService.EnsureColumnsForService(svc.DisplayName);
+                }
+
                 Services.Add(svc);
                 _logger?.Log($"Loaded service {svc.DisplayName}", LogLevel.Debug);
             }
@@ -256,6 +262,41 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return true;
             };
             FilteredServices.Refresh();
+        }
+
+        private IServiceDescriptor? ResolveDescriptor(string? descriptorId, ServiceType serviceType)
+        {
+            if (!string.IsNullOrWhiteSpace(descriptorId) && _catalog.TryGetById(descriptorId!, out var descriptor))
+            {
+                return descriptor;
+            }
+
+            if (_catalog.TryGetByLegacyType(serviceType, out descriptor))
+            {
+                return descriptor;
+            }
+
+            return null;
+        }
+
+        private string GetDisplayPrefix(ServiceType serviceType)
+        {
+            var descriptor = ResolveDescriptor(null, serviceType);
+            if (descriptor is not null)
+            {
+                var presentation = descriptor.Presentation;
+                if (!string.IsNullOrWhiteSpace(presentation.DisplayLabel))
+                {
+                    return presentation.DisplayLabel!;
+                }
+
+                if (!string.IsNullOrWhiteSpace(descriptor.DisplayName))
+                {
+                    return descriptor.DisplayName;
+                }
+            }
+
+            return serviceType.ToLegacyString();
         }
 
         public void OnServiceLogAdded(ServiceListModel svc, LogEntry entry)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -15,6 +16,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         public string DisplayName { get; set; } = string.Empty;
         public ServiceType Type { get; set; }
+        public string DescriptorId { get; set; } = string.Empty;
+        public object? DescriptorPayload { get; set; }
         [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 
@@ -107,46 +110,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        /// <summary>
-        /// TCP-specific configuration for this service, if applicable.
-        /// </summary>
-        public TcpServiceOptions? TcpOptions { get; set; }
-
-        /// <summary>
-        /// FTP server-specific configuration for this service, if applicable.
-        /// </summary>
-        public FtpServerOptions? FtpOptions { get; set; }
-
-        /// <summary>
-        /// HTTP-specific configuration for this service, if applicable.
-        /// </summary>
-        public HttpServiceOptions? HttpOptions { get; set; }
-
-        /// <summary>
-        /// HID-specific configuration for this service, if applicable.
-        /// </summary>
-        public HidServiceOptions? HidOptions { get; set; }
-
-        /// <summary>
-        /// Heartbeat-specific configuration for this service, if applicable.
-        /// </summary>
-        public HeartbeatServiceOptions? HeartbeatOptions { get; set; }
-
-        /// <summary>
-        /// File Observer-specific configuration for this service, if applicable.
-        /// </summary>
-        public FileObserverServiceOptions? FileObserverOptions { get; set; }
-
-        /// <summary>
-        /// SCP-specific configuration for this service, if applicable.
-        /// </summary>
-        public ScpServiceOptions? ScpOptions { get; set; }
-
-        /// <summary>
-        /// CSV creator-specific configuration for this service, if applicable.
-        /// </summary>
-        public CsvServiceOptions? CsvOptions { get; set; }
-
         public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
 
         private bool _isActive;
@@ -225,24 +188,108 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        public void SetColorsByType()
+        public void ApplyDescriptor(IServiceDescriptor? descriptor, string? nameSuffix = null)
         {
-            (BackgroundColor, BorderColor) = Type switch
+            if (descriptor is not null)
             {
-                ServiceType.Tcp => (WpfBrushes.LightBlue, WpfBrushes.DarkBlue),
-                ServiceType.Http => (WpfBrushes.LightGreen, WpfBrushes.DarkGreen),
-                ServiceType.FileObserver => (WpfBrushes.LightSalmon, WpfBrushes.DarkSalmon),
-                ServiceType.Hid => (WpfBrushes.LightYellow, WpfBrushes.Goldenrod),
-                ServiceType.Heartbeat => (WpfBrushes.LightPink, WpfBrushes.DeepPink),
-                ServiceType.Scp => (WpfBrushes.LightCyan, WpfBrushes.CadetBlue),
-                ServiceType.Mqtt => (WpfBrushes.LightGoldenrodYellow, WpfBrushes.Goldenrod),
-                ServiceType.Ftp => (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
-                ServiceType.Csv => (WpfBrushes.LightGray, WpfBrushes.Gray),
-                _ => (WpfBrushes.LightGray, WpfBrushes.Gray)
-            };
+                DescriptorId = descriptor.Id;
+                if (descriptor.LegacyType.HasValue)
+                {
+                    Type = descriptor.LegacyType.Value;
+                }
+            }
+
+            var presentation = descriptor?.Presentation ?? ServicePresentationMetadata.Empty;
+            var prefix = descriptor is not null ? ResolveDisplayPrefix(descriptor) : Type.ToLegacyString();
+
+            if (!string.IsNullOrWhiteSpace(nameSuffix))
+            {
+                DisplayName = $"{prefix} - {nameSuffix}";
+            }
+            else if (string.IsNullOrWhiteSpace(DisplayName))
+            {
+                DisplayName = prefix;
+            }
+
+            SetColorsByType(presentation);
+        }
+
+        public void SetColorsByType(ServicePresentationMetadata metadata)
+        {
+            if (!TryApplyMetadataColors(metadata))
+            {
+                (BackgroundColor, BorderColor) = LegacyColorMap.TryGetValue(Type, out var brushes)
+                    ? brushes
+                    : (WpfBrushes.LightGray, WpfBrushes.Gray);
+            }
+
             OnPropertyChanged(nameof(BackgroundColor));
             OnPropertyChanged(nameof(BorderColor));
         }
+
+        public TOptions? GetPayload<TOptions>() where TOptions : class => DescriptorPayload as TOptions;
+
+        public void SetPayload<TOptions>(TOptions? payload) where TOptions : class => DescriptorPayload = payload;
+
+        private static string ResolveDisplayPrefix(IServiceDescriptor descriptor)
+        {
+            if (!string.IsNullOrWhiteSpace(descriptor.Presentation.DisplayLabel))
+            {
+                return descriptor.Presentation.DisplayLabel!;
+            }
+
+            if (!string.IsNullOrWhiteSpace(descriptor.DisplayName))
+            {
+                return descriptor.DisplayName;
+            }
+
+            return descriptor.LegacyType?.ToLegacyString() ?? descriptor.Id;
+        }
+
+        private bool TryApplyMetadataColors(ServicePresentationMetadata metadata)
+        {
+            if (metadata is null)
+            {
+                return false;
+            }
+
+            var brushConverter = new System.Windows.Media.BrushConverter();
+            if (!string.IsNullOrWhiteSpace(metadata.PrimaryAccentColor)
+                && !string.IsNullOrWhiteSpace(metadata.SecondaryAccentColor))
+            {
+                try
+                {
+                    var background = (WpfBrush?)brushConverter.ConvertFromString(metadata.PrimaryAccentColor!);
+                    var border = (WpfBrush?)brushConverter.ConvertFromString(metadata.SecondaryAccentColor!);
+                    if (background is not null && border is not null)
+                    {
+                        BackgroundColor = background;
+                        BorderColor = border;
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // Ignore conversion failures and fall back to legacy colors.
+                }
+            }
+
+            return false;
+        }
+
+        private static readonly IReadOnlyDictionary<ServiceType, (WpfBrush Background, WpfBrush Border)> LegacyColorMap =
+            new Dictionary<ServiceType, (WpfBrush, WpfBrush)>
+            {
+                [ServiceType.Tcp] = (WpfBrushes.LightBlue, WpfBrushes.DarkBlue),
+                [ServiceType.Http] = (WpfBrushes.LightGreen, WpfBrushes.DarkGreen),
+                [ServiceType.FileObserver] = (WpfBrushes.LightSalmon, WpfBrushes.DarkSalmon),
+                [ServiceType.Hid] = (WpfBrushes.LightYellow, WpfBrushes.Goldenrod),
+                [ServiceType.Heartbeat] = (WpfBrushes.LightPink, WpfBrushes.DeepPink),
+                [ServiceType.Scp] = (WpfBrushes.LightCyan, WpfBrushes.CadetBlue),
+                [ServiceType.Mqtt] = (WpfBrushes.LightGoldenrodYellow, WpfBrushes.Goldenrod),
+                [ServiceType.Ftp] = (WpfBrushes.LightSteelBlue, WpfBrushes.SteelBlue),
+                [ServiceType.Csv] = (WpfBrushes.LightGray, WpfBrushes.Gray)
+            };
     }
 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -193,7 +193,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         public void SetService(ServiceListModel service)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
-            _options = service.TcpOptions ?? new TcpServiceOptions();
+            var payload = service.GetPayload<TcpServiceOptions>();
+            if (payload is null)
+            {
+                payload = new TcpServiceOptions();
+                service.SetPayload(payload);
+            }
+
+            _options = payload;
             ServiceType = service.Type;
             ServiceName = service.DisplayName.Split(" - ").Last();
             Script = string.IsNullOrWhiteSpace(_options.Script)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Controls.Primitives;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -86,7 +87,8 @@ namespace DesktopApplicationTemplate.UI.Views
 
         public Page? GetOrCreateServicePage(ServiceListModel svc)
         {
-            if (!TryGetDescriptorId(svc.Type, out var descriptorId))
+            var descriptorId = svc.DescriptorId;
+            if (string.IsNullOrWhiteSpace(descriptorId) && !TryGetDescriptorId(svc.Type, out descriptorId))
             {
                 return svc.ServicePage;
             }
@@ -149,13 +151,15 @@ namespace DesktopApplicationTemplate.UI.Views
             _createServicePage = page;
             page.ServiceCreated += (name, type) =>
             {
+                var descriptor = ResolveDescriptor(type);
                 var svc = new ServiceListModel
                 {
-                    DisplayName = $"{type.ToLegacyString()} - {name}",
-                    Type = type,
+                    Type = descriptor?.LegacyType ?? type,
+                    DescriptorId = descriptor?.Id ?? type.ToDescriptorId(),
                     IsActive = false
                 };
-                svc.SetColorsByType();
+
+                svc.ApplyDescriptor(descriptor, name);
                 svc.LogAdded += _viewModel.OnServiceLogAdded;
                 svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
                 GetOrCreateServicePage(svc);
@@ -164,7 +168,9 @@ namespace DesktopApplicationTemplate.UI.Views
                 _viewModel.SelectedService = svc;
                 ServiceList.ScrollIntoView(svc);
                 if (svc.ServicePage != null)
+                {
                     ShowPage(svc.ServicePage);
+                }
                 _ = _viewModel.SaveServicesAsync();
             };
             page.ServiceTypeSelected += NavigateTo;
@@ -205,9 +211,18 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
+            var descriptor = ResolveDescriptor(descriptorId);
+            var name = ExtractFactoryName(options);
+            var payload = ExtractFactoryPayload(options);
+
             var factory = factoryFactory();
             var svc = factory.Create(options);
-            svc.SetColorsByType();
+            if (payload is not null && svc.DescriptorPayload is null)
+            {
+                svc.DescriptorPayload = payload;
+            }
+
+            svc.ApplyDescriptor(descriptor, name);
             svc.LogAdded += _viewModel.OnServiceLogAdded;
             svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
 
@@ -216,14 +231,66 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.SelectedService = svc;
             ServiceList.ScrollIntoView(svc);
             if (svc.ServicePage != null)
+            {
                 ShowPage(svc.ServicePage);
+            }
+
             await _viewModel.SaveServicesAsync();
             _logger?.LogDebug("AddService workflow completed");
         }
 
+        private IServiceDescriptor? ResolveDescriptor(ServiceType serviceType) => ResolveDescriptor(null, serviceType);
+
+        private IServiceDescriptor? ResolveDescriptor(string descriptorId) => ResolveDescriptor(descriptorId, null);
+
+        private IServiceDescriptor? ResolveDescriptor(string? descriptorId, ServiceType? serviceType)
+        {
+            if (!string.IsNullOrWhiteSpace(descriptorId) && _catalog.TryGetById(descriptorId!, out var descriptor))
+            {
+                return descriptor;
+            }
+
+            if (serviceType.HasValue && _catalog.TryGetByLegacyType(serviceType.Value, out descriptor))
+            {
+                return descriptor;
+            }
+
+            if (serviceType.HasValue && _catalog.LegacyMap.TryGetValue(serviceType.Value, out var fallbackId) && _catalog.TryGetById(fallbackId, out descriptor))
+            {
+                return descriptor;
+            }
+
+            return null;
+        }
+
+        private string GetDisplayPrefix(ServiceListModel svc)
+        {
+            var descriptor = ResolveDescriptor(svc.DescriptorId, svc.Type);
+            if (descriptor is not null)
+            {
+                var presentation = descriptor.Presentation;
+                if (!string.IsNullOrWhiteSpace(presentation.DisplayLabel))
+                {
+                    return presentation.DisplayLabel!;
+                }
+
+                if (!string.IsNullOrWhiteSpace(descriptor.DisplayName))
+                {
+                    return descriptor.DisplayName;
+                }
+            }
+
+            return svc.Type.ToLegacyString();
+        }
+
+        private static string? ExtractFactoryName(object? options) => options?.GetType().GetProperty("Name")?.GetValue(options) as string;
+
+        private static object? ExtractFactoryPayload(object? options) => options?.GetType().GetProperty("Options")?.GetValue(options);
+
         private bool TryGetDescriptorId(ServiceType serviceType, out string descriptorId)
         {
-            if (_catalog.TryGetByLegacyType(serviceType, out var descriptor))
+            var descriptor = ResolveDescriptor(serviceType);
+            if (descriptor is not null)
             {
                 descriptorId = descriptor.Id;
                 return true;
@@ -310,7 +377,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     {
                         namePart = _viewModel.GenerateServiceName(svc.Type);
                     }
-                    svc.DisplayName = $"{svc.Type.ToLegacyString()} - {namePart}";
+                    svc.DisplayName = $"{GetDisplayPrefix(svc)} - {namePart}";
                     await _viewModel.SaveServicesAsync();
                 }
             }


### PR DESCRIPTION
## Summary
- replace typed option fields with descriptor identifiers and payload storage on `ServiceListModel`
- hydrate services, edit handlers, and factories through descriptor metadata and payload serializers
- update `ServicePersistence` and related tests to persist descriptor IDs and legacy payload mappings

## Testing
- not run (tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dc39f7845083268a67c38479d75a87