### PR TITLE
Add Microsoft.Extensions.Options dependency to services common project

### DIFF
--- a/DesktopApplicationTemplate.Services.Common/DesktopApplicationTemplate.Services.Common.csproj
+++ b/DesktopApplicationTemplate.Services.Common/DesktopApplicationTemplate.Services.Common.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Options package reference to DesktopApplicationTemplate.Services.Common alongside logging abstractions

## Testing
- `dotnet restore DesktopApplicationTemplate.Services.Common/DesktopApplicationTemplate.Services.Common.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3d1b6cf88326871f29dfb26762ca