### PR TITLE
Fix packaging task assembly resolution and remove selfheal references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,7 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-.codex-selfheal/
 
 # Auto-generated designer files
 *.designer.cs

--- a/DesktopApplicationTemplate.UI/Navigation/ServiceUiRegistry.cs
+++ b/DesktopApplicationTemplate.UI/Navigation/ServiceUiRegistry.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.Configuration;
-using DesktopApplicationTemplate.UI.EditHandlers;
 using DesktopApplicationTemplate.UI.Factories;
+using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Navigation;

--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.targets
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.targets
@@ -1,17 +1,19 @@
 <Project>
+  <PropertyGroup>
+    <ServicePluginPackagingTaskAssembly Condition="'$(ServicePluginPackagingTaskAssembly)' == '' and Exists('$(MSBuildThisFileDirectory)bin\\$(Configuration)\\net8.0\\ServicePlugin.Packaging.dll')">
+      $(MSBuildThisFileDirectory)bin\$(Configuration)\net8.0\ServicePlugin.Packaging.dll
+    </ServicePluginPackagingTaskAssembly>
+    <ServicePluginPackagingTaskAssembly Condition="'$(ServicePluginPackagingTaskAssembly)' == '' and Exists('$(MSBuildThisFileDirectory)bin\\Debug\\net8.0\\ServicePlugin.Packaging.dll')">
+      $(MSBuildThisFileDirectory)bin\Debug\net8.0\ServicePlugin.Packaging.dll
+    </ServicePluginPackagingTaskAssembly>
+    <ServicePluginPackagingTaskAssembly Condition="'$(ServicePluginPackagingTaskAssembly)' == '' and Exists('$(MSBuildThisFileDirectory)bin\\Release\\net8.0\\ServicePlugin.Packaging.dll')">
+      $(MSBuildThisFileDirectory)bin\Release\net8.0\ServicePlugin.Packaging.dll
+    </ServicePluginPackagingTaskAssembly>
+  </PropertyGroup>
+
   <UsingTask TaskName="ServicePlugin.Packaging.Tasks.CreateServicePluginArchive"
-             TaskFactory="RoslynCodeTaskFactory"
-             AssemblyFile="$(MSBuildBinPath)/Microsoft.Build.Tasks.Core.dll">
-    <Task>
-      <Reference Include="System" />
-      <Reference Include="System.Core" />
-      <Reference Include="System.Runtime" />
-      <Reference Include="System.IO.Compression" />
-      <Reference Include="Microsoft.Build.Framework" />
-      <Reference Include="Microsoft.Build.Utilities.Core" />
-      <Code Type="Class" Source="$(MSBuildThisFileDirectory)Tasks/CreateServicePluginArchive.cs" />
-    </Task>
-  </UsingTask>
+             AssemblyFile="$(ServicePluginPackagingTaskAssembly)"
+             Condition="Exists('$(ServicePluginPackagingTaskAssembly)')" />
 
   <Target Name="PackServicePlugin" AfterTargets="Build" Condition="'$(ServicePluginEnablePackaging)' != 'false'">
     <ItemGroup>
@@ -55,7 +57,10 @@
       <_ResolvedPackageVersion Condition="'$(ServicePluginPackageVersion)' != ''">$(ServicePluginPackageVersion)</_ResolvedPackageVersion>
     </PropertyGroup>
 
-    <CreateServicePluginArchive
+    <Error Condition="!Exists('$(ServicePluginPackagingTaskAssembly)')"
+           Text="The service plug-in packaging task assembly could not be located. Build the ServicePlugin.Packaging project to generate '$(ServicePluginPackagingTaskAssembly)'." />
+
+    <CreateServicePluginArchive Condition="Exists('$(ServicePluginPackagingTaskAssembly)')"
         Files="@(_ServicePluginFiles)"
         OutputDirectory="$(ServicePluginPackageOutput)"
         PackageId="$(ServicePluginPackageId)"


### PR DESCRIPTION
## Summary
- import the edit service handler namespace in the navigation registry
- resolve the packaging MSBuild task from the built assembly and guard against missing outputs
- drop the leftover selfheal ignore entry

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd577787c88326b2ebc59578b801e4