### PR TITLE
Fix behaviors namespace declaration in MainWindow

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
-        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
+        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
 
         xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
         mc:Ignorable="d"


### PR DESCRIPTION
## Summary
- update the behaviors XML namespace in `MainWindow.xaml` so WPF resolves types from the current assembly

## Testing
- `dotnet clean DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(fails: `dotnet` command not available in container)*
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(not run due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_68dd45ec652483268e325bae604c83e5