### PR TITLE
Refactor service factory flow to use descriptor-aware context

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServiceFactoryTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceFactoryTests.cs
@@ -3,6 +3,7 @@ using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -36,32 +37,41 @@ public class ServiceFactoryTests
     public void Create_ReturnsServicePage(ServiceType type)
     {
         var provider = App.AppHost.Services;
+        var catalog = provider.GetRequiredService<IServiceCatalog>();
         var factory = provider.GetKeyedService<IServiceFactory>(type);
         Assert.NotNull(factory);
 
-        object ctx = type switch
+        _ = catalog.TryGetByLegacyType(type, out var descriptor);
+        if (descriptor is null && catalog.LegacyMap.TryGetValue(type, out var legacyId) && catalog.TryGetById(legacyId, out var mapped))
         {
-            ServiceType.Mqtt => new ServiceFactoryOptions<MqttServiceOptions>("mqtt", new MqttServiceOptions
+            descriptor = mapped;
+        }
+
+        var descriptorId = descriptor?.Id ?? (catalog.LegacyMap.TryGetValue(type, out var fallbackId) ? fallbackId : type.ToLegacyString());
+
+        var (serviceName, payload) = type switch
+        {
+            ServiceType.Mqtt => ("mqtt", (object)new MqttServiceOptions
             {
                 Host = "localhost",
                 Port = 1883,
                 ClientId = "client"
             }),
-            ServiceType.Ftp => new ServiceFactoryOptions<FtpServerOptions>("ftp", new FtpServerOptions
+            ServiceType.Ftp => ("ftp", (object)new FtpServerOptions
             {
                 RootPath = "."
             }),
-            ServiceType.Http => new ServiceFactoryOptions<HttpServiceOptions>("http", new HttpServiceOptions
+            ServiceType.Http => ("http", (object)new HttpServiceOptions
             {
                 BaseUrl = "http://localhost"
             }),
-            ServiceType.Tcp => new ServiceFactoryOptions<TcpServiceOptions>("tcp", new TcpServiceOptions
+            ServiceType.Tcp => ("tcp", (object)new TcpServiceOptions
             {
                 Host = "localhost",
                 Port = 1
             }),
-            ServiceType.Hid => new ServiceFactoryOptions<HidServiceOptions>("hid", new HidServiceOptions()),
-            ServiceType.Scp => new ServiceFactoryOptions<ScpServiceOptions>("scp", new ScpServiceOptions
+            ServiceType.Hid => ("hid", (object)new HidServiceOptions()),
+            ServiceType.Scp => ("scp", (object)new ScpServiceOptions
             {
                 Host = "host",
                 Username = "user",
@@ -69,22 +79,24 @@ public class ServiceFactoryTests
                 LocalPath = "local",
                 RemotePath = "remote"
             }),
-            ServiceType.Csv => new ServiceFactoryOptions<CsvServiceOptions>("csv", new CsvServiceOptions
+            ServiceType.Csv => ("csv", (object)new CsvServiceOptions
             {
                 OutputPath = "."
             }),
-            ServiceType.FileObserver => new ServiceFactoryOptions<FileObserverServiceOptions>("fo", new FileObserverServiceOptions
+            ServiceType.FileObserver => ("fo", (object)new FileObserverServiceOptions
             {
                 FilePath = "."
             }),
-            ServiceType.Heartbeat => new ServiceFactoryOptions<HeartbeatServiceOptions>("hb", new HeartbeatServiceOptions
+            ServiceType.Heartbeat => ("hb", (object)new HeartbeatServiceOptions
             {
                 BaseMessage = "ping"
             }),
             _ => throw new NotSupportedException()
         };
 
-        var svc = factory!.Create(ctx);
+        var context = new ServiceFactoryContext(descriptorId, serviceName, payload, descriptor);
+
+        var svc = factory!.Create(context);
         Assert.NotNull(svc.ServicePage);
     }
 }

--- a/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/CsvServiceFactory.cs
@@ -1,36 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class CsvServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Csv;
 
-        public CsvServiceFactory(Func<MainView> getMainView)
+        public CsvServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<CsvServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<CsvServiceOptions>() ?? new CsvServiceOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.Csv,
-                DescriptorId = CsvServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FileObserverServiceFactory.cs
@@ -1,36 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class FileObserverServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.FileObserver;
 
-        public FileObserverServiceFactory(Func<MainView> getMainView)
+        public FileObserverServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<FileObserverServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<FileObserverServiceOptions>() ?? new FileObserverServiceOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.FileObserver,
-                DescriptorId = FileObserverServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/FtpServiceFactory.cs
@@ -1,11 +1,11 @@
-using DesktopApplicationTemplate.UI.Views;
 using System;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -13,28 +13,40 @@ namespace DesktopApplicationTemplate.UI.Factories
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Ftp;
 
-        public FtpServiceFactory(IServiceProvider services, Func<MainView> getMainView)
+        public FtpServiceFactory(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<FtpServerOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<FtpServerOptions>() ?? new FtpServerOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.Ftp,
-                DescriptorId = FtpServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HeartbeatServiceFactory.cs
@@ -1,36 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class HeartbeatServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Heartbeat;
 
-        public HeartbeatServiceFactory(Func<MainView> getMainView)
+        public HeartbeatServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<HeartbeatServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<HeartbeatServiceOptions>() ?? new HeartbeatServiceOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.Heartbeat,
-                DescriptorId = HeartbeatServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HidServiceFactory.cs
@@ -1,36 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class HidServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Hid;
 
-        public HidServiceFactory(Func<MainView> getMainView)
+        public HidServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<HidServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<HidServiceOptions>() ?? new HidServiceOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.Hid,
-                DescriptorId = HidServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/HttpServiceFactory.cs
@@ -1,36 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class HttpServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Http;
 
-        public HttpServiceFactory(Func<MainView> getMainView)
+        public HttpServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<HttpServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<HttpServiceOptions>() ?? new HttpServiceOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.Http,
-                DescriptorId = HttpServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/IServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/IServiceFactory.cs
@@ -7,6 +7,6 @@ namespace DesktopApplicationTemplate.UI.Factories
     public interface IServiceFactory
     {
         ServiceType ServiceType { get; }
-        ServiceListModel Create(object options);
+        ServiceListModel Create(ServiceFactoryContext context);
     }
 }

--- a/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/MqttServiceFactory.cs
@@ -1,4 +1,6 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
@@ -8,8 +10,6 @@ using DesktopApplicationTemplate.UI.Views.Mqtt;
 using DesktopApplicationTemplate.UI.Views.Mqtt.Edit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
@@ -18,29 +18,41 @@ namespace DesktopApplicationTemplate.UI.Factories
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
         private readonly MainViewModel _mainViewModel;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Mqtt;
 
-        public MqttServiceFactory(IServiceProvider services, Func<MainView> getMainView, MainViewModel mainViewModel)
+        public MqttServiceFactory(IServiceProvider services, Func<MainView> getMainView, MainViewModel mainViewModel, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
             _mainViewModel = mainViewModel;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<MqttServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<MqttServiceOptions>() ?? new MqttServiceOptions();
 
             var newService = new ServiceListModel
             {
                 Type = ServiceType.Mqtt,
-                DescriptorId = MqttServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             newService.SetPayload(options);
+
+            newService.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(newService);
 

--- a/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ScpServiceFactory.cs
@@ -1,35 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class ScpServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Scp;
 
-        public ScpServiceFactory(Func<MainView> getMainView)
+        public ScpServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<ScpServiceOptions>)optionsObj;
-            var name = ctx.Name;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<ScpServiceOptions>() ?? new ScpServiceOptions();
 
             var svc = new ServiceListModel
             {
-                DisplayName = $"{ServiceType.Scp.ToLegacyString()} - {name}",
                 Type = ServiceType.Scp,
-                IsActive = false,
-                ScpOptions = options
+                DescriptorId = context.DescriptorId,
+                IsActive = false
             };
+
+            svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Factories/ServiceFactoryContext.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ServiceFactoryContext.cs
@@ -1,0 +1,28 @@
+using System;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.UI.Factories
+{
+    public sealed class ServiceFactoryContext
+    {
+        public ServiceFactoryContext(string descriptorId, string serviceName, object? payload, IServiceDescriptor? descriptor = null)
+        {
+            DescriptorId = string.IsNullOrWhiteSpace(descriptorId)
+                ? throw new ArgumentException("Descriptor ID cannot be null or whitespace", nameof(descriptorId))
+                : descriptorId;
+            ServiceName = serviceName ?? string.Empty;
+            Payload = payload;
+            Descriptor = descriptor;
+        }
+
+        public string DescriptorId { get; }
+
+        public string ServiceName { get; }
+
+        public object? Payload { get; }
+
+        public IServiceDescriptor? Descriptor { get; }
+
+        public TPayload? GetPayload<TPayload>() where TPayload : class => Payload as TPayload;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Factories/ServiceFactoryOptions.cs
+++ b/DesktopApplicationTemplate.UI/Factories/ServiceFactoryOptions.cs
@@ -1,4 +1,0 @@
-namespace DesktopApplicationTemplate.UI.Factories
-{
-    public record ServiceFactoryOptions<TOptions>(string Name, TOptions Options);
-}

--- a/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
+++ b/DesktopApplicationTemplate.UI/Factories/TcpServiceFactory.cs
@@ -1,36 +1,48 @@
 using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
-using DesktopApplicationTemplate.Models;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
 
 namespace DesktopApplicationTemplate.UI.Factories
 {
     public class TcpServiceFactory : IServiceFactory
     {
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public ServiceType ServiceType => ServiceType.Tcp;
 
-        public TcpServiceFactory(Func<MainView> getMainView)
+        public TcpServiceFactory(Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
-        public ServiceListModel Create(object optionsObj)
+        public ServiceListModel Create(ServiceFactoryContext context)
         {
-            var ctx = (ServiceFactoryOptions<TcpServiceOptions>)optionsObj;
-            var options = ctx.Options;
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var descriptor = _catalog.TryGetById(context.DescriptorId, out var resolved)
+                ? resolved
+                : context.Descriptor;
+
+            var options = context.GetPayload<TcpServiceOptions>() ?? new TcpServiceOptions();
 
             var svc = new ServiceListModel
             {
                 Type = ServiceType.Tcp,
-                DescriptorId = TcpServiceDescriptor.DescriptorId,
+                DescriptorId = context.DescriptorId,
                 IsActive = false
             };
 
             svc.SetPayload(options);
+
+            svc.ApplyDescriptor(descriptor, context.ServiceName);
 
             _getMainView().GetOrCreateServicePage(svc);
 

--- a/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/CsvNavigationHandler.cs
@@ -1,7 +1,7 @@
-using DesktopApplicationTemplate.UI.Views;
 using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.Csv.Edit;
 using DesktopApplicationTemplate.UI.ViewModels.Csv.Advanced;
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Csv.Edit;
 using DesktopApplicationTemplate.UI.Views.Csv.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => CsvServiceDescriptor.DescriptorId;
 
-        public CsvNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public CsvNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -52,7 +55,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<CsvServiceOptions>(name, (CsvServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FileObserverNavigationHandler.cs
@@ -1,7 +1,7 @@
-using DesktopApplicationTemplate.UI.Views;
 using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Create;
 using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Advanced;
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.FileObserver.Create;
 using DesktopApplicationTemplate.UI.Views.FileObserver.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => FileObserverServiceDescriptor.DescriptorId;
 
-        public FileObserverNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public FileObserverNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -51,7 +54,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<FileObserverServiceOptions>(name, (FileObserverServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/FtpNavigationHandler.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Ftp.Create;
 using DesktopApplicationTemplate.UI.Views.Ftp.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => FtpServiceDescriptor.DescriptorId;
 
-        public FtpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public FtpNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -51,7 +54,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<FtpServerOptions>(name, (FtpServerOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HeartbeatNavigationHandler.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Heartbeat.Create;
 using DesktopApplicationTemplate.UI.Views.Heartbeat.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => HeartbeatServiceDescriptor.DescriptorId;
 
-        public HeartbeatNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public HeartbeatNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -51,7 +54,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<HeartbeatServiceOptions>(name, (HeartbeatServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HidNavigationHandler.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Hid.Create;
 using DesktopApplicationTemplate.UI.Views.Hid.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => HidServiceDescriptor.DescriptorId;
 
-        public HidNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public HidNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -51,7 +54,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<HidServiceOptions>(name, (HidServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/HttpNavigationHandler.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Http.Create;
 using DesktopApplicationTemplate.UI.Views.Http.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => HttpServiceDescriptor.DescriptorId;
 
-        public HttpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public HttpNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -51,7 +54,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<HttpServiceOptions>(name, (HttpServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/MqttNavigationHandler.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Mqtt.Create;
 using DesktopApplicationTemplate.UI.Views.Mqtt.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => MqttServiceDescriptor.DescriptorId;
 
-        public MqttNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public MqttNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -50,7 +53,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<MqttServiceOptions>(name, (MqttServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
 
     }

--- a/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ScpNavigationHandler.cs
@@ -9,6 +9,7 @@ using DesktopApplicationTemplate.UI.Views.Scp.Create;
 using DesktopApplicationTemplate.UI.Views.Scp.Advanced;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -19,13 +20,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => ScpServiceDescriptor.DescriptorId;
 
-        public ScpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public ScpNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -51,7 +54,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<ScpServiceOptions>(name, (ScpServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/TcpNavigationHandler.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Tcp.Create;
 using DesktopApplicationTemplate.UI.Views.Tcp.Create;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Configuration;
 
@@ -17,13 +18,15 @@ namespace DesktopApplicationTemplate.UI.Navigation
     {
         private readonly IServiceProvider _services;
         private readonly Func<MainView> _getMainView;
+        private readonly IServiceCatalog _catalog;
 
         public string DescriptorId => TcpServiceDescriptor.DescriptorId;
 
-        public TcpNavigationHandler(IServiceProvider services, Func<MainView> getMainView)
+        public TcpNavigationHandler(IServiceProvider services, Func<MainView> getMainView, IServiceCatalog catalog)
         {
             _services = services;
             _getMainView = getMainView;
+            _catalog = catalog;
         }
 
         public Page CreateView(string defaultName)
@@ -40,7 +43,9 @@ namespace DesktopApplicationTemplate.UI.Navigation
         public Task AddServiceAsync(string name, object options)
         {
             var mainView = _getMainView();
-            return mainView.AddServiceAsync(DescriptorId, new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
+            _catalog.TryGetById(DescriptorId, out var descriptor);
+            var context = new ServiceFactoryContext(DescriptorId, name, options, descriptor);
+            return mainView.AddServiceAsync(context);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.UI.Navigation;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.Models;
@@ -218,30 +219,39 @@ namespace DesktopApplicationTemplate.UI.Views
 
 
 
-        internal async Task AddServiceAsync(string descriptorId, object options)
+        internal async Task AddServiceAsync(ServiceFactoryContext context)
         {
-            if (!_uiRegistry.Factories.TryGetValue(descriptorId, out var factoryFactory))
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!_uiRegistry.Factories.TryGetValue(context.DescriptorId, out var factoryFactory))
             {
                 return;
             }
 
-            var descriptor = ResolveDescriptor(descriptorId);
-            var name = ExtractFactoryName(options);
-            var payload = ExtractFactoryPayload(options);
-
             var factory = factoryFactory();
-            var svc = factory.Create(options);
-            if (payload is not null && svc.DescriptorPayload is null)
+            var svc = factory.Create(context);
+
+            if (string.IsNullOrWhiteSpace(svc.DescriptorId))
             {
-                svc.DescriptorPayload = payload;
+                svc.DescriptorId = context.DescriptorId;
             }
 
-            svc.ApplyDescriptor(descriptor, name);
+            if (svc.DescriptorPayload is null && context.Payload is not null)
+            {
+                svc.DescriptorPayload = context.Payload;
+            }
+
             svc.LogAdded += _viewModel.OnServiceLogAdded;
             svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
 
             _viewModel.Services.Add(svc);
-            _logger?.LogInformation("Service {Name} added", svc.DisplayName);
+            var displayName = string.IsNullOrWhiteSpace(svc.DisplayName)
+                ? context.ServiceName
+                : svc.DisplayName;
+            _logger?.LogInformation("Service {Name} added", displayName);
             _viewModel.SelectedService = svc;
             ServiceList.ScrollIntoView(svc);
             if (svc.ServicePage != null)
@@ -296,10 +306,6 @@ namespace DesktopApplicationTemplate.UI.Views
 
             return svc.Type.ToLegacyString();
         }
-
-        private static string? ExtractFactoryName(object? options) => options?.GetType().GetProperty("Name")?.GetValue(options) as string;
-
-        private static object? ExtractFactoryPayload(object? options) => options?.GetType().GetProperty("Options")?.GetValue(options);
 
         private bool TryGetDescriptorId(ServiceType serviceType, out string descriptorId)
         {


### PR DESCRIPTION
## Summary
- introduce a descriptor-aware `ServiceFactoryContext` that carries the descriptor ID, user-visible name, and payload for service creation
- update service factories to consume the new context and resolve descriptor metadata when constructing `ServiceListModel` instances
- refresh navigation handlers, MainWindow integration, and factory tests to build the new context objects and keep service creation coverage intact

## Testing
- Not run (rely on CI)

------
https://chatgpt.com/codex/tasks/task_e_68dd1be150d483269738bfa7f3ef1123