### PR TITLE
Refactor MQTT client service into Core

### DIFF
--- a/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
+++ b/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
   </ItemGroup>
 

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/IMqttClientService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/IMqttClientService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
+
+/// <summary>
+/// Defines MQTT client operations for connecting, subscribing, and publishing messages.
+/// </summary>
+public interface IMqttClientService
+{
+    /// <summary>
+    /// Gets a value indicating whether the MQTT client is currently connected.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// Raised when the connection state changes.
+    /// </summary>
+    event EventHandler<bool>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Connects to the MQTT broker using stored or override options.
+    /// </summary>
+    Task ConnectAsync(MqttServiceOptions? overrideOptions = null, CancellationToken token = default);
+
+    /// <summary>
+    /// Subscribes to a topic with the specified quality of service level.
+    /// </summary>
+    Task<MqttClientSubscribeResult> SubscribeAsync(string topic, MqttQualityOfServiceLevel qos, CancellationToken token = default);
+
+    /// <summary>
+    /// Unsubscribes from a topic.
+    /// </summary>
+    Task<MqttClientUnsubscribeResult> UnsubscribeAsync(string topic, CancellationToken token = default);
+
+    /// <summary>
+    /// Publishes a single message to a topic.
+    /// </summary>
+    Task PublishAsync(string topic, string message, CancellationToken token = default);
+
+    /// <summary>
+    /// Publishes multiple messages grouped by endpoint.
+    /// </summary>
+    Task PublishAsync(IDictionary<string, IEnumerable<string>> endpointMessages, CancellationToken token = default);
+
+    /// <summary>
+    /// Disconnects from the MQTT broker if connected.
+    /// </summary>
+    Task DisconnectAsync(CancellationToken token = default);
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttService.cs
@@ -1,29 +1,27 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Services;
-using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
-using DesktopApplicationTemplate.UI.Models;
 using Microsoft.Extensions.Options;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Protocol;
 
-namespace DesktopApplicationTemplate.UI.Services;
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 
 /// <summary>
 /// Provides MQTT connectivity and tokenized message publishing.
 /// </summary>
-public class MqttService
+public class MqttService : IMqttClientService
 {
     private readonly IMqttClient _client;
     private readonly IMessageRoutingService _routingService;
     private readonly ILoggingService _logger;
     private readonly MqttServiceOptions _options;
-    private readonly Dictionary<string, TagSubscription> _tagSubscriptions = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttService"/> class.
@@ -59,47 +57,20 @@ public class MqttService
         };
     }
 
-    /// <summary>
-    /// Gets a value indicating whether the client is connected.
-    /// </summary>
+    /// <inheritdoc />
     public bool IsConnected => _client.IsConnected;
 
-    /// <summary>
-    /// Raised when the connection state changes.
-    /// </summary>
+    /// <inheritdoc />
     public event EventHandler<bool>? ConnectionStateChanged;
 
-    private void OnConnectionStateChanged(bool connected) => ConnectionStateChanged?.Invoke(this, connected);
-
-    /// <summary>
-    /// Raised when tag subscription metadata changes.
-    /// </summary>
-    public event EventHandler<TagSubscription>? TagSubscriptionChanged;
-
-    /// <summary>
-    /// Gets the current set of tag subscriptions.
-    /// </summary>
-    public IReadOnlyCollection<TagSubscription> TagSubscriptions => _tagSubscriptions.Values;
-
-    /// <summary>
-    /// Adds or updates a tag subscription and notifies listeners.
-    /// </summary>
-    /// <param name="subscription">The subscription to upsert.</param>
-    public void UpdateTagSubscription(TagSubscription subscription)
-    {
-        ArgumentNullException.ThrowIfNull(subscription);
-        _tagSubscriptions[subscription.Topic] = subscription;
-        TagSubscriptionChanged?.Invoke(this, subscription);
-    }
-
-    /// <summary>
-    /// Connects to the MQTT broker using configured or override options.
-    /// </summary>
+    /// <inheritdoc />
     public async Task ConnectAsync(MqttServiceOptions? overrideOptions = null, CancellationToken token = default)
     {
         var opts = overrideOptions ?? _options;
         if (string.IsNullOrWhiteSpace(opts.Host))
+        {
             throw new ArgumentException("Host cannot be null or whitespace.", nameof(overrideOptions));
+        }
 
         _logger.Log("MQTT connect start", LogLevel.Debug);
 
@@ -193,19 +164,13 @@ public class MqttService
         }
     }
 
-    /// <summary>
-    /// Subscribes to a topic with the specified quality of service level.
-    /// </summary>
-    /// <param name="topic">The topic to subscribe to.</param>
-    /// <param name="qos">The desired QoS level.</param>
-    /// <param name="token">Cancellation token.</param>
-    /// <returns>The MQTT subscribe result when successful.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="topic"/> is null or whitespace.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the broker rejects the subscription.</exception>
+    /// <inheritdoc />
     public async Task<MqttClientSubscribeResult> SubscribeAsync(string topic, MqttQualityOfServiceLevel qos, CancellationToken token = default)
     {
         if (string.IsNullOrWhiteSpace(topic))
+        {
             throw new ArgumentException("Topic cannot be null or whitespace.", nameof(topic));
+        }
 
         _logger.Log("MQTT subscribe start", LogLevel.Debug);
 
@@ -219,17 +184,10 @@ public class MqttService
 
         var result = await _client.SubscribeAsync(options, token).ConfigureAwait(false);
 
-        var success = true;
-        foreach (var item in result.Items)
-        {
-            if (item.ResultCode != MqttClientSubscribeResultCode.GrantedQoS0 &&
-                item.ResultCode != MqttClientSubscribeResultCode.GrantedQoS1 &&
-                item.ResultCode != MqttClientSubscribeResultCode.GrantedQoS2)
-            {
-                success = false;
-                break;
-            }
-        }
+        var success = result.Items.All(item =>
+            item.ResultCode == MqttClientSubscribeResultCode.GrantedQoS0 ||
+            item.ResultCode == MqttClientSubscribeResultCode.GrantedQoS1 ||
+            item.ResultCode == MqttClientSubscribeResultCode.GrantedQoS2);
 
         if (!success)
         {
@@ -242,18 +200,13 @@ public class MqttService
         return result;
     }
 
-    /// <summary>
-    /// Unsubscribes from a topic.
-    /// </summary>
-    /// <param name="topic">The topic to unsubscribe from.</param>
-    /// <param name="token">Cancellation token.</param>
-    /// <returns>The MQTT unsubscribe result when successful.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="topic"/> is null or whitespace.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the broker rejects the request.</exception>
+    /// <inheritdoc />
     public async Task<MqttClientUnsubscribeResult> UnsubscribeAsync(string topic, CancellationToken token = default)
     {
         if (string.IsNullOrWhiteSpace(topic))
+        {
             throw new ArgumentException("Topic cannot be null or whitespace.", nameof(topic));
+        }
 
         _logger.Log("MQTT unsubscribe start", LogLevel.Debug);
 
@@ -267,9 +220,7 @@ public class MqttService
         return result;
     }
 
-    /// <summary>
-    /// Publishes a single message to an endpoint.
-    /// </summary>
+    /// <inheritdoc />
     public async Task PublishAsync(string topic, string message, CancellationToken token = default)
     {
         ArgumentNullException.ThrowIfNull(topic);
@@ -285,9 +236,7 @@ public class MqttService
         _logger.Log("MQTT publish finished", LogLevel.Debug);
     }
 
-    /// <summary>
-    /// Publishes multiple messages per endpoint.
-    /// </summary>
+    /// <inheritdoc />
     public async Task PublishAsync(IDictionary<string, IEnumerable<string>> endpointMessages, CancellationToken token = default)
     {
         ArgumentNullException.ThrowIfNull(endpointMessages);
@@ -300,9 +249,7 @@ public class MqttService
         }
     }
 
-    /// <summary>
-    /// Disconnects from the broker if connected.
-    /// </summary>
+    /// <inheritdoc />
     public async Task DisconnectAsync(CancellationToken token = default)
     {
         if (_client.IsConnected)
@@ -310,4 +257,6 @@ public class MqttService
             await _client.DisconnectAsync(cancellationToken: token).ConfigureAwait(false);
         }
     }
+
+    private void OnConnectionStateChanged(bool connected) => ConnectionStateChanged?.Invoke(this, connected);
 }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
+
+/// <summary>
+/// Extension methods for registering MQTT client services.
+/// </summary>
+public static class MqttServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the MQTT client service implementation.
+    /// </summary>
+    public static IServiceCollection AddMqttClientService(this IServiceCollection services)
+    {
+        services.AddSingleton<IMqttClientService, MqttService>();
+        return services;
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -180,7 +180,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<ScpServiceViewModel>();
             services.AddSingleton<HidViewModel>();
             services.AddSingleton<HidViews>();
-            services.AddSingleton<MqttService>();
+            services.AddMqttClientService();
             services.AddSingleton<FTPServiceView>();
             services.AddSingleton<FtpServiceViewModel>();
             services.AddFtpServer(builder => builder

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
@@ -4,7 +4,6 @@ using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.UI.Helpers;
-using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
@@ -14,7 +13,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
 /// </summary>
 public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingViewModel
 {
-    private readonly MqttService _service;
+    private readonly IMqttClientService _clientService;
     private MqttServiceOptions _options;
 
     private string _host = string.Empty;
@@ -30,11 +29,11 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
     /// Initializes a new instance of the <see cref="MqttEditConnectionViewModel"/> class.
     /// </summary>
     public MqttEditConnectionViewModel(
-        MqttService service,
+        IMqttClientService clientService,
         IOptions<MqttServiceOptions> options,
         ILoggingService? logger = null)
     {
-        _service = service ?? throw new ArgumentNullException(nameof(service));
+        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         Logger = logger;
 
@@ -44,12 +43,12 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         CancelCommand = new RelayCommand(Cancel);
         ToggleSubscriptionCommand = new AsyncRelayCommand(ToggleSubscriptionAsync);
 
-        _service.ConnectionStateChanged += (_, c) =>
+        _clientService.ConnectionStateChanged += (_, c) =>
         {
             IsConnected = c;
             OnPropertyChanged(nameof(SubscriptionButtonText));
         };
-        IsConnected = _service.IsConnected;
+        IsConnected = _clientService.IsConnected;
     }
 
     /// <inheritdoc />
@@ -208,7 +207,7 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         _options.Password = _password;
         _options.ConnectionType = _connectionType;
         _options.WebSocketPath = _webSocketPath;
-        await _service.ConnectAsync(_options).ConfigureAwait(false);
+        await _clientService.ConnectAsync(_options).ConfigureAwait(false);
         Logger?.Log("MQTT connection update finished", LogLevel.Debug);
         RequestClose?.Invoke(this, EventArgs.Empty);
     }
@@ -230,13 +229,13 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         if (IsConnected)
         {
             Logger?.Log("MQTT unsubscribe start", LogLevel.Debug);
-            await _service.DisconnectAsync().ConfigureAwait(false);
+            await _clientService.DisconnectAsync().ConfigureAwait(false);
             Logger?.Log("MQTT unsubscribe finished", LogLevel.Debug);
         }
         else
         {
             Logger?.Log("MQTT subscribe start", LogLevel.Debug);
-            await _service.ConnectAsync().ConfigureAwait(false);
+            await _clientService.ConnectAsync().ConfigureAwait(false);
             Logger?.Log("MQTT subscribe finished", LogLevel.Debug);
         }
         RequestClose?.Invoke(this, EventArgs.Empty);

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttServiceViewModel.cs
@@ -7,7 +7,6 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
-using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.Options;
 using MQTTnet.Protocol;
 
@@ -18,7 +17,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt;
 /// </summary>
 public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel, INetworkAwareViewModel
 {
-    private readonly MqttService _service;
+    private readonly IMqttClientService _clientService;
     private readonly IMessageRoutingService _routing;
     private readonly SaveConfirmationHelper _saveHelper;
     private readonly MqttServiceOptions _options;
@@ -33,19 +32,19 @@ public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel,
     /// Initializes a new instance of the <see cref="MqttServiceViewModel"/> class.
     /// </summary>
     public MqttServiceViewModel(
-        MqttService service,
+        IMqttClientService clientService,
         IMessageRoutingService routing,
         SaveConfirmationHelper saveHelper,
         IOptions<MqttServiceOptions> options,
         ILoggingService? logger = null)
     {
-        _service = service ?? throw new ArgumentNullException(nameof(service));
+        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
         _routing = routing ?? throw new ArgumentNullException(nameof(routing));
         _saveHelper = saveHelper ?? throw new ArgumentNullException(nameof(saveHelper));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         Logger = logger;
 
-        _service.ConnectionStateChanged += (_, connected) => IsConnected = connected;
+        _clientService.ConnectionStateChanged += (_, connected) => IsConnected = connected;
 
         Topics = new ObservableCollection<string>();
         Messages = new ObservableCollection<MqttEndpointMessage>();
@@ -457,7 +456,7 @@ public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel,
         Logger?.Log("MQTT connect start", LogLevel.Debug);
         try
         {
-            await _service.ConnectAsync(options ?? _options).ConfigureAwait(false);
+            await _clientService.ConnectAsync(options ?? _options).ConfigureAwait(false);
             IsConnected = true;
             Logger?.Log("MQTT connect finished", LogLevel.Debug);
         }
@@ -477,16 +476,16 @@ public class MqttServiceViewModel : ValidatableViewModelBase, ILoggingViewModel,
             return;
         Logger?.Log("MQTT publish start", LogLevel.Debug);
         var topic = _routing.ResolveTokens(SelectedMessage.Endpoint);
-        await _service.PublishAsync(topic, SelectedMessage.Message).ConfigureAwait(false);
+        await _clientService.PublishAsync(topic, SelectedMessage.Message).ConfigureAwait(false);
         Logger?.Log("MQTT publish finished", LogLevel.Debug);
     }
 
     private void DisconnectIfConnected()
     {
-        if (!_service.IsConnected)
+        if (!_clientService.IsConnected)
             return;
         Logger?.Log("Disconnecting MQTT due to configuration change", LogLevel.Debug);
-        _ = _service.DisconnectAsync();
+        _ = _clientService.DisconnectAsync();
     }
 
     private void Save() => _saveHelper.Show();

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
@@ -10,7 +10,6 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
-using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.Options;
 using MQTTnet.Protocol;
 
@@ -22,7 +21,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt;
 [SupportedOSPlatform("windows")]
 public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingViewModel
     {
-    private readonly MqttService _service;
+    private readonly IMqttClientService _clientService;
     private readonly MqttServiceOptions _options;
     private readonly AsyncRelayCommand _addTopicCommand;
     private readonly AsyncRelayCommand _removeTopicCommand;
@@ -38,17 +37,16 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttTagSubscriptionsViewModel"/> class.
     /// </summary>
-    public MqttTagSubscriptionsViewModel(MqttService service, IOptions<MqttServiceOptions> options)
+    public MqttTagSubscriptionsViewModel(IMqttClientService clientService, IOptions<MqttServiceOptions> options)
     {
-        _service = service ?? throw new ArgumentNullException(nameof(service));
+        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
-        Subscriptions = new ObservableCollection<TagSubscription>(_service.TagSubscriptions);
+        Subscriptions = new ObservableCollection<TagSubscription>();
         SubscriptionResults = new ObservableCollection<SubscriptionResult>();
         LogEntries = new ObservableCollection<LogEntry>();
-        _service.TagSubscriptionChanged += OnTagSubscriptionChanged;
-        _service.ConnectionStateChanged += (_, c) => IsConnected = c;
-        IsConnected = _service.IsConnected;
+        _clientService.ConnectionStateChanged += (_, c) => IsConnected = c;
+        IsConnected = _clientService.IsConnected;
 
         _addTopicCommand = new AsyncRelayCommand(AddTopicAsync, () => CanAddTopic);
         _removeTopicCommand = new AsyncRelayCommand(RemoveTopicAsync, () => SelectedSubscription != null);
@@ -203,7 +201,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
 
         try
         {
-            await _service.SubscribeAsync(topic, NewQoS).ConfigureAwait(false);
+            await _clientService.SubscribeAsync(topic, NewQoS).ConfigureAwait(false);
             SubscriptionResults.Add(new SubscriptionResult(topic, true, $"Subscribed to {topic}"));
             NewTopic = string.Empty;
         }
@@ -222,7 +220,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
 
         try
         {
-            await _service.UnsubscribeAsync(SelectedSubscription.Topic).ConfigureAwait(false);
+            await _clientService.UnsubscribeAsync(SelectedSubscription.Topic).ConfigureAwait(false);
         }
         catch
         {
@@ -244,7 +242,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
             return;
 
         Logger?.Log("MQTT test publish start", LogLevel.Debug);
-        await _service.PublishAsync(SelectedSubscription!.Topic, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
+        await _clientService.PublishAsync(SelectedSubscription!.Topic, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
         Logger?.Log("MQTT test publish finished", LogLevel.Debug);
     }
 
@@ -257,7 +255,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
             return;
 
         Logger?.Log("MQTT tag test publish start", LogLevel.Debug);
-        await _service.PublishAsync(sub!.Endpoint, sub.OutgoingMessage).ConfigureAwait(false);
+        await _clientService.PublishAsync(sub!.Endpoint, sub.OutgoingMessage).ConfigureAwait(false);
         Logger?.Log("MQTT tag test publish finished", LogLevel.Debug);
     }
 
@@ -266,7 +264,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         Logger?.Log("MQTT connect start", LogLevel.Debug);
         try
         {
-            await _service.ConnectAsync(_options).ConfigureAwait(false);
+            await _clientService.ConnectAsync(_options).ConfigureAwait(false);
             IsConnected = true;
             Logger?.Log("MQTT connect finished", LogLevel.Debug);
         }
@@ -280,20 +278,6 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         {
             IsConnected = false;
             Logger?.Log($"MQTT connect failed: {ex.Message}", LogLevel.Error);
-        }
-    }
-
-    private void OnTagSubscriptionChanged(object? sender, TagSubscription subscription)
-    {
-        var existing = Subscriptions.FirstOrDefault(t => t.Topic == subscription.Topic);
-        if (existing is null)
-        {
-            Subscriptions.Add(subscription);
-        }
-        else
-        {
-            existing.StatusColor = subscription.StatusColor;
-            existing.Icon = subscription.Icon;
         }
     }
 


### PR DESCRIPTION
## Summary
- move the MQTT client implementation into the core protocols layer and expose it via a new `IMqttClientService` contract
- add a core service collection extension and register the interface so UI consumers resolve the abstraction
- update MQTT view models to depend on the core interface and drop UI-only subscription state tracking

## Testing
- Not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68deeef40f5c832695e6db635fd23f3d