### PR TITLE
Update MSBuild dependencies for ServicePlugin packaging project

### DIFF
--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.csproj
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.csproj
@@ -6,8 +6,8 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.8.5" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.27" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Tasks\**\*.cs">


### PR DESCRIPTION
## Summary
- bump Microsoft.Build.Framework and Microsoft.Build.Utilities.Core dependencies in the packaging project to version 17.8.27 to satisfy NU1603 requirements

## Testing
- dotnet build ServicePlugin.Packaging/ServicePlugin.Packaging.csproj *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3f8e8a008326a61448ae0fd700b1