### PR TITLE
Fix MSBuild task base class for CreateServicePluginArchive

### DIFF
--- a/ServicePlugin.Packaging/Tasks/CreateServicePluginArchive.cs
+++ b/ServicePlugin.Packaging/Tasks/CreateServicePluginArchive.cs
@@ -12,7 +12,7 @@ namespace ServicePlugin.Packaging.Tasks;
 /// <summary>
 /// Creates distributable plug-in archives containing descriptors, dependencies, and manifests.
 /// </summary>
-public sealed class CreateServicePluginArchive : Task
+public sealed class CreateServicePluginArchive : Microsoft.Build.Utilities.Task
 {
     private static readonly char[] ExtensionSeparators = [ ';' ];
 


### PR DESCRIPTION
## Summary
- update CreateServicePluginArchive to inherit directly from Microsoft.Build.Utilities.Task to avoid ambiguity resolving the MSBuild base class

## Testing
- `dotnet build ServicePlugin.Packaging/ServicePlugin.Packaging.csproj` *(fails: command not found: dotnet in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd40f39d4883268fbef4fb9443b7d5