### PR TITLE
Fix legacy JSON test data string literal

### DIFF
--- a/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
+++ b/DesktopApplicationTemplate.Tests/ServicePersistenceTests.cs
@@ -324,14 +324,16 @@ namespace DesktopApplicationTemplate.Tests
             {
                 var descriptor = new CustomHttpDescriptor();
                 var catalog = new ServiceCatalog(new[] { descriptor });
-                var legacyJson = @"[
-    {
-        ""DisplayName"": ""HTTP Legacy"",
-        ""LegacyType"": ""http"",
-        ""LegacyTypeName"": ""Http"",
-        ""SerializedPayload"": ""{\\\"BaseUrl\\\":\\\"https://legacy.example\\\"}""
-    }
-]";
+                var legacyJson = """
+                [
+                    {
+                        "DisplayName": "HTTP Legacy",
+                        "LegacyType": "http",
+                        "LegacyTypeName": "Http",
+                        "SerializedPayload": "{\"BaseUrl\":\"https://legacy.example\"}"
+                    }
+                ]
+                """;
 
                 File.WriteAllText(ServicePersistence.FilePath, legacyJson);
                 var loaded = ServicePersistence.Load(catalog);


### PR DESCRIPTION
## Summary
- replace the HTTP legacy JSON payload test data with a raw string literal so the compiler no longer flags escape sequences

## Testing
- not run (dotnet CLI is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd50dccbd0832683fcf5b7a2e22b0b