### PR TITLE
Add plug-in loader with manifest documentation and tests

### DIFF
--- a/Codex/docs/PluginManifestSchema.md
+++ b/Codex/docs/PluginManifestSchema.md
@@ -1,0 +1,56 @@
+# Plug-in Manifest Schema
+
+The `PluginLoader` scans the configured plug-in directory for either folders or `.zip` archives that contain a `plugin.manifest.json` file. Each manifest must adhere to the schema below so the loader can validate the package, extract archives into the versioned cache, and register service modules.
+
+## Manifest Fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `id` | ✔️ | Stable identifier for the plug-in. This value is used when caching extracted archives, so it must remain constant across versions. |
+| `name` | ✔️ | Human-friendly name displayed in logs. |
+| `version` | ✔️ | Semantic version string (e.g., `1.2.0`). Different versions may coexist because each version is extracted into an isolated cache folder. |
+| `entryAssembly` | ✔️ | Relative path to the plug-in entry assembly. The loader builds an `AssemblyLoadContext` around this file to probe dependencies. |
+| `serviceAssemblies` | Optional | Collection of additional assemblies to scan for `IServiceModule` implementations. When omitted, the entry assembly is scanned. Paths are relative to the plug-in root. |
+| `probingPaths` | Optional | Relative directories that contain dependency assemblies or native libraries. Entries are added to the custom `AssemblyLoadContext` resolver so each plug-in can ship private dependency versions. |
+
+## Example Manifest
+
+```json
+{
+  "id": "Contoso.Telemetry",
+  "name": "Telemetry Services",
+  "version": "1.0.0",
+  "entryAssembly": "Contoso.Telemetry.dll",
+  "serviceAssemblies": [
+    "Contoso.Telemetry.dll",
+    "Contoso.Telemetry.Services.dll"
+  ],
+  "probingPaths": [
+    "libs",
+    "native"
+  ]
+}
+```
+
+## Packaging Guidance
+
+1. Place the manifest at the root of either the plug-in directory or `.zip` archive.
+2. All assembly paths must stay within the package root; the loader rejects paths that escape via `..` segments.
+3. When shipping a `.zip` archive, the loader extracts the archive to `<ExtractionRoot>/<id>/<version>` where `ExtractionRoot` defaults to `PluginCache` under the application base directory. Existing cache directories are replaced when a new archive is processed.
+4. Private dependencies can be placed in subdirectories referenced by `probingPaths`. They are resolved before probing shared application assemblies, allowing multiple plug-ins to ship different dependency versions simultaneously.
+
+## Configuring the Loader
+
+The loader reads configuration from the `Plugins` section:
+
+```json
+"Plugins": {
+  "Directory": "Plugins",
+  "ExtractionRoot": "PluginCache"
+}
+```
+
+- `Directory` is the location scanned for plug-in directories or archives. Relative paths are resolved against the application base directory.
+- `ExtractionRoot` controls where archives are unpacked. Relative paths are also resolved against the application base directory.
+
+Both hosts (`DesktopApplicationTemplate.UI` and `DesktopApplicationTemplate.Service`) log structured messages for successes and failures to simplify diagnostics when a plug-in cannot be loaded.

--- a/DesktopApplicationTemplate.Core/Modules/PluginLoader.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginLoader.cs
@@ -1,0 +1,437 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Loads plug-in packages and exposes their assemblies for service module discovery.
+/// </summary>
+public sealed class PluginLoader
+{
+    private const string ManifestFileName = "plugin.manifest.json";
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        AllowTrailingCommas = true,
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    private static readonly List<PluginLoadContext> ActiveContexts = new();
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private readonly PluginLoaderOptions options;
+    private readonly ILogger<PluginLoader> logger;
+    private readonly HashSet<string> loadedPlugins = new(StringComparer.OrdinalIgnoreCase);
+
+    public PluginLoader(PluginLoaderOptions options, ILogger<PluginLoader> logger)
+    {
+        this.options = options ?? throw new ArgumentNullException(nameof(options));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Creates a loader using configuration derived options.
+    /// </summary>
+    /// <param name="configuration">The configuration source.</param>
+    /// <param name="logger">The logger.</param>
+    /// <returns>The configured <see cref="PluginLoader"/> instance.</returns>
+    public static PluginLoader Create(IConfiguration configuration, ILogger<PluginLoader> logger)
+    {
+        var options = PluginLoaderOptions.FromConfiguration(configuration);
+        return new PluginLoader(options, logger);
+    }
+
+    /// <summary>
+    /// Gets the loader options.
+    /// </summary>
+    public PluginLoaderOptions Options => options;
+
+    /// <summary>
+    /// Loads plug-in assemblies from the configured directories.
+    /// </summary>
+    /// <returns>The assemblies that should be scanned for service modules.</returns>
+    public IReadOnlyCollection<Assembly> LoadPluginAssemblies()
+    {
+        var assemblies = new List<Assembly>();
+
+        if (!Directory.Exists(options.RootDirectory))
+        {
+            logger.LogDebug("Plug-in directory {PluginRoot} does not exist. No plug-ins will be loaded.", options.RootDirectory);
+            return assemblies;
+        }
+
+        foreach (var entry in Directory.EnumerateFileSystemEntries(options.RootDirectory))
+        {
+            try
+            {
+                if (Directory.Exists(entry))
+                {
+                    LoadFromDirectory(entry, assemblies);
+                }
+                else if (string.Equals(Path.GetExtension(entry), ".zip", StringComparison.OrdinalIgnoreCase))
+                {
+                    LoadFromArchive(entry, assemblies);
+                }
+                else
+                {
+                    logger.LogDebug("Skipping unsupported plug-in payload {PluginPath}.", entry);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to load plug-in payload {PluginPath}.", entry);
+            }
+        }
+
+        return new ReadOnlyCollection<Assembly>(assemblies);
+    }
+
+    /// <summary>
+    /// Combines plug-in assemblies with the currently loaded application assemblies to support module discovery.
+    /// </summary>
+    /// <param name="pluginAssemblies">Assemblies discovered by <see cref="LoadPluginAssemblies"/>.</param>
+    /// <returns>A distinct set of assemblies for module scanning.</returns>
+    public static IReadOnlyCollection<Assembly> CombineWithDefaultAssemblies(IEnumerable<Assembly> pluginAssemblies)
+    {
+        var defaultAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        var combined = defaultAssemblies
+            .Concat(pluginAssemblies ?? Array.Empty<Assembly>())
+            .Where(a => a is not null)
+            .GroupBy(a => a.FullName, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .ToArray();
+
+        return combined;
+    }
+
+    private void LoadFromArchive(string archivePath, ICollection<Assembly> assemblies)
+    {
+        using var archive = ZipFile.OpenRead(archivePath);
+        var manifestEntry = archive.GetEntry(ManifestFileName);
+        if (manifestEntry is null)
+        {
+            logger.LogWarning("Plug-in archive {ArchivePath} does not contain {ManifestFileName}.", archivePath, ManifestFileName);
+            return;
+        }
+
+        PluginManifest? manifest;
+        using (var manifestStream = manifestEntry.Open())
+        {
+            manifest = JsonSerializer.Deserialize<PluginManifest>(manifestStream, SerializerOptions);
+        }
+
+        if (!TryValidateBasicManifest(manifest, archivePath, out var basicErrors))
+        {
+            foreach (var error in basicErrors)
+            {
+                logger.LogWarning("{ManifestError}", error);
+            }
+
+            return;
+        }
+
+        var extractionPath = GetExtractionPath(manifest!);
+        if (Directory.Exists(extractionPath))
+        {
+            Directory.Delete(extractionPath, recursive: true);
+        }
+
+        Directory.CreateDirectory(extractionPath);
+        archive.ExtractToDirectory(extractionPath, overwriteFiles: true);
+
+        LoadFromDirectory(extractionPath, assemblies, archivePath);
+    }
+
+    private void LoadFromDirectory(string directoryPath, ICollection<Assembly> assemblies, string? origin = null)
+    {
+        var manifestPath = Path.Combine(directoryPath, ManifestFileName);
+        if (!File.Exists(manifestPath))
+        {
+            logger.LogWarning("Plug-in folder {PluginDirectory} does not contain {ManifestFileName}.", directoryPath, ManifestFileName);
+            return;
+        }
+
+        PluginManifest? manifest;
+        try
+        {
+            using var stream = File.OpenRead(manifestPath);
+            manifest = JsonSerializer.Deserialize<PluginManifest>(stream, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError(ex, "Plug-in manifest {ManifestPath} is invalid JSON.", manifestPath);
+            return;
+        }
+
+        if (!TryValidateManifest(manifest, directoryPath, origin ?? manifestPath, out var errors))
+        {
+            foreach (var error in errors)
+            {
+                logger.LogWarning("{ManifestError}", error);
+            }
+
+            return;
+        }
+
+        var manifestKey = CreateManifestKey(manifest!);
+        if (!loadedPlugins.Add(manifestKey))
+        {
+            logger.LogInformation("Plug-in {PluginId} version {PluginVersion} was already loaded. Skipping payload at {PluginDirectory}.", manifest!.Id, manifest.Version, directoryPath);
+            return;
+        }
+
+        var entryAssemblyPath = ResolvePath(directoryPath, manifest!.EntryAssembly);
+        if (entryAssemblyPath is null)
+        {
+            logger.LogWarning("Entry assembly {EntryAssembly} for plug-in {PluginId} resolves outside of the plug-in directory.", manifest.EntryAssembly, manifest.Id);
+            return;
+        }
+
+        var loadContext = new PluginLoadContext(entryAssemblyPath, directoryPath, manifest.ProbingPaths);
+        ActiveContexts.Add(loadContext);
+
+        var assemblyReferences = manifest.ServiceAssemblies.Count > 0
+            ? manifest.ServiceAssemblies
+            : new List<string> { manifest.EntryAssembly };
+
+        foreach (var assemblyReference in assemblyReferences)
+        {
+            var assemblyPath = ResolvePath(directoryPath, assemblyReference);
+            if (assemblyPath is null || !File.Exists(assemblyPath))
+            {
+                logger.LogWarning(
+                    "Plug-in {PluginId} references assembly {AssemblyReference} that could not be resolved.",
+                    manifest.Id,
+                    assemblyReference);
+                continue;
+            }
+
+            try
+            {
+                var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+                assemblies.Add(assembly);
+                logger.LogInformation(
+                    "Loaded plug-in assembly {AssemblyName} for {PluginId} version {PluginVersion}.",
+                    assembly.GetName().Name,
+                    manifest.Id,
+                    manifest.Version);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to load plug-in assembly {AssemblyPath} for {PluginId}.",
+                    assemblyPath,
+                    manifest.Id);
+            }
+        }
+    }
+
+    private static bool TryValidateBasicManifest(PluginManifest? manifest, string origin, out List<string> errors)
+    {
+        errors = new List<string>();
+        if (manifest is null)
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' could not be parsed."));
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Id))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'id'."));
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Version))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'version'."));
+        }
+        else if (!Version.TryParse(manifest.Version, out _))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' specifies an invalid version '{manifest.Version}'."));
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.EntryAssembly))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'entryAssembly'."));
+        }
+
+        return errors.Count == 0;
+    }
+
+    private static bool TryValidateManifest(PluginManifest? manifest, string pluginDirectory, string origin, out List<string> errors)
+    {
+        if (!TryValidateBasicManifest(manifest, origin, out errors))
+        {
+            return false;
+        }
+
+        if (manifest is null)
+        {
+            return false;
+        }
+
+        var entryAssembly = ResolvePath(pluginDirectory, manifest.EntryAssembly);
+        if (entryAssembly is null)
+        {
+            errors.Add(FormattableString.Invariant($"Entry assembly '{manifest.EntryAssembly}' resolves outside '{pluginDirectory}'."));
+        }
+        else if (!File.Exists(entryAssembly))
+        {
+            errors.Add(FormattableString.Invariant($"Entry assembly '{manifest.EntryAssembly}' was not found at '{entryAssembly}'."));
+        }
+
+        foreach (var assemblyReference in manifest.ServiceAssemblies)
+        {
+            var resolved = ResolvePath(pluginDirectory, assemblyReference);
+            if (resolved is null)
+            {
+                errors.Add(FormattableString.Invariant($"Service assembly '{assemblyReference}' resolves outside '{pluginDirectory}'."));
+                continue;
+            }
+
+            if (!File.Exists(resolved))
+            {
+                errors.Add(FormattableString.Invariant($"Service assembly '{assemblyReference}' was not found at '{resolved}'."));
+            }
+        }
+
+        foreach (var probingPath in manifest.ProbingPaths)
+        {
+            if (ResolvePath(pluginDirectory, probingPath) is null)
+            {
+                errors.Add(FormattableString.Invariant($"Probing path '{probingPath}' resolves outside '{pluginDirectory}'."));
+            }
+        }
+
+        return errors.Count == 0;
+    }
+
+    private static string CreateManifestKey(PluginManifest manifest)
+    {
+        return FormattableString.Invariant($"{manifest.Id.Trim()}|{manifest.Version.Trim()}");
+    }
+
+    private string GetExtractionPath(PluginManifest manifest)
+    {
+        var safeId = SanitizeSegment(manifest.Id);
+        var safeVersion = SanitizeSegment(manifest.Version);
+        return Path.Combine(options.ExtractionDirectory, safeId, safeVersion);
+    }
+
+    private static string? ResolvePath(string root, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            return null;
+        }
+
+        var combined = Path.GetFullPath(Path.Combine(root, relativePath));
+        var rootPath = EnsureTrailingSeparator(Path.GetFullPath(root));
+        if (!combined.StartsWith(rootPath, PathComparison))
+        {
+            return null;
+        }
+
+        return combined;
+    }
+
+    private static string EnsureTrailingSeparator(string path)
+    {
+        if (!path.EndsWith(Path.DirectorySeparatorChar) && !path.EndsWith(Path.AltDirectorySeparatorChar))
+        {
+            path += Path.DirectorySeparatorChar;
+        }
+
+        return path;
+    }
+
+    private static string SanitizeSegment(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var buffer = value.ToCharArray();
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            if (invalid.Contains(buffer[i]))
+            {
+                buffer[i] = '_';
+            }
+        }
+
+        return new string(buffer);
+    }
+
+    private sealed class PluginLoadContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver resolver;
+        private readonly IReadOnlyList<string> probingPaths;
+
+        public PluginLoadContext(string entryAssemblyPath, string pluginDirectory, IEnumerable<string> probingPaths)
+            : base(isCollectible: false)
+        {
+            if (string.IsNullOrWhiteSpace(entryAssemblyPath))
+            {
+                throw new ArgumentException("Entry assembly path must be provided", nameof(entryAssemblyPath));
+            }
+
+            resolver = new AssemblyDependencyResolver(entryAssemblyPath);
+            var rootPath = EnsureTrailingSeparator(Path.GetFullPath(pluginDirectory));
+            this.probingPaths = probingPaths
+                .Select(path => ResolvePath(rootPath, path))
+                .Where(path => path is not null)
+                .Cast<string>()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            var resolvedPath = resolver.ResolveAssemblyToPath(assemblyName);
+            if (!string.IsNullOrEmpty(resolvedPath))
+            {
+                return LoadFromAssemblyPath(resolvedPath);
+            }
+
+            foreach (var probingPath in probingPaths)
+            {
+                var candidate = Path.Combine(probingPath, assemblyName.Name + ".dll");
+                if (File.Exists(candidate))
+                {
+                    return LoadFromAssemblyPath(candidate);
+                }
+            }
+
+            return null;
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            var resolvedPath = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            if (!string.IsNullOrEmpty(resolvedPath))
+            {
+                return LoadUnmanagedDllFromPath(resolvedPath);
+            }
+
+            foreach (var probingPath in probingPaths)
+            {
+                var candidate = Path.Combine(probingPath, unmanagedDllName + ".dll");
+                if (File.Exists(candidate))
+                {
+                    return LoadUnmanagedDllFromPath(candidate);
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Core/Modules/PluginLoaderOptions.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginLoaderOptions.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Provides configuration for the <see cref="PluginLoader"/>.
+/// </summary>
+public sealed class PluginLoaderOptions
+{
+    public PluginLoaderOptions(string rootDirectory, string extractionDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(rootDirectory))
+        {
+            throw new ArgumentException("Root directory must be provided", nameof(rootDirectory));
+        }
+
+        if (string.IsNullOrWhiteSpace(extractionDirectory))
+        {
+            throw new ArgumentException("Extraction directory must be provided", nameof(extractionDirectory));
+        }
+
+        RootDirectory = EnsureAbsolutePath(rootDirectory);
+        ExtractionDirectory = EnsureAbsolutePath(extractionDirectory);
+    }
+
+    /// <summary>
+    /// Gets the directory that contains plug-in packages.
+    /// </summary>
+    public string RootDirectory { get; }
+
+    /// <summary>
+    /// Gets the directory used to extract plug-in archives.
+    /// </summary>
+    public string ExtractionDirectory { get; }
+
+    /// <summary>
+    /// Creates options using the provided configuration.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The options instance.</returns>
+    public static PluginLoaderOptions FromConfiguration(IConfiguration configuration)
+    {
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        var baseDirectory = AppContext.BaseDirectory;
+        var root = configuration["Plugins:Directory"];
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = Path.Combine(baseDirectory, "Plugins");
+        }
+        else if (!Path.IsPathRooted(root))
+        {
+            root = Path.Combine(baseDirectory, root);
+        }
+
+        var extractionRoot = configuration["Plugins:ExtractionRoot"];
+        if (string.IsNullOrWhiteSpace(extractionRoot))
+        {
+            extractionRoot = Path.Combine(baseDirectory, "PluginCache");
+        }
+        else if (!Path.IsPathRooted(extractionRoot))
+        {
+            extractionRoot = Path.Combine(baseDirectory, extractionRoot);
+        }
+
+        return new PluginLoaderOptions(root, extractionRoot);
+    }
+
+    private static string EnsureAbsolutePath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        Directory.CreateDirectory(fullPath);
+        return fullPath;
+    }
+}

--- a/DesktopApplicationTemplate.Core/Modules/PluginManifest.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginManifest.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Represents the metadata that describes a plug-in package.
+/// </summary>
+public sealed class PluginManifest
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the plug-in.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the human-friendly display name for the plug-in.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the semantic version of the plug-in.
+    /// </summary>
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the primary assembly that defines the plug-in entry point.
+    /// </summary>
+    public string EntryAssembly { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the assemblies that should be scanned for <see cref="IServiceModule"/> implementations.
+    /// When empty, <see cref="EntryAssembly"/> is used.
+    /// </summary>
+    public List<string> ServiceAssemblies { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets optional probing paths, relative to the plug-in root, where dependencies should be resolved from.
+    /// </summary>
+    public List<string> ProbingPaths { get; set; } = new();
+}

--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common;
@@ -35,7 +37,46 @@ namespace DesktopApplicationTemplate.Service
 
             return builder.ConfigureServices((hostContext, services) =>
             {
-                services.AddServiceModules();
+                var configuration = hostContext.Configuration;
+                var loggerFactory = LoggerFactory.Create(loggingBuilder =>
+                {
+                    loggingBuilder
+                        .AddConfiguration(configuration.GetSection("Logging"))
+                        .AddDebug()
+                        .AddConsole();
+                });
+
+                var pluginLoader = PluginLoader.Create(configuration, loggerFactory.CreateLogger<PluginLoader>());
+                IReadOnlyCollection<Assembly> pluginAssemblies;
+                try
+                {
+                    pluginAssemblies = pluginLoader.LoadPluginAssemblies();
+                    loggerFactory
+                        .CreateLogger<Program>()
+                        .LogInformation(
+                            "Loaded {PluginAssemblyCount} plug-in assembly(ies) from {PluginDirectory}.",
+                            pluginAssemblies.Count,
+                            pluginLoader.Options.RootDirectory);
+                }
+                catch (Exception ex)
+                {
+                    loggerFactory
+                        .CreateLogger<Program>()
+                        .LogError(
+                            ex,
+                            "Failed to load plug-ins from {PluginDirectory}.",
+                            pluginLoader.Options.RootDirectory);
+                    pluginAssemblies = Array.Empty<Assembly>();
+                }
+                finally
+                {
+                    loggerFactory.Dispose();
+                }
+
+                services.AddSingleton(pluginLoader.Options);
+
+                var assembliesForScanning = PluginLoader.CombineWithDefaultAssemblies(pluginAssemblies);
+                services.AddServiceModules(assembliesForScanning.ToArray());
                 services.AddCommonServices();
                 services.AddOptions<HeartbeatRuntimeOptions>()
                     .BindConfiguration("Heartbeat");

--- a/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
+++ b/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 

--- a/DesktopApplicationTemplate.Tests/PluginLoaderIntegrationTests.cs
+++ b/DesktopApplicationTemplate.Tests/PluginLoaderIntegrationTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public sealed class PluginLoaderIntegrationTests : IDisposable
+{
+    private readonly string rootPath;
+
+    public PluginLoaderIntegrationTests()
+    {
+        rootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+    }
+
+    [Fact]
+    public void LoaderRegistersDescriptorsFromPluginArchive()
+    {
+        var pluginSource = Path.Combine(rootPath, "package");
+        Directory.CreateDirectory(pluginSource);
+
+        var pluginsDirectory = Path.Combine(rootPath, "plugins");
+        Directory.CreateDirectory(pluginsDirectory);
+
+        var extractionDirectory = Path.Combine(rootPath, "cache");
+
+        var assemblyPath = Path.Combine(pluginSource, "SamplePlugin.dll");
+        CompilePluginAssembly(assemblyPath);
+
+        var manifestPath = Path.Combine(pluginSource, "plugin.manifest.json");
+        File.WriteAllText(manifestPath, CreateManifestJson());
+
+        var archivePath = Path.Combine(pluginsDirectory, "SamplePlugin.zip");
+        ZipFile.CreateFromDirectory(pluginSource, archivePath);
+
+        var options = new PluginLoaderOptions(pluginsDirectory, extractionDirectory);
+        var loader = new PluginLoader(options, NullLogger<PluginLoader>.Instance);
+        var pluginAssemblies = loader.LoadPluginAssemblies();
+
+        pluginAssemblies.Should().NotBeEmpty();
+
+        var services = new ServiceCollection();
+        var assembliesForScanning = PluginLoader.CombineWithDefaultAssemblies(pluginAssemblies);
+        var catalog = services.AddServiceModules(assembliesForScanning.ToArray());
+
+        catalog.Descriptors.Should().Contain(descriptor => descriptor.Id == "Sample.Plugin.Service");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(rootPath))
+        {
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    private static void CompilePluginAssembly(string outputPath)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(@"
+using System;
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SamplePlugin;
+
+public sealed class SamplePluginModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new SampleDescriptor();
+    }
+
+    private sealed class SampleDescriptor : IServiceDescriptor
+    {
+        public string Id => \"Sample.Plugin.Service\";
+        public string DisplayName => \"Sample Plugin Service\";
+        public string Category => \"Plugins\";
+        public string? Description => \"Sample descriptor\";
+        public ServiceType? LegacyType => null;
+        public IServiceOptionsSerializer? OptionsSerializer => null;
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+        public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;
+        public bool HasPayloadDescription => false;
+        public string? DescribePayload(object? payload) => null;
+    }
+}
+");
+
+        var references = GetCompilationReferences();
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(outputPath),
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var result = compilation.Emit(outputPath);
+        if (!result.Success)
+        {
+            var diagnostics = string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString()));
+            throw new InvalidOperationException($"Failed to build sample plug-in: {diagnostics}");
+        }
+    }
+
+    private static IEnumerable<MetadataReference> GetCompilationReferences()
+    {
+        var assemblies = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location));
+
+        return assemblies.Select(assembly => MetadataReference.CreateFromFile(assembly.Location));
+    }
+
+    private static string CreateManifestJson() => @"{
+  \"id\": \"Sample.Plugin\",
+  \"name\": \"Sample Plugin\",
+  \"version\": \"1.0.0\",
+  \"entryAssembly\": \"SamplePlugin.dll\",
+  \"serviceAssemblies\": [ \"SamplePlugin.dll\" ]
+}";
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -59,7 +59,45 @@ namespace DesktopApplicationTemplate.UI
 
         private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
-            var catalog = services.AddServiceModules();
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddConfiguration(configuration.GetSection("Logging"))
+                    .AddDebug()
+                    .AddConsole();
+            });
+
+            var pluginLoader = PluginLoader.Create(configuration, loggerFactory.CreateLogger<PluginLoader>());
+            IReadOnlyCollection<Assembly> pluginAssemblies;
+            try
+            {
+                pluginAssemblies = pluginLoader.LoadPluginAssemblies();
+                loggerFactory
+                    .CreateLogger<App>()
+                    .LogInformation(
+                        "Loaded {PluginAssemblyCount} plug-in assembly(ies) from {PluginDirectory}.",
+                        pluginAssemblies.Count,
+                        pluginLoader.Options.RootDirectory);
+            }
+            catch (Exception ex)
+            {
+                loggerFactory
+                    .CreateLogger<App>()
+                    .LogError(
+                        ex,
+                        "Failed to load plug-ins from {PluginDirectory}.",
+                        pluginLoader.Options.RootDirectory);
+                pluginAssemblies = Array.Empty<Assembly>();
+            }
+            finally
+            {
+                loggerFactory.Dispose();
+            }
+
+            services.AddSingleton(pluginLoader.Options);
+
+            var assembliesForScanning = PluginLoader.CombineWithDefaultAssemblies(pluginAssemblies);
+            var catalog = services.AddServiceModules(assembliesForScanning.ToArray());
             var registrations = InitializeServices(services, catalog);
 
             services.AddSingleton<IServiceUiRegistry>(sp => ServiceUiRegistry.Create(sp, catalog, registrations));


### PR DESCRIPTION
## Summary
- add a PluginLoader service that validates plug-in manifests, extracts archives, and loads assemblies with isolated AssemblyLoadContexts
- integrate the loader into both the desktop and service hosts so plug-in assemblies are scanned before module discovery, logging successes and failures
- document the plug-in manifest schema and add an integration test that verifies a packaged plug-in registers its descriptor

## Testing
- not run (windows-specific test suite)


------
https://chatgpt.com/codex/tasks/task_e_68dd2bb7b6ac8326b27d479f22160be1