### PR TITLE
Add plugin import workflow and descriptor refresh

### DIFF
--- a/DesktopApplicationTemplate.Core/Modules/ServiceModuleDiscovery.cs
+++ b/DesktopApplicationTemplate.Core/Modules/ServiceModuleDiscovery.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Provides helpers for discovering and instantiating <see cref="IServiceModule"/> implementations.
+/// </summary>
+public static class ServiceModuleDiscovery
+{
+    /// <summary>
+    /// Creates module instances from the provided assemblies.
+    /// </summary>
+    /// <param name="assemblies">The assemblies to scan.</param>
+    /// <returns>The instantiated modules.</returns>
+    public static IReadOnlyList<IServiceModule> InstantiateModules(IEnumerable<Assembly> assemblies)
+    {
+        if (assemblies is null)
+        {
+            throw new ArgumentNullException(nameof(assemblies));
+        }
+
+        var moduleType = typeof(IServiceModule);
+        return assemblies
+            .SelectMany(static assembly => assembly?.GetTypes() ?? Array.Empty<Type>())
+            .Where(type => moduleType.IsAssignableFrom(type) && !type.IsAbstract && !type.IsInterface)
+            .Select(Activator.CreateInstance)
+            .OfType<IServiceModule>()
+            .ToList();
+    }
+
+    /// <summary>
+    /// Invokes <see cref="IServiceModule.RegisterServices(IServiceCollection)"/> for the provided modules.
+    /// </summary>
+    /// <param name="modules">The modules to register.</param>
+    /// <param name="services">The service collection to populate.</param>
+    public static void RegisterModules(IEnumerable<IServiceModule> modules, IServiceCollection services)
+    {
+        if (modules is null)
+        {
+            throw new ArgumentNullException(nameof(modules));
+        }
+
+        if (services is null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        foreach (var module in modules)
+        {
+            module.RegisterServices(services);
+        }
+    }
+
+    /// <summary>
+    /// Collects descriptors exposed by the provided modules.
+    /// </summary>
+    /// <param name="modules">The modules to inspect.</param>
+    /// <returns>The descriptors exported by the modules.</returns>
+    public static IReadOnlyCollection<IServiceDescriptor> DescribeServices(IEnumerable<IServiceModule> modules)
+    {
+        if (modules is null)
+        {
+            throw new ArgumentNullException(nameof(modules));
+        }
+
+        var descriptors = new List<IServiceDescriptor>();
+        foreach (var module in modules)
+        {
+            var moduleDescriptors = module.DescribeServices() ?? Enumerable.Empty<IServiceDescriptor>();
+            descriptors.AddRange(moduleDescriptors);
+        }
+
+        return descriptors;
+    }
+}

--- a/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Modules/ServiceModuleExtensions.cs
@@ -27,22 +27,9 @@ public static class ServiceModuleExtensions
             assemblies = AppDomain.CurrentDomain.GetAssemblies();
         }
 
-        var moduleType = typeof(IServiceModule);
-        var modules = assemblies
-            .SelectMany(a => a.GetTypes())
-            .Where(t => moduleType.IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface)
-            .Select(t => Activator.CreateInstance(t))
-            .OfType<IServiceModule>()
-            .ToList();
-
-        var descriptors = new List<IServiceDescriptor>();
-        foreach (var module in modules)
-        {
-            module.RegisterServices(services);
-            var moduleDescriptors = module.DescribeServices() ?? Enumerable.Empty<IServiceDescriptor>();
-            descriptors.AddRange(moduleDescriptors);
-        }
-
+        var modules = ServiceModuleDiscovery.InstantiateModules(assemblies);
+        ServiceModuleDiscovery.RegisterModules(modules, services);
+        var descriptors = ServiceModuleDiscovery.DescribeServices(modules);
         var catalog = new ServiceCatalog(descriptors);
         services.TryAddSingleton<IServiceCatalog>(_ => catalog);
         return catalog;

--- a/DesktopApplicationTemplate.Core/Services/IServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceCatalog.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using DesktopApplicationTemplate.Models;
 
@@ -14,6 +15,11 @@ public interface IServiceCatalog
     IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
 
     /// <summary>
+    /// Raised when the descriptor collection changes.
+    /// </summary>
+    event EventHandler? DescriptorsChanged;
+
+    /// <summary>
     /// Gets a mapping of legacy <see cref="ServiceType"/> values to descriptor identifiers.
     /// </summary>
     IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
@@ -27,4 +33,10 @@ public interface IServiceCatalog
     /// Attempts to retrieve a descriptor from a legacy <see cref="ServiceType"/>.
     /// </summary>
     bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor);
+
+    /// <summary>
+    /// Replaces the descriptor collection with the provided entries.
+    /// </summary>
+    /// <param name="descriptors">The descriptors to register.</param>
+    void UpdateDescriptors(IEnumerable<IServiceDescriptor> descriptors);
 }

--- a/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
@@ -10,58 +10,73 @@ namespace DesktopApplicationTemplate.Core.Services;
 /// </summary>
 public sealed class ServiceCatalog : IServiceCatalog
 {
-    private readonly IReadOnlyDictionary<string, IServiceDescriptor> _descriptorsById;
-    private readonly IReadOnlyDictionary<ServiceType, IServiceDescriptor> _descriptorsByLegacy;
-    private readonly IReadOnlyDictionary<ServiceType, string> _legacyMap;
+    private readonly object _sync = new();
+    private IReadOnlyDictionary<string, IServiceDescriptor> _descriptorsById = new Dictionary<string, IServiceDescriptor>(StringComparer.Ordinal);
+    private IReadOnlyDictionary<ServiceType, IServiceDescriptor> _descriptorsByLegacy = new Dictionary<ServiceType, IServiceDescriptor>();
+    private IReadOnlyDictionary<ServiceType, string> _legacyMap = new Dictionary<ServiceType, string>();
+    private IReadOnlyCollection<IServiceDescriptor> _descriptors = Array.Empty<IServiceDescriptor>();
 
     public ServiceCatalog(IEnumerable<IServiceDescriptor> descriptors)
     {
-        if (descriptors is null)
-        {
-            throw new ArgumentNullException(nameof(descriptors));
-        }
-
-        var builders = new Dictionary<string, ServiceDescriptorBuilder>(StringComparer.Ordinal);
-        foreach (var descriptor in descriptors)
-        {
-            if (!builders.TryGetValue(descriptor.Id, out var builder))
-            {
-                builder = new ServiceDescriptorBuilder(descriptor.Id);
-                builders.Add(descriptor.Id, builder);
-            }
-
-            builder.Merge(descriptor);
-        }
-
-        var snapshots = builders.Values.Select(b => b.Build()).ToList();
-
-        _descriptorsById = snapshots.ToDictionary(d => d.Id, d => (IServiceDescriptor)d, StringComparer.Ordinal);
-        var legacyLookup = new Dictionary<ServiceType, IServiceDescriptor>();
-        foreach (var descriptor in snapshots)
-        {
-            if (descriptor.LegacyType is { } legacy)
-            {
-                if (!legacyLookup.TryAdd(legacy, descriptor))
-                {
-                    throw new InvalidOperationException($"Legacy service type '{legacy}' is already mapped to descriptor '{legacyLookup[legacy].Id}'.");
-                }
-            }
-        }
-
-        _descriptorsByLegacy = legacyLookup;
-        _legacyMap = legacyLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id, StringComparer.Ordinal);
-        Descriptors = snapshots;
+        UpdateDescriptors(descriptors);
     }
 
-    public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
+    public IReadOnlyCollection<IServiceDescriptor> Descriptors => _descriptors;
 
     public IReadOnlyDictionary<ServiceType, string> LegacyMap => _legacyMap;
+
+    public event EventHandler? DescriptorsChanged;
 
     public bool TryGetById(string id, out IServiceDescriptor descriptor) =>
         _descriptorsById.TryGetValue(id, out descriptor!);
 
     public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) =>
         _descriptorsByLegacy.TryGetValue(legacyType, out descriptor!);
+
+    public void UpdateDescriptors(IEnumerable<IServiceDescriptor> descriptors)
+    {
+        if (descriptors is null)
+        {
+            throw new ArgumentNullException(nameof(descriptors));
+        }
+
+        lock (_sync)
+        {
+            var builders = new Dictionary<string, ServiceDescriptorBuilder>(StringComparer.Ordinal);
+            foreach (var descriptor in descriptors)
+            {
+                if (!builders.TryGetValue(descriptor.Id, out var builder))
+                {
+                    builder = new ServiceDescriptorBuilder(descriptor.Id);
+                    builders.Add(descriptor.Id, builder);
+                }
+
+                builder.Merge(descriptor);
+            }
+
+            var snapshots = builders.Values.Select(b => b.Build()).ToList();
+
+            var descriptorsById = snapshots.ToDictionary(d => d.Id, d => (IServiceDescriptor)d, StringComparer.Ordinal);
+            var legacyLookup = new Dictionary<ServiceType, IServiceDescriptor>();
+            foreach (var descriptor in snapshots)
+            {
+                if (descriptor.LegacyType is { } legacy)
+                {
+                    if (!legacyLookup.TryAdd(legacy, descriptor))
+                    {
+                        throw new InvalidOperationException($"Legacy service type '{legacy}' is already mapped to descriptor '{legacyLookup[legacy].Id}'.");
+                    }
+                }
+            }
+
+            _descriptorsById = descriptorsById;
+            _descriptorsByLegacy = legacyLookup;
+            _legacyMap = legacyLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id, StringComparer.Ordinal);
+            _descriptors = snapshots;
+        }
+
+        DescriptorsChanged?.Invoke(this, EventArgs.Empty);
+    }
 
     private sealed class ServiceDescriptorBuilder
     {

--- a/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/CreateServiceViewModelTests.cs
@@ -17,7 +17,7 @@ namespace DesktopApplicationTemplate.Tests
                 "service.test",
                 "Test",
                 ServiceType.Tcp,
-                new ServicePresentationMetadata("🧪", null, null, "Catalog Label"));
+                new ServicePresentationMetadata("🧪", "#123456", "#654321", "Catalog Label"));
             var catalog = new StubCatalog(descriptor);
 
             var vm = new CreateServiceViewModel(catalog);
@@ -27,6 +27,10 @@ namespace DesktopApplicationTemplate.Tests
             Assert.Equal("Catalog Label", metadata.DisplayLabel);
             Assert.Equal("🧪", metadata.IconGlyph);
             Assert.Equal(ServiceType.Tcp, metadata.LegacyType);
+            Assert.Equal("Test", metadata.Category);
+            Assert.Null(metadata.Description);
+            Assert.Equal("#123456", metadata.PrimaryAccentColor);
+            Assert.Equal("#654321", metadata.SecondaryAccentColor);
             ConsoleTestLogger.LogPass();
         }
 
@@ -55,21 +59,39 @@ namespace DesktopApplicationTemplate.Tests
 
             public StubCatalog(params IServiceDescriptor[] descriptors)
             {
-                _descriptorsById = descriptors.ToDictionary(d => d.Id, StringComparer.Ordinal);
-                _descriptorsByType = descriptors
-                    .Where(d => d.LegacyType.HasValue)
-                    .ToDictionary(d => d.LegacyType!.Value, d => d, EqualityComparer<ServiceType>.Default);
-                Descriptors = _descriptorsById.Values.ToArray();
-                LegacyMap = _descriptorsByType.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id);
+                _descriptorsById = new Dictionary<string, IServiceDescriptor>(StringComparer.Ordinal);
+                _descriptorsByType = new Dictionary<ServiceType, IServiceDescriptor>();
+                UpdateDescriptors(descriptors);
             }
 
-            public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; }
+            public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; private set; } = Array.Empty<IServiceDescriptor>();
 
-            public IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
+            public IReadOnlyDictionary<ServiceType, string> LegacyMap { get; private set; } = new Dictionary<ServiceType, string>();
+
+            public event EventHandler? DescriptorsChanged;
 
             public bool TryGetById(string id, out IServiceDescriptor descriptor) => _descriptorsById.TryGetValue(id, out descriptor!);
 
             public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) => _descriptorsByType.TryGetValue(legacyType, out descriptor!);
+
+            public void UpdateDescriptors(IEnumerable<IServiceDescriptor> descriptors)
+            {
+                _descriptorsById.Clear();
+                _descriptorsByType.Clear();
+                var snapshot = descriptors.ToArray();
+                foreach (var descriptor in snapshot)
+                {
+                    _descriptorsById[descriptor.Id] = descriptor;
+                    if (descriptor.LegacyType is { } legacy)
+                    {
+                        _descriptorsByType[legacy] = descriptor;
+                    }
+                }
+
+                Descriptors = snapshot;
+                LegacyMap = _descriptorsByType.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id);
+                DescriptorsChanged?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         private sealed class StubDescriptor : IServiceDescriptor

--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -145,9 +145,17 @@ internal sealed class StubCatalog : IServiceCatalog
 
     public IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
 
+    public event EventHandler? DescriptorsChanged
+    {
+        add { }
+        remove { }
+    }
+
     public bool TryGetById(string id, out IServiceDescriptor descriptor) => _descriptorsById.TryGetValue(id, out descriptor!);
 
     public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) => _descriptorsByType.TryGetValue(legacyType, out descriptor!);
+
+    public void UpdateDescriptors(IEnumerable<IServiceDescriptor> descriptors) => throw new NotSupportedException();
 
     private sealed class StubDescriptor : IServiceDescriptor
     {

--- a/DesktopApplicationTemplate.Tests/MainViewEditServiceTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewEditServiceTests.cs
@@ -29,7 +29,7 @@ public class MainViewEditServiceTests
         var mocks = Enum.GetValues<ServiceType>()
             .ToDictionary(t => t, _ => new Mock<IEditServiceHandler>());
         var dict = mocks.ToDictionary(k => k.Key, v => v.Value.Object);
-        var vm = new MainViewModel(csv, networkVm, network.Object, dict);
+        var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object, dict);
         var service = TestHelpers.CreateService(type, "svc");
 
         vm.EditServiceCommand.Execute(service);
@@ -57,7 +57,7 @@ public class MainViewEditServiceTests
         var mocks = Enum.GetValues<ServiceType>()
             .ToDictionary(t => t, _ => new Mock<IEditServiceHandler>());
         var dict = mocks.ToDictionary(k => k.Key, v => v.Value.Object);
-        var vm = new MainViewModel(csv, networkVm, network.Object, dict);
+        var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object, dict);
         var service = new ServiceListModel { Type = (ServiceType)999, DisplayName = "Unknown" };
 
         vm.EditServiceCommand.Execute(service);

--- a/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelFilterTests.cs
@@ -22,7 +22,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object);
             var svc1 = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
             svc1.IsActive = true;
             svc1.Order = 0;

--- a/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewModelTests.cs
@@ -16,6 +16,7 @@ using MQTTnet.Client;
 using Microsoft.Extensions.Options;
 using MQTTnet;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace DesktopApplicationTemplate.Tests
 {
@@ -28,7 +29,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object);
             var s1 = TestHelpers.CreateService(ServiceType.Http, "HTTP1");
             s1.IsActive = false;
             s1.Order = 0;
@@ -59,7 +60,7 @@ namespace DesktopApplicationTemplate.Tests
             var oldPath = ServicePersistence.FilePath;
             try
             {
-                var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>(), logger.Object, servicesPath);
+                var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object, loggingService: logger.Object, servicesFilePath: servicesPath);
                 var service = TestHelpers.CreateService(type, name);
                 vm.Services.Add(service);
                 vm.SelectedService = service;
@@ -87,7 +88,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object);
             var svc = TestHelpers.CreateService(type, name);
             svc.Logs.Add(new LogEntry { Message = "test" });
             vm.Services.Add(svc);
@@ -107,7 +108,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object);
             var svc = TestHelpers.CreateService(type, name);
             svc.Logs.Add(new LogEntry { Message = "first" });
             vm.Services.Add(svc);
@@ -130,7 +131,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object);
             bool raised = false;
             vm.PropertyChanged += (s, e) => { if (e.PropertyName == "DisplayLogs") raised = true; };
             var svc = TestHelpers.CreateService(type, name);
@@ -152,7 +153,7 @@ namespace DesktopApplicationTemplate.Tests
             var networkVm = new NetworkConfigurationViewModel(network.Object);
             var handler = new Mock<IEditServiceHandler>();
             var handlers = new Dictionary<ServiceType, IEditServiceHandler> { { ServiceType.Mqtt, handler.Object } };
-            var vm = new MainViewModel(csv, networkVm, network.Object, handlers);
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object, handlers);
             var svc = TestHelpers.CreateService(ServiceType.Mqtt, "Test");
             vm.Services.Add(svc);
 
@@ -162,10 +163,10 @@ namespace DesktopApplicationTemplate.Tests
             ConsoleTestLogger.LogPass();
         }
 
-        private class TestMainViewModel : MainViewModel
+        private sealed class TestMainViewModel : MainViewModel
         {
             public TestMainViewModel(CsvService csv, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService)
-                : base(csv, networkConfig, networkService, new Dictionary<ServiceType, IEditServiceHandler>())
+                : base(csv, networkConfig, networkService, new FakeServiceUiRegistry(), FakeServiceCatalog.CreateWithAllLegacyTypes(), new StubFileDialogService(), new TestPluginImportService())
             {
             }
 
@@ -174,6 +175,12 @@ namespace DesktopApplicationTemplate.Tests
                 Services.Add(svc);
                 OnPropertyChanged(nameof(ServicesCreated));
                 OnPropertyChanged(nameof(CurrentActiveServices));
+            }
+
+            private sealed class TestPluginImportService : IPluginImportService
+            {
+                public Task<PluginImportResult> ImportAsync(string sourcePath, CancellationToken cancellationToken = default)
+                    => Task.FromResult(new PluginImportResult(false, string.Empty, null, Array.Empty<IServiceDescriptor>()));
             }
         }
 
@@ -234,7 +241,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(new CsvViewerViewModel(new StubFileDialogService(), configPath));
             var network = new Mock<INetworkConfigurationService>();
             var networkVm = new NetworkConfigurationViewModel(network.Object);
-            var vm = new MainViewModel(csv, networkVm, network.Object, new Dictionary<ServiceType, IEditServiceHandler>());
+            var vm = TestHelpers.CreateMainViewModel(csv, networkVm, network.Object);
 
             bool raised = false;
             vm.AddServiceRequested += () => raised = true;

--- a/DesktopApplicationTemplate.Tests/PluginImportWorkflowTests.cs
+++ b/DesktopApplicationTemplate.Tests/PluginImportWorkflowTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.Tests;
+
+public sealed class PluginImportWorkflowTests : IDisposable
+{
+    private readonly string rootPath;
+
+    public PluginImportWorkflowTests()
+    {
+        rootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(rootPath);
+    }
+
+    [Fact]
+    public async Task ImportingPluginAddsDescriptorToCreateServiceViewModel()
+    {
+        var pluginSource = Path.Combine(rootPath, "plugin");
+        Directory.CreateDirectory(pluginSource);
+
+        var pluginsDirectory = Path.Combine(rootPath, "plugins");
+        Directory.CreateDirectory(pluginsDirectory);
+
+        var extractionDirectory = Path.Combine(rootPath, "cache");
+
+        var assemblyPath = Path.Combine(pluginSource, "SamplePlugin.dll");
+        CompilePluginAssembly(assemblyPath);
+
+        var manifestPath = Path.Combine(pluginSource, "plugin.manifest.json");
+        File.WriteAllText(manifestPath, CreateManifestJson());
+
+        var archivePath = Path.Combine(pluginsDirectory, "SamplePlugin.ccp");
+        ZipFile.CreateFromDirectory(pluginSource, archivePath);
+
+        var options = new PluginLoaderOptions(pluginsDirectory, extractionDirectory);
+        var catalog = new FakeServiceCatalog();
+        var loggerFactory = NullLoggerFactory.Instance;
+        var importService = new PluginImportService(options, catalog, NullLogger<PluginImportService>.Instance, loggerFactory);
+        var createViewModel = new CreateServiceViewModel(catalog);
+
+        Assert.Empty(createViewModel.ServiceDescriptors);
+
+        var result = await importService.ImportAsync(archivePath);
+        Assert.True(result.Success);
+        Assert.NotEmpty(result.ImportedDescriptors);
+
+        var metadata = Assert.Single(createViewModel.ServiceDescriptors);
+        Assert.Equal("Plugins", metadata.Category);
+        Assert.Equal("Demo descriptor", metadata.Description);
+        Assert.Equal("✨", metadata.IconGlyph);
+        Assert.Equal("#FF112233", metadata.PrimaryAccentColor);
+        Assert.Equal("#FF445566", metadata.SecondaryAccentColor);
+
+        ConsoleTestLogger.LogPass();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(rootPath))
+        {
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    private static void CompilePluginAssembly(string outputPath)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(@"
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SamplePlugin;
+
+public sealed class SamplePluginModule : IServiceModule
+{
+    public void RegisterServices(IServiceCollection services)
+    {
+    }
+
+    public IEnumerable<IServiceDescriptor> DescribeServices()
+    {
+        yield return new SampleDescriptor();
+    }
+
+    private sealed class SampleDescriptor : IServiceDescriptor
+    {
+        public string Id => \"Sample.Plugin.Service\";
+        public string DisplayName => \"Sample Plugin Service\";
+        public string Category => \"Plugins\";
+        public string? Description => \"Demo descriptor\";
+        public ServiceType? LegacyType => ServiceType.Tcp;
+        public IServiceOptionsSerializer? OptionsSerializer => null;
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories => System.Array.Empty<ServiceFactoryBinding>();
+        public ServicePresentationMetadata Presentation => new(\"✨\", \"#FF112233\", \"#FF445566\", \"Plugin Service\");
+        public bool HasPayloadDescription => false;
+        public string? DescribePayload(object? payload) => null;
+    }
+}
+");
+
+        var references = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+            .Select(assembly => MetadataReference.CreateFromFile(assembly.Location));
+
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(outputPath),
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var result = compilation.Emit(outputPath);
+        if (!result.Success)
+        {
+            var diagnostics = string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString()));
+            throw new InvalidOperationException($"Failed to build sample plug-in: {diagnostics}");
+        }
+    }
+
+    private static string CreateManifestJson() => @"{
+  \"id\": \"Sample.Plugin\",
+  \"name\": \"Sample Plugin\",
+  \"version\": \"1.0.0\",
+  \"entryAssembly\": \"SamplePlugin.dll\",
+  \"serviceAssemblies\": [ \"SamplePlugin.dll\" ]
+}";
+}

--- a/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServiceListModelTests.cs
@@ -55,7 +55,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(csvVm);
             var net = new StubNetworkService();
             var netVm = new NetworkConfigurationViewModel(net);
-            var main = new MainViewModel(csv, netVm, net, new Dictionary<ServiceType, IEditServiceHandler>(), servicesFilePath: Path.Combine(tempDir, "services.json"));
+            var main = TestHelpers.CreateMainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
             main.Services.Add(TestHelpers.CreateService(type, baseName));
             var secondName = baseName[..^1] + "2";
@@ -79,7 +79,7 @@ namespace DesktopApplicationTemplate.Tests
             var csv = new CsvService(csvVm);
             var net = new StubNetworkService();
             var netVm = new NetworkConfigurationViewModel(net);
-            var main = new MainViewModel(csv, netVm, net, new Dictionary<ServiceType, IEditServiceHandler>(), servicesFilePath: Path.Combine(tempDir, "services.json"));
+            var main = TestHelpers.CreateMainViewModel(csv, netVm, net, servicesFilePath: Path.Combine(tempDir, "services.json"));
 
             var svc1 = TestHelpers.CreateService(type, baseName);
             var svc2 = TestHelpers.CreateService(type, baseName[..^1] + "2");

--- a/DesktopApplicationTemplate.Tests/StubFileDialogService.cs
+++ b/DesktopApplicationTemplate.Tests/StubFileDialogService.cs
@@ -13,6 +13,6 @@ internal class StubFileDialogService : IFileDialogService
         _folderPath = folderPath;
     }
 
-    public string? OpenFile() => _filePath;
+    public string? OpenFile(string? filter = null, string? title = null) => _filePath;
     public string? SelectFolder() => _folderPath;
 }

--- a/DesktopApplicationTemplate.Tests/TestDoubles.cs
+++ b/DesktopApplicationTemplate.Tests/TestDoubles.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Navigation;
+using System.Windows.Controls;
+
+namespace DesktopApplicationTemplate.Tests;
+
+internal sealed class FakeServiceCatalog : IServiceCatalog
+{
+    private readonly Dictionary<string, IServiceDescriptor> descriptorsById = new(StringComparer.Ordinal);
+    private readonly Dictionary<ServiceType, IServiceDescriptor> descriptorsByLegacy = new();
+
+    public FakeServiceCatalog(IEnumerable<IServiceDescriptor>? descriptors = null)
+    {
+        UpdateDescriptors(descriptors ?? Array.Empty<IServiceDescriptor>());
+    }
+
+    public IReadOnlyCollection<IServiceDescriptor> Descriptors { get; private set; } = Array.Empty<IServiceDescriptor>();
+
+    public IReadOnlyDictionary<ServiceType, string> LegacyMap { get; private set; } = new Dictionary<ServiceType, string>();
+
+    public event EventHandler? DescriptorsChanged;
+
+    public bool TryGetById(string id, out IServiceDescriptor descriptor) => descriptorsById.TryGetValue(id, out descriptor!);
+
+    public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) => descriptorsByLegacy.TryGetValue(legacyType, out descriptor!);
+
+    public void UpdateDescriptors(IEnumerable<IServiceDescriptor> descriptors)
+    {
+        descriptorsById.Clear();
+        descriptorsByLegacy.Clear();
+        var snapshot = descriptors.ToArray();
+        foreach (var descriptor in snapshot)
+        {
+            descriptorsById[descriptor.Id] = descriptor;
+            if (descriptor.LegacyType is { } legacy)
+            {
+                descriptorsByLegacy[legacy] = descriptor;
+            }
+        }
+
+        Descriptors = snapshot;
+        LegacyMap = descriptorsByLegacy.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id);
+        DescriptorsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public static FakeServiceCatalog CreateWithAllLegacyTypes()
+    {
+        var descriptors = Enum.GetValues<ServiceType>()
+            .Select(type => new SimpleDescriptor(type.ToDescriptorId(), type.ToLegacyString(), type))
+            .Cast<IServiceDescriptor>();
+        return new FakeServiceCatalog(descriptors);
+    }
+
+    private sealed class SimpleDescriptor : IServiceDescriptor
+    {
+        public SimpleDescriptor(string id, string name, ServiceType legacyType)
+        {
+            Id = id;
+            DisplayName = name;
+            LegacyType = legacyType;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public string Category => "Test";
+
+        public string? Description => null;
+
+        public ServiceType? LegacyType { get; }
+
+        public IServiceOptionsSerializer? OptionsSerializer => null;
+
+        public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
+
+        public ServicePresentationMetadata Presentation => new(null, null, null, DisplayName);
+
+        public bool HasPayloadDescription => false;
+
+        public string? DescribePayload(object? payload) => null;
+    }
+}
+
+internal sealed class FakeServiceUiRegistry : IServiceUiRegistry
+{
+    public FakeServiceUiRegistry(
+        IReadOnlyDictionary<string, Func<Page>>? servicePages = null,
+        IReadOnlyDictionary<string, Func<INavigationHandler>>? navigationHandlers = null,
+        IReadOnlyDictionary<string, Func<IServiceFactory>>? factories = null,
+        IReadOnlyDictionary<string, Func<IEditServiceHandler>>? editHandlers = null)
+    {
+        ServicePages = servicePages ?? new Dictionary<string, Func<Page>>();
+        NavigationHandlers = navigationHandlers ?? new Dictionary<string, Func<INavigationHandler>>();
+        Factories = factories ?? new Dictionary<string, Func<IServiceFactory>>();
+        EditHandlers = editHandlers ?? new Dictionary<string, Func<IEditServiceHandler>>();
+    }
+
+    public IReadOnlyDictionary<string, Func<Page>> ServicePages { get; }
+
+    public IReadOnlyDictionary<string, Func<INavigationHandler>> NavigationHandlers { get; }
+
+    public IReadOnlyDictionary<string, Func<IServiceFactory>> Factories { get; }
+
+    public IReadOnlyDictionary<string, Func<IEditServiceHandler>> EditHandlers { get; }
+}

--- a/DesktopApplicationTemplate.Tests/TestHelpers.cs
+++ b/DesktopApplicationTemplate.Tests/TestHelpers.cs
@@ -1,6 +1,13 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.Navigation;
+using DesktopApplicationTemplate.UI.Factories;
 
 namespace DesktopApplicationTemplate.Tests;
 
@@ -12,4 +19,48 @@ public static class TestHelpers
         DescriptorId = type.ToDescriptorId(),
         DisplayName = $"{type.ToLegacyString()} - {name}"
     };
+
+    public static MainViewModel CreateMainViewModel(
+        CsvService csvService,
+        NetworkConfigurationViewModel networkConfig,
+        INetworkConfigurationService networkService,
+        IDictionary<ServiceType, IEditServiceHandler>? editHandlers = null,
+        ILoggingService? loggingService = null,
+        string? servicesFilePath = null,
+        IPluginImportService? pluginImportService = null,
+        FakeServiceCatalog? catalog = null,
+        IServiceUiRegistry? registry = null)
+    {
+        catalog ??= FakeServiceCatalog.CreateWithAllLegacyTypes();
+        var editHandlerFactories = new Dictionary<string, Func<IEditServiceHandler>>(StringComparer.Ordinal);
+        if (editHandlers != null)
+        {
+            foreach (var kvp in editHandlers)
+            {
+                var descriptorId = kvp.Key.ToDescriptorId();
+                editHandlerFactories[descriptorId] = () => kvp.Value;
+            }
+        }
+
+        registry ??= new FakeServiceUiRegistry(editHandlers: editHandlerFactories);
+        var fileDialog = new StubFileDialogService();
+        var importService = pluginImportService ?? new NullPluginImportService();
+
+        return new MainViewModel(
+            csvService,
+            networkConfig,
+            networkService,
+            registry,
+            catalog,
+            fileDialog,
+            importService,
+            loggingService,
+            servicesFilePath);
+    }
+
+    private sealed class NullPluginImportService : IPluginImportService
+    {
+        public Task<PluginImportResult> ImportAsync(string sourcePath, CancellationToken cancellationToken = default)
+            => Task.FromResult(new PluginImportResult(false, "Import not available in tests.", null, Array.Empty<IServiceDescriptor>()));
+    }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -111,6 +111,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<ILoggingService, LoggingService>();
             services.AddSingleton<IMessageRoutingService, MessageRoutingService>();
             services.AddSingleton<IFileDialogService, FileDialogService>();
+            services.AddSingleton<IPluginImportService, PluginImportService>();
             services.AddCommonServices();
             services.AddSingleton<SaveConfirmationHelper>();
             services.AddSingleton<CloseConfirmationHelper>();

--- a/DesktopApplicationTemplate.UI/Helpers/StringToBrushConverter.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/StringToBrushConverter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace DesktopApplicationTemplate.UI.Helpers;
+
+public sealed class StringToBrushConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var colorValue = value as string;
+        if (!string.IsNullOrWhiteSpace(colorValue))
+        {
+            try
+            {
+                return (Brush)new BrushConverter().ConvertFromString(colorValue)!;
+            }
+            catch (FormatException)
+            {
+                return Brushes.Transparent;
+            }
+        }
+
+        if (parameter is string fallback && !string.IsNullOrWhiteSpace(fallback))
+        {
+            try
+            {
+                return (Brush)new BrushConverter().ConvertFromString(fallback)!;
+            }
+            catch (FormatException)
+            {
+                return Brushes.Transparent;
+            }
+        }
+
+        return Brushes.Transparent;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => Binding.DoNothing;
+}

--- a/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
@@ -5,9 +5,13 @@ namespace DesktopApplicationTemplate.UI.Services
 {
     public class FileDialogService : IFileDialogService
     {
-        public string? OpenFile()
+        public string? OpenFile(string? filter = null, string? title = null)
         {
-            var dialog = new Microsoft.Win32.OpenFileDialog();
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Filter = string.IsNullOrWhiteSpace(filter) ? "All Files (*.*)|*.*" : filter,
+                Title = string.IsNullOrWhiteSpace(title) ? "Select File" : title
+            };
             return dialog.ShowDialog() == true ? dialog.FileName : null;
         }
 

--- a/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
@@ -5,7 +5,9 @@ namespace DesktopApplicationTemplate.UI.Services
         /// <summary>
         /// Opens a file selection dialog and returns the chosen file path or null if cancelled.
         /// </summary>
-        string? OpenFile();
+        /// <param name="filter">Optional filter applied to the dialog.</param>
+        /// <param name="title">Optional dialog title.</param>
+        string? OpenFile(string? filter = null, string? title = null);
 
         /// <summary>
         /// Opens a folder selection dialog and returns the chosen directory path or null if cancelled.

--- a/DesktopApplicationTemplate.UI/Services/IPluginImportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IPluginImportService.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.UI.Services;
+
+/// <summary>
+/// Imports plug-in packages and updates the service catalog.
+/// </summary>
+public interface IPluginImportService
+{
+    /// <summary>
+    /// Imports the specified plug-in archive.
+    /// </summary>
+    /// <param name="sourcePath">The source archive path.</param>
+    /// <param name="cancellationToken">An optional cancellation token.</param>
+    /// <returns>The result of the import operation.</returns>
+    Task<PluginImportResult> ImportAsync(string sourcePath, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Represents the outcome of a plug-in import operation.
+/// </summary>
+/// <param name="Success">Indicates whether the import succeeded.</param>
+/// <param name="Message">A user-friendly message describing the outcome.</param>
+/// <param name="DestinationPath">The destination path of the imported payload, if any.</param>
+/// <param name="ImportedDescriptors">Descriptors discovered during the import.</param>
+public sealed record PluginImportResult(
+    bool Success,
+    string Message,
+    string? DestinationPath,
+    IReadOnlyCollection<IServiceDescriptor> ImportedDescriptors);

--- a/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.UI.Services;
+
+/// <summary>
+/// Handles importing plug-in archives and refreshing the descriptor catalog.
+/// </summary>
+public sealed class PluginImportService : IPluginImportService
+{
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".ccp",
+        ".chapp",
+    };
+
+    private readonly PluginLoaderOptions _options;
+    private readonly IServiceCatalog _catalog;
+    private readonly ILogger<PluginImportService> _logger;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public PluginImportService(
+        PluginLoaderOptions options,
+        IServiceCatalog catalog,
+        ILogger<PluginImportService> logger,
+        ILoggerFactory loggerFactory)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+    }
+
+    public Task<PluginImportResult> ImportAsync(string sourcePath, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+        {
+            return Task.FromResult(new PluginImportResult(false, "No plug-in package was selected.", null, Array.Empty<IServiceDescriptor>()));
+        }
+
+        var extension = Path.GetExtension(sourcePath);
+        if (!SupportedExtensions.Contains(extension))
+        {
+            var message = $"Unsupported plug-in extension '{extension}'.";
+            _logger.LogWarning(message);
+            return Task.FromResult(new PluginImportResult(false, message, null, Array.Empty<IServiceDescriptor>()));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            Directory.CreateDirectory(_options.RootDirectory);
+            var fileName = Path.GetFileName(sourcePath);
+            var destinationPath = Path.Combine(_options.RootDirectory, fileName);
+
+            if (!PathsEqual(sourcePath, destinationPath))
+            {
+                _logger.LogInformation("Copying plug-in package {Source} to {Destination}.", sourcePath, destinationPath);
+                File.Copy(sourcePath, destinationPath, overwrite: true);
+            }
+
+            var loaderLogger = _loggerFactory.CreateLogger<PluginLoader>();
+            var loader = new PluginLoader(_options, loaderLogger);
+            IReadOnlyCollection<Assembly> pluginAssemblies = loader.LoadPluginAssemblies();
+
+            var modules = ServiceModuleDiscovery.InstantiateModules(pluginAssemblies);
+            var descriptors = ServiceModuleDiscovery.DescribeServices(modules);
+
+            if (descriptors.Count == 0)
+            {
+                var message = "The package did not expose any service descriptors.";
+                _logger.LogWarning(message);
+                return Task.FromResult(new PluginImportResult(false, message, destinationPath, Array.Empty<IServiceDescriptor>()));
+            }
+
+            var merged = new Dictionary<string, IServiceDescriptor>(StringComparer.Ordinal);
+            foreach (var descriptor in _catalog.Descriptors)
+            {
+                merged[descriptor.Id] = descriptor;
+            }
+
+            foreach (var descriptor in descriptors)
+            {
+                merged[descriptor.Id] = descriptor;
+            }
+
+            _catalog.UpdateDescriptors(merged.Values);
+
+            var successMessage = descriptors.Count == 1
+                ? "Imported 1 service descriptor."
+                : $"Imported {descriptors.Count} service descriptors.";
+            _logger.LogInformation("{Message} Package: {PackagePath}.", successMessage, destinationPath);
+
+            return Task.FromResult(new PluginImportResult(true, successMessage, destinationPath, descriptors));
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Plug-in import cancelled.");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to import plug-in package from {Source}.", sourcePath);
+            return Task.FromResult(new PluginImportResult(false, "Import failed. Check logs for details.", null, Array.Empty<IServiceDescriptor>()));
+        }
+    }
+
+    private static bool PathsEqual(string first, string second)
+    {
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), comparison);
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -9,7 +9,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class CreateServiceViewModel : ViewModelBase
     {
-        public record ServiceDescriptorMetadata(string DescriptorId, string DisplayLabel, string IconGlyph, ServiceType LegacyType);
+        public record ServiceDescriptorMetadata(
+            string DescriptorId,
+            string DisplayLabel,
+            string IconGlyph,
+            ServiceType? LegacyType,
+            string Category,
+            string? Description,
+            string PrimaryAccentColor,
+            string SecondaryAccentColor);
 
         private readonly IServiceCatalog _catalog;
         private readonly Dictionary<string, ServiceType> _descriptorLegacyTypes;
@@ -22,30 +30,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 ? new HashSet<string>(existingNames)
                 : new HashSet<string>();
 
-            var descriptorsWithLegacy = _catalog.Descriptors
-                .Where(descriptor => descriptor.LegacyType.HasValue)
-                .Select(descriptor =>
-                {
-                    var presentation = descriptor.Presentation;
-                    var displayLabel = !string.IsNullOrWhiteSpace(presentation.DisplayLabel)
-                        ? presentation.DisplayLabel!
-                        : descriptor.DisplayName;
-                    var iconGlyph = !string.IsNullOrWhiteSpace(presentation.IconGlyph)
-                        ? presentation.IconGlyph!
-                        : string.Empty;
-
-                    return new ServiceDescriptorMetadata(
-                        descriptor.Id,
-                        displayLabel,
-                        iconGlyph,
-                        descriptor.LegacyType!.Value);
-                })
-                .ToList();
-
-            _descriptorLegacyTypes = descriptorsWithLegacy
-                .ToDictionary(metadata => metadata.DescriptorId, metadata => metadata.LegacyType, StringComparer.Ordinal);
-
-            ServiceDescriptors = new ObservableCollection<ServiceDescriptorMetadata>(descriptorsWithLegacy);
+            _descriptorLegacyTypes = new Dictionary<string, ServiceType>(StringComparer.Ordinal);
+            ServiceDescriptors = new ObservableCollection<ServiceDescriptorMetadata>();
+            _catalog.DescriptorsChanged += (_, _) => RefreshServiceDescriptors();
+            RefreshServiceDescriptors();
         }
 
         public ObservableCollection<ServiceDescriptorMetadata> ServiceDescriptors { get; }
@@ -100,5 +88,52 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         // OnPropertyChanged provided by ViewModelBase
+
+        private void RefreshServiceDescriptors()
+        {
+            var descriptorsWithLegacy = _catalog.Descriptors
+                .Select(descriptor =>
+                {
+                    var presentation = descriptor.Presentation;
+                    var displayLabel = !string.IsNullOrWhiteSpace(presentation.DisplayLabel)
+                        ? presentation.DisplayLabel!
+                        : descriptor.DisplayName;
+                    var iconGlyph = !string.IsNullOrWhiteSpace(presentation.IconGlyph)
+                        ? presentation.IconGlyph!
+                        : string.Empty;
+                    var primary = !string.IsNullOrWhiteSpace(presentation.PrimaryAccentColor)
+                        ? presentation.PrimaryAccentColor!
+                        : string.Empty;
+                    var secondary = !string.IsNullOrWhiteSpace(presentation.SecondaryAccentColor)
+                        ? presentation.SecondaryAccentColor!
+                        : string.Empty;
+
+                    return new ServiceDescriptorMetadata(
+                        descriptor.Id,
+                        displayLabel,
+                        iconGlyph,
+                        descriptor.LegacyType,
+                        descriptor.Category,
+                        descriptor.Description,
+                        primary,
+                        secondary);
+                })
+                .ToList();
+
+            _descriptorLegacyTypes.Clear();
+            foreach (var metadata in descriptorsWithLegacy)
+            {
+                if (metadata.LegacyType is { } legacyType)
+                {
+                    _descriptorLegacyTypes[metadata.DescriptorId] = legacyType;
+                }
+            }
+
+            ServiceDescriptors.Clear();
+            foreach (var metadata in descriptorsWithLegacy)
+            {
+                ServiceDescriptors.Add(metadata);
+            }
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -38,11 +38,31 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 LogViewModel.SetLogs(_selectedService?.Logs ?? AllLogs);
                 (RemoveServiceCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
                 (EditServiceCommand as RelayCommand<ServiceListModel?>)?.RaiseCanExecuteChanged();
-            }
+}
+
+    public enum ImportFeedbackStatus
+    {
+        Success,
+        Error
+    }
+
+    public sealed class ImportFeedbackEventArgs : EventArgs
+    {
+        public ImportFeedbackEventArgs(ImportFeedbackStatus status, string message)
+        {
+            Status = status;
+            Message = message ?? throw new ArgumentNullException(nameof(message));
         }
+
+        public ImportFeedbackStatus Status { get; }
+
+        public string Message { get; }
+    }
+}
         public ICommand AddServiceCommand { get; }
         public ICommand RemoveServiceCommand { get; }
         public ICommand EditServiceCommand { get; }
+        public ICommand ImportServiceCommand { get; }
         public int ServicesCreated => Services.Count;
         public int CurrentActiveServices => Services.Count(s => s.IsActive);
 
@@ -61,10 +81,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly INetworkConfigurationService _networkService;
         private readonly IServiceUiRegistry _uiRegistry;
         private readonly IServiceCatalog _catalog;
+        private readonly IFileDialogService _fileDialogService;
+        private readonly IPluginImportService _pluginImportService;
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
-        public MainViewModel(CsvService csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, IServiceUiRegistry uiRegistry, IServiceCatalog catalog, ILoggingService? logger = null, string? servicesFilePath = null)
+        public MainViewModel(
+            CsvService csvService,
+            NetworkConfigurationViewModel networkConfig,
+            INetworkConfigurationService networkService,
+            IServiceUiRegistry uiRegistry,
+            IServiceCatalog catalog,
+            IFileDialogService fileDialogService,
+            IPluginImportService pluginImportService,
+            ILoggingService? logger = null,
+            string? servicesFilePath = null)
         {
             _csvService = csvService;
             _networkService = networkService;
@@ -72,6 +103,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             NetworkConfig = networkConfig;
             _uiRegistry = uiRegistry;
             _catalog = catalog;
+            _fileDialogService = fileDialogService ?? throw new ArgumentNullException(nameof(fileDialogService));
+            _pluginImportService = pluginImportService ?? throw new ArgumentNullException(nameof(pluginImportService));
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceListModel.ResolveService = (descriptorKey, name) =>
@@ -97,6 +130,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             AddServiceCommand = new RelayCommand(AddService);
             RemoveServiceCommand = new AsyncRelayCommand(RemoveSelectedServiceAsync, () => SelectedService != null);
             EditServiceCommand = new RelayCommand<ServiceListModel?>(EditService, svc => svc != null);
+            ImportServiceCommand = new AsyncRelayCommand(ImportServiceAsync);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
             Filters.PropertyChanged += (_, __) => ApplyFilters();
             LoadServices();
@@ -127,6 +161,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         public event Action? AddServiceRequested;
+        public event EventHandler<ImportFeedbackEventArgs>? ImportFeedback;
         private void EditService(ServiceListModel? service)
         {
             var target = service ?? SelectedService;
@@ -148,6 +183,49 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _logger?.Log("AddService invoked", LogLevel.Debug);
             AddServiceRequested?.Invoke();
             _logger?.Log("AddService completed", LogLevel.Debug);
+        }
+
+        private async Task ImportServiceAsync()
+        {
+            var selectedPath = _fileDialogService.OpenFile(
+                "Service Packages (*.ccp;*.chapp)|*.ccp;*.chapp|All Files (*.*)|*.*",
+                "Import Service Package");
+
+            if (string.IsNullOrWhiteSpace(selectedPath))
+            {
+                _logger?.Log("Service import cancelled by user.", LogLevel.Debug);
+                return;
+            }
+
+            _logger?.Log($"Importing service package from {selectedPath}.", LogLevel.Information);
+
+            PluginImportResult result;
+            try
+            {
+                result = await _pluginImportService.ImportAsync(selectedPath).ConfigureAwait(true);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger?.Log("Service import cancelled.", LogLevel.Information);
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger?.Log($"Service import failed: {ex.Message}", LogLevel.Error);
+                ImportFeedback?.Invoke(this, new ImportFeedbackEventArgs(ImportFeedbackStatus.Error, "Import failed. Check logs for details."));
+                return;
+            }
+
+            if (result.Success)
+            {
+                _logger?.Log($"Imported service package '{Path.GetFileName(selectedPath)}'. {result.Message}", LogLevel.Information);
+                ImportFeedback?.Invoke(this, new ImportFeedbackEventArgs(ImportFeedbackStatus.Success, result.Message));
+            }
+            else
+            {
+                _logger?.Log($"Service import reported issues for '{selectedPath}': {result.Message}", LogLevel.Warning);
+                ImportFeedback?.Invoke(this, new ImportFeedbackEventArgs(ImportFeedbackStatus.Error, result.Message));
+            }
         }
 
         internal string GenerateServiceName(ServiceType serviceType)

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
@@ -3,7 +3,12 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI"
         mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringToBrushConverter x:Key="StringToBrushConverter" />
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -16,24 +21,47 @@
         <ItemsControl Grid.Row="1" ItemsSource="{Binding ServiceDescriptors}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <WrapPanel Width="400" />
+                    <WrapPanel Width="600" />
                 </ItemsPanelTemplate>
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <StackPanel Margin="10" HorizontalAlignment="Center">
-                        <Button Width="80" Height="80" Click="ServiceType_Click">
-                            <Button.Template>
-                                <ControlTemplate TargetType="Button">
-                                    <Border CornerRadius="40" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1">
-                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                                    </Border>
-                                </ControlTemplate>
-                            </Button.Template>
-                            <TextBlock Text="{Binding IconGlyph}" FontSize="40" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Button>
-                        <TextBlock Text="{Binding DisplayLabel}" HorizontalAlignment="Center" Margin="0,5,0,0"/>
-                    </StackPanel>
+                    <Button Click="ServiceType_Click"
+                            Padding="0"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Cursor="Hand">
+                        <Button.Template>
+                            <ControlTemplate TargetType="Button">
+                                <Border CornerRadius="12"
+                                        Background="{Binding SecondaryAccentColor, Converter={StaticResource StringToBrushConverter}, ConverterParameter=#FFF1F5F9}"
+                                        BorderBrush="{Binding PrimaryAccentColor, Converter={StaticResource StringToBrushConverter}, ConverterParameter=#FF38BDF8}"
+                                        BorderThickness="1"
+                                        Padding="12">
+                                    <StackPanel>
+                                        <Border Width="48"
+                                                Height="48"
+                                                CornerRadius="24"
+                                                Background="{Binding PrimaryAccentColor, Converter={StaticResource StringToBrushConverter}, ConverterParameter=#FF38BDF8}"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding IconGlyph}"
+                                                       FontSize="28"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center" />
+                                        </Border>
+                                        <TextBlock Text="{Binding DisplayLabel}" FontWeight="Bold" FontSize="16" Margin="0,12,0,0" />
+                                        <TextBlock Text="{Binding Category}" Foreground="#FF1F2937" Margin="0,4,0,0" />
+                                        <TextBlock Text="{Binding Description}"
+                                                   Margin="0,6,0,0"
+                                                   TextWrapping="Wrap"
+                                                   Foreground="#FF4B5563"
+                                                   Visibility="{Binding Description, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}" />
+                                    </StackPanel>
+                                </Border>
+                            </ControlTemplate>
+                        </Button.Template>
+                    </Button>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -70,6 +70,7 @@
                     <Button Content="+" Width="30" Click="AddService_Click" Background="#E6E6E6" Foreground="#333333"/>
                     <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click" Background="#E6E6E6" Foreground="#333333"/>
                     <Button x:Name="FilterButton" Content="☰" Width="30" Margin="5,0,0,0" Click="FilterButton_Click" Background="#E6E6E6" Foreground="#333333"/>
+                    <Button Content="Import" Margin="5,0,0,0" Background="#E6E6E6" Foreground="#333333" Command="{Binding ImportServiceCommand}"/>
                     <Popup x:Name="FilterPopup" PlacementTarget="{Binding ElementName=FilterButton}" Placement="Bottom" StaysOpen="False" DataContext="{Binding DataContext, ElementName=FilterButton}">
                         <Border Background="White" CornerRadius="5" Padding="10">
                             <local:FilterPanel DataContext="{Binding Filters}"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -45,10 +45,12 @@ namespace DesktopApplicationTemplate.UI.Views
             }
             DataContext = _viewModel;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
+            _viewModel.ImportFeedback += OnImportFeedback;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
             CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
             Closing += (_, _) => _logger?.LogInformation("MainView closing");
+            Closed += (_, _) => _viewModel.ImportFeedback -= OnImportFeedback;
             ShowHome();
         }
 
@@ -146,6 +148,13 @@ namespace DesktopApplicationTemplate.UI.Views
         private void OnAddServiceRequested()
         {
             ShowCreateServiceSelectionPage();
+        }
+
+        private void OnImportFeedback(object? sender, ImportFeedbackEventArgs e)
+        {
+            var icon = e.Status == ImportFeedbackStatus.Success ? MessageBoxImage.Information : MessageBoxImage.Warning;
+            var title = e.Status == ImportFeedbackStatus.Success ? "Import Complete" : "Import Failed";
+            MessageBox.Show(this, e.Message, title, MessageBoxButton.OK, icon);
         }
 
         public void ShowCreateServiceSelectionPage()


### PR DESCRIPTION
## Summary
- add a plug-in import service and command that copies archives, reloads the catalog, and surfaces user feedback
- enhance the create service page to display rich descriptor metadata and updated styling for imported services
- extend service catalog infrastructure and tests to support runtime descriptor refreshes and cover the import workflow

## Testing
- ⚠️ `dotnet build DesktopApplicationTemplate.sln` *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3336519083269adcc2310f5e0839