### PR TITLE
Restrict CI workflow to master and beta branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,14 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - dev
-      - feature/**
-      - bugfix/**
+      - master
+      - beta
     tags:
       - 'v*'
   pull_request:
     branches:
-      - main
-      # dev branch intentionally excluded so PRs targeting dev skip CI checks
+      - master
+      - beta
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- limit the CI workflow triggers to only push and pull request events targeting the master and beta branches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd61d28c70832680089a7e5f777ef5