### PR TITLE
Add dependency injection package to core tests

### DIFF
--- a/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
+++ b/DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.DependencyInjection package reference to the core test project to enable BuildServiceProvider usage

## Testing
- ⚠️ `dotnet restore DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj` *(fails: dotnet not available in container)*
- ⚠️ `dotnet build DesktopApplicationTemplate.Core.Tests/DesktopApplicationTemplate.Core.Tests.csproj` *(not run due to restore failure)*

------
https://chatgpt.com/codex/tasks/task_e_68dd43d06a7883268aecb3e30d35c21a