### PR TITLE
Update relay sample DI abstractions package version

### DIFF
--- a/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
+++ b/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />

--- a/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
+++ b/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
@@ -17,7 +17,7 @@
     <ProjectReference Include="..\..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
     <ProjectReference Include="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.csproj" ReferenceOutputAssembly="false" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
   <Import Project="..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets" Condition="Exists('..\..\ServicePlugin.Packaging\ServicePlugin.Packaging.targets')" />


### PR DESCRIPTION
## Summary
- align the Microsoft.Extensions.DependencyInjection.Abstractions package version to 9.0.0 in the relay sample plug-ins to match restore resolution

## Testing
- dotnet restore DesktopApplicationTemplate.sln

------
https://chatgpt.com/codex/tasks/task_e_68dd465c63188326b13f4e2f513cfafe