### PR TITLE
Update helper namespace references for UI helpers

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI"
+        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringToBrushConverter x:Key="StringToBrushConverter" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
-        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI"
+        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
 


### PR DESCRIPTION
## Summary
- remove the assembly qualifier from the helpers XML namespace in the main window and create service page XAML so the markup compiler can resolve UI converters

## Testing
- dotnet clean DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj *(fails: `dotnet` command is unavailable in the container environment)*
- dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj *(fails: `dotnet` command is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3da46e4c83269cc8ee9cdecaf2e8