### PR TITLE
Add service plug-in packaging infrastructure and samples

### DIFF
--- a/Codex/docs/CustomServiceGuide.md
+++ b/Codex/docs/CustomServiceGuide.md
@@ -38,3 +38,15 @@ Modules are discovered at startup by calling `services.AddServiceModules()` duri
 4. **Implement an `IServiceModule`** – register the service, view models, and views with the DI container.
 5. **Wire up navigation** – add create and edit handlers or factory entries so the main window can navigate to the new views.
 6. **Test and document** – run `dotnet` commands and update docs as needed.
+
+## Package and distribute plug-ins
+
+1. **Import the packaging targets** – reference `ServicePlugin.Packaging` by adding the props/targets pair to the plug-in `.csproj`. This enables the `PackServicePlugin` target after every build.
+2. **Author `plugin.manifest.json`** – populate the manifest with the plug-in id, name, version, entry assembly, and any assemblies that expose `IServiceModule` implementations. The loader validates the manifest against the schema documented in `Codex/docs/PluginManifestSchema.md`.
+3. **Build to create archives** – run `dotnet build` for the plug-in. The packaging target copies the manifest, compiled assemblies, and dependencies into `.ccp` and `.chapp` archives under `bin/<configuration>/<tfm>/plugins`.
+4. **Distribute the archive** – drop the generated archive into the host's plug-in directory (or publish it via your preferred channel). The loader extracts each archive into its versioned cache and automatically registers the descriptors.
+
+### Reusable resources
+
+- **Template** – `Templates/ServicePluginTemplate` exposes a `dotnet new codex-serviceplugin` template that scaffolds a descriptor, runtime factory, manifest, and packaging imports.
+- **Samples** – `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` provide ready-to-build examples that produce distributable archives during CI, making them ideal smoke tests for packaging changes.

--- a/DesktopApplicationTemplate.sln
+++ b/DesktopApplicationTemplate.sln
@@ -20,7 +20,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestCommon", "TestCommon\TestCommon.csproj", "{2D1E1965-95BB-4F93-AC82-BD76A28D2BE1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.Services.Common", "DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj", "{B5FBD6C7-8C2E-4A9F-B92F-5F8F41C3A5BB}"
-
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServicePlugin.Packaging", "ServicePlugin.Packaging\ServicePlugin.Packaging.csproj", "{F5F988AC-1954-4AB1-AF56-550B49AB3FC7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TcpRelayPlugin", "Samples\TcpRelayPlugin\TcpRelayPlugin.csproj", "{9418FD88-A3EC-4764-8E89-05B5F1BCEF02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpRelayPlugin", "Samples\HttpRelayPlugin\HttpRelayPlugin.csproj", "{384D53FF-4D25-4009-8AB7-6CEAECB954F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServicePluginTemplate", "Templates\ServicePluginTemplate\ServicePluginTemplate.csproj", "{1ED21731-2F3F-4A42-A9BD-8EA34C705B1C}"
 EndProject
 
 Global
@@ -65,7 +72,23 @@ Global
                 {B5FBD6C7-8C2E-4A9F-B92F-5F8F41C3A5BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {B5FBD6C7-8C2E-4A9F-B92F-5F8F41C3A5BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {B5FBD6C7-8C2E-4A9F-B92F-5F8F41C3A5BB}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {F5F988AC-1954-4AB1-AF56-550B49AB3FC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F5F988AC-1954-4AB1-AF56-550B49AB3FC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F5F988AC-1954-4AB1-AF56-550B49AB3FC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F5F988AC-1954-4AB1-AF56-550B49AB3FC7}.Release|Any CPU.Build.0 = Release|Any CPU
+                {9418FD88-A3EC-4764-8E89-05B5F1BCEF02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9418FD88-A3EC-4764-8E89-05B5F1BCEF02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9418FD88-A3EC-4764-8E89-05B5F1BCEF02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9418FD88-A3EC-4764-8E89-05B5F1BCEF02}.Release|Any CPU.Build.0 = Release|Any CPU
+                {384D53FF-4D25-4009-8AB7-6CEAECB954F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {384D53FF-4D25-4009-8AB7-6CEAECB954F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {384D53FF-4D25-4009-8AB7-6CEAECB954F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {384D53FF-4D25-4009-8AB7-6CEAECB954F4}.Release|Any CPU.Build.0 = Release|Any CPU
+                {1ED21731-2F3F-4A42-A9BD-8EA34C705B1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {1ED21731-2F3F-4A42-A9BD-8EA34C705B1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {1ED21731-2F3F-4A42-A9BD-8EA34C705B1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {1ED21731-2F3F-4A42-A9BD-8EA34C705B1C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -154,6 +154,28 @@ Dynamic DI modules are enabled by `services.AddServiceModules()`, which scans as
 
 4. Wire up navigation and edit handlers for the new `ServiceType` and document any changes.
 
+## Packaging service plug-ins
+
+The repository ships with an MSBuild packaging project that bundles plug-in assets into distributable `.ccp` and `.chapp` archives. To enable packaging in a plug-in project:
+
+1. Import `ServicePlugin.Packaging` before and after the project body:
+
+   ```xml
+   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props" />
+   ...
+   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" />
+   ```
+
+2. Author a `plugin.manifest.json` file at the project root. The manifest must identify the plug-in id, name, version, entry assembly, and any assemblies that expose `IServiceModule` implementations. See `Codex/docs/PluginManifestSchema.md` for field descriptions.
+3. Build the plug-in with `dotnet build`. The packaging targets run after compilation and emit archives to `bin/<configuration>/<tfm>/plugins`. Set `ServicePluginArchiveExtensions` to `.ccp`, `.chapp`, or both (the default).
+
+Each archive contains the manifest, compiled descriptors, and copy-local dependencies under `libs/`. Hosts can drop either archive into the plug-in directory and the loader will extract it into the cache configured by `PluginLoaderOptions`.
+
+### Templates and samples
+
+- **Template:** `Templates/ServicePluginTemplate` publishes a `dotnet new codex-serviceplugin` template that scaffolds a plug-in project with descriptor, runtime factory, manifest, and packaging imports. Install it locally with `dotnet new install Templates/ServicePluginTemplate` and scaffold new plug-ins under a folder where `..\..\ServicePlugin.Packaging` resolves to the repository root.
+- **Samples:** `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` demonstrate packaging refactored services. Both projects import `ServicePlugin.Packaging` and build `.ccp` / `.chapp` archives during CI. Use them as regression tests when evolving the packaging logic.
+
 ## Testing services locally
 
 After building the solution, run the UI project and navigate to the desired service page. Most services expose a test action (for example, "Send" on the HTTP page or "Test Script" on the TCP page) that can be executed locally. Logs for each service are displayed next to the editor fields.

--- a/Samples/HttpRelayPlugin/Descriptors/HttpRelayServiceDescriptor.cs
+++ b/Samples/HttpRelayPlugin/Descriptors/HttpRelayServiceDescriptor.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
+using HttpRelayPlugin.Runtime;
+
+namespace HttpRelayPlugin.Descriptors;
+
+public sealed class HttpRelayServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = "sample.services.http";
+
+    public HttpRelayServiceDescriptor(IServiceOptionsSerializer? optionsSerializer = null)
+        : base(
+            DescriptorId,
+            "Sample HTTP Relay",
+            "Networking",
+            "Demonstrates packaging the HTTP descriptor as a plug-in.",
+            ServiceType.Http,
+            optionsSerializer,
+            CreateFactories(),
+            new ServicePresentationMetadata(
+                "🌐",
+                "#FF2563EB",
+                "#FF1D4ED8",
+                "HTTP Relay"))
+    {
+    }
+
+    private static IReadOnlyCollection<ServiceFactoryBinding> CreateFactories() =>
+    [
+        ServiceFactoryBinding.Create(
+            ServiceFactoryKind.Runtime,
+            typeof(IServiceRuntimeFactory),
+            services => services.GetRequiredService<HttpRelayRuntimeFactory>())
+    ];
+}

--- a/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
+++ b/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props')" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>HttpRelayPlugin</AssemblyName>
+    <RootNamespace>HttpRelayPlugin</RootNamespace>
+    <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">Sample.HttpRelay</ServicePluginPackageId>
+    <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">1.0.0</ServicePluginPackageVersion>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp;.chapp</ServicePluginArchiveExtensions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
+    <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
+    <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />
+</Project>

--- a/Samples/HttpRelayPlugin/Modules/HttpRelayModule.cs
+++ b/Samples/HttpRelayPlugin/Modules/HttpRelayModule.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using HttpRelayPlugin.Descriptors;
+using HttpRelayPlugin.Runtime;
+
+namespace HttpRelayPlugin.Modules;
+
+public sealed class HttpRelayModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<HttpRelayRuntimeFactory>();
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new HttpRelayServiceDescriptor();
+    }
+}

--- a/Samples/HttpRelayPlugin/Runtime/HttpRelayRuntimeFactory.cs
+++ b/Samples/HttpRelayPlugin/Runtime/HttpRelayRuntimeFactory.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HttpRelayPlugin.Runtime;
+
+public sealed class HttpRelayRuntimeFactory : IServiceRuntimeFactory
+{
+    private readonly ILogger<HttpRelayRuntimeFactory> logger;
+
+    public HttpRelayRuntimeFactory(ILogger<HttpRelayRuntimeFactory> logger)
+    {
+        this.logger = logger;
+    }
+
+    public IServiceRuntime Create(ServiceRuntimeContext context) => new HttpRelayRuntime(logger, context);
+
+    private sealed class HttpRelayRuntime : IServiceRuntime
+    {
+        private readonly ILogger logger;
+        private readonly ServiceRuntimeContext context;
+
+        public HttpRelayRuntime(ILogger logger, ServiceRuntimeContext context)
+        {
+            this.logger = logger;
+            this.context = context;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            logger.LogInformation("Disposing HTTP relay runtime for {DescriptorId}.", context.DescriptorId);
+            return ValueTask.CompletedTask;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Starting HTTP relay runtime for {DescriptorId}.", context.DescriptorId);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Stopping HTTP relay runtime for {DescriptorId}.", context.DescriptorId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Samples/HttpRelayPlugin/plugin.manifest.json
+++ b/Samples/HttpRelayPlugin/plugin.manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "Sample.HttpRelay",
+  "name": "Sample HTTP Relay",
+  "version": "1.0.0",
+  "entryAssembly": "HttpRelayPlugin.dll",
+  "serviceAssemblies": [
+    "HttpRelayPlugin.dll"
+  ],
+  "probingPaths": [
+    "libs"
+  ]
+}

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -1,0 +1,8 @@
+# Plug-in Samples
+
+The `Samples` folder contains plug-in projects that exercise the `ServicePlugin.Packaging` MSBuild integration:
+
+1. **TcpRelayPlugin** packages a TCP descriptor and runtime factory that log lifecycle events.
+2. **HttpRelayPlugin** demonstrates the same workflow for an HTTP descriptor.
+
+Each project imports `ServicePlugin.Packaging` so building them produces `.ccp` and `.chapp` archives under `bin/<configuration>/<tfm>/plugins`. Use these samples to validate packaging changes locally or in CI pipelines by adding `dotnet build Samples/TcpRelayPlugin` and `dotnet build Samples/HttpRelayPlugin` to the workflow.

--- a/Samples/TcpRelayPlugin/Descriptors/TcpRelayServiceDescriptor.cs
+++ b/Samples/TcpRelayPlugin/Descriptors/TcpRelayServiceDescriptor.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.Services.Common.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
+using TcpRelayPlugin.Runtime;
+
+namespace TcpRelayPlugin.Descriptors;
+
+public sealed class TcpRelayServiceDescriptor : ServiceDescriptorBase
+{
+    public const string DescriptorId = "sample.services.tcp";
+
+    public TcpRelayServiceDescriptor(IServiceOptionsSerializer? optionsSerializer = null)
+        : base(
+            DescriptorId,
+            "Sample TCP Relay",
+            "Networking",
+            "Demonstrates packaging the TCP descriptor as a plug-in.",
+            ServiceType.Tcp,
+            optionsSerializer,
+            CreateFactories(),
+            new ServicePresentationMetadata(
+                "🔁",
+                "#FF0EA5E9",
+                "#FF1E3A8A",
+                "TCP Relay"))
+    {
+    }
+
+    private static IReadOnlyCollection<ServiceFactoryBinding> CreateFactories() =>
+    [
+        ServiceFactoryBinding.Create(
+            ServiceFactoryKind.Runtime,
+            typeof(IServiceRuntimeFactory),
+            services => services.GetRequiredService<TcpRelayRuntimeFactory>())
+    ];
+}

--- a/Samples/TcpRelayPlugin/Modules/TcpRelayModule.cs
+++ b/Samples/TcpRelayPlugin/Modules/TcpRelayModule.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using TcpRelayPlugin.Descriptors;
+using TcpRelayPlugin.Runtime;
+
+namespace TcpRelayPlugin.Modules;
+
+public sealed class TcpRelayModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<TcpRelayRuntimeFactory>();
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new TcpRelayServiceDescriptor();
+    }
+}

--- a/Samples/TcpRelayPlugin/Runtime/TcpRelayRuntimeFactory.cs
+++ b/Samples/TcpRelayPlugin/Runtime/TcpRelayRuntimeFactory.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace TcpRelayPlugin.Runtime;
+
+public sealed class TcpRelayRuntimeFactory : IServiceRuntimeFactory
+{
+    private readonly ILogger<TcpRelayRuntimeFactory> logger;
+
+    public TcpRelayRuntimeFactory(ILogger<TcpRelayRuntimeFactory> logger)
+    {
+        this.logger = logger;
+    }
+
+    public IServiceRuntime Create(ServiceRuntimeContext context) => new TcpRelayRuntime(logger, context);
+
+    private sealed class TcpRelayRuntime : IServiceRuntime
+    {
+        private readonly ILogger logger;
+        private readonly ServiceRuntimeContext context;
+
+        public TcpRelayRuntime(ILogger logger, ServiceRuntimeContext context)
+        {
+            this.logger = logger;
+            this.context = context;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            logger.LogInformation("Disposing TCP relay runtime for {DescriptorId}.", context.DescriptorId);
+            return ValueTask.CompletedTask;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Starting TCP relay runtime for {DescriptorId}.", context.DescriptorId);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Stopping TCP relay runtime for {DescriptorId}.", context.DescriptorId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
+++ b/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props')" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>TcpRelayPlugin</AssemblyName>
+    <RootNamespace>TcpRelayPlugin</RootNamespace>
+    <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">Sample.TcpRelay</ServicePluginPackageId>
+    <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">1.0.0</ServicePluginPackageVersion>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp;.chapp</ServicePluginArchiveExtensions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
+    <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
+    <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />
+</Project>

--- a/Samples/TcpRelayPlugin/plugin.manifest.json
+++ b/Samples/TcpRelayPlugin/plugin.manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "Sample.TcpRelay",
+  "name": "Sample TCP Relay",
+  "version": "1.0.0",
+  "entryAssembly": "TcpRelayPlugin.dll",
+  "serviceAssemblies": [
+    "TcpRelayPlugin.dll"
+  ],
+  "probingPaths": [
+    "libs"
+  ]
+}

--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.csproj
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.8.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.5" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Tasks\**\*.cs">
+      <DependentUpon></DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ServicePlugin.Packaging.props" Pack="true" PackagePath="build" />
+    <None Include="ServicePlugin.Packaging.targets" Pack="true" PackagePath="build" />
+  </ItemGroup>
+</Project>

--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.props
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <ServicePluginManifest Condition="'$(ServicePluginManifest)' == ''">$(MSBuildProjectDirectory)\plugin.manifest.json</ServicePluginManifest>
+    <ServicePluginPackageOutput Condition="'$(ServicePluginPackageOutput)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)plugins\</ServicePluginPackageOutput>
+    <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">$(AssemblyName)</ServicePluginPackageId>
+    <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">$(Version)</ServicePluginPackageVersion>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp</ServicePluginArchiveExtensions>
+    <ServicePluginIncludeReferenceCopyLocal Condition="'$(ServicePluginIncludeReferenceCopyLocal)' == ''">true</ServicePluginIncludeReferenceCopyLocal>
+    <ServicePluginIncludeEntryAssembly Condition="'$(ServicePluginIncludeEntryAssembly)' == ''">true</ServicePluginIncludeEntryAssembly>
+  </PropertyGroup>
+</Project>

--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.targets
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.targets
@@ -1,0 +1,68 @@
+<Project>
+  <UsingTask TaskName="ServicePlugin.Packaging.Tasks.CreateServicePluginArchive"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyName="ServicePlugin.Packaging.Tasks">
+    <Task>
+      <Reference Include="System" />
+      <Reference Include="System.Core" />
+      <Reference Include="System.Runtime" />
+      <Reference Include="System.IO.Compression" />
+      <Reference Include="Microsoft.Build.Framework" />
+      <Reference Include="Microsoft.Build.Utilities.Core" />
+      <Code Type="Class" Source="$(MSBuildThisFileDirectory)Tasks\CreateServicePluginArchive.cs" />
+    </Task>
+  </UsingTask>
+
+  <Target Name="PackServicePlugin" AfterTargets="Build" Condition="'$(ServicePluginEnablePackaging)' != 'false'">
+    <ItemGroup>
+      <_ServicePluginManifest Include="$(ServicePluginManifest)" Condition="Exists('$(ServicePluginManifest)')">
+        <PackagePath>plugin.manifest.json</PackagePath>
+        <Kind>Manifest</Kind>
+      </_ServicePluginManifest>
+
+      <_ServicePluginAssemblies Include="$(TargetPath)" Condition="'$(ServicePluginIncludeEntryAssembly)' == 'true' and Exists('$(TargetPath)')">
+        <PackagePath>%(Filename)%(Extension)</PackagePath>
+        <Kind>Assembly</Kind>
+      </_ServicePluginAssemblies>
+
+      <_ServicePluginAssemblies Include="@(ServicePluginDescriptorAssembly)" Condition="'%(Identity)' != ''">
+        <PackagePath Condition="'%(PackagePath)' == ''">%(Filename)%(Extension)</PackagePath>
+        <Kind Condition="'%(Kind)' == ''">Assembly</Kind>
+      </_ServicePluginAssemblies>
+
+      <_ServicePluginDependencies Include="@(ServicePluginDependency)" Condition="'%(Identity)' != ''">
+        <PackagePath Condition="'%(PackagePath)' == ''">libs/%(Filename)%(Extension)</PackagePath>
+        <Kind Condition="'%(Kind)' == ''">Dependency</Kind>
+      </_ServicePluginDependencies>
+
+      <_ServicePluginDependencies Include="@(ReferenceCopyLocalPaths)" Condition="'$(ServicePluginIncludeReferenceCopyLocal)' == 'true'">
+        <PackagePath>libs/%(Filename)%(Extension)</PackagePath>
+        <Kind>Dependency</Kind>
+      </_ServicePluginDependencies>
+
+      <_ServicePluginContent Include="@(ServicePluginContent)" Condition="'%(Identity)' != ''">
+        <PackagePath Condition="'%(PackagePath)' == ''">%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+        <Kind Condition="'%(Kind)' == ''">Content</Kind>
+      </_ServicePluginContent>
+
+      <_ServicePluginFiles Include="@(_ServicePluginManifest);@(_ServicePluginAssemblies);@(_ServicePluginDependencies);@(_ServicePluginContent)">
+        <PackagePath Condition="'%(PackagePath)' == ''">%(Filename)%(Extension)</PackagePath>
+      </_ServicePluginFiles>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_ResolvedPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">1.0.0</_ResolvedPackageVersion>
+      <_ResolvedPackageVersion Condition="'$(ServicePluginPackageVersion)' != ''">$(ServicePluginPackageVersion)</_ResolvedPackageVersion>
+    </PropertyGroup>
+
+    <CreateServicePluginArchive
+        Files="@(_ServicePluginFiles)"
+        OutputDirectory="$(ServicePluginPackageOutput)"
+        PackageId="$(ServicePluginPackageId)"
+        PackageVersion="$(_ResolvedPackageVersion)"
+        ArchiveExtensions="$(ServicePluginArchiveExtensions)"
+        BuildMetadataTimestampFormat="$(ServicePluginBuildMetadataTimestampFormat)">
+      <Output TaskParameter="CreatedPackages" ItemName="ServicePluginPackages" />
+    </CreateServicePluginArchive>
+  </Target>
+</Project>

--- a/ServicePlugin.Packaging/Tasks/CreateServicePluginArchive.cs
+++ b/ServicePlugin.Packaging/Tasks/CreateServicePluginArchive.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace ServicePlugin.Packaging.Tasks;
+
+/// <summary>
+/// Creates distributable plug-in archives containing descriptors, dependencies, and manifests.
+/// </summary>
+public sealed class CreateServicePluginArchive : Task
+{
+    private static readonly char[] ExtensionSeparators = [ ';' ];
+
+    [Required]
+    public ITaskItem[] Files { get; set; } = Array.Empty<ITaskItem>();
+
+    [Required]
+    public string OutputDirectory { get; set; } = string.Empty;
+
+    [Required]
+    public string PackageId { get; set; } = string.Empty;
+
+    [Required]
+    public string PackageVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the archive extensions (e.g. ".ccp;.chapp").
+    /// </summary>
+    [Required]
+    public string ArchiveExtensions { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional timestamp format appended to package versions.
+    /// </summary>
+    public string? BuildMetadataTimestampFormat { get; set; }
+
+    [Output]
+    public ITaskItem[] CreatedPackages { get; private set; } = Array.Empty<ITaskItem>();
+
+    public override bool Execute()
+    {
+        if (Files.Length == 0)
+        {
+            Log.LogError("No files were supplied to the plug-in packager.");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(PackageId))
+        {
+            Log.LogError("Service plug-in packages require a PackageId.");
+            return false;
+        }
+
+        var version = string.IsNullOrWhiteSpace(PackageVersion) ? "1.0.0" : PackageVersion.Trim();
+        if (!string.IsNullOrWhiteSpace(BuildMetadataTimestampFormat))
+        {
+            var timestamp = DateTimeOffset.UtcNow.ToString(BuildMetadataTimestampFormat, CultureInfo.InvariantCulture);
+            version = FormattableString.Invariant($"{version}+{timestamp}");
+        }
+
+        var extensions = ParseExtensions();
+        if (extensions.Count == 0)
+        {
+            Log.LogError("At least one archive extension must be specified.");
+            return false;
+        }
+
+        var manifestFound = false;
+        var packages = new List<ITaskItem>();
+
+        foreach (var extension in extensions)
+        {
+            var packagePath = CreateArchive(version, extension, ref manifestFound);
+            if (packagePath is null)
+            {
+                return false;
+            }
+
+            packages.Add(new TaskItem(packagePath));
+        }
+
+        if (!manifestFound)
+        {
+            Log.LogError("Plug-in packages must include a manifest. Mark the manifest item with metadata 'Kind=Manifest'.");
+            return false;
+        }
+
+        CreatedPackages = packages.ToArray();
+        return !Log.HasLoggedErrors;
+    }
+
+    private IReadOnlyCollection<string> ParseExtensions()
+    {
+        var entries = (ArchiveExtensions ?? string.Empty)
+            .Split(ExtensionSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .DefaultIfEmpty(".ccp")
+            .Select(NormalizeExtension)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return entries;
+    }
+
+    private static string NormalizeExtension(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ".ccp";
+        }
+
+        return value.StartsWith('.') ? value : $".{value}";
+    }
+
+    private string? CreateArchive(string version, string extension, ref bool manifestFound)
+    {
+        try
+        {
+            Directory.CreateDirectory(OutputDirectory);
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, showStackTrace: true);
+            return null;
+        }
+
+        var archiveFileName = $"{PackageId}-{version}{extension}";
+        var archivePath = Path.Combine(OutputDirectory, archiveFileName);
+
+        var stagingRoot = Path.Combine(Path.GetTempPath(), $"ServicePlugin_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(stagingRoot);
+
+        try
+        {
+            foreach (var file in Files)
+            {
+                var sourcePath = file.ItemSpec;
+                if (!File.Exists(sourcePath))
+                {
+                    Log.LogError($"Packaged file '{sourcePath}' does not exist.");
+                    return null;
+                }
+
+                var packagePath = file.GetMetadata("PackagePath");
+                if (string.IsNullOrWhiteSpace(packagePath))
+                {
+                    packagePath = Path.GetFileName(sourcePath);
+                }
+
+                if (string.Equals(file.GetMetadata("Kind"), "Manifest", StringComparison.OrdinalIgnoreCase))
+                {
+                    manifestFound = true;
+                }
+
+                var destinationPath = Path.Combine(stagingRoot, packagePath);
+                var destinationDirectory = Path.GetDirectoryName(destinationPath);
+                if (!string.IsNullOrEmpty(destinationDirectory))
+                {
+                    Directory.CreateDirectory(destinationDirectory);
+                }
+
+                File.Copy(sourcePath, destinationPath, overwrite: true);
+            }
+
+            if (File.Exists(archivePath))
+            {
+                File.Delete(archivePath);
+            }
+
+            ZipFile.CreateFromDirectory(stagingRoot, archivePath, CompressionLevel.Optimal, includeBaseDirectory: false);
+            Log.LogMessage(MessageImportance.High, $"Created service plug-in archive: {archivePath}");
+            return archivePath;
+        }
+        catch (Exception ex)
+        {
+            Log.LogErrorFromException(ex, showStackTrace: true);
+            return null;
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(stagingRoot))
+                {
+                    Directory.Delete(stagingRoot, recursive: true);
+                }
+            }
+            catch (Exception cleanupEx)
+            {
+                Log.LogWarning($"Failed to clean staging directory '{stagingRoot}': {cleanupEx.Message}");
+            }
+        }
+    }
+}

--- a/Templates/ServicePluginTemplate/.template.config/template.json
+++ b/Templates/ServicePluginTemplate/.template.config/template.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "DesktopApplicationTemplate maintainers",
+  "classifications": [
+    "Codex",
+    "Service",
+    "Plugin"
+  ],
+  "identity": "DesktopApplicationTemplate.ServicePlugin",
+  "name": "Codex Service Plug-in",
+  "shortName": "codex-serviceplugin",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "ServicePluginTemplate",
+  "preferNameDirectory": true,
+  "symbols": {
+    "pluginId": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "__PluginId__",
+      "defaultValue": "Contoso.Telemetry",
+      "description": "Stable identifier used by the plug-in manifest."
+    },
+    "pluginName": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "__PluginName__",
+      "defaultValue": "Contoso Telemetry Services",
+      "description": "Human-friendly name surfaced in logs."
+    },
+    "pluginVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "__PluginVersion__",
+      "defaultValue": "1.0.0",
+      "description": "Semantic version for the plug-in archive."
+    },
+    "descriptorId": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "__DescriptorId__",
+      "defaultValue": "contoso.telemetry.service",
+      "description": "Identifier for the sample descriptor implementation."
+    },
+    "descriptorCategory": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "__DescriptorCategory__",
+      "defaultValue": "Telemetry",
+      "description": "Category displayed in the host UI."
+    }
+  }
+}

--- a/Templates/ServicePluginTemplate/Descriptors/TemplateServiceDescriptor.cs
+++ b/Templates/ServicePluginTemplate/Descriptors/TemplateServiceDescriptor.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace ServicePluginTemplate.Descriptors;
+
+/// <summary>
+/// Demonstrates how a service descriptor advertises runtime capabilities and UI metadata.
+/// </summary>
+public sealed class TemplateServiceDescriptor : IServiceDescriptor
+{
+    private static readonly IReadOnlyCollection<ServiceFactoryBinding> DescriptorFactories = new[]
+    {
+        ServiceFactoryBinding.Create(
+            ServiceFactoryKind.Runtime,
+            typeof(IServiceRuntimeFactory),
+            serviceProvider => serviceProvider.GetService(typeof(Runtime.TemplateRuntimeFactory))
+                ?? throw new InvalidOperationException("Template runtime factory is not registered."))
+    };
+
+    public string Id => "__DescriptorId__";
+
+    public string DisplayName => "__PluginName__";
+
+    public string Category => "__DescriptorCategory__";
+
+    public string? Description => "Demonstrates how to advertise runtime services from a plug-in package.";
+
+    public ServiceType? LegacyType => null;
+
+    public IServiceOptionsSerializer? OptionsSerializer => null;
+
+    public IReadOnlyCollection<ServiceFactoryBinding> Factories => DescriptorFactories;
+
+    public ServicePresentationMetadata Presentation => new(
+        IconGlyph: "\uE7F8",
+        PrimaryAccentColor: "#2563EB",
+        SecondaryAccentColor: "#93C5FD",
+        DisplayLabel: "__PluginName__");
+
+    public bool HasPayloadDescription => false;
+
+    public string? DescribePayload(object? payload) => null;
+}

--- a/Templates/ServicePluginTemplate/Modules/TemplateServiceModule.cs
+++ b/Templates/ServicePluginTemplate/Modules/TemplateServiceModule.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using ServicePluginTemplate.Descriptors;
+using ServicePluginTemplate.Runtime;
+
+namespace ServicePluginTemplate.Modules;
+
+/// <summary>
+/// Registers dependencies and descriptors exposed by the sample plug-in.
+/// </summary>
+public sealed class TemplateServiceModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<TemplateRuntimeFactory>();
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new TemplateServiceDescriptor();
+    }
+}

--- a/Templates/ServicePluginTemplate/README.md
+++ b/Templates/ServicePluginTemplate/README.md
@@ -1,0 +1,25 @@
+# Codex Service Plug-in Template
+
+This template demonstrates how to build a service plug-in that can be packaged with the `ServicePlugin.Packaging` project. It implements:
+
+1. A manifest (`plugin.manifest.json`) that is zipped into `.ccp` and `.chapp` archives.
+2. An `IServiceModule` (`TemplateServiceModule`) that registers runtime dependencies.
+3. A descriptor (`TemplateServiceDescriptor`) that advertises runtime bindings.
+4. A runtime factory (`TemplateRuntimeFactory`) that logs lifecycle events.
+
+Install the template locally and scaffold a new plug-in within the repository root:
+
+```bash
+# From the repository root
+dotnet new install Templates/ServicePluginTemplate
+mkdir Plugins
+cd Plugins
+dotnet new codex-serviceplugin -n Contoso.Telemetry.Plugin \
+  --pluginId Contoso.Telemetry \
+  --pluginName "Contoso Telemetry" \
+  --pluginVersion 1.0.0 \
+  --descriptorId contoso.telemetry.service \
+  --descriptorCategory Telemetry
+```
+
+The generated project automatically imports `ServicePlugin.Packaging` so building the project produces distributable archives under `bin/<configuration>/<tfm>/plugins`.

--- a/Templates/ServicePluginTemplate/Runtime/TemplateRuntimeFactory.cs
+++ b/Templates/ServicePluginTemplate/Runtime/TemplateRuntimeFactory.cs
@@ -1,0 +1,51 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace ServicePluginTemplate.Runtime;
+
+/// <summary>
+/// Provides a sample runtime workflow that logs lifecycle events.
+/// </summary>
+public sealed class TemplateRuntimeFactory : IServiceRuntimeFactory
+{
+    private readonly ILogger<TemplateRuntimeFactory> logger;
+
+    public TemplateRuntimeFactory(ILogger<TemplateRuntimeFactory> logger)
+    {
+        this.logger = logger;
+    }
+
+    public IServiceRuntime Create(ServiceRuntimeContext context) => new TemplateServiceRuntime(logger, context);
+
+    private sealed class TemplateServiceRuntime : IServiceRuntime
+    {
+        private readonly ILogger logger;
+        private readonly ServiceRuntimeContext context;
+
+        public TemplateServiceRuntime(ILogger logger, ServiceRuntimeContext context)
+        {
+            this.logger = logger;
+            this.context = context;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            logger.LogInformation("Disposing runtime for {DescriptorId}.", context.DescriptorId);
+            return ValueTask.CompletedTask;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Starting sample runtime for {DescriptorId}.", context.DescriptorId);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Stopping sample runtime for {DescriptorId}.", context.DescriptorId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Templates/ServicePluginTemplate/ServicePluginTemplate.csproj
+++ b/Templates/ServicePluginTemplate/ServicePluginTemplate.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.props')" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>ServicePluginTemplate</AssemblyName>
+    <RootNamespace>ServicePluginTemplate</RootNamespace>
+    <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">__PluginId__</ServicePluginPackageId>
+    <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">__PluginVersion__</ServicePluginPackageVersion>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp;.chapp</ServicePluginArchiveExtensions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
+    <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />
+</Project>

--- a/Templates/ServicePluginTemplate/plugin.manifest.json
+++ b/Templates/ServicePluginTemplate/plugin.manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "__PluginId__",
+  "name": "__PluginName__",
+  "version": "__PluginVersion__",
+  "entryAssembly": "ServicePluginTemplate.dll",
+  "serviceAssemblies": [
+    "ServicePluginTemplate.dll"
+  ],
+  "probingPaths": [
+    "libs"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the ServicePlugin.Packaging MSBuild project with inline packaging task that emits .ccp/.chapp archives from compiled descriptors, dependencies, and manifests
- publish a ServicePluginTemplate dotnet new template that scaffolds a descriptor, runtime factory, manifest, and packaging configuration
- create TcpRelayPlugin and HttpRelayPlugin sample projects that build distributable plug-in archives and document the packaging workflow in the README and CustomServiceGuide

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd2f3808a883269378140a51104328