### PR TITLE
Refactor create service selection to use descriptor metadata

### DIFF
--- a/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
@@ -1,25 +1,106 @@
-using DesktopApplicationTemplate.UI.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.ViewModels;
 using Xunit;
 
 namespace DesktopApplicationTemplate.Tests
 {
     public class CreateServiceViewModelTests
     {
-        [Theory]
-        [InlineData(ServiceType.Tcp)]
-        [InlineData(ServiceType.Http)]
-        [InlineData(ServiceType.Csv)]
-        [InlineData(ServiceType.Scp)]
-        [InlineData(ServiceType.Mqtt)]
-        [InlineData(ServiceType.Ftp)]
-        public void GenerateDefaultName_ReturnsIncrementedName(ServiceType type)
+        [Fact]
+        public void ServiceDescriptors_UsePresentationMetadata()
         {
-            var existing = new[] { $"{type.ToLegacyString()}1" };
-            var vm = new CreateServiceViewModel(existing);
-            var name = vm.GenerateDefaultName(type);
-            Assert.Equal($"{type.ToLegacyString()}2", name);
+            var descriptor = new StubDescriptor(
+                "service.test",
+                "Test",
+                ServiceType.Tcp,
+                new ServicePresentationMetadata("🧪", null, null, "Catalog Label"));
+            var catalog = new StubCatalog(descriptor);
+
+            var vm = new CreateServiceViewModel(catalog);
+
+            var metadata = Assert.Single(vm.ServiceDescriptors);
+            Assert.Equal(descriptor.Id, metadata.DescriptorId);
+            Assert.Equal("Catalog Label", metadata.DisplayLabel);
+            Assert.Equal("🧪", metadata.IconGlyph);
+            Assert.Equal(ServiceType.Tcp, metadata.LegacyType);
             ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void GenerateDefaultName_ReturnsIncrementedName()
+        {
+            var descriptor = new StubDescriptor(
+                "service.test",
+                "Test",
+                ServiceType.Http,
+                new ServicePresentationMetadata("🌐", null, null, "HTTP"));
+            var catalog = new StubCatalog(descriptor);
+            var existing = new[] { "HTTP1" };
+
+            var vm = new CreateServiceViewModel(catalog, existing);
+            var name = vm.GenerateDefaultName(descriptor.Id);
+
+            Assert.Equal("HTTP2", name);
+            ConsoleTestLogger.LogPass();
+        }
+
+        private sealed class StubCatalog : IServiceCatalog
+        {
+            private readonly Dictionary<string, IServiceDescriptor> _descriptorsById;
+            private readonly Dictionary<ServiceType, IServiceDescriptor> _descriptorsByType;
+
+            public StubCatalog(params IServiceDescriptor[] descriptors)
+            {
+                _descriptorsById = descriptors.ToDictionary(d => d.Id, StringComparer.Ordinal);
+                _descriptorsByType = descriptors
+                    .Where(d => d.LegacyType.HasValue)
+                    .ToDictionary(d => d.LegacyType!.Value, d => d, EqualityComparer<ServiceType>.Default);
+                Descriptors = _descriptorsById.Values.ToArray();
+                LegacyMap = _descriptorsByType.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id);
+            }
+
+            public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
+
+            public IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
+
+            public bool TryGetById(string id, out IServiceDescriptor descriptor) => _descriptorsById.TryGetValue(id, out descriptor!);
+
+            public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) => _descriptorsByType.TryGetValue(legacyType, out descriptor!);
+        }
+
+        private sealed class StubDescriptor : IServiceDescriptor
+        {
+            public StubDescriptor(string id, string displayName, ServiceType legacyType, ServicePresentationMetadata presentation)
+            {
+                Id = id;
+                DisplayName = displayName;
+                LegacyType = legacyType;
+                Presentation = presentation;
+            }
+
+            public string Id { get; }
+
+            public string DisplayName { get; }
+
+            public string Category => "Test";
+
+            public string? Description => null;
+
+            public ServiceType? LegacyType { get; }
+
+            public IServiceOptionsSerializer? OptionsSerializer => null;
+
+            public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+
+            public ServicePresentationMetadata Presentation { get; }
+
+            public bool HasPayloadDescription => false;
+
+            public string? DescribePayload(object? payload) => null;
         }
     }
 }

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -52,21 +52,21 @@ public class MainViewCreateNavigationTests
             { ServiceType.Mqtt, ServiceDescriptorIds.Mqtt },
             { ServiceType.Ftp, ServiceDescriptorIds.Ftp }
         });
-        typeof(MainView).GetField("_uiRegistry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+        typeof(MainView).GetField("_uiRegistry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)! 
             .SetValue(view, registry);
-        typeof(MainView).GetField("_catalog", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+        typeof(MainView).GetField("_catalog", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)! 
             .SetValue(view, catalog);
-        typeof(MainView).GetField("_createServicePage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+        typeof(MainView).GetField("_createServicePage", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)! 
             .SetValue(view, null);
         var method = typeof(MainView).GetMethod("NavigateTo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
         // Act
-        method.Invoke(view, new object[] { type });
+        method.Invoke(view, new object[] { targetDescriptor });
 
         // Assert
         foreach (var kvp in handlerMocks)
         {
-            if (kvp.Key == type)
+            if (kvp.Key == targetDescriptor)
             {
                 kvp.Value.Verify(h => h.CreateView(type.ToLegacyString()), Times.Once);
             }
@@ -95,7 +95,7 @@ public class MainViewCreateNavigationTests
         var method = typeof(MainView).GetMethod("NavigateTo", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
         // Act
-        method.Invoke(view, new object[] { ServiceType.Http });
+        method.Invoke(view, new object[] { ServiceDescriptorIds.Http });
 
         // Assert
         var frame = (Frame)typeof(MainView).GetField("ContentFrame")!.GetValue(view)!;

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -1,40 +1,104 @@
-using System.Collections.ObjectModel;
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class CreateServiceViewModel : ViewModelBase
     {
-        public record ServiceTypeMetadata(ServiceType Type, string DisplayText, string Icon);
+        public record ServiceDescriptorMetadata(string DescriptorId, string DisplayLabel, string IconGlyph, ServiceType LegacyType);
 
-        public ObservableCollection<ServiceTypeMetadata> ServiceTypes { get; } = new()
-        {
-            new(ServiceType.Tcp, "TCP", "🔗"),
-            new(ServiceType.Http, "HTTP", "🌐"),
-            new(ServiceType.Csv, "CSV Creator", "📄"),
-            new(ServiceType.Scp, "SCP", "📦"),
-            new(ServiceType.Mqtt, "MQTT", "📡"),
-            new(ServiceType.Ftp, "FTP Server", "🖥️")
-        };
-
+        private readonly IServiceCatalog _catalog;
+        private readonly Dictionary<string, ServiceType> _descriptorLegacyTypes;
         private readonly HashSet<string> _existingNames;
 
-        public CreateServiceViewModel(IEnumerable<string>? existingNames = null)
+        public CreateServiceViewModel(IServiceCatalog catalog, IEnumerable<string>? existingNames = null)
         {
-            _existingNames = existingNames != null ? new HashSet<string>(existingNames) : new HashSet<string>();
+            _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+            _existingNames = existingNames != null
+                ? new HashSet<string>(existingNames)
+                : new HashSet<string>();
+
+            var descriptorsWithLegacy = _catalog.Descriptors
+                .Where(descriptor => descriptor.LegacyType.HasValue)
+                .Select(descriptor =>
+                {
+                    var presentation = descriptor.Presentation;
+                    var displayLabel = !string.IsNullOrWhiteSpace(presentation.DisplayLabel)
+                        ? presentation.DisplayLabel!
+                        : descriptor.DisplayName;
+                    var iconGlyph = !string.IsNullOrWhiteSpace(presentation.IconGlyph)
+                        ? presentation.IconGlyph!
+                        : string.Empty;
+
+                    return new ServiceDescriptorMetadata(
+                        descriptor.Id,
+                        displayLabel,
+                        iconGlyph,
+                        descriptor.LegacyType!.Value);
+                })
+                .ToList();
+
+            _descriptorLegacyTypes = descriptorsWithLegacy
+                .ToDictionary(metadata => metadata.DescriptorId, metadata => metadata.LegacyType, StringComparer.Ordinal);
+
+            ServiceDescriptors = new ObservableCollection<ServiceDescriptorMetadata>(descriptorsWithLegacy);
         }
 
-        public string GenerateDefaultName(ServiceType serviceType)
+        public ObservableCollection<ServiceDescriptorMetadata> ServiceDescriptors { get; }
+
+        public bool TryGetLegacyType(string descriptorId, out ServiceType serviceType)
         {
-            var typeName = serviceType.ToLegacyString();
-            int index = 1;
-            while (_existingNames.Contains($"{typeName}{index}"))
+            if (descriptorId is null)
+            {
+                serviceType = default;
+                return false;
+            }
+
+            return _descriptorLegacyTypes.TryGetValue(descriptorId, out serviceType);
+        }
+
+        public string GenerateDefaultName(string descriptorId)
+        {
+            var baseName = ResolveBaseName(descriptorId);
+            var index = 1;
+            var candidate = FormattableString.Invariant($"{baseName}{index}");
+            while (_existingNames.Contains(candidate))
             {
                 index++;
+                candidate = FormattableString.Invariant($"{baseName}{index}");
             }
-            return $"{typeName}{index}";
+
+            return candidate;
         }
+
+        private string ResolveBaseName(string descriptorId)
+        {
+            if (!string.IsNullOrWhiteSpace(descriptorId) && _catalog.TryGetById(descriptorId, out var descriptor))
+            {
+                if (descriptor.LegacyType is ServiceType legacyType)
+                {
+                    return legacyType.ToLegacyString();
+                }
+
+                var label = descriptor.Presentation.DisplayLabel;
+                if (!string.IsNullOrWhiteSpace(label))
+                {
+                    return label!;
+                }
+
+                if (!string.IsNullOrWhiteSpace(descriptor.DisplayName))
+                {
+                    return descriptor.DisplayName;
+                }
+            }
+
+            return descriptorId;
+        }
+
         // OnPropertyChanged provided by ViewModelBase
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
@@ -13,7 +13,7 @@
 
         <TextBlock Grid.Row="0" Text="Select Service Type" FontSize="16" FontWeight="Bold" HorizontalAlignment="Center"/>
 
-        <ItemsControl Grid.Row="1" ItemsSource="{Binding ServiceTypes}">
+        <ItemsControl Grid.Row="1" ItemsSource="{Binding ServiceDescriptors}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
                     <WrapPanel Width="400" />
@@ -30,9 +30,9 @@
                                     </Border>
                                 </ControlTemplate>
                             </Button.Template>
-                            <TextBlock Text="{Binding Icon}" FontSize="40" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding IconGlyph}" FontSize="40" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Button>
-                        <TextBlock Text="{Binding DisplayText}" HorizontalAlignment="Center" Margin="0,5,0,0"/>
+                        <TextBlock Text="{Binding DisplayLabel}" HorizontalAlignment="Center" Margin="0,5,0,0"/>
                     </StackPanel>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -1,40 +1,46 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
-using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Navigation;
+using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
     public partial class CreateServicePage : Page
     {
         private readonly CreateServiceViewModel _viewModel;
-        public event Action<string, ServiceType>? ServiceCreated;
-        public event Action<ServiceType>? ServiceTypeSelected;
+        private readonly IServiceUiRegistry _uiRegistry;
+        public event Action<string, string>? ServiceCreated;
+        public event Action<string>? ServiceDescriptorSelected;
         public event Action? Cancelled;
 
-        public CreateServicePage(CreateServiceViewModel viewModel)
+        public CreateServicePage(CreateServiceViewModel viewModel, IServiceUiRegistry uiRegistry)
         {
             InitializeComponent();
             _viewModel = viewModel;
+            _uiRegistry = uiRegistry;
             DataContext = _viewModel;
         }
 
         private void ServiceType_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button { DataContext: CreateServiceViewModel.ServiceTypeMetadata meta } button)
+            if (sender is Button { DataContext: CreateServiceViewModel.ServiceDescriptorMetadata meta })
             {
-                var name = _viewModel.GenerateDefaultName(meta.Type);
-                if (meta.Type is ServiceType.Mqtt or ServiceType.Tcp or ServiceType.Heartbeat or ServiceType.Ftp or ServiceType.Http or ServiceType.Hid or ServiceType.Csv or ServiceType.FileObserver or ServiceType.Scp)
+                var descriptorId = meta.DescriptorId;
+                var name = _viewModel.GenerateDefaultName(descriptorId);
+                if (_uiRegistry.NavigationHandlers.ContainsKey(descriptorId))
                 {
-                    ServiceTypeSelected?.Invoke(meta.Type);
+                    ServiceDescriptorSelected?.Invoke(descriptorId);
                     return;
                 }
-                ServiceCreated?.Invoke(name, meta.Type);
+                ServiceCreated?.Invoke(name, descriptorId);
             }
         }
 
-        public string GenerateDefaultName(ServiceType type) => _viewModel.GenerateDefaultName(type);
+        public string GenerateDefaultName(string descriptorId) => _viewModel.GenerateDefaultName(descriptorId);
+
+        public bool TryGetLegacyType(string descriptorId, out ServiceType serviceType) => _viewModel.TryGetLegacyType(descriptorId, out serviceType);
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -149,13 +149,27 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             var page = App.AppHost.Services.GetRequiredService<CreateServicePage>();
             _createServicePage = page;
-            page.ServiceCreated += (name, type) =>
+            page.ServiceCreated += (name, descriptorId) =>
             {
-                var descriptor = ResolveDescriptor(type);
+                var descriptor = ResolveDescriptor(descriptorId);
+                ServiceType serviceType;
+                if (descriptor?.LegacyType is ServiceType resolvedType)
+                {
+                    serviceType = resolvedType;
+                }
+                else if (page.TryGetLegacyType(descriptorId, out var fallbackType))
+                {
+                    serviceType = fallbackType;
+                }
+                else
+                {
+                    _logger?.LogWarning("No legacy type registered for descriptor {DescriptorId}", descriptorId);
+                    return;
+                }
                 var svc = new ServiceListModel
                 {
-                    Type = descriptor?.LegacyType ?? type,
-                    DescriptorId = descriptor?.Id ?? type.ToDescriptorId(),
+                    Type = serviceType,
+                    DescriptorId = descriptor?.Id ?? descriptorId,
                     IsActive = false
                 };
 
@@ -173,20 +187,20 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
                 _ = _viewModel.SaveServicesAsync();
             };
-            page.ServiceTypeSelected += NavigateTo;
+            page.ServiceDescriptorSelected += NavigateTo;
             page.Cancelled += ShowHome;
             ShowPage(page);
         }
 
         private CreateServicePage? _createServicePage;
 
-        private void NavigateTo(ServiceType serviceType)
+        private void NavigateTo(string descriptorId)
         {
-            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType.ToLegacyString();
-            if (!TryGetDescriptorId(serviceType, out var descriptorId))
-            {
-                return;
-            }
+            var descriptor = ResolveDescriptor(descriptorId);
+            var defaultName = _createServicePage?.GenerateDefaultName(descriptorId)
+                ?? descriptor?.LegacyType?.ToLegacyString()
+                ?? descriptor?.DisplayName
+                ?? descriptorId;
 
             if (_uiRegistry.NavigationHandlers.TryGetValue(descriptorId, out var handlerFactory))
             {


### PR DESCRIPTION
## Summary
- build `CreateServiceViewModel` from `IServiceCatalog` so the create menu shows descriptor-provided labels and icons
- switch `CreateServicePage` to descriptor-id based bindings and routing logic backed by the UI registry
- update `MainView` workflow and tests to operate on descriptor identifiers and verify descriptor metadata driven behaviour

## Testing
- not run (Windows-only WPF solution; rely on CI `dotnet test --settings tests.runsettings`)


------
https://chatgpt.com/codex/tasks/task_e_68dd188b30008326b7f7441e8d3d17d3