### PR TITLE
Fix import feedback handler type references and packaging task loading

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -150,10 +150,10 @@ namespace DesktopApplicationTemplate.UI.Views
             ShowCreateServiceSelectionPage();
         }
 
-        private void OnImportFeedback(object? sender, ImportFeedbackEventArgs e)
+        private void OnImportFeedback(object? sender, MainViewModel.ImportFeedbackEventArgs e)
         {
-            var icon = e.Status == ImportFeedbackStatus.Success ? MessageBoxImage.Information : MessageBoxImage.Warning;
-            var title = e.Status == ImportFeedbackStatus.Success ? "Import Complete" : "Import Failed";
+            var icon = e.Status == MainViewModel.ImportFeedbackStatus.Success ? MessageBoxImage.Information : MessageBoxImage.Warning;
+            var title = e.Status == MainViewModel.ImportFeedbackStatus.Success ? "Import Complete" : "Import Failed";
             MessageBox.Show(this, e.Message, title, MessageBoxButton.OK, icon);
         }
 

--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.targets
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.targets
@@ -1,7 +1,7 @@
 <Project>
   <UsingTask TaskName="ServicePlugin.Packaging.Tasks.CreateServicePluginArchive"
              TaskFactory="RoslynCodeTaskFactory"
-             AssemblyName="ServicePlugin.Packaging.Tasks">
+             AssemblyFile="$(MSBuildBinPath)/Microsoft.Build.Tasks.Core.dll">
     <Task>
       <Reference Include="System" />
       <Reference Include="System.Core" />
@@ -9,7 +9,7 @@
       <Reference Include="System.IO.Compression" />
       <Reference Include="Microsoft.Build.Framework" />
       <Reference Include="Microsoft.Build.Utilities.Core" />
-      <Code Type="Class" Source="$(MSBuildThisFileDirectory)Tasks\CreateServicePluginArchive.cs" />
+      <Code Type="Class" Source="$(MSBuildThisFileDirectory)Tasks/CreateServicePluginArchive.cs" />
     </Task>
   </UsingTask>
 


### PR DESCRIPTION
## Summary
1. Update the main window import feedback handler to reference the nested event args and status types from `MainViewModel`.
2. Point the Roslyn task factory at `Microsoft.Build.Tasks.Core.dll` and normalize source paths so the packaging task loads cross-platform.

## Testing
- Not run (Windows-specific build targets are unsupported in this environment).

------
https://chatgpt.com/codex/tasks/task_e_68dd4c10b9988326a5ded3661b3fccfa