### PR TITLE
Update logging abstractions package version

### DIFF
--- a/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
+++ b/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 

--- a/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
+++ b/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 

--- a/Templates/ServicePluginTemplate/ServicePluginTemplate.csproj
+++ b/Templates/ServicePluginTemplate/ServicePluginTemplate.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>
 
   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />


### PR DESCRIPTION
## Summary
- bump Microsoft.Extensions.Logging.Abstractions to version 8.0.3 for the sample relay plugins and service plugin template projects to align with dependency requirements

## Testing
- ⚠️ `dotnet restore DesktopApplicationTemplate.sln` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3f139bf88326b931a08c47c67b81