### PR TITLE
Align Roslyn package version in DesktopApplicationTemplate.Tests

### DIFF
--- a/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
+++ b/DesktopApplicationTemplate.Tests/DesktopApplicationTemplate.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- bump Microsoft.CodeAnalysis.CSharp package reference to version 4.12.0 in the test project to match the rest of the solution

## Testing
- dotnet restore DesktopApplicationTemplate.sln *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3e69546c8326b462e8c03062d0b1