### PR TITLE
Fix legacy map dictionary comparer

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
@@ -71,7 +71,7 @@ public sealed class ServiceCatalog : IServiceCatalog
 
             _descriptorsById = descriptorsById;
             _descriptorsByLegacy = legacyLookup;
-            _legacyMap = legacyLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id, StringComparer.Ordinal);
+            _legacyMap = legacyLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id);
             _descriptors = snapshots;
         }
 


### PR DESCRIPTION
## Summary
- remove the redundant string comparer when projecting the legacy service map so the compiler can infer generic arguments

## Testing
- `dotnet build DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj` *(fails: `dotnet` command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd41d2b6a88326b1d5aa4631287299