### PR TITLE
Include ServiceType namespace in template descriptor

### DIFF
--- a/Templates/ServicePluginTemplate/Descriptors/TemplateServiceDescriptor.cs
+++ b/Templates/ServicePluginTemplate/Descriptors/TemplateServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 
 namespace ServicePluginTemplate.Descriptors;
 


### PR DESCRIPTION
## Summary
- add the DesktopApplicationTemplate.Models namespace to the template service descriptor so `LegacyType` resolves to `ServiceType`

## Testing
- dotnet build Templates/ServicePluginTemplate/ServicePluginTemplate.csproj *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4441c68c8326bb18f41f8101e3ac