### PR TITLE
Update docs for descriptor plug-in workflow

### DIFF
--- a/Codex/CollaborationGuidelines.txt
+++ b/Codex/CollaborationGuidelines.txt
@@ -44,6 +44,13 @@ Unit Testing Insights
 - Configure dependencies through DI to keep tests focused and deterministic.
 - Monitor GitHub Actions for the `dotnet test` run and summarize the CI outcome in `Codex/docs/CollaborationAndDebugTips.txt`. If CI cannot complete, coordinate with a Windows collaborator for follow-up diagnostics.
 
+Descriptor & Plug-in CI Tasks
+-----------------------------
+1. **Package sample plug-ins** – GitHub Actions builds `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` with `dotnet build` so the generated `.ccp`/`.chapp` archives verify packaging targets. Capture the CI log links when these builds surface errors.
+2. **Validate descriptor catalog tests** – CI executes `dotnet test DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj --filter ServiceCatalog` to confirm descriptors advertise presentation metadata, legacy mappings, and conflict detection. Reference this test output when reviewing descriptor or migration changes.
+3. **Exercise template scaffolds** – When the service plug-in template changes, add `dotnet new install Templates/ServicePluginTemplate` and a sample `dotnet build` invocation to the CI pipeline (or a one-off workflow run) to confirm descriptors scaffold correctly.
+4. **Record outcomes** – Note the status of these tasks in `Codex/docs/CollaborationAndDebugTips.txt`, especially when migrations affect persistence or descriptor bindings.
+
 Miscellaneous Tips
 ------------------
 - Validate all file paths, indexes, and dictionary keys before use to avoid runtime errors.

--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Migration routine converts legacy service type names to `ServiceType` and logs unmapped values.
 - `IServiceModule` interface enables service-specific DI registration and modules are discovered and registered automatically at startup.
 - Static `ServiceTypeExtensions` maps service types to short codes for reuse in serialization and configuration.
+- Documentation now outlines the descriptor-first plug-in workflow, enum-to-descriptor migration steps, QA verification checklist, and CI packaging guidance while noting legacy compatibility through `LegacyType` mappings.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.

--- a/Codex/docs/CustomServiceGuide.md
+++ b/Codex/docs/CustomServiceGuide.md
@@ -1,43 +1,32 @@
 # Custom Service Guide
 
-This guide explains how to extend the application with new services by reusing existing components and `IServiceModule`.
+This guide explains how to extend the application with descriptor-driven services, migrate legacy enum-based implementations, and package the result as a plug-in.
 
-## Reuse shared components
+## Understand the descriptor workflow
 
-- **ServiceRule**: central validation helper injected into create and edit view models for required field checks.
-- **ServiceScreen**: wraps user interactions for options models and exposes events that views can bind to.
-- **Base view models**: inherit from `ServiceCreateViewModelBase` and `ServiceEditViewModelBase` to get common save logic, logging, and navigation.
-- **Shared controls**: components such as `ServiceLogView` and `ServiceMessageTableView` provide consistent UI panels that can be embedded in new service pages.
+1. **Descriptors advertise capability** – implement `IServiceDescriptor` (or inherit from `ServiceDescriptorBase`) to describe presentation metadata, runtime factories, and serialization behavior. The descriptor identifier becomes the primary lookup key for persistence, navigation, and plug-in imports.
+2. **Modules bundle registrations** – each plug-in exposes one or more `IServiceModule` implementations. During host startup `services.AddServiceModules()` discovers these modules, registers their dependencies, and aggregates their descriptors into the shared `IServiceCatalog`.
+3. **Attributes connect UI handlers** – classes tagged with `ServiceDescriptorRegistrationAttribute` declare how view models, navigation handlers, and other UI assets bind to a descriptor identifier. The application maps descriptor ids to these registrations at boot.
+4. **Legacy services stay compatible** – descriptors may expose `LegacyType` values so persisted enum-based services load through the new catalog automatically.
 
-## Register dependencies with `IServiceModule`
+## Migrate an enum-based service
 
-`IServiceModule` allows each service to package its DI registrations. Implement the interface for your service and expose the corresponding `ServiceType`:
+Use this checklist when upgrading a service that previously depended on the `ServiceType` enum:
 
-```csharp
-public class SampleServiceModule : IServiceModule
-{
-    public ServiceType Type => ServiceType.Sample;
+1. **Create a descriptor** – add a new class that derives from `ServiceDescriptorBase`. Provide a stable `DescriptorId`, fill in presentation metadata, and pass the legacy enum value to the base constructor.
+2. **Expose factories** – populate the descriptor's `ServiceFactoryBinding` collection so runtime factories, editors, and navigation handlers can resolve through `IServiceCatalog`.
+3. **Register descriptor-aware handlers** – annotate edit, navigation, and runtime factory classes with `ServiceDescriptorRegistrationAttribute(DescriptorId, kind)` so dependency injection connects them to the descriptor instead of enum switches.
+4. **Update persistence hooks** – ensure the service's options serializer implements `IServiceOptionsSerializer` and is referenced by the descriptor. Persisted records should prefer `DescriptorId` while continuing to supply `LegacyType` for migrations.
+5. **Remove enum branches** – replace `switch` statements and lookup tables keyed by `ServiceType` with descriptor id dictionaries (for example, `IServiceCatalog.Descriptors`). When legacy values remain necessary, convert them with `ServiceTypeExtensions.ToDescriptorId()`.
+6. **Validate migrations** – load existing persisted data through `ServicePersistence` to confirm legacy enum values resolve to the descriptor id and that UI bindings display descriptor metadata.
 
-    public void RegisterServices(IServiceCollection services)
-    {
-        services.AddSingleton<SampleService>();
-        services.AddTransient<SampleCreateViewModel>();
-        services.AddTransient<SampleEditViewModel>();
-        services.AddTransient<SamplePage>();
-    }
-}
-```
+## Build a descriptor-first service
 
-Modules are discovered at startup by calling `services.AddServiceModules()` during host configuration.
-
-## Adding a new service type
-
-1. **Update the enum** – add a value to `ServiceType` to identify the service.
-2. **Create options and implementation** – define an options class and the runtime service that executes the work.
-3. **Build the UI** – create view models and views, reusing `ServiceRule`, `ServiceScreen`, and base classes for common behavior.
-4. **Implement an `IServiceModule`** – register the service, view models, and views with the DI container.
-5. **Wire up navigation** – add create and edit handlers or factory entries so the main window can navigate to the new views.
-6. **Test and document** – run `dotnet` commands and update docs as needed.
+1. **Define options and runtime logic** – create an options model, runtime service, and any supporting factories that perform the work.
+2. **Implement the descriptor** – derive from `ServiceDescriptorBase`, provide presentation metadata, wire in factories, and optionally supply a payload description delegate for UI tooltips.
+3. **Author UI bindings** – create view models and pages that reuse shared helpers (`ServiceRule`, `ServiceScreen`, `ServiceCreateViewModelBase`, `ServiceEditViewModelBase`, `ServiceLogView`, and `ServiceMessageTableView`). Decorate each class with `ServiceDescriptorRegistrationAttribute` so the host links it to the descriptor id.
+4. **Register via `IServiceModule`** – implement an `IServiceModule` that adds the runtime services, view models, and views to dependency injection and yields the descriptor from `DescribeServices()`.
+5. **Document and test** – update the README and changelog with the new descriptor, and rely on CI to execute descriptor-focused tests described in `Codex/CollaborationGuidelines.txt`.
 
 ## Package and distribute plug-ins
 
@@ -50,3 +39,4 @@ Modules are discovered at startup by calling `services.AddServiceModules()` duri
 
 - **Template** – `Templates/ServicePluginTemplate` exposes a `dotnet new codex-serviceplugin` template that scaffolds a descriptor, runtime factory, manifest, and packaging imports.
 - **Samples** – `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` provide ready-to-build examples that produce distributable archives during CI, making them ideal smoke tests for packaging changes.
+- **Verification** – follow the QA checklist in `Codex/docs/PluginVerificationChecklist.md` to confirm imports, descriptor rendering, and persistence migrations before releasing new plug-ins.

--- a/Codex/docs/PluginVerificationChecklist.md
+++ b/Codex/docs/PluginVerificationChecklist.md
@@ -1,0 +1,32 @@
+# Plug-in Verification Checklist
+
+Use this checklist to validate descriptor-based plug-ins before distributing them. Complete every numbered action item during QA and capture results in your test notes.
+
+## Import and catalog
+
+1. Import the `.ccp` or `.chapp` package through the plug-in import workflow and confirm the archive extracts without errors.
+2. Inspect the log output to verify each descriptor id, version, and assembly was registered with `IServiceCatalog`.
+3. Restart the application (or trigger catalog refresh) to ensure descriptors survive reload and appear in the service creation list.
+
+## Descriptor rendering
+
+1. Confirm the service list displays the descriptor label, category, icon glyph, and accent colors supplied by the descriptor metadata.
+2. Open the create and edit views to validate descriptor descriptions, payload tooltips, and any payload summaries exposed via `DescribePayload`.
+3. Trigger UI elements tagged with `ServiceDescriptorRegistrationAttribute` (navigation handlers, command bars, log panels) to ensure they resolve via the descriptor id.
+
+## Persistence and migration
+
+1. Create a service instance, save it, and verify the persisted record stores the descriptor id alongside any legacy type metadata.
+2. Reopen the service to confirm options deserialize via the descriptor's `IServiceOptionsSerializer` implementation.
+3. If migrating from an enum-based service, load an older configuration and ensure `ServicePersistence` upgrades it to the descriptor id without data loss.
+
+## Runtime behavior
+
+1. Execute runtime operations (start, stop, send test message, etc.) and observe logs for descriptor-scoped entries and errors.
+2. Dispose or uninstall the plug-in to confirm descriptors are removed from the catalog and dependent services fail gracefully or prompt for migration.
+
+## CI coverage
+
+1. Ensure `dotnet build` succeeds for the plug-in project with `ServicePlugin.Packaging` imports enabled, producing archives under `bin/<configuration>/<tfm>/plugins`.
+2. Review GitHub Actions output for `DesktopApplicationTemplate.Core.Tests` descriptor catalog tests and add new cases if descriptors expose additional metadata.
+3. Document all findings (pass/fail and log links) in `Codex/docs/CollaborationAndDebugTips.txt` or the release tracking system.

--- a/README.md
+++ b/README.md
@@ -123,36 +123,32 @@ The UI exposes several built in service types. A brief description of each is sh
 
 Each service has an editor page where the parameters and test messages can be modified.  A **Help** button is available on these pages to display common ASCII commands (ACK, NAK, ENQ, ETX) which can be inserted when building protocol messages.
 
-## Extending the application
+## Descriptor-based plug-in workflow
 
-`ServiceType` is an enum that identifies each supported service category. It is serialized using short codes and still recognizes legacy names so existing configurations continue to load.
+Descriptors replace the legacy `ServiceType` enum as the primary identifier for services. Each descriptor:
 
-Dictionary-based edit handlers are registered for each `ServiceType` and injected into the main view model as a lookup. When a user edits a service, the view model resolves the handler from that dictionary instead of relying on large switch statements, making it easy to plug in new handlers.
+1. Supplies metadata (label, category, description, icon glyphs, and accent colors) displayed throughout the UI.
+2. Advertises runtime factories and serializers through `ServiceFactoryBinding` entries.
+3. Optionally exposes a `LegacyType` so persisted enum-based services migrate seamlessly.
 
-Dynamic DI modules are enabled by `services.AddServiceModules()`, which scans assemblies for `IServiceModule` implementations and calls their `RegisterServices` methods. Dropping a new module into the application automatically registers its services without manual wiring.
+During startup `services.AddServiceModules()` discovers `IServiceModule` implementations, registers their dependencies, and gathers descriptors into the shared `IServiceCatalog`. Classes decorated with `ServiceDescriptorRegistrationAttribute` expose navigation handlers, editors, and runtime factories keyed by descriptor id—no manual switch statements required.
 
-### Adding a new service example
+### Migrate an enum-based service
 
-1. Add a value to the `ServiceType` enum.
-2. Implement the service and its UI components.
-3. Create an `IServiceModule` for DI registration:
+1. Create a descriptor class (for example, derive from `ServiceDescriptorBase`) that exposes a stable `DescriptorId`, presentation metadata, and the previous enum value via the base constructor.
+2. Update runtime factories, view models, and navigation handlers to depend on descriptor ids. Decorate each class with `ServiceDescriptorRegistrationAttribute` so dependency injection binds it to the descriptor.
+3. Ensure persistence emits the descriptor id and, when applicable, the legacy enum value. `ServicePersistence` automatically upgrades records by consulting `IServiceCatalog` and `ServiceTypeExtensions.ToDescriptorId()`.
+4. Remove enum-driven `switch` statements in favor of descriptor lookups from `IServiceCatalog` or descriptor id dictionaries.
+5. Validate the migration with the QA checklist in `Codex/docs/PluginVerificationChecklist.md` before releasing the change.
 
-   ```csharp
-   public class SampleServiceModule : IServiceModule
-   {
-       public ServiceType Type => ServiceType.Sample;
+### Add a descriptor-first service
 
-       public void RegisterServices(IServiceCollection services)
-       {
-           services.AddSingleton<SampleService>();
-           services.AddTransient<SampleCreateViewModel>();
-           services.AddTransient<SampleEditViewModel>();
-           services.AddTransient<SamplePage>();
-       }
-   }
-   ```
-
-4. Wire up navigation and edit handlers for the new `ServiceType` and document any changes.
+1. Build the runtime: define options, runtime services, and supporting dependencies.
+2. Implement the descriptor with presentation metadata and factory bindings.
+3. Create view models and XAML pages that reuse shared helpers such as `ServiceCreateViewModelBase`, `ServiceEditViewModelBase`, `ServiceRule`, and `ServiceLogView`.
+4. Annotate navigation handlers, editors, and runtime factories with `ServiceDescriptorRegistrationAttribute(DescriptorId, kind)` so the app wires them automatically.
+5. Register everything inside an `IServiceModule` by returning the descriptor from `DescribeServices()` and adding dependencies in `RegisterServices`.
+6. Package and test the plug-in as described below.
 
 ## Packaging service plug-ins
 
@@ -174,7 +170,8 @@ Each archive contains the manifest, compiled descriptors, and copy-local depende
 ### Templates and samples
 
 - **Template:** `Templates/ServicePluginTemplate` publishes a `dotnet new codex-serviceplugin` template that scaffolds a plug-in project with descriptor, runtime factory, manifest, and packaging imports. Install it locally with `dotnet new install Templates/ServicePluginTemplate` and scaffold new plug-ins under a folder where `..\..\ServicePlugin.Packaging` resolves to the repository root.
-- **Samples:** `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` demonstrate packaging refactored services. Both projects import `ServicePlugin.Packaging` and build `.ccp` / `.chapp` archives during CI. Use them as regression tests when evolving the packaging logic.
+- **Samples:** `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` demonstrate packaging descriptor-based services. Both projects import `ServicePlugin.Packaging`, emit archives during CI, and exercise descriptor metadata in tests.
+- **Verification:** Follow `Codex/docs/PluginVerificationChecklist.md` to confirm import flows, descriptor rendering, and persistence migrations prior to distributing new packages.
 
 ## Testing services locally
 

--- a/Templates/ServicePluginTemplate/README.md
+++ b/Templates/ServicePluginTemplate/README.md
@@ -7,6 +7,13 @@ This template demonstrates how to build a service plug-in that can be packaged w
 3. A descriptor (`TemplateServiceDescriptor`) that advertises runtime bindings.
 4. A runtime factory (`TemplateRuntimeFactory`) that logs lifecycle events.
 
+When migrating an existing enum-based service, start by cloning this template and then:
+
+1. Copy the legacy options model and runtime logic into the generated project.
+2. Replace the placeholder descriptor with one that calls the `ServiceDescriptorBase` constructor using your legacy `ServiceType` value so persisted records upgrade automatically.
+3. Port create/edit view models and tag them with `ServiceDescriptorRegistrationAttribute` so the host binds them to the descriptor id.
+4. Update persistence helpers to emit the descriptor id and validate the upgrade by following `Codex/docs/PluginVerificationChecklist.md`.
+
 Install the template locally and scaffold a new plug-in within the repository root:
 
 ```bash


### PR DESCRIPTION
## Summary
- document the descriptor-first plug-in workflow and enum migration path across contributor onboarding materials
- add QA checklist and CI guidance for packaging builds and descriptor catalog tests
- update release notes to highlight compatibility expectations for descriptor-based services

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dd3885ae3883269ee20f1a48291fda