### PR TITLE
Fix ServiceDefinition payload parameter and update ServiceLogView namespace

### DIFF
--- a/DesktopApplicationTemplate.Service/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Service/ServiceManager.cs
@@ -265,7 +265,7 @@ public sealed class ServiceManager : IAsyncDisposable, IDisposable
                 resolution.LegacyType,
                 record.IsActive,
                 record.AssociatedServices ?? new List<string>(),
-                payload: null));
+                Payload: null));
         }
 
         return result;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -7,8 +7,7 @@
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
-
-        xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
+        xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
         mc:Ignorable="d"
         Title="MainView"
         MinWidth="800" MinHeight="600" Height="600"


### PR DESCRIPTION
## Summary
- correct the named argument used when creating `ServiceDefinition` instances for legacy records
- adjust the `ServiceLogView` XML namespace in `MainWindow.xaml` so the control resolves within the UI assembly

## Testing
- not run (WPF projects require Windows tooling not available in this container)


------
https://chatgpt.com/codex/tasks/task_e_68dd4a6ca98c8326951b5b5efbff3e1b