### PR TITLE
Fix test infrastructure namespaces

### DIFF
--- a/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
+++ b/DesktopApplicationTemplate.Tests/MainViewCreateNavigationTests.cs
@@ -10,6 +10,7 @@ using System.Windows.Controls;
 using Xunit;
 using DesktopApplicationTemplate.Services.Common.Descriptors;
 using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.EditHandlers;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Serialization;

--- a/DesktopApplicationTemplate.Tests/TestDoubles.cs
+++ b/DesktopApplicationTemplate.Tests/TestDoubles.cs
@@ -5,11 +5,12 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Factories;
 using DesktopApplicationTemplate.UI.Navigation;
+using DesktopApplicationTemplate.UI.Services;
 using System.Windows.Controls;
 
 namespace DesktopApplicationTemplate.Tests;
 
-internal sealed class FakeServiceCatalog : IServiceCatalog
+public sealed class FakeServiceCatalog : IServiceCatalog
 {
     private readonly Dictionary<string, IServiceDescriptor> descriptorsById = new(StringComparer.Ordinal);
     private readonly Dictionary<ServiceType, IServiceDescriptor> descriptorsByLegacy = new();

--- a/DesktopApplicationTemplate.UI/Services/IEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/Services/IEditServiceHandler.cs
@@ -1,6 +1,6 @@
 using DesktopApplicationTemplate.UI.ViewModels;
 
-namespace DesktopApplicationTemplate.UI;
+namespace DesktopApplicationTemplate.UI.Services;
 
 /// <summary>
 /// Handles edit requests for a specific service type.

--- a/TestCommon/ConsoleTestLogger.cs
+++ b/TestCommon/ConsoleTestLogger.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace DesktopApplicationTemplate.Tests;
+namespace TestCommon;
 
 public static class ConsoleTestLogger
 {

--- a/TestCommon/TestCommon.csproj
+++ b/TestCommon/TestCommon.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>DesktopApplicationTemplate.Tests</RootNamespace>
+    <RootNamespace>TestCommon</RootNamespace>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>

--- a/TestCommon/WindowsFactAttribute.cs
+++ b/TestCommon/WindowsFactAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using Xunit;
 
-namespace DesktopApplicationTemplate.Tests;
+namespace TestCommon;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public class WindowsFactAttribute : FactAttribute


### PR DESCRIPTION
## Summary
- align `IEditServiceHandler` with the `DesktopApplicationTemplate.UI.Services` namespace used throughout the UI layer
- expose `FakeServiceCatalog` for public helpers and update test doubles to import edit handlers from the correct namespace
- retarget the `TestCommon` project namespace to `TestCommon` so consuming tests can resolve shared fixtures

## Testing
- not run (Windows-only UI dependencies prevent local execution)


------
https://chatgpt.com/codex/tasks/task_e_68dd522966e48326ae9b6a81815075e3