### PR TITLE
Add PeakIoT plug-in archive support

### DIFF
--- a/Codex/CollaborationGuidelines.txt
+++ b/Codex/CollaborationGuidelines.txt
@@ -39,7 +39,7 @@ Draw.io Integration
 
 Descriptor & Plug-in CI Tasks
 -----------------------------
-1. **Package sample plug-ins** – GitHub Actions builds `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` with `dotnet build` so the generated `.ccp`/`.chapp` archives verify packaging targets. Capture the CI log links when these builds surface errors.
+1. **Package sample plug-ins** – GitHub Actions builds `Samples/TcpRelayPlugin` and `Samples/HttpRelayPlugin` with `dotnet build` so the generated `.peakiot` (and legacy `.ccp`/`.chapp`) archives verify packaging targets. Capture the CI log links when these builds surface errors.
 2. **Exercise template scaffolds** – When the service plug-in template changes, add `dotnet new install Templates/ServicePluginTemplate` and a sample `dotnet build` invocation to the CI pipeline (or a one-off workflow run) to confirm descriptors scaffold correctly.
 3. **Record outcomes** – Note the status of these tasks in `Codex/docs/CollaborationAndDebugTips.txt`, especially when migrations affect persistence or descriptor bindings.
 

--- a/Codex/docs/CustomServiceGuide.md
+++ b/Codex/docs/CustomServiceGuide.md
@@ -32,8 +32,8 @@ Use this checklist when upgrading a service that previously depended on the `Ser
 
 1. **Import the packaging targets** – reference `ServicePlugin.Packaging` by adding the props/targets pair to the plug-in `.csproj`. This enables the `PackServicePlugin` target after every build.
 2. **Author `plugin.manifest.json`** – populate the manifest with the plug-in id, name, version, entry assembly, and any assemblies that expose `IServiceModule` implementations. The loader validates the manifest against the schema documented in `Codex/docs/PluginManifestSchema.md`.
-3. **Build to create archives** – run `dotnet build` for the plug-in. The packaging target copies the manifest, compiled assemblies, and dependencies into `.ccp` and `.chapp` archives under `bin/<configuration>/<tfm>/plugins`.
-4. **Distribute the archive** – drop the generated archive into the host's plug-in directory (or publish it via your preferred channel). The loader extracts each archive into its versioned cache and automatically registers the descriptors.
+3. **Build to create archives** – run `dotnet build` for the plug-in. The packaging target copies the manifest, compiled assemblies, and dependencies into `.peakiot` archives (alongside optional legacy `.ccp`/`.chapp` outputs) under `bin/<configuration>/<tfm>/plugins`.
+4. **Distribute the archive** – drop the generated archive into the host's plug-in directory (or publish it via your preferred channel). The loader extracts each supported archive into its versioned cache and automatically registers the descriptors.
 
 ### Reusable resources
 

--- a/Codex/docs/PluginVerificationChecklist.md
+++ b/Codex/docs/PluginVerificationChecklist.md
@@ -4,7 +4,7 @@ Use this checklist to validate descriptor-based plug-ins before distributing the
 
 ## Import and catalog
 
-1. Import the `.ccp` or `.chapp` package through the plug-in import workflow and confirm the archive extracts without errors.
+1. Import the `.peakiot` package (or a legacy `.ccp`/`.chapp` archive if required) through the plug-in import workflow and confirm the archive extracts without errors.
 2. Inspect the log output to verify each descriptor id, version, and assembly was registered with `IServiceCatalog`.
 3. Restart the application (or trigger catalog refresh) to ensure descriptors survive reload and appear in the service creation list.
 

--- a/DesktopApplicationTemplate.Core/Modules/PluginLoader.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginLoader.cs
@@ -29,6 +29,13 @@ public sealed class PluginLoader
     private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
+    private static readonly HashSet<string> SupportedArchiveExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".peakiot",
+        ".ccp",
+        ".chapp",
+        ".zip",
+    };
 
     private readonly PluginLoaderOptions options;
     private readonly ILogger<PluginLoader> logger;
@@ -79,7 +86,7 @@ public sealed class PluginLoader
                 {
                     LoadFromDirectory(entry, assemblies);
                 }
-                else if (string.Equals(Path.GetExtension(entry), ".zip", StringComparison.OrdinalIgnoreCase))
+                else if (SupportedArchiveExtensions.Contains(Path.GetExtension(entry)))
                 {
                     LoadFromArchive(entry, assemblies);
                 }

--- a/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
@@ -15,11 +15,14 @@ namespace DesktopApplicationTemplate.UI.Services;
 /// </summary>
 public sealed class PluginImportService : IPluginImportService
 {
-    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly string[] SupportedExtensionList =
     {
+        ".peakiot",
         ".ccp",
         ".chapp",
     };
+
+    private static readonly HashSet<string> SupportedExtensions = new(SupportedExtensionList, StringComparer.OrdinalIgnoreCase);
 
     private readonly PluginLoaderOptions _options;
     private readonly IServiceCatalog _catalog;
@@ -48,7 +51,7 @@ public sealed class PluginImportService : IPluginImportService
         var extension = Path.GetExtension(sourcePath);
         if (!SupportedExtensions.Contains(extension))
         {
-            var message = $"Unsupported plug-in extension '{extension}'.";
+            var message = $"Unsupported plug-in extension '{extension}'. Supported extensions: {string.Join(", ", SupportedExtensionList)}.";
             _logger.LogWarning(message);
             return Task.FromResult(new PluginImportResult(false, message, null, Array.Empty<IServiceDescriptor>()));
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -189,7 +189,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private async Task ImportServiceAsync()
         {
             var selectedPath = _fileDialogService.OpenFile(
-                "Service Packages (*.ccp;*.chapp)|*.ccp;*.chapp|All Files (*.*)|*.*",
+                "Service Packages (*.peakiot;*.ccp;*.chapp)|*.peakiot;*.ccp;*.chapp|All Files (*.*)|*.*",
                 "Import Service Package");
 
             if (string.IsNullOrWhiteSpace(selectedPath))

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ During startup `services.AddServiceModules()` discovers `IServiceModule` impleme
 
 ## Packaging service plug-ins
 
-The repository ships with an MSBuild packaging project that bundles plug-in assets into distributable `.ccp` and `.chapp` archives. To enable packaging in a plug-in project:
+The repository ships with an MSBuild packaging project that bundles plug-in assets into distributable `.peakiot` archives (and optional legacy `.ccp`/`.chapp` packages). To enable packaging in a plug-in project:
 
 1. Import `ServicePlugin.Packaging` before and after the project body:
 
@@ -151,9 +151,9 @@ The repository ships with an MSBuild packaging project that bundles plug-in asse
    ```
 
 2. Author a `plugin.manifest.json` file at the project root. The manifest must identify the plug-in id, name, version, entry assembly, and any assemblies that expose `IServiceModule` implementations. See `Codex/docs/PluginManifestSchema.md` for field descriptions.
-3. Build the plug-in with `dotnet build`. The packaging targets run after compilation and emit archives to `bin/<configuration>/<tfm>/plugins`. Set `ServicePluginArchiveExtensions` to `.ccp`, `.chapp`, or both (the default).
+3. Build the plug-in with `dotnet build`. The packaging targets run after compilation and emit archives to `bin/<configuration>/<tfm>/plugins`. Set `ServicePluginArchiveExtensions` to `.peakiot` (the default) or include legacy extensions such as `.ccp`/`.chapp` when older hosts require them.
 
-Each archive contains the manifest, compiled descriptors, and copy-local dependencies under `libs/`. Hosts can drop either archive into the plug-in directory and the loader will extract it into the cache configured by `PluginLoaderOptions`.
+Each archive contains the manifest, compiled descriptors, and copy-local dependencies under `libs/`. Hosts can drop any supported archive into the plug-in directory and the loader will extract it into the cache configured by `PluginLoaderOptions`.
 
 ### Templates and samples
 

--- a/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
+++ b/Samples/HttpRelayPlugin/HttpRelayPlugin.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>HttpRelayPlugin</RootNamespace>
     <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">Sample.HttpRelay</ServicePluginPackageId>
     <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">1.0.0</ServicePluginPackageVersion>
-    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp;.chapp</ServicePluginArchiveExtensions>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.peakiot;.ccp;.chapp</ServicePluginArchiveExtensions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -5,4 +5,4 @@ The `Samples` folder contains plug-in projects that exercise the `ServicePlugin.
 1. **TcpRelayPlugin** packages a TCP descriptor and runtime factory that log lifecycle events.
 2. **HttpRelayPlugin** demonstrates the same workflow for an HTTP descriptor.
 
-Each project imports `ServicePlugin.Packaging` so building them produces `.ccp` and `.chapp` archives under `bin/<configuration>/<tfm>/plugins`. Use these samples to validate packaging changes locally or in CI pipelines by adding `dotnet build Samples/TcpRelayPlugin` and `dotnet build Samples/HttpRelayPlugin` to the workflow.
+Each project imports `ServicePlugin.Packaging` so building them produces `.peakiot` archives (and legacy `.ccp`/`.chapp` packages for backward compatibility) under `bin/<configuration>/<tfm>/plugins`. Use these samples to validate packaging changes locally or in CI pipelines by adding `dotnet build Samples/TcpRelayPlugin` and `dotnet build Samples/HttpRelayPlugin` to the workflow.

--- a/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
+++ b/Samples/TcpRelayPlugin/TcpRelayPlugin.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>TcpRelayPlugin</RootNamespace>
     <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">Sample.TcpRelay</ServicePluginPackageId>
     <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">1.0.0</ServicePluginPackageVersion>
-    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp;.chapp</ServicePluginArchiveExtensions>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.peakiot;.ccp;.chapp</ServicePluginArchiveExtensions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ServicePlugin.Packaging/ServicePlugin.Packaging.props
+++ b/ServicePlugin.Packaging/ServicePlugin.Packaging.props
@@ -4,7 +4,7 @@
     <ServicePluginPackageOutput Condition="'$(ServicePluginPackageOutput)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)plugins\</ServicePluginPackageOutput>
     <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">$(AssemblyName)</ServicePluginPackageId>
     <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">$(Version)</ServicePluginPackageVersion>
-    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp</ServicePluginArchiveExtensions>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.peakiot;.ccp;.chapp</ServicePluginArchiveExtensions>
     <ServicePluginIncludeReferenceCopyLocal Condition="'$(ServicePluginIncludeReferenceCopyLocal)' == ''">true</ServicePluginIncludeReferenceCopyLocal>
     <ServicePluginIncludeEntryAssembly Condition="'$(ServicePluginIncludeEntryAssembly)' == ''">true</ServicePluginIncludeEntryAssembly>
   </PropertyGroup>

--- a/ServicePlugin.Packaging/Tasks/CreateServicePluginArchive.cs
+++ b/ServicePlugin.Packaging/Tasks/CreateServicePluginArchive.cs
@@ -14,6 +14,7 @@ namespace ServicePlugin.Packaging.Tasks;
 /// </summary>
 public sealed class CreateServicePluginArchive : Microsoft.Build.Utilities.Task
 {
+    private const string DefaultArchiveExtension = ".peakiot";
     private static readonly char[] ExtensionSeparators = [ ';' ];
 
     [Required]
@@ -29,7 +30,7 @@ public sealed class CreateServicePluginArchive : Microsoft.Build.Utilities.Task
     public string PackageVersion { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the archive extensions (e.g. ".ccp;.chapp").
+    /// Gets or sets the archive extensions (e.g. ".peakiot;.ccp").
     /// </summary>
     [Required]
     public string ArchiveExtensions { get; set; } = string.Empty;
@@ -98,22 +99,34 @@ public sealed class CreateServicePluginArchive : Microsoft.Build.Utilities.Task
     {
         var entries = (ArchiveExtensions ?? string.Empty)
             .Split(ExtensionSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .DefaultIfEmpty(".ccp")
             .Select(NormalizeExtension)
+            .Where(static value => !string.IsNullOrWhiteSpace(value))
+            .ToList();
+
+        if (entries.Count == 0)
+        {
+            entries.Add(DefaultArchiveExtension);
+        }
+
+        if (!entries.Contains(DefaultArchiveExtension, StringComparer.OrdinalIgnoreCase))
+        {
+            entries.Insert(0, DefaultArchiveExtension);
+        }
+
+        return entries
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
-
-        return entries;
     }
 
     private static string NormalizeExtension(string value)
     {
         if (string.IsNullOrWhiteSpace(value))
         {
-            return ".ccp";
+            return DefaultArchiveExtension;
         }
 
-        return value.StartsWith('.') ? value : $".{value}";
+        var trimmed = value.Trim();
+        return trimmed.StartsWith('.', StringComparison.Ordinal) ? trimmed : FormattableString.Invariant($".{trimmed}");
     }
 
     private string? CreateArchive(string version, string extension, ref bool manifestFound)

--- a/Templates/ServicePluginTemplate/README.md
+++ b/Templates/ServicePluginTemplate/README.md
@@ -2,7 +2,7 @@
 
 This template demonstrates how to build a service plug-in that can be packaged with the `ServicePlugin.Packaging` project. It implements:
 
-1. A manifest (`plugin.manifest.json`) that is zipped into `.ccp` and `.chapp` archives.
+1. A manifest (`plugin.manifest.json`) that is zipped into `.peakiot` archives (with optional legacy `.ccp`/`.chapp` outputs).
 2. An `IServiceModule` (`TemplateServiceModule`) that registers runtime dependencies.
 3. A descriptor (`TemplateServiceDescriptor`) that advertises runtime bindings.
 4. A runtime factory (`TemplateRuntimeFactory`) that logs lifecycle events.

--- a/Templates/ServicePluginTemplate/ServicePluginTemplate.csproj
+++ b/Templates/ServicePluginTemplate/ServicePluginTemplate.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>ServicePluginTemplate</RootNamespace>
     <ServicePluginPackageId Condition="'$(ServicePluginPackageId)' == ''">__PluginId__</ServicePluginPackageId>
     <ServicePluginPackageVersion Condition="'$(ServicePluginPackageVersion)' == ''">__PluginVersion__</ServicePluginPackageVersion>
-    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.ccp;.chapp</ServicePluginArchiveExtensions>
+    <ServicePluginArchiveExtensions Condition="'$(ServicePluginArchiveExtensions)' == ''">.peakiot;.ccp;.chapp</ServicePluginArchiveExtensions>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- default packaging settings now emit `.peakiot` archives alongside normalized legacy extensions
- recognize `.peakiot`, `.ccp`, and `.chapp` payloads throughout the loader, importer, and UI copy
- refresh template/sample projects and docs to highlight `.peakiot` packages and legacy compatibility

## Testing
- dotnet build ServicePlugin.Packaging/ServicePlugin.Packaging.csproj *(fails: dotnet not installed in container)*
- dotnet build Samples/TcpRelayPlugin/TcpRelayPlugin.csproj *(fails: dotnet not installed in container)*
- dotnet build Samples/HttpRelayPlugin/HttpRelayPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5d9cfecc83268fc96270728c53af