### PR TITLE
Surface descriptor presentation metadata across service UI

### DIFF
--- a/Codex/docs/CollaborationAndDebugTips.txt
+++ b/Codex/docs/CollaborationAndDebugTips.txt
@@ -9,6 +9,14 @@ Purpose: Running log of what worked, what broke, and why.
 - Always record environment limitations (e.g., missing dotnet runtime).
 - When Windows collaborators run builds or tests, capture the commands and summarize their results so Codex can reference them.
 
+[2025-10-07 12:00] Topic: Service descriptor presentation bindings
+Context: Updated service list entries and detail pages to consume descriptor metadata (labels, icons, accent colors) emitted by the shared catalog.
+Observations: `ServiceListModel` now exposes presentation properties, MainWindow binds icons/tooltip colors, and each detail page shows a descriptor banner. Added regression tests that snapshot built-in descriptor colors/icons. Local dotnet tooling still unavailable, so CI must validate.
+Effective Prompts / Instructions that worked: User request to propagate descriptor metadata through the UI.
+Decisions & Rationale: Centralize presentation data to reduce duplication and avoid stale legacy colors.
+Action Items: Monitor CI for WPF regressions on Windows.
+Related Commits/PRs:
+
 [2025-10-06 09:00] Topic: Self-heal automation removal
 Context: Disabled Codex's automated pipeline repair to avoid self-directed patch generation.
 Observations: Deleted `.github/workflows/self-heal.yml` and the `Codex/tools/selfheal` script, so CI failures now require manual triage.

--- a/DesktopApplicationTemplate.Tests/ServicePresentationBindingTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePresentationBindingTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Modules;
+using DesktopApplicationTemplate.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public class ServicePresentationBindingTests
+{
+    [Fact]
+    public void ServiceListModel_UsesDescriptorMetadataForBuiltInServices()
+    {
+        var module = new UiServiceModule();
+        var descriptors = module.DescribeServices()
+            .Where(descriptor => descriptor.LegacyType.HasValue)
+            .ToList();
+
+        var expected = new Dictionary<ServiceType, ExpectedSnapshot>
+        {
+            [ServiceType.Csv] = new("CSV Creator", "📄", "#FFD3D3D3", "#FF808080", "Generate CSV output from message payloads."),
+            [ServiceType.FileObserver] = new("File Observer", string.Empty, "#FFFFA07A", "#FFE9967A", "Monitor directories for changes and trigger automation flows."),
+            [ServiceType.Ftp] = new("FTP Server", "🖥️", "#FFB0C4DE", "#FF4682B4", "Transfer files to remote hosts using the FTP protocol."),
+            [ServiceType.Heartbeat] = new("Heartbeat", string.Empty, "#FFFFB6C1", "#FFFF1493", "Emit periodic heartbeat messages for monitoring integrations."),
+            [ServiceType.Hid] = new("HID", string.Empty, "#FFFFFFE0", "#FFDAA520", "Interact with Human Interface Devices for automation scenarios."),
+            [ServiceType.Http] = new("HTTP", "🌐", "#FF90EE90", "#FF006400", "Interact with HTTP endpoints for automation workflows."),
+            [ServiceType.Mqtt] = new("MQTT", "📡", "#FFFAFAD2", "#FFDAA520", "Connect to MQTT brokers and manage topic subscriptions."),
+            [ServiceType.Scp] = new("SCP", "📦", "#FFE0FFFF", "#FF5F9EA0", "Transfer files securely using the SCP protocol."),
+            [ServiceType.Tcp] = new("TCP", "🔗", "#FFADD8E6", "#FF00008B", "Send and receive messages over TCP or UDP."),
+        };
+
+        foreach (var descriptor in descriptors)
+        {
+            var legacyType = descriptor.LegacyType!.Value;
+            var service = new ServiceListModel { Type = legacyType };
+
+            service.ApplyDescriptor(descriptor);
+
+            var snapshot = expected[legacyType];
+            service.DisplayName.Should().Be(snapshot.Label);
+            service.DescriptorLabel.Should().Be(snapshot.Label);
+            (service.IconGlyph ?? string.Empty).Should().Be(snapshot.IconGlyph);
+            service.DescriptorDescription.Should().Be(snapshot.Description);
+            service.DescriptorTooltip.Should().Be(snapshot.ExpectedTooltip);
+            service.BackgroundColor.ToString().Should().Be(snapshot.BackgroundColor);
+            service.BorderColor.ToString().Should().Be(snapshot.BorderColor);
+        }
+    }
+
+    private sealed record ExpectedSnapshot(
+        string Label,
+        string IconGlyph,
+        string BackgroundColor,
+        string BorderColor,
+        string Description)
+    {
+        public string ExpectedTooltip => string.IsNullOrWhiteSpace(Description)
+            ? Label
+            : $"{Label}: {Description}";
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -21,6 +21,83 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 
+        private string _descriptorLabel = string.Empty;
+        public string DescriptorLabel
+        {
+            get => _descriptorLabel;
+            private set
+            {
+                if (_descriptorLabel != value)
+                {
+                    _descriptorLabel = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DescriptorTooltip));
+                }
+            }
+        }
+
+        private string _descriptorDescription = string.Empty;
+        public string DescriptorDescription
+        {
+            get => _descriptorDescription;
+            private set
+            {
+                if (_descriptorDescription != value)
+                {
+                    _descriptorDescription = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(DescriptorTooltip));
+                }
+            }
+        }
+
+        private string _descriptorCategory = string.Empty;
+        public string DescriptorCategory
+        {
+            get => _descriptorCategory;
+            private set
+            {
+                if (_descriptorCategory != value)
+                {
+                    _descriptorCategory = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string? _iconGlyph;
+        public string? IconGlyph
+        {
+            get => _iconGlyph;
+            private set
+            {
+                if (!string.Equals(_iconGlyph, value, StringComparison.Ordinal))
+                {
+                    _iconGlyph = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private ServicePresentationMetadata _presentationMetadata = ServicePresentationMetadata.Empty;
+        public ServicePresentationMetadata PresentationMetadata
+        {
+            get => _presentationMetadata;
+            private set
+            {
+                var normalized = ServicePresentationMetadata.Normalize(value);
+                if (_presentationMetadata != normalized)
+                {
+                    _presentationMetadata = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string DescriptorTooltip => string.IsNullOrWhiteSpace(DescriptorDescription)
+            ? DescriptorLabel
+            : $"{DescriptorLabel}: {DescriptorDescription}";
+
         private WpfBrush _backgroundColor = WpfBrushes.LightGray;
         public WpfBrush BackgroundColor
         {
@@ -197,10 +274,24 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 {
                     Type = descriptor.LegacyType.Value;
                 }
+                DescriptorCategory = descriptor.Category ?? string.Empty;
+                DescriptorDescription = descriptor.Description ?? string.Empty;
+                PresentationMetadata = descriptor.Presentation;
+                DescriptorLabel = ResolveDisplayPrefix(descriptor);
+                IconGlyph = !string.IsNullOrWhiteSpace(PresentationMetadata.IconGlyph)
+                    ? PresentationMetadata.IconGlyph
+                    : null;
+            }
+            else
+            {
+                DescriptorCategory = string.Empty;
+                DescriptorDescription = string.Empty;
+                PresentationMetadata = ServicePresentationMetadata.Empty;
+                DescriptorLabel = Type.ToLegacyString();
+                IconGlyph = null;
             }
 
-            var presentation = descriptor?.Presentation ?? ServicePresentationMetadata.Empty;
-            var prefix = descriptor is not null ? ResolveDisplayPrefix(descriptor) : Type.ToLegacyString();
+            var prefix = DescriptorLabel;
 
             if (!string.IsNullOrWhiteSpace(nameSuffix))
             {
@@ -211,7 +302,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 DisplayName = prefix;
             }
 
-            SetColorsByType(presentation);
+            SetColorsByType(PresentationMetadata);
         }
 
         public void SetColorsByType(ServicePresentationMetadata metadata)

--- a/DesktopApplicationTemplate.UI/Views/Csv/CsvServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Csv/CsvServiceView.xaml
@@ -8,14 +8,35 @@
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackPanel Margin="0 0 0 10">
+        <Border Grid.Row="0" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+            <DockPanel>
+                <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                        Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                        Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                    <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                               FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+                <StackPanel>
+                    <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                               Foreground="Gray" TextWrapping="Wrap"
+                               Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+        <StackPanel Grid.Row="1" Margin="0 0 0 10">
             <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
                 <TextBlock Text="Output Directory:" VerticalAlignment="Center" Margin="0,0,5,0"/>
                 <TextBox Text="{Binding Configuration.OutputDirectory}" Width="300"
@@ -33,14 +54,14 @@
                 </Grid>
             </StackPanel>
         </StackPanel>
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Configuration.Columns}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedColumn}">
+        <DataGrid Grid.Row="2" ItemsSource="{Binding Configuration.Columns}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedColumn}">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
                 <DataGridTextColumn Header="Service" Binding="{Binding Service}" Width="*"/>
                 <DataGridTextColumn Header="Script" Binding="{Binding Script}" Width="*"/>
             </DataGrid.Columns>
         </DataGrid>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Add Column" Command="{Binding AddColumnCommand}" Width="90"/>
             <Button Content="Remove" Command="{Binding RemoveColumnCommand}" Width="70" Margin="5,0,0,0"/>
             <Button Content="Save" Command="{Binding SaveCommand}" Width="60" Margin="5,0,0,0"/>

--- a/DesktopApplicationTemplate.UI/Views/FileObserver/FileObserverView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserver/FileObserverView.xaml
@@ -9,9 +9,11 @@
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
@@ -21,8 +23,28 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
+        <Border Grid.Row="0" Grid.ColumnSpan="2" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+            <DockPanel>
+                <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                        Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                        Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                    <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                               FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+                <StackPanel>
+                    <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                               Foreground="Gray" TextWrapping="Wrap"
+                               Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+
         <!-- Observer List Panel -->
-        <StackPanel Grid.Column="0" Margin="0,0,10,0">
+        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,0,10,0">
             <TextBlock Text="File Observers" FontWeight="Bold" Margin="0 0 0 10"/>
             <ListBox ItemsSource="{Binding Observers}"
                      SelectedItem="{Binding SelectedObserver}"
@@ -35,7 +57,7 @@
         </StackPanel>
 
         <!-- Main Panel -->
-        <StackPanel Grid.Column="1" Margin="10 0 0 0">
+        <StackPanel Grid.Row="1" Grid.Column="1" Margin="10 0 0 0">
             <TextBlock Text="Chappie FTP File Observer" FontSize="16" FontWeight="Bold" TextAlignment="Center"/>
 
             <!-- File Path -->
@@ -97,7 +119,7 @@
             </Grid>
         </StackPanel>
 
-        <StackPanel Grid.ColumnSpan="2" Grid.Row="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <StackPanel Grid.ColumnSpan="2" Grid.Row="3" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Save Configuration" Command="{Binding SaveCommand}" Width="150"/>
         </StackPanel>
     </Grid>

--- a/DesktopApplicationTemplate.UI/Views/Ftp/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Ftp/FTPServiceView.xaml
@@ -8,26 +8,48 @@
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:BooleanToBrushConverter x:Key="BooleanToBrushConverter" TrueBrush="Green" FalseBrush="Red"/>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal">
+        <Border Grid.Row="0" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+            <DockPanel>
+                <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                        Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                        Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                    <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                               FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+                <StackPanel>
+                    <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                               Foreground="Gray" TextWrapping="Wrap"
+                               Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+        <StackPanel Grid.Row="1" Orientation="Horizontal">
             <Ellipse Width="10" Height="10" Fill="{Binding IsServerRunning, Converter={StaticResource BooleanToBrushConverter}}" Margin="0,0,5,0"/>
             <TextBlock Text="{Binding ServerStatus}" FontWeight="Bold" FontSize="14"/>
             <TextBlock Text="{Binding ConnectedClients, StringFormat=Clients: {0}}" Margin="10,0,0,0"/>
         </StackPanel>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,10,0,0">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
             <Button Content="Start" Width="100" Margin="0,0,5,0" Command="{Binding StartServerCommand}"/>
             <Button Content="Stop" Width="100" Command="{Binding StopServerCommand}"/>
         </StackPanel>
-        <GroupBox Header="Active Transfers" Grid.Row="2" Margin="0,10,0,0">
+        <GroupBox Header="Active Transfers" Grid.Row="3" Margin="0,10,0,0">
             <ItemsControl ItemsSource="{Binding Transfers}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
@@ -39,7 +61,7 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </GroupBox>
-        <GroupBox Header="Uploaded Files" Grid.Row="3" Margin="0,10,0,0">
+        <GroupBox Header="Uploaded Files" Grid.Row="4" Margin="0,10,0,0">
             <ListBox ItemsSource="{Binding UploadedFiles}">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
@@ -53,7 +75,7 @@
                 </ListBox.ItemTemplate>
             </ListBox>
         </GroupBox>
-        <GroupBox Header="Downloaded Files" Grid.Row="4" Margin="0,10,0,0">
+        <GroupBox Header="Downloaded Files" Grid.Row="5" Margin="0,10,0,0">
             <ListBox ItemsSource="{Binding DownloadedFiles}">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
@@ -67,6 +89,6 @@
                 </ListBox.ItemTemplate>
             </ListBox>
         </GroupBox>
-        <shared:ServiceLogView x:Name="LogView" Grid.Row="5" Margin="0,10,0,0" />
+        <shared:ServiceLogView x:Name="LogView" Grid.Row="6" Margin="0,10,0,0" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/Http/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Http/HttpServiceView.xaml
@@ -18,6 +18,7 @@
         <SolidColorBrush x:Key="SecondaryColor" Color="#d3d3d3"/>
         <SolidColorBrush x:Key="DangerColor" Color="#ff6961"/>
         <SolidColorBrush x:Key="WarningColor" Color="#f8d568"/>
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
 
 
@@ -25,14 +26,34 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock Text="HTTP Tester" FontSize="20" FontWeight="Bold" Margin="0,0,0,10"/>
+        <Border Grid.Row="0" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+            <DockPanel>
+                <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                        Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                        Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                    <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                               FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+                <StackPanel>
+                    <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                               Foreground="Gray" TextWrapping="Wrap"
+                               Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
 
-        <StackPanel Orientation="Horizontal" Margin="0 0 0 10">
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0 0 0 10">
             <ComboBox Width="100" ItemsSource="{Binding Methods}" SelectedItem="{Binding SelectedMethod}" />
             <Grid Width="400" Margin="10 0">
                 <TextBox Text="{Binding Url, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}" Name="UrlTextBox"
@@ -48,18 +69,18 @@
             <Button Content="Help" Width="80" Margin="5,0,0,0" Click="Help_Click" Background="{StaticResource SecondaryColor}"/>
         </StackPanel>
 
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Headers}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHeader}" Margin="0 0 0 10" Height="100" MaxWidth="300">
+        <DataGrid Grid.Row="2" ItemsSource="{Binding Headers}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHeader}" Margin="0 0 0 10" Height="100" MaxWidth="300">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Key" Binding="{Binding Key}" Width="*"/>
                 <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="*"/>
             </DataGrid.Columns>
         </DataGrid>
-        <StackPanel Orientation="Horizontal" Grid.Row="1" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="0,110,0,0">
+        <StackPanel Orientation="Horizontal" Grid.Row="3" HorizontalAlignment="Right" Margin="0,5,0,0">
             <Button Content="Add" Width="50" Command="{Binding AddHeaderCommand}" Background="{StaticResource PrimaryColor}"/>
             <Button Content="Remove" Width="60" Margin="5,0,0,0" Command="{Binding RemoveHeaderCommand}" Background="{StaticResource DangerColor}"/>
         </StackPanel>
 
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="4">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="*"/>
@@ -84,9 +105,9 @@
             </StackPanel>
         </Grid>
 
-        <shared:ServiceLogView Grid.Row="3" Margin="0,10,0,0" x:Name="LogView" />
+        <shared:ServiceLogView Grid.Row="5" Margin="0,10,0,0" x:Name="LogView" />
 
-        <StackPanel Grid.Row="4" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <StackPanel Grid.Row="6" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Save Configuration" Command="{Binding SaveCommand}" Width="150" Background="{StaticResource PrimaryColor}"/>
         </StackPanel>
     </Grid>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -23,6 +23,7 @@
                 <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+            <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
         </ResourceDictionary>
     </Window.Resources>
 
@@ -85,7 +86,8 @@
                             <DataTemplate>
                                 <Border CornerRadius="8" BorderBrush="{Binding BorderColor}" Background="{Binding BackgroundColor}" BorderThickness="2" Padding="5" Margin="2"
                                         PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown" PreviewMouseMove="ServiceItem_PreviewMouseMove"
-                                        AllowDrop="True" Drop="ServiceItem_Drop" MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown">
+                                        AllowDrop="True" Drop="ServiceItem_Drop" MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown"
+                                        ToolTip="{Binding DescriptorTooltip}">
                                     <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
                                         <Border.ContextMenu>
                                             <ContextMenu>
@@ -99,15 +101,24 @@
                                         </Border.ContextMenu>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
                                                 <ColumnDefinition Width="*"/>
                                                 <ColumnDefinition Width="Auto"/>
                                             </Grid.ColumnDefinitions>
-                                            <StackPanel>
+                                            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,10,0">
+                                                <Border Width="36" Height="36" CornerRadius="18" Background="{Binding BackgroundColor}" BorderBrush="{Binding BorderColor}" BorderThickness="1"
+                                                        Visibility="{Binding IconGlyph, Converter={StaticResource NullToVisibilityConverter}}">
+                                                    <TextBlock Text="{Binding IconGlyph}" FontSize="20" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                </Border>
+                                            </StackPanel>
+                                            <StackPanel Grid.Column="1">
                                                 <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
                                                 <TextBlock Text="{Binding ExecutionTimeText}" />
+                                                <TextBlock Text="{Binding DescriptorDescription}" Foreground="Gray" TextWrapping="Wrap"
+                                                           Visibility="{Binding DescriptorDescription, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
                                                 <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" />
                                             </StackPanel>
-                                            <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}" Style="{StaticResource ToggleSwitchStyle}"/>
+                                            <ToggleButton Grid.Column="2" IsChecked="{Binding IsActive, Mode=TwoWay}" Style="{StaticResource ToggleSwitchStyle}"/>
                                         </Grid>
                                     </Border>
                                 </Border>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -127,6 +127,8 @@ namespace DesktopApplicationTemplate.UI.Views
                     logHost.SetServiceContext(svc);
                 }
 
+                ApplyServicePresentationMetadata(svc);
+
             }
 
             return svc.ServicePage;
@@ -287,25 +289,28 @@ namespace DesktopApplicationTemplate.UI.Views
             return null;
         }
 
-        private string GetDisplayPrefix(ServiceListModel svc)
+        private void ApplyServicePresentationMetadata(ServiceListModel service)
         {
-            var descriptor = ResolveDescriptor(svc.DescriptorId, svc.Type);
-            if (descriptor is not null)
+            if (service.ServicePage is null)
             {
-                var presentation = descriptor.Presentation;
-                if (!string.IsNullOrWhiteSpace(presentation.DisplayLabel))
-                {
-                    return presentation.DisplayLabel!;
-                }
-
-                if (!string.IsNullOrWhiteSpace(descriptor.DisplayName))
-                {
-                    return descriptor.DisplayName;
-                }
+                return;
             }
 
-            return svc.Type.ToLegacyString();
+            var page = service.ServicePage;
+            page.Tag = service;
+            ToolTipService.SetToolTip(page, service.DescriptorTooltip);
+            page.Resources["ServiceDisplayName"] = service.DisplayName;
+            page.Resources["ServiceDescriptorLabel"] = service.DescriptorLabel;
+            page.Resources["ServiceDescriptorDescription"] = service.DescriptorDescription;
+            page.Resources["ServiceIconGlyph"] = service.IconGlyph;
+            page.Resources["ServiceBackgroundBrush"] = service.BackgroundColor;
+            page.Resources["ServiceBorderBrush"] = service.BorderColor;
         }
+
+        private string GetDisplayPrefix(ServiceListModel svc) =>
+            string.IsNullOrWhiteSpace(svc.DescriptorLabel)
+                ? svc.Type.ToLegacyString()
+                : svc.DescriptorLabel;
 
         private bool TryGetDescriptorId(ServiceType serviceType, out string descriptorId)
         {

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
@@ -17,16 +17,38 @@
             </ObjectDataProvider.MethodParameters>
         </ObjectDataProvider>
         <helpers:BooleanToBrushConverter x:Key="BoolToBrush" TrueBrush="Green" FalseBrush="Red" />
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
+        <Border Grid.Row="0" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+            <DockPanel>
+                <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                        Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                        Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                    <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                               FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+                <StackPanel>
+                    <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                               Foreground="Gray" TextWrapping="Wrap"
+                               Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
         <!-- Connection bar -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
             <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80" AutomationProperties.Name="Connect MQTT"/>
             <Ellipse Width="10" Height="10" Margin="5,0,0,0" Fill="{Binding IsConnected, Converter={StaticResource BoolToBrush}}"/>
             <TextBox Text="{Binding NewTopic}" Width="200" Margin="10,0,0,0" x:Name="NewTopicBox" ToolTip="Topic to subscribe"
@@ -42,7 +64,7 @@
             <Button Content="Remove" Command="{Binding RemoveTopicCommand}" Width="70" Margin="5,0,0,0"/>
         </StackPanel>
         <!-- Subscriptions list -->
-        <DataGrid Grid.Row="1"
+        <DataGrid Grid.Row="2"
                   ItemsSource="{Binding Subscriptions}"
                   SelectedItem="{Binding SelectedSubscription}"
                   AutoGenerateColumns="False"
@@ -69,7 +91,7 @@
             </DataGrid.Columns>
         </DataGrid>
         <!-- Test message bar -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,10,0,0">
             <TextBox Text="{Binding SelectedSubscription.OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"
                      Width="200"
                      x:Name="TestMessageBox"
@@ -89,6 +111,6 @@
         </StackPanel>
 
         <!-- Log entries -->
-        <shared:ServiceLogView Grid.Row="3" Margin="0,10,0,0" x:Name="LogView" />
+        <shared:ServiceLogView Grid.Row="4" Margin="0,10,0,0" x:Name="LogView" />
     </Grid>
 </Page>

--- a/DesktopApplicationTemplate.UI/Views/Scp/SCPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Scp/SCPServiceView.xaml
@@ -8,13 +8,37 @@
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
     </Page.Resources>
     <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*"/>
             <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
-        <StackPanel Grid.Column="0" Margin="10">
+        <Border Grid.Row="0" Grid.ColumnSpan="2" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+            <DockPanel>
+                <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                        Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                        Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                    <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                               FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+                <StackPanel>
+                    <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                    <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                               Foreground="Gray" TextWrapping="Wrap"
+                               Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                </StackPanel>
+            </DockPanel>
+        </Border>
+        <StackPanel Grid.Row="1" Grid.Column="0" Margin="10">
             <Grid Margin="0,0,0,5">
                 <TextBox Text="{Binding Host}" x:Name="HostBox" behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
                 <TextBlock Text="Host (e.g. 192.168.1.30)" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0"
@@ -51,7 +75,7 @@
             </Grid>
             <Button Content="Send" Command="{Binding TransferCommand}" Width="100"/>
         </StackPanel>
-        <Border Grid.Column="1" Margin="10" Background="#E6E6E6" CornerRadius="5" Padding="10">
+        <Border Grid.Row="1" Grid.Column="1" Margin="10" Background="#E6E6E6" CornerRadius="5" Padding="10">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -4,15 +4,41 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    </Page.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
-            <Grid Grid.Row="0" Margin="0,0,0,10">
+            <Border Grid.Row="0" CornerRadius="8" BorderThickness="1" Padding="10" Margin="0,0,0,10"
+                    Background="{Binding Tag.BackgroundColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                    BorderBrush="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                    ToolTip="{Binding Tag.DescriptorTooltip, RelativeSource={RelativeSource AncestorType=Page}}">
+                <DockPanel>
+                    <Border Width="40" Height="40" CornerRadius="20" Margin="0,0,10,0"
+                            Background="{Binding Tag.BorderColor, RelativeSource={RelativeSource AncestorType=Page}}"
+                            Visibility="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource NullToVisibilityConverter}}">
+                        <TextBlock Text="{Binding Tag.IconGlyph, RelativeSource={RelativeSource AncestorType=Page}}"
+                                   FontSize="22" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <StackPanel>
+                        <TextBlock Text="{Binding Tag.DisplayName, RelativeSource={RelativeSource AncestorType=Page}}" FontWeight="Bold" />
+                        <TextBlock Text="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}}"
+                                   Foreground="Gray" TextWrapping="Wrap"
+                                   Visibility="{Binding Tag.DescriptorDescription, RelativeSource={RelativeSource AncestorType=Page}, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+
+            <Grid Grid.Row="1" Margin="0,0,0,10">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="*"/>
@@ -29,7 +55,7 @@
                 </StackPanel>
             </Grid>
 
-            <Grid Grid.Row="1" Margin="0,10,0,0">
+            <Grid Grid.Row="2" Margin="0,10,0,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- drive the main service list and detail banners from descriptor presentation metadata, including icons, labels, colors, and tooltips
- push descriptor context into service pages via MainWindow so each detail view renders a metadata header
- add ServicePresentationBindingTests to snapshot built-in descriptor colors/icons and document the new flow for collaborators

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68dd1fbc687c8326b069d2704f700565