### PR TITLE
Fix MainViewModel property closure and import feedback types

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -38,27 +38,28 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 LogViewModel.SetLogs(_selectedService?.Logs ?? AllLogs);
                 (RemoveServiceCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
                 (EditServiceCommand as RelayCommand<ServiceListModel?>)?.RaiseCanExecuteChanged();
-}
-
-    public enum ImportFeedbackStatus
-    {
-        Success,
-        Error
-    }
-
-    public sealed class ImportFeedbackEventArgs : EventArgs
-    {
-        public ImportFeedbackEventArgs(ImportFeedbackStatus status, string message)
-        {
-            Status = status;
-            Message = message ?? throw new ArgumentNullException(nameof(message));
+            }
         }
 
-        public ImportFeedbackStatus Status { get; }
+        public enum ImportFeedbackStatus
+        {
+            Success,
+            Error
+        }
 
-        public string Message { get; }
-    }
-}
+        public sealed class ImportFeedbackEventArgs : EventArgs
+        {
+            public ImportFeedbackEventArgs(ImportFeedbackStatus status, string message)
+            {
+                Status = status;
+                Message = message ?? throw new ArgumentNullException(nameof(message));
+            }
+
+            public ImportFeedbackStatus Status { get; }
+
+            public string Message { get; }
+        }
+
         public ICommand AddServiceCommand { get; }
         public ICommand RemoveServiceCommand { get; }
         public ICommand EditServiceCommand { get; }


### PR DESCRIPTION
## Summary
- close the SelectedService setter so the property compiles
- keep ImportFeedbackStatus and ImportFeedbackEventArgs nested inside MainViewModel

## Testing
- not run (Windows desktop targets are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd4b3d9fbc8326aa2cd1fe0e479523