### PR TITLE
Rewrite plugin test resources without raw strings

### DIFF
--- a/DesktopApplicationTemplate.Tests/PluginImportWorkflowTests.cs
+++ b/DesktopApplicationTemplate.Tests/PluginImportWorkflowTests.cs
@@ -77,41 +77,43 @@ public sealed class PluginImportWorkflowTests : IDisposable
 
     private static void CompilePluginAssembly(string outputPath)
     {
-        var syntaxTree = CSharpSyntaxTree.ParseText(@"
-using System.Collections.Generic;
-using DesktopApplicationTemplate.Core.Modules;
-using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Models;
-using Microsoft.Extensions.DependencyInjection;
+        var pluginSourceCode = string.Join(
+            Environment.NewLine,
+            "using System.Collections.Generic;",
+            "using DesktopApplicationTemplate.Core.Modules;",
+            "using DesktopApplicationTemplate.Core.Services;",
+            "using DesktopApplicationTemplate.Models;",
+            "using Microsoft.Extensions.DependencyInjection;",
+            string.Empty,
+            "namespace SamplePlugin;",
+            string.Empty,
+            "public sealed class SamplePluginModule : IServiceModule",
+            "{",
+            "    public void RegisterServices(IServiceCollection services)",
+            "    {",
+            "    }",
+            string.Empty,
+            "    public IEnumerable<IServiceDescriptor> DescribeServices()",
+            "    {",
+            "        yield return new SampleDescriptor();",
+            "    }",
+            string.Empty,
+            "    private sealed class SampleDescriptor : IServiceDescriptor",
+            "    {",
+            "        public string Id => \"Sample.Plugin.Service\";",
+            "        public string DisplayName => \"Sample Plugin Service\";",
+            "        public string Category => \"Plugins\";",
+            "        public string? Description => \"Demo descriptor\";",
+            "        public ServiceType? LegacyType => ServiceType.Tcp;",
+            "        public IServiceOptionsSerializer? OptionsSerializer => null;",
+            "        public IReadOnlyCollection<ServiceFactoryBinding> Factories => System.Array.Empty<ServiceFactoryBinding>();",
+            "        public ServicePresentationMetadata Presentation => new(\"✨\", \"#FF112233\", \"#FF445566\", \"Plugin Service\");",
+            "        public bool HasPayloadDescription => false;",
+            "        public string? DescribePayload(object? payload) => null;",
+            "    }",
+            "}");
 
-namespace SamplePlugin;
-
-public sealed class SamplePluginModule : IServiceModule
-{
-    public void RegisterServices(IServiceCollection services)
-    {
-    }
-
-    public IEnumerable<IServiceDescriptor> DescribeServices()
-    {
-        yield return new SampleDescriptor();
-    }
-
-    private sealed class SampleDescriptor : IServiceDescriptor
-    {
-        public string Id => \"Sample.Plugin.Service\";
-        public string DisplayName => \"Sample Plugin Service\";
-        public string Category => \"Plugins\";
-        public string? Description => \"Demo descriptor\";
-        public ServiceType? LegacyType => ServiceType.Tcp;
-        public IServiceOptionsSerializer? OptionsSerializer => null;
-        public IReadOnlyCollection<ServiceFactoryBinding> Factories => System.Array.Empty<ServiceFactoryBinding>();
-        public ServicePresentationMetadata Presentation => new(\"✨\", \"#FF112233\", \"#FF445566\", \"Plugin Service\");
-        public bool HasPayloadDescription => false;
-        public string? DescribePayload(object? payload) => null;
-    }
-}
-");
+        var syntaxTree = CSharpSyntaxTree.ParseText(pluginSourceCode);
 
         var references = AppDomain.CurrentDomain
             .GetAssemblies()
@@ -132,11 +134,13 @@ public sealed class SamplePluginModule : IServiceModule
         }
     }
 
-    private static string CreateManifestJson() => @"{
-  \"id\": \"Sample.Plugin\",
-  \"name\": \"Sample Plugin\",
-  \"version\": \"1.0.0\",
-  \"entryAssembly\": \"SamplePlugin.dll\",
-  \"serviceAssemblies\": [ \"SamplePlugin.dll\" ]
-}";
+    private static string CreateManifestJson() => string.Join(
+        Environment.NewLine,
+        "{",
+        "  \"id\": \"Sample.Plugin\",",
+        "  \"name\": \"Sample Plugin\",",
+        "  \"version\": \"1.0.0\",",
+        "  \"entryAssembly\": \"SamplePlugin.dll\",",
+        "  \"serviceAssemblies\": [ \"SamplePlugin.dll\" ]",
+        "}");
 }

--- a/DesktopApplicationTemplate.Tests/PluginLoaderIntegrationTests.cs
+++ b/DesktopApplicationTemplate.Tests/PluginLoaderIntegrationTests.cs
@@ -67,42 +67,44 @@ public sealed class PluginLoaderIntegrationTests : IDisposable
 
     private static void CompilePluginAssembly(string outputPath)
     {
-        var syntaxTree = CSharpSyntaxTree.ParseText(@"
-using System;
-using System.Collections.Generic;
-using DesktopApplicationTemplate.Core.Modules;
-using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Models;
-using Microsoft.Extensions.DependencyInjection;
+        var pluginSourceCode = string.Join(
+            Environment.NewLine,
+            "using System;",
+            "using System.Collections.Generic;",
+            "using DesktopApplicationTemplate.Core.Modules;",
+            "using DesktopApplicationTemplate.Core.Services;",
+            "using DesktopApplicationTemplate.Models;",
+            "using Microsoft.Extensions.DependencyInjection;",
+            string.Empty,
+            "namespace SamplePlugin;",
+            string.Empty,
+            "public sealed class SamplePluginModule : IServiceModule",
+            "{",
+            "    public void RegisterServices(IServiceCollection services)",
+            "    {",
+            "    }",
+            string.Empty,
+            "    public IEnumerable<IServiceDescriptor> DescribeServices()",
+            "    {",
+            "        yield return new SampleDescriptor();",
+            "    }",
+            string.Empty,
+            "    private sealed class SampleDescriptor : IServiceDescriptor",
+            "    {",
+            "        public string Id => \"Sample.Plugin.Service\";",
+            "        public string DisplayName => \"Sample Plugin Service\";",
+            "        public string Category => \"Plugins\";",
+            "        public string? Description => \"Sample descriptor\";",
+            "        public ServiceType? LegacyType => null;",
+            "        public IServiceOptionsSerializer? OptionsSerializer => null;",
+            "        public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();",
+            "        public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;",
+            "        public bool HasPayloadDescription => false;",
+            "        public string? DescribePayload(object? payload) => null;",
+            "    }",
+            "}");
 
-namespace SamplePlugin;
-
-public sealed class SamplePluginModule : IServiceModule
-{
-    public void RegisterServices(IServiceCollection services)
-    {
-    }
-
-    public IEnumerable<IServiceDescriptor> DescribeServices()
-    {
-        yield return new SampleDescriptor();
-    }
-
-    private sealed class SampleDescriptor : IServiceDescriptor
-    {
-        public string Id => \"Sample.Plugin.Service\";
-        public string DisplayName => \"Sample Plugin Service\";
-        public string Category => \"Plugins\";
-        public string? Description => \"Sample descriptor\";
-        public ServiceType? LegacyType => null;
-        public IServiceOptionsSerializer? OptionsSerializer => null;
-        public IReadOnlyCollection<ServiceFactoryBinding> Factories => Array.Empty<ServiceFactoryBinding>();
-        public ServicePresentationMetadata Presentation => ServicePresentationMetadata.Empty;
-        public bool HasPayloadDescription => false;
-        public string? DescribePayload(object? payload) => null;
-    }
-}
-");
+        var syntaxTree = CSharpSyntaxTree.ParseText(pluginSourceCode);
 
         var references = GetCompilationReferences();
         var compilation = CSharpCompilation.Create(
@@ -128,11 +130,13 @@ public sealed class SamplePluginModule : IServiceModule
         return assemblies.Select(assembly => MetadataReference.CreateFromFile(assembly.Location));
     }
 
-    private static string CreateManifestJson() => @"{
-  \"id\": \"Sample.Plugin\",
-  \"name\": \"Sample Plugin\",
-  \"version\": \"1.0.0\",
-  \"entryAssembly\": \"SamplePlugin.dll\",
-  \"serviceAssemblies\": [ \"SamplePlugin.dll\" ]
-}";
+    private static string CreateManifestJson() => string.Join(
+        Environment.NewLine,
+        "{",
+        "  \"id\": \"Sample.Plugin\",",
+        "  \"name\": \"Sample Plugin\",",
+        "  \"version\": \"1.0.0\",",
+        "  \"entryAssembly\": \"SamplePlugin.dll\",",
+        "  \"serviceAssemblies\": [ \"SamplePlugin.dll\" ]",
+        "}");
 }


### PR DESCRIPTION
## Summary
- construct the generated plug-in source code with string.Join so Roslyn can compile it without depending on raw string literals
- build the embedded manifest JSON using string.Join to avoid escape sequences while remaining compatible with older compilers

## Testing
- not run (Windows-only `dotnet test --settings tests.runsettings`)


------
https://chatgpt.com/codex/tasks/task_e_68dd4f2bda54832681c3c3934d8ba115