### PR TITLE
Persist services using descriptor payload serialization

### DIFF
--- a/Codex/docs/ServicePersistenceFormat.md
+++ b/Codex/docs/ServicePersistenceFormat.md
@@ -1,0 +1,53 @@
+# Service Persistence File Format
+
+DesktopApplicationTemplate persists registered services to a JSON file (`services.json` by default). Each entry captures descriptor metadata, runtime state, and a descriptor-defined options payload. This document summarizes the contract so plug-in authors can ensure their descriptors remain compatible across releases.
+
+## High-level structure
+
+The file stores an array of service records:
+
+```json
+[
+  {
+    "DisplayName": "HTTP - My API",
+    "DescriptorId": "custom.http",
+    "LegacyType": "http",
+    "LegacyTypeName": "Http",
+    "IsActive": false,
+    "Created": "2025-10-07T18:42:11.3246188Z",
+    "Order": 0,
+    "AssociatedServices": ["TCP - Listener"],
+    "SerializedPayload": "{\"BaseUrl\":\"https://example.com\"}",
+    "TotalExecutionTimeMs": 0.0,
+    "ExecutionCount": 0
+  }
+]
+```
+
+All properties use PascalCase to match the serialized `PersistedServiceRecord` members. Null values are omitted because persistence enables `JsonIgnoreCondition.WhenWritingNull`.
+
+### Core fields
+
+1. **`DescriptorId`** – Stable identifier exposed by the descriptor. Service persistence always prefers descriptor identifiers to locate factories and serializers.
+2. **`SerializedPayload`** – Descriptor-provided serialization of the options payload. `ServicePersistence` invokes `IServiceOptionsSerializer.Serialize` on save and `Deserialize` on load, so plug-ins can choose any JSON shape that fits their options model.
+3. **`LegacyType` / `LegacyTypeName`** – Compatibility values retained for migrations. `LegacyType` uses the short code written by `ServiceTypeJsonConverter` (for example, `"tcp"`); `LegacyTypeName` records the enum name (for example, `"Tcp"`). During load, the catalog uses `IServiceCatalog.LegacyMap` to translate legacy codes into the correct descriptor.
+4. **State metadata** – `DisplayName`, `IsActive`, `Created`, `Order`, `AssociatedServices`, `TotalExecutionTimeMs`, and `ExecutionCount` mirror the values surfaced by `ServiceListModel`.
+
+### Descriptor payload contract
+
+- Implement `IServiceOptionsSerializer` (or `IServiceOptionsSerializer<TOptions>`) on your descriptor to control persistence.
+- `SerializedPayload` **must** be valid JSON representing your options type. The serializer can emit compact or indented JSON; persistence stores the raw string.
+- When loading, `ServicePersistence` passes the stored string to `Deserialize`. If the serializer is unavailable, the loader falls back to `JsonSerializer.Deserialize<object>`.
+
+### Backward compatibility
+
+- Older files may contain a `Payload` object instead of `SerializedPayload`. The loader still supports this legacy shape by deserializing the JSON object via the descriptor serializer.
+- Very old releases used service-type names (`"ServiceType": "FTP"`). Those entries are mapped through `ServiceTypeExtensions.TryParse` and `IServiceCatalog.LegacyMap` so descriptors continue to resolve.
+- Descriptors should preserve their identifiers and keep their serializers backward compatible. If options evolve, support migrating legacy JSON inside your `IServiceOptionsSerializer` implementation.
+
+## Validation checklist for plug-in authors
+
+1. Provide a unique `DescriptorId` and `LegacyType` (if migrating an enum-based service).
+2. Supply an `IServiceOptionsSerializer` that round-trips your options and tolerates historical payload shapes.
+3. Confirm your descriptor registers factories so `MainViewModel` can request the appropriate UI/service factory during load.
+4. Add automated tests that serialize services using your descriptor and verify that deserialization restores the expected options and metadata.

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -23,8 +23,18 @@ namespace DesktopApplicationTemplate.Tests
             var a = TestHelpers.CreateService(ServiceType.Heartbeat, "A");
             var b = TestHelpers.CreateService(ServiceType.Tcp, "B");
             var services = new List<ServiceListModel> { a, b };
-            ServiceListModel.ResolveService = (type, name) =>
-                services.Find(s => s.Type == type && s.DisplayName.Split(" - ").Last() == name);
+            ServiceListModel.ResolveService = (descriptorKey, name) =>
+            {
+                var key = descriptorKey;
+                if (ServiceTypeExtensions.TryParse(descriptorKey, out var parsed))
+                {
+                    key = parsed.ToDescriptorId();
+                }
+
+                return services.Find(s =>
+                    string.Equals(s.DescriptorId, key, StringComparison.OrdinalIgnoreCase) &&
+                    s.DisplayName.Split(" - ").Last().Equals(name, StringComparison.OrdinalIgnoreCase));
+            };
 
             a.AddLog("TCP.B.Test message");
 

--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,6 +47,37 @@ namespace DesktopApplicationTemplate.Tests
                 Assert.Equal("A", loaded[0].DisplayName);
                 Assert.Contains("B", loaded[0].AssociatedServices);
                 Assert.Equal(loaded.Count, loaded.Select(s => s.DisplayName).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+            }
+            finally
+            {
+                ServicePersistence.FilePath = oldPath;
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void Save_WritesSerializedPayloadBlob()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            string oldPath = ServicePersistence.FilePath;
+            ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
+            try
+            {
+                var catalog = CreateCatalog();
+                var service = TestHelpers.CreateService(ServiceType.Tcp, "One");
+                service.SetPayload(new TcpServiceOptions { Host = "localhost", Port = 1234 });
+                ServicePersistence.Save(new[] { service }, catalog);
+
+                var json = File.ReadAllText(ServicePersistence.FilePath);
+                using var document = JsonDocument.Parse(json);
+                var record = Assert.Single(document.RootElement.EnumerateArray());
+                Assert.False(record.TryGetProperty("Payload", out _));
+                var serialized = record.GetProperty("SerializedPayload");
+                Assert.Equal(JsonValueKind.String, serialized.ValueKind);
+                Assert.Contains("\"Host\":\"localhost\"", serialized.GetString());
             }
             finally
             {
@@ -240,6 +272,85 @@ namespace DesktopApplicationTemplate.Tests
         }
 
         [Fact]
+        public void Load_DeserializesLegacyPayloadElement()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            string oldPath = ServicePersistence.FilePath;
+            ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
+
+            try
+            {
+                var catalog = CreateCatalog();
+                var legacyJson = @"[
+    {
+        ""DisplayName"": ""Legacy Tcp"",
+        ""DescriptorId"": ""service.tcp"",
+        ""LegacyType"": ""tcp"",
+        ""LegacyTypeName"": ""Tcp"",
+        ""Payload"": {
+            ""Host"": ""legacy-host"",
+            ""Port"": 55
+        }
+    }
+]";
+
+                File.WriteAllText(ServicePersistence.FilePath, legacyJson);
+                var loaded = ServicePersistence.Load(catalog);
+                var info = Assert.Single(loaded);
+                Assert.Equal(ServiceDescriptorIds.Tcp, info.DescriptorId);
+                var payload = Assert.IsType<TcpServiceOptions>(info.Payload);
+                Assert.Equal("legacy-host", payload.Host);
+                Assert.Equal(55, payload.Port);
+            }
+            finally
+            {
+                ServicePersistence.FilePath = oldPath;
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
+        public void Load_UsesCompatibilityMapForLegacyCodes()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            string oldPath = ServicePersistence.FilePath;
+            ServicePersistence.FilePath = Path.Combine(tempDir, "services.json");
+
+            try
+            {
+                var descriptor = new CustomHttpDescriptor();
+                var catalog = new ServiceCatalog(new[] { descriptor });
+                var legacyJson = @"[
+    {
+        ""DisplayName"": ""HTTP Legacy"",
+        ""LegacyType"": ""http"",
+        ""LegacyTypeName"": ""Http"",
+        ""SerializedPayload"": ""{\\\"BaseUrl\\\":\\\"https://legacy.example\\\"}""
+    }
+]";
+
+                File.WriteAllText(ServicePersistence.FilePath, legacyJson);
+                var loaded = ServicePersistence.Load(catalog);
+                var info = Assert.Single(loaded);
+                Assert.Equal(descriptor.Id, info.DescriptorId);
+                Assert.Equal(ServiceType.Http, info.ServiceType);
+                var payload = Assert.IsType<HttpServiceOptions>(info.Payload);
+                Assert.Equal("https://legacy.example", payload.BaseUrl);
+            }
+            finally
+            {
+                ServicePersistence.FilePath = oldPath;
+                Directory.Delete(tempDir, true);
+            }
+
+            ConsoleTestLogger.LogPass();
+        }
+
+        [Fact]
         public void Load_PreservesLegacyFtpOptions()
         {
             var host = Host.CreateDefaultBuilder()
@@ -406,6 +517,31 @@ namespace DesktopApplicationTemplate.Tests
             public void Reload()
             {
             }
+        }
+
+        private sealed class CustomHttpDescriptor : IServiceDescriptor
+        {
+            private readonly IServiceOptionsSerializer _serializer = new JsonServiceOptionsSerializer<HttpServiceOptions>();
+
+            public string Id => "custom.http";
+
+            public string DisplayName => "Custom HTTP";
+
+            public string Category => "Networking";
+
+            public string? Description => null;
+
+            public ServiceType? LegacyType => ServiceType.Http;
+
+            public IServiceOptionsSerializer? OptionsSerializer => _serializer;
+
+            public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+
+            public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;
+
+            public bool HasPayloadDescription => false;
+
+            public string? DescribePayload(object? payload) => null;
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -32,18 +32,23 @@ namespace DesktopApplicationTemplate.Persistence
             foreach (var service in services)
             {
                 var descriptor = ResolveDescriptor(service.DescriptorId, service.Type, catalog);
-                var payload = CreatePayloadElement(service.DescriptorPayload, descriptor?.OptionsSerializer);
+                var legacyType = descriptor?.LegacyType ?? (service.Type != default ? service.Type : null);
+                var serializedPayload = SerializePayload(service.DescriptorPayload, descriptor);
+                var payloadElement = serializedPayload is null
+                    ? CreatePayloadElement(service.DescriptorPayload, descriptor?.OptionsSerializer)
+                    : null;
                 records.Add(new PersistedServiceRecord
                 {
                     DisplayName = service.DisplayName,
-                    DescriptorId = descriptor?.Id ?? ResolveDescriptorId(service),
-                    LegacyType = service.Type,
-                    LegacyTypeName = service.Type.ToString(),
+                    DescriptorId = descriptor?.Id ?? ResolveDescriptorId(service, catalog),
+                    LegacyType = legacyType,
+                    LegacyTypeName = legacyType?.ToString() ?? service.Type.ToString(),
                     IsActive = service.IsActive,
                     Created = DateTime.Now,
                     Order = index++,
                     AssociatedServices = new List<string>(service.AssociatedServices),
-                    Payload = payload,
+                    Payload = payloadElement,
+                    SerializedPayload = serializedPayload,
                     TotalExecutionTimeMs = service.TotalExecutionTimeMs,
                     ExecutionCount = service.ExecutionCount
                 });
@@ -124,7 +129,7 @@ namespace DesktopApplicationTemplate.Persistence
             foreach (var record in records.OrderBy(r => r.Order))
             {
                 var descriptor = ResolveDescriptor(record.DescriptorId, record.LegacyType ?? ParseLegacyType(record.LegacyTypeName), catalog);
-                var payload = DeserializePayload(record.Payload, descriptor?.OptionsSerializer);
+                var payload = DeserializePayload(record, descriptor);
 
                 var info = new ServiceInfo
                 {
@@ -205,10 +210,16 @@ namespace DesktopApplicationTemplate.Persistence
                 return descriptor;
             }
 
+            if (legacyType.HasValue && catalog.LegacyMap.TryGetValue(legacyType.Value, out var mappedId) &&
+                catalog.TryGetById(mappedId, out descriptor))
+            {
+                return descriptor;
+            }
+
             return null;
         }
 
-        private static string ResolveDescriptorId(ServiceListModel service)
+        private static string ResolveDescriptorId(ServiceListModel service, IServiceCatalog catalog)
         {
             if (!string.IsNullOrWhiteSpace(service.DescriptorId))
             {
@@ -217,6 +228,16 @@ namespace DesktopApplicationTemplate.Persistence
 
             if (service.Type != default)
             {
+                if (catalog.TryGetByLegacyType(service.Type, out var descriptor))
+                {
+                    return descriptor.Id;
+                }
+
+                if (catalog.LegacyMap.TryGetValue(service.Type, out var mappedId))
+                {
+                    return mappedId;
+                }
+
                 return service.Type.ToDescriptorId();
             }
 
@@ -256,25 +277,80 @@ namespace DesktopApplicationTemplate.Persistence
             return JsonSerializer.SerializeToElement(payload, payload.GetType(), SerializerOptions);
         }
 
-        private static object? DeserializePayload(JsonElement? element, IServiceOptionsSerializer? serializer)
+        private static object? DeserializePayload(PersistedServiceRecord record, IServiceDescriptor? descriptor)
         {
-            if (!element.HasValue)
+            if (descriptor?.OptionsSerializer is { } serializer && !string.IsNullOrWhiteSpace(record.SerializedPayload))
+            {
+                return serializer.Deserialize(record.SerializedPayload);
+            }
+
+            if (!string.IsNullOrWhiteSpace(record.SerializedPayload))
+            {
+                try
+                {
+                    return JsonSerializer.Deserialize<object>(record.SerializedPayload, SerializerOptions);
+                }
+                catch (JsonException)
+                {
+                    return record.SerializedPayload;
+                }
+            }
+
+            if (!record.Payload.HasValue)
             {
                 return null;
             }
 
-            var value = element.Value;
-            if (value.ValueKind == JsonValueKind.Null || value.ValueKind == JsonValueKind.Undefined)
+            var element = record.Payload.Value;
+            if (element.ValueKind == JsonValueKind.Null || element.ValueKind == JsonValueKind.Undefined)
             {
                 return null;
             }
 
-            if (serializer is not null)
+            if (descriptor?.OptionsSerializer is { } legacySerializer)
             {
-                return serializer.Deserialize(value);
+                return legacySerializer.Deserialize(element);
             }
 
-            return value.Deserialize<object>(SerializerOptions);
+            return element.Deserialize<object>(SerializerOptions);
+        }
+
+        private static string? SerializePayload(object? payload, IServiceDescriptor? descriptor)
+        {
+            if (payload is null)
+            {
+                return null;
+            }
+
+            var serializer = descriptor?.OptionsSerializer;
+            if (serializer is null)
+            {
+                return JsonSerializer.Serialize(payload, payload.GetType(), SerializerOptions);
+            }
+
+            var options = EnsureOptionsInstance(payload, serializer);
+            return serializer.Serialize(options);
+        }
+
+        private static object EnsureOptionsInstance(object payload, IServiceOptionsSerializer serializer)
+        {
+            if (payload is JsonElement element)
+            {
+                return serializer.Deserialize(element);
+            }
+
+            if (payload is JsonDocument document)
+            {
+                return serializer.Deserialize(document.RootElement);
+            }
+
+            if (serializer.OptionsType.IsInstanceOfType(payload))
+            {
+                return payload;
+            }
+
+            var json = JsonSerializer.Serialize(payload, payload.GetType(), SerializerOptions);
+            return serializer.Deserialize(json);
         }
 
         private static ServiceType? ParseLegacyType(string? value)
@@ -348,6 +424,7 @@ namespace DesktopApplicationTemplate.Persistence
         public int Order { get; set; }
         public List<string>? AssociatedServices { get; set; }
         public JsonElement? Payload { get; set; }
+        public string? SerializedPayload { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -17,6 +17,7 @@ using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Navigation;
+using DesktopApplicationTemplate.UI.Factories;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -73,10 +74,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _catalog = catalog;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
-            ServiceListModel.ResolveService = (type, name) =>
-                Services.FirstOrDefault(s =>
-                    s.Type == type &&
+            ServiceListModel.ResolveService = (descriptorKey, name) =>
+            {
+                var normalized = NormalizeDescriptorKey(descriptorKey);
+                ServiceType? legacyType = null;
+                if (ServiceTypeExtensions.TryParse(descriptorKey, out var parsed))
+                {
+                    legacyType = parsed;
+                }
+
+                return Services.FirstOrDefault(s =>
+                    (string.Equals(s.DescriptorId, normalized, StringComparison.OrdinalIgnoreCase) ||
+                     string.Equals(s.DescriptorId, descriptorKey, StringComparison.OrdinalIgnoreCase) ||
+                     (legacyType.HasValue && s.Type == legacyType.Value)) &&
                     s.DisplayName.Split(" - ").Last().Equals(name, StringComparison.OrdinalIgnoreCase));
+            };
             if (!string.IsNullOrWhiteSpace(servicesFilePath))
             {
                 ServicePersistence.FilePath = servicesFilePath!;
@@ -206,24 +218,47 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             foreach (var info in existing.OrderBy(i => i.Order))
             {
                 var descriptor = ResolveDescriptor(info.DescriptorId, info.ServiceType);
+                var descriptorId = descriptor?.Id ?? info.DescriptorId;
                 var serviceType = descriptor?.LegacyType ?? info.ServiceType;
-                var svc = new ServiceListModel
+                ServiceListModel svc;
+
+                if (!string.IsNullOrWhiteSpace(descriptorId) &&
+                    _uiRegistry.Factories.TryGetValue(descriptorId, out var factoryFactory))
                 {
-                    DisplayName = info.DisplayName,
-                    Type = serviceType,
-                    DescriptorId = descriptor?.Id ?? info.DescriptorId,
-                    DescriptorPayload = info.Payload,
-                    IsActive = info.IsActive,
-                    Order = info.Order,
-                    TotalExecutionTimeMs = info.TotalExecutionTimeMs,
-                    ExecutionCount = info.ExecutionCount
-                };
-                foreach (var a in info.AssociatedServices ?? new List<string>())
+                    var factory = factoryFactory();
+                    var context = new ServiceFactoryContext(descriptorId, info.DisplayName, info.Payload, descriptor);
+                    svc = factory.Create(context);
+                    svc.DisplayName = info.DisplayName;
+                }
+                else
                 {
-                    svc.AssociatedServices.Add(a);
+                    svc = new ServiceListModel
+                    {
+                        DescriptorId = descriptorId,
+                        Type = serviceType,
+                        DescriptorPayload = info.Payload
+                    };
+                    svc.ApplyDescriptor(descriptor);
                 }
 
-                svc.ApplyDescriptor(descriptor);
+                svc.IsActive = info.IsActive;
+                svc.Order = info.Order;
+                svc.TotalExecutionTimeMs = info.TotalExecutionTimeMs;
+                svc.ExecutionCount = info.ExecutionCount;
+
+                foreach (var a in info.AssociatedServices ?? new List<string>())
+                {
+                    if (!svc.AssociatedServices.Contains(a))
+                    {
+                        svc.AssociatedServices.Add(a);
+                    }
+                }
+
+                if (info.Payload is not null && svc.DescriptorPayload is null)
+                {
+                    svc.DescriptorPayload = info.Payload;
+                }
+
                 svc.LogAdded += OnServiceLogAdded;
                 svc.ActiveChanged += OnServiceActiveChanged;
                 if (svc.Type != ServiceType.Csv)
@@ -276,7 +311,43 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return descriptor;
             }
 
+            if (_catalog.LegacyMap.TryGetValue(serviceType, out var mappedId) &&
+                _catalog.TryGetById(mappedId, out descriptor))
+            {
+                return descriptor;
+            }
+
             return null;
+        }
+
+        private string NormalizeDescriptorKey(string descriptorKey)
+        {
+            if (string.IsNullOrWhiteSpace(descriptorKey))
+            {
+                return descriptorKey;
+            }
+
+            if (_catalog.TryGetById(descriptorKey, out var descriptor))
+            {
+                return descriptor.Id;
+            }
+
+            if (ServiceTypeExtensions.TryParse(descriptorKey, out var legacy))
+            {
+                if (_catalog.LegacyMap.TryGetValue(legacy, out var mappedId))
+                {
+                    return mappedId;
+                }
+
+                if (_catalog.TryGetByLegacyType(legacy, out descriptor))
+                {
+                    return descriptor.Id;
+                }
+
+                return legacy.ToDescriptorId();
+            }
+
+            return descriptorKey;
         }
 
         private string GetDisplayPrefix(ServiceType serviceType)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -187,7 +187,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
+        public static Func<string, string, ServiceListModel?>? ResolveService { get; set; }
 
         private bool _isActive;
         public bool IsActive
@@ -247,20 +247,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var m = Regex.Match(message, @"^([^.]+)\.([^.]+)\.(.+)$");
             if (m.Success && ResolveService != null)
             {
-                var typeStr = m.Groups[1].Value;
+                var descriptorKey = m.Groups[1].Value;
                 var name = m.Groups[2].Value;
                 var msg = m.Groups[3].Value;
-                if (ServiceTypeExtensions.TryParse(typeStr, out var type))
+                var target = ResolveService(descriptorKey, name);
+                if (target != null && target != this)
                 {
-                    var target = ResolveService(type, name);
-                    if (target != null && target != this)
-                    {
-                        if (!AssociatedServices.Contains(target.DisplayName))
-                            AssociatedServices.Add(target.DisplayName);
-                        if (!target.AssociatedServices.Contains(DisplayName))
-                            target.AssociatedServices.Add(DisplayName);
-                        target.AddLog(msg, color, level, false);
-                    }
+                    if (!AssociatedServices.Contains(target.DisplayName))
+                        AssociatedServices.Add(target.DisplayName);
+                    if (!target.AssociatedServices.Contains(DisplayName))
+                        target.AssociatedServices.Add(DisplayName);
+                    target.AddLog(msg, color, level, false);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- store descriptor IDs with descriptor-managed payload blobs and map legacy types through the catalog when saving or loading services
- resolve saved services via descriptor-aware factories and update log cross-link resolution to rely on descriptor keys
- add regression tests covering new payload serialization, legacy payload shapes, and legacy compatibility along with persistence format documentation for plug-in authors

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68dd2424727483268e8420c9177dcd0c