### PR TITLE
Bump DI abstractions for relay plugins

### DIFF
--- a/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
+++ b/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.3" />
   </ItemGroup>
 
   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />

--- a/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
+++ b/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.3" />
   </ItemGroup>
 
   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />


### PR DESCRIPTION
## Summary
- bump Microsoft.Extensions.DependencyInjection.Abstractions to version 8.0.3 for the HTTP and TCP relay plugin samples

## Testing
- dotnet restore Samples/HttpRelayPlugin/HttpRelayPlugin.csproj *(fails: `dotnet` is not installed in the container)*
- dotnet restore Samples/TcpRelayPlugin/TcpRelayPlugin.csproj *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4234afec832691ad15bef0c8c35a