### PR TITLE
Add configuration abstractions reference to core project

### DIFF
--- a/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
+++ b/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Configuration.Abstractions to the core project to support PluginLoader types

## Testing
- ⚠️ `dotnet restore DesktopApplicationTemplate.sln` *(fails: `dotnet` CLI is not available in this environment)*
- ⚠️ `dotnet build DesktopApplicationTemplate.sln` *(fails: `dotnet` CLI is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3c57bcf083268a6128b03a764a0e