### PR TITLE
Decouple host wiring for plugin-based services

### DIFF
--- a/DesktopApplicationTemplate.Service/Program.cs
+++ b/DesktopApplicationTemplate.Service/Program.cs
@@ -6,12 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using DesktopApplicationTemplate.Core.Modules;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Services.Common;
-using DesktopApplicationTemplate.Services.Common.Runtime;
-using DesktopApplicationTemplate.Service.Services;
-using FubarDev.FtpServer;
-using FubarDev.FtpServer.FileSystem.DotNet;
 
 namespace DesktopApplicationTemplate.Service
 {
@@ -78,14 +73,8 @@ namespace DesktopApplicationTemplate.Service
                 var assembliesForScanning = PluginLoader.CombineWithDefaultAssemblies(pluginAssemblies);
                 services.AddServiceModules(assembliesForScanning.ToArray());
                 services.AddCommonServices();
-                services.AddOptions<HeartbeatRuntimeOptions>()
-                    .BindConfiguration("Heartbeat");
                 services.AddSingleton<ServiceManager>();
                 services.AddHostedService<Worker>();
-                services.AddFtpServer(builder => builder
-                    .UseDotNetFileSystem()
-                    .EnableAnonymousAuthentication());
-                services.AddSingleton<IFtpServerService, FtpServerService>();
             });
         }
     }

--- a/DesktopApplicationTemplate.Services.Common/CommonServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Services.Common/CommonServiceCollectionExtensions.cs
@@ -17,8 +17,6 @@ public static class CommonServiceCollectionExtensions
         services.AddSingleton<IServiceRule, ServiceRule>();
         services.AddTransient(typeof(IServiceScreen<>), typeof(ServiceScreen<>));
         services.AddSingleton<IFileSearchService, FileSearchService>();
-        services.AddSingleton<HeartbeatRuntimeFactory>();
-        services.AddOptions<HeartbeatRuntimeOptions>();
         return services;
     }
 }

--- a/DesktopApplicationTemplate.Services.Common/CommonServicesModule.cs
+++ b/DesktopApplicationTemplate.Services.Common/CommonServicesModule.cs
@@ -1,14 +1,13 @@
+using System;
 using System.Collections.Generic;
 using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
-using DesktopApplicationTemplate.Services.Common.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.Services.Common;
 
 /// <summary>
-/// Registers shared service descriptors.
+/// Provides shared service module hooks for common infrastructure.
 /// </summary>
 public sealed class CommonServicesModule : IServiceModule
 {
@@ -17,23 +16,5 @@ public sealed class CommonServicesModule : IServiceModule
         // Shared services are registered through extension methods elsewhere.
     }
 
-    public IEnumerable<IServiceDescriptor> DescribeServices()
-    {
-        yield return new MqttServiceDescriptor();
-        yield return new HttpServiceDescriptor();
-        yield return new FtpServiceDescriptor();
-        yield return new HidServiceDescriptor();
-        yield return new CsvServiceDescriptor();
-        yield return new FileObserverServiceDescriptor();
-        yield return new ScpServiceDescriptor();
-        yield return new TcpServiceDescriptor();
-        yield return new HeartbeatServiceDescriptor(
-            factories: new[]
-            {
-                ServiceFactoryBinding.Create(
-                    ServiceFactoryKind.Runtime,
-                    typeof(IServiceRuntimeFactory),
-                    sp => sp.GetRequiredService<HeartbeatRuntimeFactory>())
-            });
-    }
+    public IEnumerable<IServiceDescriptor> DescribeServices() => Array.Empty<IServiceDescriptor>();
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -16,9 +16,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using MQTTnet;
-using FubarDev.FtpServer;
-using FubarDev.FtpServer.FileSystem.DotNet;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -100,7 +97,7 @@ namespace DesktopApplicationTemplate.UI
 
             var assembliesForScanning = PluginLoader.CombineWithDefaultAssemblies(pluginAssemblies);
             var catalog = services.AddServiceModules(assembliesForScanning.ToArray());
-            var registrations = InitializeServices(services, catalog);
+            var registrations = InitializeServices(services, catalog, pluginAssemblies);
 
             services.AddSingleton<IServiceUiRegistry>(sp => ServiceUiRegistry.Create(sp, catalog, registrations));
 
@@ -120,10 +117,6 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<ServiceMessageTableViewModel>();
             services.AddSingleton<DependencyChecker>();
-            services.AddFtpServer(builder => builder
-                .UseDotNetFileSystem()
-                .EnableAnonymousAuthentication());
-            services.AddSingleton<IFtpServerService, DesktopApplicationTemplate.Service.Services.FtpServerService>();
             services.AddSingleton<SettingsViewModel>();
             services.AddTransient<SplashWindow>();
             services.AddTransient<CreateServicePage>();
@@ -135,24 +128,56 @@ namespace DesktopApplicationTemplate.UI
             services.Configure<AppSettings>(configuration.GetSection("AppSettings"));
             services.Configure<MqttServiceOptions>(configuration.GetSection("MqttService"));
             services.Configure<TcpServiceOptions>(configuration.GetSection("TcpService"));
-            services.AddOptions<DesktopApplicationTemplate.UI.Services.FtpServerOptions>()
-                .BindConfiguration("FtpServer");
-            services.AddOptions<HidServiceOptions>();
-            services.AddOptions<HeartbeatServiceOptions>();
-            services.AddOptions<FileObserverServiceOptions>();
-            services.AddOptions<CsvServiceOptions>();
-            services.AddOptions<ScpServiceOptions>();
         }
 
-        private static IReadOnlyCollection<ServiceRegistrationInfo> InitializeServices(IServiceCollection services, IServiceCatalog catalog)
+        private static IReadOnlyCollection<ServiceRegistrationInfo> InitializeServices(
+            IServiceCollection services,
+            IServiceCatalog catalog,
+            IEnumerable<Assembly> pluginAssemblies)
         {
             var descriptorIds = new HashSet<string>(catalog.Descriptors.Select(d => d.Id), StringComparer.Ordinal);
             var registrations = new List<ServiceRegistrationInfo>();
             var registeredTypes = new HashSet<Type>();
             var registrationKeys = new HashSet<string>(StringComparer.Ordinal);
-            var assembly = typeof(App).Assembly;
+            var assemblies = BuildAssemblySet(pluginAssemblies);
 
-            foreach (var type in assembly.GetTypes())
+            foreach (var assembly in assemblies)
+            {
+                RegisterAttributedTypes(assembly, descriptorIds, services, registrations, registeredTypes, registrationKeys);
+            }
+
+            ApplyConventionRegistrations(services, catalog, registrations, registeredTypes, registrationKeys, assemblies);
+
+            return registrations;
+        }
+
+        private static IReadOnlyCollection<Assembly> BuildAssemblySet(IEnumerable<Assembly> pluginAssemblies)
+        {
+            var assemblies = new List<Assembly> { typeof(App).Assembly };
+
+            if (pluginAssemblies != null)
+            {
+                foreach (var assembly in pluginAssemblies)
+                {
+                    if (assembly is not null && assemblies.All(a => !string.Equals(a.FullName, assembly.FullName, StringComparison.Ordinal)))
+                    {
+                        assemblies.Add(assembly);
+                    }
+                }
+            }
+
+            return assemblies;
+        }
+
+        private static void RegisterAttributedTypes(
+            Assembly assembly,
+            ISet<string> descriptorIds,
+            IServiceCollection services,
+            ICollection<ServiceRegistrationInfo> registrations,
+            ISet<Type> registeredTypes,
+            ISet<string> registrationKeys)
+        {
+            foreach (var type in GetLoadableTypes(assembly))
             {
                 var attributes = type.GetCustomAttributes<ServiceDescriptorRegistrationAttribute>(inherit: false);
                 foreach (var attribute in attributes)
@@ -173,10 +198,6 @@ namespace DesktopApplicationTemplate.UI
                     }
                 }
             }
-
-            ApplyConventionRegistrations(services, catalog, registrations, registeredTypes, registrationKeys, assembly);
-
-            return registrations;
         }
 
         private static void RegisterType(IServiceCollection services, Type implementationType, ServiceLifetime lifetime)
@@ -201,8 +222,13 @@ namespace DesktopApplicationTemplate.UI
             ICollection<ServiceRegistrationInfo> registrations,
             ISet<Type> registeredTypes,
             ISet<string> registrationKeys,
-            Assembly assembly)
+            IReadOnlyCollection<Assembly> assemblies)
         {
+            var candidateTypes = assemblies
+                .SelectMany(GetLoadableTypes)
+                .Where(t => t.IsClass && !t.IsAbstract)
+                .ToList();
+
             foreach (var descriptor in catalog.Descriptors)
             {
                 if (!TryGetServicePrefix(descriptor, out var prefix))
@@ -210,8 +236,8 @@ namespace DesktopApplicationTemplate.UI
                     continue;
                 }
 
-                var matchingTypes = assembly.GetTypes()
-                    .Where(t => t.IsClass && !t.IsAbstract && t.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+                var matchingTypes = candidateTypes
+                    .Where(t => t.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
                 foreach (var type in matchingTypes)
                 {
@@ -231,6 +257,18 @@ namespace DesktopApplicationTemplate.UI
                         }
                     }
                 }
+            }
+        }
+
+        private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(type => type is not null).Cast<Type>();
             }
         }
 

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -26,11 +26,10 @@
     <PackageReference Include="RoslynPad.Editor.Windows" Version="4.12.1" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.12.19" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\DesktopApplicationTemplate.Service\DesktopApplicationTemplate.Service.csproj" />
-    <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
-    <ProjectReference Include="..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
+      <ProjectReference Include="..\DesktopApplicationTemplate.Services.Common\DesktopApplicationTemplate.Services.Common.csproj" />
+    </ItemGroup>
 
   <ItemGroup>
     <Page Update="Views/**/*.xaml">

--- a/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
+++ b/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
@@ -1,13 +1,8 @@
-using System.Collections.Generic;
 using DesktopApplicationTemplate.Core.Modules;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Core.Services.Serialization;
-using DesktopApplicationTemplate.Services.Common.Descriptors;
-using DesktopApplicationTemplate.UI.Factories;
-using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
-using DesktopApplicationTemplate.UI.Navigation;
 using System;
+using System.Collections.Generic;
 
 namespace DesktopApplicationTemplate.UI.Modules;
 
@@ -15,119 +10,8 @@ public sealed class UiServiceModule : IServiceModule
 {
     public void RegisterServices(IServiceCollection services)
     {
-        // UI service registrations remain in App.xaml configuration for now.
+        // Cross-cutting UI service registrations remain in App.xaml configuration for now.
     }
 
-    public IEnumerable<IServiceDescriptor> DescribeServices()
-    {
-        yield return new MqttServiceDescriptor(
-            new JsonServiceOptionsSerializer<MqttServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, MqttServiceDescriptor.DescriptorId),
-                        MqttServiceDescriptor.DescriptorId)
-            });
-
-        yield return new HttpServiceDescriptor(
-            new JsonServiceOptionsSerializer<HttpServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, HttpServiceDescriptor.DescriptorId),
-                        HttpServiceDescriptor.DescriptorId)
-            });
-
-        yield return new FtpServiceDescriptor(
-            new JsonServiceOptionsSerializer<FtpServerOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, FtpServiceDescriptor.DescriptorId),
-                        FtpServiceDescriptor.DescriptorId)
-            });
-
-        yield return new HidServiceDescriptor(
-            new JsonServiceOptionsSerializer<HidServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, HidServiceDescriptor.DescriptorId),
-                        HidServiceDescriptor.DescriptorId)
-            });
-
-        yield return new CsvServiceDescriptor(
-            new JsonServiceOptionsSerializer<CsvServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, CsvServiceDescriptor.DescriptorId),
-                        CsvServiceDescriptor.DescriptorId)
-            });
-
-        yield return new FileObserverServiceDescriptor(
-            new JsonServiceOptionsSerializer<FileObserverServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, FileObserverServiceDescriptor.DescriptorId),
-                        FileObserverServiceDescriptor.DescriptorId)
-            });
-
-        yield return new ScpServiceDescriptor(
-            new JsonServiceOptionsSerializer<ScpServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, ScpServiceDescriptor.DescriptorId),
-                        ScpServiceDescriptor.DescriptorId)
-            });
-
-        yield return new TcpServiceDescriptor(
-            new JsonServiceOptionsSerializer<TcpServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, TcpServiceDescriptor.DescriptorId),
-                        TcpServiceDescriptor.DescriptorId)
-            });
-
-        yield return new HeartbeatServiceDescriptor(
-            new JsonServiceOptionsSerializer<HeartbeatServiceOptions>(),
-            new[]
-            {
-                    ServiceFactoryBinding.Create(
-                        ServiceFactoryKind.UserInterface,
-                        typeof(IServiceFactory),
-                        sp => ResolveFactory(sp, HeartbeatServiceDescriptor.DescriptorId),
-                        HeartbeatServiceDescriptor.DescriptorId)
-            });
-    }
-
-    private static object ResolveFactory(IServiceProvider services, string descriptorId)
-    {
-        var registry = services.GetRequiredService<IServiceUiRegistry>();
-        if (!registry.Factories.TryGetValue(descriptorId, out var factory))
-        {
-            throw new InvalidOperationException($"No UI factory registered for descriptor '{descriptorId}'.");
-        }
-
-        return factory();
-    }
+    public IEnumerable<IServiceDescriptor> DescribeServices() => Array.Empty<IServiceDescriptor>();
 }


### PR DESCRIPTION
## Summary
- update the UI bootstrapper to scan plug-in assemblies for descriptor attributes and rely on plug-ins for service-specific registrations
- remove built-in descriptor catalogs and plug-in service wiring from the shared and UI modules while keeping common infrastructure
- streamline the service host project to depend on plug-ins for runtime options and FTP wiring, and drop the UI -> service project reference

## Testing
- ⚠️ `dotnet build DesktopApplicationTemplate.Service/DesktopApplicationTemplate.Service.csproj` *(fails: `dotnet` command is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5ee2e31c8326884bc1e46c1afd56