### PR TITLE
Refactor ServiceManager to use descriptor-provided runtimes

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/IServiceRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceRuntime.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Represents a runtime workflow that can be started and stopped by the host.
+/// </summary>
+public interface IServiceRuntime : IAsyncDisposable
+{
+    /// <summary>
+    /// Starts the runtime workflow.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel startup.</param>
+    Task StartAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Stops the runtime workflow.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel shutdown.</param>
+    Task StopAsync(CancellationToken cancellationToken);
+}

--- a/DesktopApplicationTemplate.Core/Services/IServiceRuntimeFactory.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceRuntimeFactory.cs
@@ -1,0 +1,14 @@
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Creates <see cref="IServiceRuntime"/> instances for descriptor driven services.
+/// </summary>
+public interface IServiceRuntimeFactory
+{
+    /// <summary>
+    /// Creates a runtime instance for the supplied context.
+    /// </summary>
+    /// <param name="context">Activation metadata describing the requested service.</param>
+    /// <returns>A configured runtime instance.</returns>
+    IServiceRuntime Create(ServiceRuntimeContext context);
+}

--- a/DesktopApplicationTemplate.Core/Services/ServiceRuntimeContext.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceRuntimeContext.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Describes the runtime activation request for a service descriptor instance.
+/// </summary>
+public sealed class ServiceRuntimeContext
+{
+    public ServiceRuntimeContext(
+        IServiceDescriptor descriptor,
+        string descriptorId,
+        string displayName,
+        IReadOnlyCollection<string> associatedServices,
+        object? payload)
+    {
+        Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        DescriptorId = descriptorId ?? throw new ArgumentNullException(nameof(descriptorId));
+        DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+        AssociatedServices = associatedServices ?? Array.Empty<string>();
+        Payload = payload;
+    }
+
+    /// <summary>
+    /// Gets the descriptor that provided the runtime binding.
+    /// </summary>
+    public IServiceDescriptor Descriptor { get; }
+
+    /// <summary>
+    /// Gets the descriptor identifier for the runtime instance.
+    /// </summary>
+    public string DescriptorId { get; }
+
+    /// <summary>
+    /// Gets the display name configured for the runtime instance.
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Gets additional service associations configured for the runtime instance.
+    /// </summary>
+    public IReadOnlyCollection<string> AssociatedServices { get; }
+
+    /// <summary>
+    /// Gets the payload supplied by persistence, when available.
+    /// </summary>
+    public object? Payload { get; }
+}

--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -5,8 +5,9 @@ using System.Linq;
 using System;
 using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Service.Services;
 using DesktopApplicationTemplate.Services.Common;
+using DesktopApplicationTemplate.Services.Common.Runtime;
+using DesktopApplicationTemplate.Service.Services;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
 
@@ -35,8 +36,11 @@ namespace DesktopApplicationTemplate.Service
             return builder.ConfigureServices((hostContext, services) =>
             {
                 services.AddServiceModules();
-                services.AddHostedService<Worker>(); // register the background service
                 services.AddCommonServices();
+                services.AddOptions<HeartbeatRuntimeOptions>()
+                    .BindConfiguration("Heartbeat");
+                services.AddSingleton<ServiceManager>();
+                services.AddHostedService<Worker>();
                 services.AddFtpServer(builder => builder
                     .UseDotNetFileSystem()
                     .EnableAnonymousAuthentication());

--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -1,268 +1,572 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
-namespace DesktopApplicationTemplate.Service
+namespace DesktopApplicationTemplate.Service;
+
+public sealed class ServiceManager : IAsyncDisposable, IDisposable
 {
-    public class ServiceInfo
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly ILogger<ServiceManager> _logger;
+    private readonly IConfiguration _configuration;
+    private readonly IServiceCatalog _catalog;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly string _servicesFilePath;
+    private readonly string _activeServicesFilePath;
+    private readonly Dictionary<string, RunningService> _running = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ServiceRecord> _records = new(StringComparer.Ordinal);
+
+    public ServiceManager(
+        ILogger<ServiceManager> logger,
+        IConfiguration configuration,
+        IServiceCatalog catalog,
+        IServiceScopeFactory scopeFactory,
+        string? servicesFilePath = null)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+
+        _servicesFilePath = servicesFilePath ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
+        _activeServicesFilePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "activeservices.txt"));
+    }
+
+    public IReadOnlyCollection<string> ActiveServices => _running.Keys.ToList();
+
+    public void Sync() => SyncAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+    public async Task SyncAsync(CancellationToken cancellationToken)
+    {
+        var definitions = LoadDefinitions();
+        var activeNames = new HashSet<string>(definitions.Where(d => d.IsActive).Select(d => d.DisplayName), StringComparer.Ordinal);
+
+        foreach (var definition in definitions.Where(d => d.IsActive))
+        {
+            if (_running.ContainsKey(definition.DisplayName))
+            {
+                continue;
+            }
+
+            await StartServiceAsync(definition, cancellationToken).ConfigureAwait(false);
+        }
+
+        foreach (var name in _running.Keys.ToList())
+        {
+            if (!activeNames.Contains(name))
+            {
+                await StopServiceAsync(name, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async Task StopAllAsync(CancellationToken cancellationToken)
+    {
+        foreach (var name in _running.Keys.ToList())
+        {
+            await StopServiceAsync(name, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (_running.Count == 0)
+        {
+            DeleteActiveServicesFile();
+            _records.Clear();
+        }
+    }
+
+    public void Dispose()
+    {
+        StopAllAsync(CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAllAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private IReadOnlyList<ServiceDefinition> LoadDefinitions()
+    {
+        if (!File.Exists(_servicesFilePath))
+        {
+            return MapConfiguration();
+        }
+
+        string json;
+        try
+        {
+            json = File.ReadAllText(_servicesFilePath);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogWarning(ex, "Failed to read services file '{FilePath}'. Falling back to configuration.", _servicesFilePath);
+            return MapConfiguration();
+        }
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return MapConfiguration();
+        }
+
+        try
+        {
+            var records = JsonSerializer.Deserialize<List<PersistedServiceRecord>>(json, SerializerOptions) ?? new();
+            if (records.Count > 0)
+            {
+                return MapRecords(records);
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Unable to parse persisted services file '{FilePath}'. Attempting legacy format.", _servicesFilePath);
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogWarning(ex, "Unsupported data encountered in services file '{FilePath}'. Attempting legacy format.", _servicesFilePath);
+        }
+
+        try
+        {
+            var legacy = JsonSerializer.Deserialize<List<ServiceInfoLegacy>>(json, SerializerOptions) ?? new();
+            if (legacy.Count > 0)
+            {
+                return MapLegacyRecords(legacy);
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Unable to parse legacy services file '{FilePath}'. Falling back to configuration.", _servicesFilePath);
+        }
+
+        return MapConfiguration();
+    }
+
+    private IReadOnlyList<ServiceDefinition> MapConfiguration()
+    {
+        var items = _configuration.GetSection("Services").Get<List<ServiceConfig>>() ?? new List<ServiceConfig>();
+        var ordered = items
+            .Select((item, index) => new { Item = item, Order = item.Order, Index = index })
+            .OrderBy(entry => entry.Order)
+            .ThenBy(entry => entry.Index)
+            .Select(entry => entry.Item);
+
+        var result = new List<ServiceDefinition>();
+        foreach (var item in ordered)
+        {
+            if (string.IsNullOrWhiteSpace(item.DisplayName))
+            {
+                _logger.LogWarning("Service entry missing a display name. Skipping configuration row.");
+                continue;
+            }
+
+            var resolution = ResolveDescriptor(item.DescriptorId, ParseLegacyType(item.ServiceType));
+            if (resolution.Descriptor is null)
+            {
+                _logger.LogWarning(
+                    "No descriptor found for service '{DisplayName}' (DescriptorId: '{DescriptorId}', Legacy: '{LegacyType}').",
+                    item.DisplayName,
+                    resolution.DescriptorId,
+                    item.ServiceType);
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.ServiceType) && string.IsNullOrWhiteSpace(item.DescriptorId))
+            {
+                _logger.LogInformation(
+                    "Translated legacy service type '{Legacy}' for '{DisplayName}' to descriptor '{DescriptorId}'.",
+                    item.ServiceType,
+                    item.DisplayName,
+                    resolution.DescriptorId);
+            }
+
+            result.Add(new ServiceDefinition(
+                item.DisplayName,
+                resolution.DescriptorId,
+                resolution.Descriptor,
+                resolution.LegacyType,
+                item.IsActive,
+                Array.Empty<string>(),
+                payload: null));
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<ServiceDefinition> MapRecords(IEnumerable<PersistedServiceRecord> records)
+    {
+        var result = new List<ServiceDefinition>();
+        foreach (var record in records.OrderBy(r => r.Order))
+        {
+            var legacyName = record.LegacyType?.ToString() ?? record.LegacyTypeName;
+            var resolution = ResolveDescriptor(record.DescriptorId, ParseLegacyType(legacyName));
+            if (resolution.Descriptor is null)
+            {
+                _logger.LogWarning(
+                    "Descriptor '{DescriptorId}' referenced by '{DisplayName}' is not registered. Skipping runtime activation.",
+                    resolution.DescriptorId,
+                    record.DisplayName);
+                continue;
+            }
+
+            var payload = DeserializePayload(record, resolution.Descriptor);
+
+            result.Add(new ServiceDefinition(
+                record.DisplayName,
+                resolution.DescriptorId,
+                resolution.Descriptor,
+                resolution.LegacyType,
+                record.IsActive,
+                record.AssociatedServices ?? new List<string>(),
+                payload));
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<ServiceDefinition> MapLegacyRecords(IEnumerable<ServiceInfoLegacy> legacy)
+    {
+        var result = new List<ServiceDefinition>();
+        foreach (var record in legacy.OrderBy(r => r.Order))
+        {
+            if (!ServiceTypeExtensions.TryParse(record.ServiceType, out var legacyType))
+            {
+                _logger.LogWarning("Unmapped legacy service type '{Type}' for '{Name}'.", record.ServiceType, record.DisplayName);
+                continue;
+            }
+
+            var resolution = ResolveDescriptor(record.DescriptorId, legacyType);
+            if (resolution.Descriptor is null)
+            {
+                _logger.LogWarning(
+                    "Descriptor resolution failed for legacy service '{Name}' with type '{Type}'.", record.DisplayName, record.ServiceType);
+                continue;
+            }
+
+            result.Add(new ServiceDefinition(
+                record.DisplayName,
+                resolution.DescriptorId,
+                resolution.Descriptor,
+                resolution.LegacyType,
+                record.IsActive,
+                record.AssociatedServices ?? new List<string>(),
+                payload: null));
+        }
+
+        return result;
+    }
+
+    private DescriptorResolution ResolveDescriptor(string? descriptorId, ServiceType? legacyType)
+    {
+        if (!string.IsNullOrWhiteSpace(descriptorId) && _catalog.TryGetById(descriptorId, out var descriptorById))
+        {
+            return new DescriptorResolution(descriptorById.Id, descriptorById, descriptorById.LegacyType ?? legacyType);
+        }
+
+        if (legacyType is not null)
+        {
+            if (_catalog.TryGetByLegacyType(legacyType.Value, out var descriptorByLegacy))
+            {
+                return new DescriptorResolution(descriptorByLegacy.Id, descriptorByLegacy, legacyType);
+            }
+
+            if (_catalog.LegacyMap.TryGetValue(legacyType.Value, out var mappedId) &&
+                _catalog.TryGetById(mappedId, out var mappedDescriptor))
+            {
+                return new DescriptorResolution(mappedDescriptor.Id, mappedDescriptor, legacyType);
+            }
+
+            return new DescriptorResolution(legacyType.Value.ToDescriptorId(), null, legacyType);
+        }
+
+        if (!string.IsNullOrWhiteSpace(descriptorId) && _catalog.TryGetById(descriptorId, out var fallbackDescriptor))
+        {
+            return new DescriptorResolution(fallbackDescriptor.Id, fallbackDescriptor, fallbackDescriptor.LegacyType);
+        }
+
+        return new DescriptorResolution(descriptorId ?? string.Empty, null, legacyType);
+    }
+
+    private static ServiceType? ParseLegacyType(string? value)
+        => ServiceTypeExtensions.TryParse(value, out var parsed) ? parsed : null;
+
+    private object? DeserializePayload(PersistedServiceRecord record, IServiceDescriptor descriptor)
+    {
+        if (descriptor.OptionsSerializer is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(record.SerializedPayload))
+            {
+                return descriptor.OptionsSerializer.Deserialize(record.SerializedPayload);
+            }
+
+            if (record.Payload is JsonElement element)
+            {
+                return descriptor.OptionsSerializer.Deserialize(element);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize payload for '{DisplayName}'. Using default options instead.", record.DisplayName);
+        }
+
+        try
+        {
+            return descriptor.OptionsSerializer.CreateDefaultOptions();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create default payload for '{DisplayName}'.", record.DisplayName);
+            return null;
+        }
+    }
+
+    private async Task StartServiceAsync(ServiceDefinition definition, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Starting service '{Name}' using descriptor '{DescriptorId}'.",
+            definition.DisplayName,
+            definition.DescriptorId);
+
+        var scope = _scopeFactory.CreateScope();
+        try
+        {
+            var binding = definition.Descriptor.Factories
+                .FirstOrDefault(f => f.Kind == ServiceFactoryKind.Runtime && typeof(IServiceRuntimeFactory).IsAssignableFrom(f.ContractType));
+
+            if (binding is null)
+            {
+                _logger.LogWarning(
+                    "Descriptor '{DescriptorId}' does not expose a runtime factory. Service '{Name}' will not be started.",
+                    definition.DescriptorId,
+                    definition.DisplayName);
+                scope.Dispose();
+                return;
+            }
+
+            if (binding.Resolver(scope.ServiceProvider) is not IServiceRuntimeFactory factory)
+            {
+                _logger.LogWarning(
+                    "Runtime factory for descriptor '{DescriptorId}' does not implement {Contract}.",
+                    definition.DescriptorId,
+                    typeof(IServiceRuntimeFactory).Name);
+                scope.Dispose();
+                return;
+            }
+
+            var context = new ServiceRuntimeContext(
+                definition.Descriptor,
+                definition.DescriptorId,
+                definition.DisplayName,
+                definition.AssociatedServices,
+                definition.Payload);
+
+            var runtime = factory.Create(context);
+            if (runtime is null)
+            {
+                _logger.LogWarning(
+                    "Runtime factory for descriptor '{DescriptorId}' returned null. Service '{Name}' will not be started.",
+                    definition.DescriptorId,
+                    definition.DisplayName);
+                scope.Dispose();
+                return;
+            }
+            await runtime.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            var running = new RunningService(scope, runtime, definition);
+            _running[definition.DisplayName] = running;
+
+            _records[definition.DisplayName] = new ServiceRecord(
+                definition.DisplayName,
+                definition.DescriptorId,
+                definition.LegacyType,
+                DateTimeOffset.UtcNow);
+
+            WriteActiveServices();
+
+            _logger.LogInformation(
+                "Service '{Name}' started with descriptor '{DescriptorId}'.",
+                definition.DisplayName,
+                definition.DescriptorId);
+        }
+        catch (Exception ex)
+        {
+            scope.Dispose();
+            _logger.LogError(ex, "Failed to start service '{Name}'.", definition.DisplayName);
+        }
+    }
+
+    private async Task StopServiceAsync(string displayName, CancellationToken cancellationToken)
+    {
+        if (!_running.TryGetValue(displayName, out var running))
+        {
+            return;
+        }
+
+        _logger.LogInformation("Stopping service '{Name}'.", displayName);
+
+        _running.Remove(displayName);
+
+        try
+        {
+            await running.Runtime.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error stopping service '{Name}'.", displayName);
+        }
+        finally
+        {
+            try
+            {
+                await running.Runtime.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error disposing runtime for service '{Name}'.", displayName);
+            }
+
+            running.Scope.Dispose();
+        }
+
+        if (_records.TryGetValue(displayName, out var record))
+        {
+            record.Status = "Stopped";
+        }
+
+        WriteActiveServices();
+
+        if (_running.Count == 0)
+        {
+            DeleteActiveServicesFile();
+            _records.Clear();
+        }
+
+        _logger.LogInformation("Service '{Name}' stopped.", displayName);
+    }
+
+    private void WriteActiveServices()
+    {
+        try
+        {
+            var pid = Process.GetCurrentProcess().Id;
+            var lines = _records.Values
+                .Select(r => FormattableString.Invariant(
+                    $"{pid}\t{r.Name}\t{r.DescriptorId}\t{(r.LegacyType?.ToLegacyString() ?? string.Empty)}\t{r.StartTime:o}\t{r.Status}"))
+                .ToArray();
+
+            if (lines.Length == 0)
+            {
+                DeleteActiveServicesFile();
+                return;
+            }
+
+            File.WriteAllLines(_activeServicesFilePath, lines);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to write active services file '{FilePath}'.", _activeServicesFilePath);
+        }
+    }
+
+    private void DeleteActiveServicesFile()
+    {
+        try
+        {
+            if (File.Exists(_activeServicesFilePath))
+            {
+                File.Delete(_activeServicesFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to delete active services file '{FilePath}'.", _activeServicesFilePath);
+        }
+    }
+
+    private sealed record ServiceDefinition(
+        string DisplayName,
+        string DescriptorId,
+        IServiceDescriptor Descriptor,
+        ServiceType? LegacyType,
+        bool IsActive,
+        IReadOnlyCollection<string> AssociatedServices,
+        object? Payload);
+
+    private readonly record struct DescriptorResolution(
+        string DescriptorId,
+        IServiceDescriptor? Descriptor,
+        ServiceType? LegacyType);
+
+    private sealed record RunningService(IServiceScope Scope, IServiceRuntime Runtime, ServiceDefinition Definition);
+
+    private sealed class ServiceRecord
+    {
+        public ServiceRecord(string name, string descriptorId, ServiceType? legacyType, DateTimeOffset startTime)
+        {
+            Name = name;
+            DescriptorId = descriptorId;
+            LegacyType = legacyType;
+            StartTime = startTime;
+        }
+
+        public string Name { get; }
+        public string DescriptorId { get; }
+        public ServiceType? LegacyType { get; }
+        public DateTimeOffset StartTime { get; }
+        public string Status { get; set; } = "Running";
+    }
+
+    private sealed class ServiceConfig
     {
         public string DisplayName { get; set; } = string.Empty;
-        public ServiceType ServiceType { get; set; }
+        public string? DescriptorId { get; set; }
+        public string? ServiceType { get; set; }
         public bool IsActive { get; set; }
-        public DateTime Created { get; set; }
         public int Order { get; set; }
     }
 
-    public class ServiceManager : IDisposable
+    private sealed class PersistedServiceRecord
     {
-        private readonly ILogger<ServiceManager> _logger;
-        private readonly IConfiguration _config;
-        private readonly string _filePath;
-        private readonly Dictionary<string, RunningService> _running = new();
-        private readonly Dictionary<string, ServiceRecord> _records = new();
-        private readonly string _activeServicesFilePath;
+        public string DisplayName { get; set; } = string.Empty;
+        public string DescriptorId { get; set; } = string.Empty;
+        public ServiceType? LegacyType { get; set; }
+        public string? LegacyTypeName { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime Created { get; set; }
+        public int Order { get; set; }
+        public List<string>? AssociatedServices { get; set; }
+        public JsonElement? Payload { get; set; }
+        public string? SerializedPayload { get; set; }
+    }
 
-        private sealed class RunningService
-        {
-            public CancellationTokenSource CancellationTokenSource { get; init; } = default!;
-            public Task Task { get; init; } = default!;
-            public DateTime StartTime { get; init; }
-            public ServiceType ServiceType { get; init; }
-        }
-
-        private sealed class ServiceRecord
-        {
-            public string Name { get; init; } = string.Empty;
-            public ServiceType ServiceType { get; init; }
-            public DateTime StartTime { get; init; }
-            public string Status { get; set; } = string.Empty;
-        }
-
-        public IReadOnlyCollection<string> ActiveServices => _running.Keys.ToList();
-
-        public ServiceManager(ILogger<ServiceManager> logger, IConfiguration config, string? filePath = null)
-        {
-            _logger = logger;
-            _config = config;
-            _filePath = filePath ?? Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
-            _activeServicesFilePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "..", "activeservices.txt"));
-        }
-
-        public void Sync()
-        {
-            var infos = Load();
-            var active = new HashSet<string>(infos.Where(i => i.IsActive).Select(i => i.DisplayName));
-
-            foreach (var info in infos.Where(i => i.IsActive))
-            {
-                if (!_running.ContainsKey(info.DisplayName))
-                    StartService(info);
-            }
-
-            foreach (var name in _running.Keys.ToList())
-            {
-                if (!active.Contains(name))
-                    StopService(name);
-            }
-        }
-
-        private sealed class ServiceInfoConfig
-        {
-            public string DisplayName { get; set; } = string.Empty;
-            public string ServiceType { get; set; } = string.Empty;
-            public bool IsActive { get; set; }
-            public int Order { get; set; }
-        }
-
-        private sealed class ServiceInfoLegacy
-        {
-            public string DisplayName { get; set; } = string.Empty;
-            public string ServiceType { get; set; } = string.Empty;
-            public bool IsActive { get; set; }
-            public DateTime Created { get; set; }
-            public int Order { get; set; }
-        }
-
-        private List<ServiceInfo> Load()
-        {
-            if (!File.Exists(_filePath))
-            {
-                var configs = _config.GetSection("Services").Get<List<ServiceInfoConfig>>() ?? new List<ServiceInfoConfig>();
-                var results = new List<ServiceInfo>();
-                foreach (var cfg in configs)
-                {
-                    if (ServiceTypeExtensions.TryParse(cfg.ServiceType, out var type))
-                    {
-                        results.Add(new ServiceInfo
-                        {
-                            DisplayName = cfg.DisplayName,
-                            ServiceType = type,
-                            IsActive = cfg.IsActive,
-                            Created = DateTime.Now,
-                            Order = cfg.Order
-                        });
-                    }
-                    else
-                    {
-                        _logger.LogWarning("Unmapped service type '{Type}' for '{Name}'", cfg.ServiceType, cfg.DisplayName);
-                    }
-                }
-                return results;
-            }
-            try
-            {
-                var json = File.ReadAllText(_filePath);
-                var legacy = JsonSerializer.Deserialize<List<ServiceInfoLegacy>>(json) ?? new List<ServiceInfoLegacy>();
-                var results = new List<ServiceInfo>();
-                foreach (var info in legacy)
-                {
-                    if (ServiceTypeExtensions.TryParse(info.ServiceType, out var type))
-                    {
-                        results.Add(new ServiceInfo
-                        {
-                            DisplayName = info.DisplayName,
-                            ServiceType = type,
-                            IsActive = info.IsActive,
-                            Created = info.Created,
-                            Order = info.Order
-                        });
-                    }
-                    else
-                    {
-                        _logger.LogWarning("Unmapped service type '{Type}' for '{Name}'", info.ServiceType, info.DisplayName);
-                    }
-                }
-                return results;
-            }
-            catch
-            {
-                return new List<ServiceInfo>();
-            }
-        }
-
-        private void StartService(ServiceInfo info)
-        {
-            _logger.LogInformation("Starting {type} service: {name}", info.ServiceType, info.DisplayName);
-            var cts = new CancellationTokenSource();
-            var start = DateTime.UtcNow;
-            var task = Task.Run(() => RunServiceLoop(info, cts.Token));
-            _running[info.DisplayName] = new RunningService
-            {
-                CancellationTokenSource = cts,
-                Task = task,
-                StartTime = start,
-                ServiceType = info.ServiceType
-            };
-
-            _records[info.DisplayName] = new ServiceRecord
-            {
-                Name = info.DisplayName,
-                ServiceType = info.ServiceType,
-                StartTime = start,
-                Status = "Running"
-            };
-
-            WriteActiveServices();
-
-            _logger.LogInformation("Started service: {name}", info.DisplayName);
-        }
-
-        private void StopService(string name)
-        {
-            if (_running.TryGetValue(name, out var service))
-            {
-                _logger.LogInformation("Stopping service: {name}", name);
-                service.CancellationTokenSource.Cancel();
-                _running.Remove(name);
-                if (_records.TryGetValue(name, out var record))
-                    record.Status = "Stopped";
-                WriteActiveServices();
-                _logger.LogInformation("Stopped service: {name}", name);
-            }
-        }
-
-        private async Task RunServiceLoop(ServiceInfo info, CancellationToken token)
-        {
-            if (info.ServiceType == ServiceType.Heartbeat)
-            {
-                var hb = _config.GetSection("Heartbeat");
-                var message = hb.GetValue<string>("Message", "PING");
-                var interval = hb.GetValue<int>("IntervalSeconds", 30);
-                while (!token.IsCancellationRequested)
-                {
-                    _logger.LogInformation("[{name}] {msg}", info.DisplayName, message);
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(interval), token);
-                    }
-                    catch (TaskCanceledException)
-                    {
-                    }
-                }
-            }
-            else
-            {
-                while (!token.IsCancellationRequested)
-                {
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(10), token);
-                    }
-                    catch (TaskCanceledException)
-                    {
-                    }
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            foreach (var running in _running.Values)
-                running.CancellationTokenSource.Cancel();
-
-            foreach (var record in _records.Values)
-            {
-                if (record.Status != "Stopped")
-                    record.Status = "Stopped";
-            }
-
-            WriteActiveServices();
-
-            _running.Clear();
-            _records.Clear();
-            if (File.Exists(_activeServicesFilePath))
-            {
-                try
-                {
-                    File.Delete(_activeServicesFilePath);
-                }
-                catch
-                {
-                }
-            }
-        }
-
-        private void WriteActiveServices()
-        {
-            try
-            {
-                var pid = Process.GetCurrentProcess().Id;
-                var lines = _records.Values
-                    .Select(r => $"{pid}\t{r.Name}\t{r.ServiceType.ToLegacyString()}\t{r.StartTime:o}\t{r.Status}")
-                    .ToArray();
-                File.WriteAllLines(_activeServicesFilePath, lines);
-            }
-            catch
-            {
-            }
-        }
+    private sealed class ServiceInfoLegacy
+    {
+        public string DisplayName { get; set; } = string.Empty;
+        public string ServiceType { get; set; } = string.Empty;
+        public string? DescriptorId { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime Created { get; set; }
+        public int Order { get; set; }
+        public List<string>? AssociatedServices { get; set; }
     }
 }

--- a/DesktopApplicationTemplate.Service/Worker.cs
+++ b/DesktopApplicationTemplate.Service/Worker.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,34 +9,23 @@ namespace DesktopApplicationTemplate.Service
     public class Worker : BackgroundService
     {
         private readonly ILogger<Worker> _logger;
-        private readonly ILoggerFactory _loggerFactory;
-        private readonly IConfiguration _config;
-        
-        public string HeartbeatMessage { get; private set; } = string.Empty;
-        public int IntervalSeconds { get; private set; }
+        private readonly ServiceManager _serviceManager;
 
-        public Worker(ILogger<Worker> logger, ILoggerFactory loggerFactory, IConfiguration config)
+        public Worker(ILogger<Worker> logger, ServiceManager serviceManager)
         {
-            _logger = logger;
-            _loggerFactory = loggerFactory;
-            _config = config;
-            var hbSection = _config.GetSection("Heartbeat");
-            HeartbeatMessage = hbSection.GetValue<string>("Message") ?? "PING";
-            IntervalSeconds = hbSection.GetValue<int>("IntervalSeconds", 30);
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _serviceManager = serviceManager ?? throw new ArgumentNullException(nameof(serviceManager));
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             _logger.LogInformation("Service starting at: {time}", DateTimeOffset.Now);
-            _logger.LogDebug("Heartbeat interval set to {interval}s with message '{message}'", IntervalSeconds, HeartbeatMessage);
-
-            using var manager = new ServiceManager(_loggerFactory.CreateLogger<ServiceManager>(), _config);
 
             try
             {
                 while (!stoppingToken.IsCancellationRequested)
                 {
-                    manager.Sync();
+                    await _serviceManager.SyncAsync(stoppingToken).ConfigureAwait(false);
                     await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
                 }
             }
@@ -51,6 +39,7 @@ namespace DesktopApplicationTemplate.Service
             }
             finally
             {
+                await _serviceManager.StopAllAsync(stoppingToken).ConfigureAwait(false);
                 _logger.LogInformation("Service stopping at: {time}", DateTimeOffset.Now);
             }
         }

--- a/DesktopApplicationTemplate.Service/appsettings.Development.json
+++ b/DesktopApplicationTemplate.Service/appsettings.Development.json
@@ -8,7 +8,7 @@
   "Services": [
     {
       "DisplayName": "Heartbeat",
-      "ServiceType": "HB",
+      "DescriptorId": "service.heartbeat",
       "IsActive": true,
       "Order": 0
     }

--- a/DesktopApplicationTemplate.Service/appsettings.json
+++ b/DesktopApplicationTemplate.Service/appsettings.json
@@ -8,7 +8,7 @@
   "Services": [
     {
       "DisplayName": "Heartbeat",
-      "ServiceType": "HB",
+      "DescriptorId": "service.heartbeat",
       "IsActive": true,
       "Order": 0
     }

--- a/DesktopApplicationTemplate.Services.Common/CommonServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Services.Common/CommonServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Services.Common.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.Services.Common;
@@ -16,6 +17,8 @@ public static class CommonServiceCollectionExtensions
         services.AddSingleton<IServiceRule, ServiceRule>();
         services.AddTransient(typeof(IServiceScreen<>), typeof(ServiceScreen<>));
         services.AddSingleton<IFileSearchService, FileSearchService>();
+        services.AddSingleton<HeartbeatRuntimeFactory>();
+        services.AddOptions<HeartbeatRuntimeOptions>();
         return services;
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/CommonServicesModule.cs
+++ b/DesktopApplicationTemplate.Services.Common/CommonServicesModule.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
+using DesktopApplicationTemplate.Services.Common.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.Services.Common;
@@ -26,6 +27,13 @@ public sealed class CommonServicesModule : IServiceModule
         yield return new FileObserverServiceDescriptor();
         yield return new ScpServiceDescriptor();
         yield return new TcpServiceDescriptor();
-        yield return new HeartbeatServiceDescriptor();
+        yield return new HeartbeatServiceDescriptor(
+            factories: new[]
+            {
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.Runtime,
+                    typeof(IServiceRuntimeFactory),
+                    sp => sp.GetRequiredService<HeartbeatRuntimeFactory>())
+            });
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/Runtime/HeartbeatRuntimeFactory.cs
+++ b/DesktopApplicationTemplate.Services.Common/Runtime/HeartbeatRuntimeFactory.cs
@@ -1,0 +1,24 @@
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DesktopApplicationTemplate.Services.Common.Runtime;
+
+internal sealed class HeartbeatRuntimeFactory : IServiceRuntimeFactory
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IOptionsMonitor<HeartbeatRuntimeOptions> _options;
+
+    public HeartbeatRuntimeFactory(ILoggerFactory loggerFactory, IOptionsMonitor<HeartbeatRuntimeOptions> options)
+    {
+        _loggerFactory = loggerFactory;
+        _options = options;
+    }
+
+    public IServiceRuntime Create(ServiceRuntimeContext context)
+    {
+        var logger = _loggerFactory.CreateLogger<HeartbeatRuntimeService>();
+        var options = _options.CurrentValue;
+        return new HeartbeatRuntimeService(logger, options, context.DisplayName);
+    }
+}

--- a/DesktopApplicationTemplate.Services.Common/Runtime/HeartbeatRuntimeOptions.cs
+++ b/DesktopApplicationTemplate.Services.Common/Runtime/HeartbeatRuntimeOptions.cs
@@ -1,0 +1,17 @@
+namespace DesktopApplicationTemplate.Services.Common.Runtime;
+
+/// <summary>
+/// Options controlling the heartbeat runtime workflow.
+/// </summary>
+public class HeartbeatRuntimeOptions
+{
+    /// <summary>
+    /// Gets or sets the heartbeat message emitted on each interval.
+    /// </summary>
+    public string Message { get; set; } = "PING";
+
+    /// <summary>
+    /// Gets or sets the interval between heartbeat emissions in seconds.
+    /// </summary>
+    public int IntervalSeconds { get; set; } = 30;
+}

--- a/DesktopApplicationTemplate.Services.Common/Runtime/HeartbeatRuntimeService.cs
+++ b/DesktopApplicationTemplate.Services.Common/Runtime/HeartbeatRuntimeService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.Services.Common.Runtime;
+
+internal sealed class HeartbeatRuntimeService : IServiceRuntime
+{
+    private readonly ILogger _logger;
+    private readonly HeartbeatRuntimeOptions _options;
+    private readonly string _displayName;
+    private CancellationTokenSource? _linkedSource;
+    private Task? _loopTask;
+
+    public HeartbeatRuntimeService(ILogger logger, HeartbeatRuntimeOptions options, string displayName)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _displayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting heartbeat runtime for {DisplayName}", _displayName);
+        _linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _loopTask = Task.Run(() => RunLoopAsync(_linkedSource.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_linkedSource is null)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Stopping heartbeat runtime for {DisplayName}", _displayName);
+        _linkedSource.Cancel();
+
+        if (_loopTask is not null)
+        {
+            try
+            {
+                await Task.WhenAny(_loopTask, Task.Delay(Timeout.Infinite, cancellationToken)).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Ignore cancellation while waiting for shutdown.
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _linkedSource?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("[{DisplayName}] {Message}", _displayName, _options.Message);
+
+                try
+                {
+                    var delay = TimeSpan.FromSeconds(Math.Max(1, _options.IntervalSeconds));
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore cancellation requests.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Heartbeat runtime for {DisplayName} encountered an error.", _displayName);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceManagerTests.cs
@@ -1,91 +1,200 @@
-using DesktopApplicationTemplate.Service;
-using DesktopApplicationTemplate.Models;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging.Abstractions;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Service;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using TestCommon;
 using Xunit;
 
-namespace DesktopApplicationTemplate.Tests
+namespace DesktopApplicationTemplate.Tests;
+
+public class ServiceManagerTests
 {
-    public class ServiceManagerTests
+    [Fact]
+    public async Task Sync_StartsAndStopsServicesBasedOnConfiguration()
     {
-        [Fact]
-        public void Sync_StartsAndStopsServicesBasedOnFile()
+        using var tempDirectory = new TempDirectory();
+        var managerSetup = CreateManager(tempDirectory.Path, descriptorId: "service.test");
+        await using var manager = managerSetup.Manager;
+
+        await manager.SyncAsync(CancellationToken.None);
+
+        var factory = managerSetup.Factory;
+        var runtime = Assert.Single(factory.CreatedRuntimes);
+        Assert.Equal(1, runtime.StartCalls);
+        Assert.Equal(0, runtime.StopCalls);
+        Assert.Equal("Service One", Assert.Single(factory.Contexts).DisplayName);
+
+        managerSetup.Configuration["Services:0:IsActive"] = "false";
+
+        await manager.SyncAsync(CancellationToken.None);
+
+        Assert.Equal(1, runtime.StartCalls);
+        Assert.Equal(1, runtime.StopCalls);
+        Assert.Empty(manager.ActiveServices);
+
+        ConsoleTestLogger.LogPass();
+    }
+
+    [Theory]
+    [InlineData("HB")]
+    [InlineData("Heartbeat")]
+    public async Task Sync_ResolvesLegacyServiceCodes(string legacyCode)
+    {
+        using var tempDirectory = new TempDirectory();
+        var setup = CreateManager(tempDirectory.Path, descriptorId: "service.test", legacyCode: legacyCode, includeDescriptorId: false);
+        await using var manager = setup.Manager;
+
+        await manager.SyncAsync(CancellationToken.None);
+
+        var factory = setup.Factory;
+        Assert.Single(factory.CreatedRuntimes);
+        Assert.Equal("service.test", Assert.Single(factory.Contexts).DescriptorId);
+
+        ConsoleTestLogger.LogPass();
+    }
+
+    private static ManagerSetup CreateManager(string tempDirectory, string descriptorId, string legacyCode = "HB", bool includeDescriptorId = true)
+    {
+        var descriptor = new TestDescriptor(descriptorId);
+        var catalog = new ServiceCatalog(new[] { descriptor });
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestRuntimeFactory>();
+        var serviceProvider = services.BuildServiceProvider();
+        var scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+
+        var values = new Dictionary<string, string?>
         {
-            var tempFile = Path.GetTempFileName();
-            try
-            {
-                var services = new[]
-                {
-                    new ServiceInfo { DisplayName = "Svc1", ServiceType = ServiceType.Heartbeat, IsActive = true, Order = 0 },
-                    new ServiceInfo { DisplayName = "Svc2", ServiceType = ServiceType.Tcp, IsActive = false, Order = 1 }
-                };
-                File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
+            ["Services:0:DisplayName"] = "Service One",
+            ["Services:0:IsActive"] = "true",
+            ["Services:0:Order"] = "0"
+        };
 
-                IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    {"Heartbeat:Message", "HB"},
-                    {"Heartbeat:IntervalSeconds", "1"}
-                }).Build();
-
-                using var manager = new ServiceManager(NullLogger<ServiceManager>.Instance, config, tempFile);
-                manager.Sync();
-
-                var runningField = typeof(ServiceManager).GetField("_running", BindingFlags.Instance | BindingFlags.NonPublic)!;
-                var running = (IDictionary<string, object>)runningField.GetValue(manager)!;
-                Assert.Contains(running.Values, r =>
-                    (ServiceType)r.GetType().GetProperty("ServiceType")!.GetValue(r)! == ServiceType.Heartbeat);
-                Assert.DoesNotContain(running.Values, r =>
-                    (ServiceType)r.GetType().GetProperty("ServiceType")!.GetValue(r)! == ServiceType.Tcp);
-
-                services[0].IsActive = false;
-                File.WriteAllText(tempFile, JsonSerializer.Serialize(services));
-                manager.Sync();
-
-                running = (IDictionary<string, object>)runningField.GetValue(manager)!;
-                Assert.Empty(running);
-            }
-            finally
-            {
-                File.Delete(tempFile);
-            }
-            ConsoleTestLogger.LogPass();
+        if (includeDescriptorId)
+        {
+            values["Services:0:DescriptorId"] = descriptorId;
+        }
+        else
+        {
+            values["Services:0:ServiceType"] = legacyCode;
         }
 
-        [Theory]
-        [InlineData("HB", ServiceType.Heartbeat)]
-        [InlineData("Heartbeat", ServiceType.Heartbeat)]
-        public void Sync_LoadsServicesFromConfiguration(string typeValue, ServiceType expected)
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var servicesFile = Path.Combine(tempDirectory, "services.json");
+        var manager = new ServiceManager(
+            NullLogger<ServiceManager>.Instance,
+            configuration,
+            catalog,
+            scopeFactory,
+            servicesFile);
+
+        var factory = serviceProvider.GetRequiredService<TestRuntimeFactory>();
+
+        return new ManagerSetup(manager, configuration, factory);
+    }
+
+    private sealed record ManagerSetup(ServiceManager Manager, IConfigurationRoot Configuration, TestRuntimeFactory Factory);
+
+    private sealed class TestRuntimeFactory : IServiceRuntimeFactory
+    {
+        private readonly List<TestRuntime> _runtimes = new();
+        private readonly List<ServiceRuntimeContext> _contexts = new();
+
+        public IReadOnlyList<TestRuntime> CreatedRuntimes => _runtimes;
+        public IReadOnlyList<ServiceRuntimeContext> Contexts => _contexts;
+
+        public IServiceRuntime Create(ServiceRuntimeContext context)
         {
-            var tempDir = Path.Combine(Path.GetTempPath(), System.Guid.NewGuid().ToString());
-            var tempFile = Path.Combine(tempDir, "services.json");
+            var runtime = new TestRuntime();
+            _runtimes.Add(runtime);
+            _contexts.Add(context);
+            return runtime;
+        }
+    }
 
-            var configValues = new Dictionary<string, string?>
+    private sealed class TestRuntime : IServiceRuntime
+    {
+        public int StartCalls { get; private set; }
+        public int StopCalls { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            StartCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopCalls++;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class TestDescriptor : IServiceDescriptor
+    {
+        private readonly IReadOnlyCollection<ServiceFactoryBinding> _factories;
+
+        public TestDescriptor(string id)
+        {
+            Id = id;
+            DisplayName = "Test Descriptor";
+            Category = "Test";
+            _factories = new[]
             {
-                {"Services:0:DisplayName", "Svc1"},
-                {"Services:0:ServiceType", typeValue},
-                {"Services:0:IsActive", "true"},
-                {"Services:0:Order", "0"},
-                {"Heartbeat:Message", "HB"},
-                {"Heartbeat:IntervalSeconds", "1"}
+                ServiceFactoryBinding.Create(
+                    ServiceFactoryKind.Runtime,
+                    typeof(IServiceRuntimeFactory),
+                    sp => sp.GetRequiredService<TestRuntimeFactory>())
             };
-            IConfiguration config = new ConfigurationBuilder()
-                .AddInMemoryCollection(configValues)
-                .Build();
+        }
 
-            using var manager = new ServiceManager(NullLogger<ServiceManager>.Instance, config, tempFile);
-            manager.Sync();
+        public string Id { get; }
+        public string DisplayName { get; }
+        public string Category { get; }
+        public string? Description => null;
+        public ServiceType? LegacyType => ServiceType.Heartbeat;
+        public IServiceOptionsSerializer? OptionsSerializer => null;
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories => _factories;
+        public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;
+        public bool HasPayloadDescription => false;
+        public string? DescribePayload(object? payload) => null;
+    }
 
-            var load = typeof(ServiceManager).GetMethod("Load", BindingFlags.Instance | BindingFlags.NonPublic)!;
-            var infos = (List<ServiceInfo>)load.Invoke(manager, null)!;
-            var info = Assert.Single(infos);
-            Assert.Equal(expected, info.ServiceType);
-            Assert.True(info.IsActive);
-            ConsoleTestLogger.LogPass();
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch
+            {
+                // ignored for test cleanup
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce descriptor runtime abstractions so the host can request IServiceRuntime instances from IServiceCatalog descriptors
- rework ServiceManager, Worker, and configuration to resolve descriptor ids, start runtime factories, and provide a heartbeat runtime implementation
- add component tests that verify ServiceManager.Sync activates and stops catalog-provided runtimes

## Testing
- `dotnet build DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2778e8d48326a982b183fae20928