### PR TITLE
Fix service definition payload argument name

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -202,7 +202,7 @@ public sealed class ServiceManager : IAsyncDisposable, IDisposable
                 resolution.LegacyType,
                 item.IsActive,
                 Array.Empty<string>(),
-                payload: null));
+                Payload: null));
         }
 
         return result;


### PR DESCRIPTION
## Summary
- adjust the ServiceDefinition call in ServiceManager.MapConfiguration to use the correct Payload argument name

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd44aa8a408326b8c225428e5f962c