### PR TITLE
Refactor protocol runtimes into Core services

### DIFF
--- a/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
+++ b/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="FluentFTP" Version="53.0.1" />
     <PackageReference Include="FubarDev.FtpServer" Version="3.1.2" />
     <PackageReference Include="SSH.NET" Version="2025.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
   </ItemGroup>
 
 </Project>

--- a/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/FileObserverChangedEventArgs.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/FileObserverChangedEventArgs.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+
+/// <summary>
+/// Provides data for <see cref="IFileObserverService.FileChanged"/>.
+/// </summary>
+public sealed class FileObserverChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileObserverChangedEventArgs"/> class.
+    /// </summary>
+    public FileObserverChangedEventArgs(string filePath, string contents)
+    {
+        FilePath = filePath;
+        Contents = contents;
+    }
+
+    /// <summary>
+    /// Gets the affected file path.
+    /// </summary>
+    public string FilePath { get; }
+
+    /// <summary>
+    /// Gets the latest contents of the file.
+    /// </summary>
+    public string Contents { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/FileObserverService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/FileObserverService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+
+/// <summary>
+/// Default implementation of <see cref="IFileObserverService"/> using <see cref="FileSystemWatcher"/>.
+/// </summary>
+public sealed class FileObserverService : IFileObserverService
+{
+    private readonly IProtocolLogger? _logger;
+    private FileObserverServiceOptions? _options;
+    private FileSystemWatcher? _watcher;
+    private string _name = nameof(FileObserverService);
+    private bool _isRunning;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileObserverService"/> class.
+    /// </summary>
+    public FileObserverService(IProtocolLogger? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler<FileObserverChangedEventArgs>? FileChanged;
+
+    /// <inheritdoc />
+    public string Name => _name;
+
+    /// <inheritdoc />
+    public bool IsRunning => _isRunning;
+
+    /// <inheritdoc />
+    public async Task ConfigureAsync(string observerName, FileObserverServiceOptions options, CancellationToken cancellationToken = default)
+    {
+        _name = observerName ?? nameof(FileObserverService);
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        await StopAsync(cancellationToken).ConfigureAwait(false);
+        _logger?.LogInformation(this, $"Configured to watch {options.FilePath}");
+    }
+
+    /// <inheritdoc />
+    public async Task<FileObserverSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await Task.Run(ReadSnapshot, cancellationToken).ConfigureAwait(false);
+        return snapshot;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options is null)
+        {
+            throw new InvalidOperationException("ConfigureAsync must be called before StartAsync.");
+        }
+
+        if (_isRunning)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.FilePath))
+        {
+            _logger?.LogWarning(this, "No file path configured for file observer");
+            return Task.CompletedTask;
+        }
+
+        var directory = Path.GetDirectoryName(_options.FilePath);
+        var fileName = Path.GetFileName(_options.FilePath);
+
+        if (string.IsNullOrEmpty(directory) || string.IsNullOrEmpty(fileName))
+        {
+            _logger?.LogWarning(this, $"Invalid file observer path {_options.FilePath}");
+            return Task.CompletedTask;
+        }
+
+        _watcher = new FileSystemWatcher(directory, fileName)
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.FileName
+        };
+
+        _watcher.Changed += OnFileChanged;
+        _watcher.Renamed += OnFileChanged;
+        _watcher.EnableRaisingEvents = true;
+        _isRunning = true;
+        _logger?.LogInformation(this, $"Started watching {_options.FilePath}");
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (_watcher is not null)
+        {
+            _logger?.LogInformation(this, "Stopping file observer");
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Changed -= OnFileChanged;
+            _watcher.Renamed -= OnFileChanged;
+            _watcher.Dispose();
+            _watcher = null;
+        }
+
+        _isRunning = false;
+        return Task.CompletedTask;
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        try
+        {
+            var snapshot = ReadSnapshot();
+            FileChanged?.Invoke(this, new FileObserverChangedEventArgs(e.FullPath, snapshot.Contents));
+            _logger?.LogInformation(this, $"File observer detected change on {e.FullPath}");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(this, ex, "Error reading observed file");
+        }
+    }
+
+    private FileObserverSnapshot ReadSnapshot()
+    {
+        if (_options is null)
+        {
+            return new FileObserverSnapshot(string.Empty, Array.Empty<string>());
+        }
+
+        string contents = string.Empty;
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(_options.FilePath) && File.Exists(_options.FilePath))
+            {
+                contents = File.ReadAllText(_options.FilePath);
+            }
+        }
+        catch (IOException ex)
+        {
+            _logger?.LogWarning(this, $"Unable to read {_options.FilePath}: {ex.Message}");
+        }
+
+        var imageNames = (_options.ImageNames ?? string.Empty)
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToArray();
+
+        return new FileObserverSnapshot(contents, imageNames);
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/FileObserverSnapshot.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/FileObserverSnapshot.cs
@@ -1,0 +1,26 @@
+namespace DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+
+/// <summary>
+/// Represents the observed file content and associated metadata.
+/// </summary>
+public sealed class FileObserverSnapshot
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileObserverSnapshot"/> class.
+    /// </summary>
+    public FileObserverSnapshot(string contents, string[] imageNames)
+    {
+        Contents = contents;
+        ImageNames = imageNames;
+    }
+
+    /// <summary>
+    /// Gets the file contents.
+    /// </summary>
+    public string Contents { get; }
+
+    /// <summary>
+    /// Gets the discovered image names.
+    /// </summary>
+    public string[] ImageNames { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/IFileObserverService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/FileObserver/IFileObserverService.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+
+/// <summary>
+/// Monitors files and directories for the file observer protocol.
+/// </summary>
+public interface IFileObserverService : IProtocolService
+{
+    /// <summary>
+    /// Raised when the observed file changes.
+    /// </summary>
+    event EventHandler<FileObserverChangedEventArgs>? FileChanged;
+
+    /// <summary>
+    /// Configures the observer for the specified service.
+    /// </summary>
+    Task ConfigureAsync(string observerName, FileObserverServiceOptions options, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the current snapshot of the observed file.
+    /// </summary>
+    Task<FileObserverSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Heartbeat/HeartbeatService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Heartbeat/HeartbeatService.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
+
+/// <summary>
+/// Implements <see cref="IHeartbeatService"/> using <see cref="PeriodicTimer"/>.
+/// </summary>
+public sealed class HeartbeatService : IHeartbeatService
+{
+    private readonly IProtocolLogger? _logger;
+    private HeartbeatServiceOptions? _options;
+    private TimeSpan _interval = TimeSpan.FromSeconds(5);
+    private CancellationTokenSource? _timerCts;
+    private Task? _timerTask;
+    private string _name = nameof(HeartbeatService);
+    private bool _isRunning;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HeartbeatService"/> class.
+    /// </summary>
+    public HeartbeatService(IProtocolLogger? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler<string>? HeartbeatGenerated;
+
+    /// <inheritdoc />
+    public string Name => _name;
+
+    /// <inheritdoc />
+    public bool IsRunning => _isRunning;
+
+    /// <inheritdoc />
+    public async Task ConfigureAsync(string serviceName, HeartbeatServiceOptions options, TimeSpan interval, CancellationToken cancellationToken = default)
+    {
+        _name = serviceName ?? nameof(HeartbeatService);
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _interval = interval <= TimeSpan.Zero ? TimeSpan.FromSeconds(5) : interval;
+
+        _logger?.LogInformation(this, $"Heartbeat configured with interval {_interval}");
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public string BuildHeartbeatMessage(HeartbeatServiceOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var message = options.BaseMessage ?? string.Empty;
+        if (options.IncludePing)
+        {
+            message += " | PING";
+        }
+
+        if (options.IncludeStatus)
+        {
+            message += " | STATUS";
+        }
+
+        _logger?.LogInformation(this, $"Heartbeat built: {message}");
+        return message;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_options is null)
+        {
+            throw new InvalidOperationException("ConfigureAsync must be called before StartAsync.");
+        }
+
+        if (_isRunning)
+        {
+            return Task.CompletedTask;
+        }
+
+        _isRunning = true;
+        _timerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var localToken = _timerCts.Token;
+        var options = _options;
+        var interval = _interval;
+
+        _logger?.LogInformation(this, "Heartbeat timer starting");
+
+        _timerTask = Task.Run(async () =>
+        {
+            using var timer = new PeriodicTimer(interval);
+            while (await timer.WaitForNextTickAsync(localToken).ConfigureAwait(false))
+            {
+                var payload = BuildHeartbeatMessage(options);
+                _logger?.LogInformation(this, "Heartbeat emitted");
+                HeartbeatGenerated?.Invoke(this, payload);
+            }
+        }, localToken);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_isRunning)
+        {
+            return;
+        }
+
+        _logger?.LogInformation(this, "Heartbeat timer stopping");
+        _isRunning = false;
+        _timerCts?.Cancel();
+
+        if (_timerTask is not null)
+        {
+            try
+            {
+                await _timerTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // expected when stopping
+            }
+        }
+
+        _timerTask = null;
+        _timerCts?.Dispose();
+        _timerCts = null;
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Heartbeat/IHeartbeatService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Heartbeat/IHeartbeatService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
+
+/// <summary>
+/// Provides timer-driven heartbeat message generation independent of the UI layer.
+/// </summary>
+public interface IHeartbeatService : IProtocolService
+{
+    /// <summary>
+    /// Raised whenever a heartbeat payload is generated.
+    /// </summary>
+    event EventHandler<string>? HeartbeatGenerated;
+
+    /// <summary>
+    /// Configures the heartbeat runtime.
+    /// </summary>
+    /// <param name="serviceName">The service name associated with the runtime.</param>
+    /// <param name="options">The heartbeat options.</param>
+    /// <param name="interval">The interval between heartbeat emissions.</param>
+    /// <param name="cancellationToken">A token used to cancel the configuration.</param>
+    Task ConfigureAsync(string serviceName, HeartbeatServiceOptions options, TimeSpan interval, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Builds a single heartbeat payload without starting the timer.
+    /// </summary>
+    /// <param name="options">The options describing the heartbeat.</param>
+    /// <returns>The formatted heartbeat message.</returns>
+    string BuildHeartbeatMessage(HeartbeatServiceOptions options);
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Http/HttpClientService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Http/HttpClientService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Http;
+
+/// <summary>
+/// Default implementation of <see cref="IHttpClientService"/> backed by <see cref="HttpClient"/>.
+/// </summary>
+public sealed class HttpClientService : IHttpClientService, IProtocolService
+{
+    private readonly IProtocolLogger? _logger;
+    private string _name = nameof(HttpClientService);
+    private bool _isRunning;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpClientService"/> class.
+    /// </summary>
+    public HttpClientService(IProtocolLogger? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => _name;
+
+    /// <inheritdoc />
+    public bool IsRunning => _isRunning;
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        _isRunning = true;
+        _logger?.LogInformation(this, "HTTP client service started");
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        _isRunning = false;
+        _logger?.LogInformation(this, "HTTP client service stopped");
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<HttpExecutionResult> ExecuteAsync(HttpExecutionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        _name = request.RequestUri?.ToString() ?? nameof(HttpClientService);
+
+        if (request.RequestUri is null)
+        {
+            throw new ArgumentException("A request URI must be supplied.", nameof(request));
+        }
+
+        _logger?.LogInformation(this, $"Preparing {request.Method} request to {request.RequestUri}");
+
+        using var client = CreateClient(request);
+        using var message = new HttpRequestMessage(request.Method, request.RequestUri);
+
+        foreach (var header in request.Headers.Where(h => !string.IsNullOrWhiteSpace(h.Key)))
+        {
+            message.Headers.TryAddWithoutValidation(header.Key, header.Value ?? string.Empty);
+        }
+
+        if (request.Body is not null && !IsBodylessMethod(request.Method))
+        {
+            message.Content = new StringContent(request.Body, Encoding.UTF8, request.ContentType);
+            _logger?.LogInformation(this, $"HTTP request body prepared ({request.Body.Length} chars)");
+        }
+
+        try
+        {
+            _logger?.LogInformation(this, "Sending HTTP request");
+            var response = await client.SendAsync(message, cancellationToken).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger?.LogInformation(this, $"HTTP request completed with status {(int)response.StatusCode}");
+            return new HttpExecutionResult(response.StatusCode, body);
+        }
+        catch (HttpRequestException httpEx)
+        {
+            _logger?.LogError(this, httpEx, "HTTP request failed");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(this, ex, "Unexpected HTTP error");
+            throw;
+        }
+        finally
+        {
+            _logger?.LogInformation(this, "HTTP request execution finished");
+        }
+    }
+
+    private static HttpClient CreateClient(HttpExecutionRequest request)
+    {
+        if (request.MessageHandler is null)
+        {
+            return new HttpClient();
+        }
+
+        return new HttpClient(request.MessageHandler, disposeHandler: false);
+    }
+
+    private static bool IsBodylessMethod(HttpMethod method)
+    {
+        return HttpMethod.Get.Equals(method) || HttpMethod.Delete.Equals(method);
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Http/HttpExecutionRequest.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Http/HttpExecutionRequest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Http;
+
+/// <summary>
+/// Describes an HTTP request to be executed by <see cref="IHttpClientService"/>.
+/// </summary>
+public sealed class HttpExecutionRequest
+{
+    /// <summary>
+    /// Gets or sets the request URI.
+    /// </summary>
+    public Uri RequestUri { get; set; } = new("http://localhost");
+
+    /// <summary>
+    /// Gets or sets the HTTP method to use when sending the request.
+    /// </summary>
+    public HttpMethod Method { get; set; } = HttpMethod.Get;
+
+    /// <summary>
+    /// Gets or sets the request body payload.
+    /// </summary>
+    public string? Body { get; set; }
+
+    /// <summary>
+    /// Gets or sets the content type applied when a body is supplied.
+    /// </summary>
+    public string ContentType { get; set; } = "application/json";
+
+    /// <summary>
+    /// Gets or sets the optional message handler to use for the request.
+    /// </summary>
+    public HttpMessageHandler? MessageHandler { get; set; }
+
+    /// <summary>
+    /// Gets the headers applied to the request.
+    /// </summary>
+    public IDictionary<string, string> Headers { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Http/HttpExecutionResult.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Http/HttpExecutionResult.cs
@@ -1,0 +1,28 @@
+using System.Net;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Http;
+
+/// <summary>
+/// Represents the outcome of executing an HTTP request.
+/// </summary>
+public sealed class HttpExecutionResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpExecutionResult"/> class.
+    /// </summary>
+    public HttpExecutionResult(HttpStatusCode statusCode, string body)
+    {
+        StatusCode = statusCode;
+        Body = body;
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code returned by the server.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// Gets the response payload returned by the server.
+    /// </summary>
+    public string Body { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Http/IHttpClientService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Http/IHttpClientService.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Http;
+
+/// <summary>
+/// Executes HTTP requests independent of any UI concerns.
+/// </summary>
+public interface IHttpClientService
+{
+    /// <summary>
+    /// Sends the supplied request and returns the response payload.
+    /// </summary>
+    /// <param name="request">The request descriptor to execute.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>The HTTP execution result.</returns>
+    Task<HttpExecutionResult> ExecuteAsync(HttpExecutionRequest request, CancellationToken cancellationToken = default);
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/ITcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/ITcpRuntime.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+/// <summary>
+/// Executes TCP runtime operations such as script evaluation without UI dependencies.
+/// </summary>
+public interface ITcpRuntime : IProtocolService
+{
+    /// <summary>
+    /// Initializes the runtime for the specified service context.
+    /// </summary>
+    /// <param name="context">The runtime context.</param>
+    /// <param name="cancellationToken">A token used to cancel the initialization.</param>
+    Task<TcpRuntimeState> InitializeAsync(TcpRuntimeContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes the supplied script with the provided message.
+    /// </summary>
+    /// <param name="request">The execution request.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    Task<TcpRuntimeState> ExecuteAsync(TcpRuntimeExecutionRequest request, CancellationToken cancellationToken = default);
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+using DesktopApplicationTemplate.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+/// <summary>
+/// Provides Roslyn-backed script execution for TCP services.
+/// </summary>
+public sealed class TcpRuntime : ITcpRuntime
+{
+    private readonly IMessageRoutingService _routingService;
+    private readonly IProtocolLogger? _logger;
+    private TcpRuntimeContext? _context;
+    private bool _isRunning;
+    private string _name = nameof(TcpRuntime);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpRuntime"/> class.
+    /// </summary>
+    public TcpRuntime(IMessageRoutingService routingService, IProtocolLogger? logger = null)
+    {
+        _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => _name;
+
+    /// <inheritdoc />
+    public bool IsRunning => _isRunning;
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        _isRunning = true;
+        _logger?.LogInformation(this, "TCP runtime started");
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        _isRunning = false;
+        _logger?.LogInformation(this, "TCP runtime stopped");
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<TcpRuntimeState> InitializeAsync(TcpRuntimeContext context, CancellationToken cancellationToken = default)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _name = $"{context.ServiceType}.{context.ServiceName}";
+
+        var options = context.Options ?? throw new ArgumentNullException(nameof(context.Options));
+        var script = string.IsNullOrWhiteSpace(options.Script) ? context.DefaultScript : options.Script;
+        var testMessage = ResolveInitialMessage(context);
+
+        _logger?.LogInformation(this, "Initializing TCP script runtime");
+
+        var output = await ExecuteScriptInternalAsync(script, testMessage, cancellationToken).ConfigureAwait(false);
+
+        options.Script = script;
+        options.LastTestMessage = testMessage;
+        options.OutputMessage = output;
+
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, testMessage);
+
+        return new TcpRuntimeState(script, testMessage, output);
+    }
+
+    /// <inheritdoc />
+    public async Task<TcpRuntimeState> ExecuteAsync(TcpRuntimeExecutionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var context = request.Context ?? throw new ArgumentException("Context is required", nameof(request));
+        _context = context;
+        _name = $"{context.ServiceType}.{context.ServiceName}";
+
+        _logger?.LogInformation(this, "Executing TCP script");
+        var output = await ExecuteScriptInternalAsync(request.Script, request.TestMessage, cancellationToken).ConfigureAwait(false);
+
+        context.Options.Script = request.Script;
+        context.Options.LastTestMessage = request.TestMessage;
+        context.Options.OutputMessage = output;
+
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, request.TestMessage);
+
+        return new TcpRuntimeState(request.Script, request.TestMessage, output);
+    }
+
+    private string ResolveInitialMessage(TcpRuntimeContext context)
+    {
+        var options = context.Options;
+        var serviceName = context.ServiceName;
+
+        if (string.IsNullOrWhiteSpace(options.LastTestMessage) &&
+            _routingService.TryGetMessage(context.ServiceType, serviceName, out var routed))
+        {
+            return routed ?? string.Empty;
+        }
+
+        return string.IsNullOrWhiteSpace(options.LastTestMessage)
+            ? $"{serviceName}-PEAK-123456789"
+            : options.LastTestMessage;
+    }
+
+    private async Task<string> ExecuteScriptInternalAsync(string script, string message, CancellationToken cancellationToken)
+    {
+        var globals = new TcpScriptGlobals { Message = message ?? string.Empty };
+        var code = (script ?? string.Empty) + "\nreturn Process(Message);";
+        var compiled = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(TcpScriptGlobals));
+        var diagnostics = compiled.Compile();
+
+        if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+        {
+            var joined = string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
+            _logger?.LogWarning(this, $"TCP script compile failed: {joined}");
+            return joined;
+        }
+
+        try
+        {
+            var result = await compiled.RunAsync(globals, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var output = result.ReturnValue ?? string.Empty;
+            _logger?.LogInformation(this, "TCP script executed successfully");
+            return output;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(this, ex, "TCP script execution failed");
+            return ex.ToString();
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeContext.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeContext.cs
@@ -1,0 +1,40 @@
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+/// <summary>
+/// Represents the configuration used to initialise a TCP runtime instance.
+/// </summary>
+public sealed class TcpRuntimeContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpRuntimeContext"/> class.
+    /// </summary>
+    public TcpRuntimeContext(ServiceType serviceType, string serviceName, TcpServiceOptions options, string defaultScript)
+    {
+        ServiceType = serviceType;
+        ServiceName = serviceName;
+        Options = options;
+        DefaultScript = defaultScript;
+    }
+
+    /// <summary>
+    /// Gets the owning service type.
+    /// </summary>
+    public ServiceType ServiceType { get; }
+
+    /// <summary>
+    /// Gets the unique service name.
+    /// </summary>
+    public string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the TCP service options.
+    /// </summary>
+    public TcpServiceOptions Options { get; }
+
+    /// <summary>
+    /// Gets the default script used when no script has been configured.
+    /// </summary>
+    public string DefaultScript { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeExecutionRequest.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeExecutionRequest.cs
@@ -1,0 +1,32 @@
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+/// <summary>
+/// Describes a request to execute a TCP script against a test message.
+/// </summary>
+public sealed class TcpRuntimeExecutionRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpRuntimeExecutionRequest"/> class.
+    /// </summary>
+    public TcpRuntimeExecutionRequest(TcpRuntimeContext context, string script, string testMessage)
+    {
+        Context = context;
+        Script = script;
+        TestMessage = testMessage;
+    }
+
+    /// <summary>
+    /// Gets the runtime context.
+    /// </summary>
+    public TcpRuntimeContext Context { get; }
+
+    /// <summary>
+    /// Gets the script to execute.
+    /// </summary>
+    public string Script { get; }
+
+    /// <summary>
+    /// Gets the test message provided by the user.
+    /// </summary>
+    public string TestMessage { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeState.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeState.cs
@@ -1,0 +1,32 @@
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+/// <summary>
+/// Represents the state produced after executing a TCP runtime operation.
+/// </summary>
+public sealed class TcpRuntimeState
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpRuntimeState"/> class.
+    /// </summary>
+    public TcpRuntimeState(string script, string testMessage, string outputMessage)
+    {
+        Script = script;
+        TestMessage = testMessage;
+        OutputMessage = outputMessage;
+    }
+
+    /// <summary>
+    /// Gets the effective script used during execution.
+    /// </summary>
+    public string Script { get; }
+
+    /// <summary>
+    /// Gets the test message supplied to the script.
+    /// </summary>
+    public string TestMessage { get; }
+
+    /// <summary>
+    /// Gets the resulting output message.
+    /// </summary>
+    public string OutputMessage { get; }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpScriptGlobals.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpScriptGlobals.cs
@@ -1,0 +1,12 @@
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+/// <summary>
+/// Provides the global variables exposed to TCP C# scripts.
+/// </summary>
+public sealed class TcpScriptGlobals
+{
+    /// <summary>
+    /// Gets or sets the inbound message provided to the script.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}

--- a/DesktopApplicationTemplate.Services/CommonServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Services/CommonServiceCollectionExtensions.cs
@@ -1,5 +1,9 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols;
+using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
+using DesktopApplicationTemplate.Core.Services.Protocols.Http;
+using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Services.Protocols;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,6 +23,10 @@ public static class CommonServiceCollectionExtensions
         services.AddTransient(typeof(IServiceScreen<>), typeof(ServiceScreen<>));
         services.AddSingleton<IFileSearchService, FileSearchService>();
         services.AddSingleton<IProtocolLogger, LoggingServiceProtocolLogger>();
+        services.AddSingleton<IHttpClientService, HttpClientService>();
+        services.AddTransient<ITcpRuntime, TcpRuntime>();
+        services.AddTransient<IHeartbeatService, HeartbeatService>();
+        services.AddTransient<IFileObserverService, FileObserverService>();
         return services;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverViewModel.cs
@@ -1,174 +1,261 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using System.Windows.Input;
-using System.Windows;
-using DesktopApplicationTemplate.UI.Helpers;
-using DesktopApplicationTemplate.Core.Services;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+using DesktopApplicationTemplate.UI.Helpers;
 
-namespace DesktopApplicationTemplate.UI.ViewModels.FileObserver
+namespace DesktopApplicationTemplate.UI.ViewModels.FileObserver;
+
+public class FileObserverViewModel : ViewModelBase
 {
-    public class FileObserverViewModel : ViewModelBase
+    public ObservableCollection<FileObserver> Observers { get; } = new();
+
+    private FileObserver? _selectedObserver;
+    public FileObserver? SelectedObserver
     {
-        public ObservableCollection<FileObserver> Observers { get; } = new();
-        private FileObserver? _selectedObserver;
-        public FileObserver? SelectedObserver
+        get => _selectedObserver;
+        set
         {
-            get => _selectedObserver;
-            set { _selectedObserver = value; OnPropertyChanged(); LoadObserverData(); }
-        }
-
-        private string _filePath = string.Empty;
-        public string FilePath
-        {
-            get => _filePath;
-            set { _filePath = value; OnPropertyChanged(); }
-        }
-
-        private string _contents = string.Empty;
-        public string Contents
-        {
-            get => _contents;
-            set { _contents = value; OnPropertyChanged(); }
-        }
-
-        private string _imageNames = string.Empty;
-        public string ImageNames
-        {
-            get => _imageNames;
-            set { _imageNames = value; OnPropertyChanged(); }
-        }
-
-        private bool _sendAllImages;
-        public bool SendAllImages
-        {
-            get => _sendAllImages;
-            set { _sendAllImages = value; OnPropertyChanged(); }
-        }
-
-        private bool _sendFirstXEnabled;
-        public bool SendFirstXEnabled
-        {
-            get => _sendFirstXEnabled;
-            set { _sendFirstXEnabled = value; OnPropertyChanged(); }
-        }
-
-        private string _sendXCount = "10";
-        public string SendXCount
-        {
-            get => _sendXCount;
-            set { _sendXCount = value; OnPropertyChanged(); }
-        }
-
-        private bool _sendTcpCommandEnabled;
-        public bool SendTcpCommandEnabled
-        {
-            get => _sendTcpCommandEnabled;
-            set { _sendTcpCommandEnabled = value; OnPropertyChanged(); }
-        }
-
-        private string _tcpCommand = string.Empty;
-        public string TcpCommand
-        {
-            get => _tcpCommand;
-            set { _tcpCommand = value; OnPropertyChanged(); }
-        }
-
-        public ICommand AddObserverCommand { get; }
-        public ICommand RemoveObserverCommand { get; }
-        public ICommand BrowseCommand { get; }
-        public ICommand SaveCommand { get; }
-
-        private readonly SaveConfirmationHelper _saveHelper;
-        private readonly IFileSearchService _fileSearchService;
-
-        public FileObserverViewModel(SaveConfirmationHelper saveHelper, IFileSearchService fileSearchService)
-        {
-            _saveHelper = saveHelper ?? throw new ArgumentNullException(nameof(saveHelper));
-            _fileSearchService = fileSearchService ?? throw new ArgumentNullException(nameof(fileSearchService));
-            AddObserverCommand = new RelayCommand(AddObserver);
-            RemoveObserverCommand = new RelayCommand(RemoveObserver);
-            BrowseCommand = new AsyncRelayCommand(BrowseFilePathAsync);
-            SaveCommand = new RelayCommand(Save);
-
-            Observers.Add(new FileObserver { Name = "Observer1" });
-        }
-
-        private void LoadObserverData()
-        {
-            if (SelectedObserver == null) return;
-
-            FilePath = SelectedObserver.FilePath;
-            Contents = SelectedObserver.Contents;
-            ImageNames = SelectedObserver.ImageNames;
-            SendAllImages = SelectedObserver.SendAll;
-            SendFirstXEnabled = SelectedObserver.SendFirstX;
-            SendXCount = SelectedObserver.XCount.ToString();
-            SendTcpCommandEnabled = SelectedObserver.SendTcp;
-            TcpCommand = SelectedObserver.TcpString;
-
-            OnPropertyChanged(null);
-        }
-
-        private void AddObserver()
-        {
-            var observer = new FileObserver { Name = $"Observer{Observers.Count + 1}" };
-            Observers.Add(observer);
-            SelectedObserver = observer;
-        }
-
-        private void RemoveObserver()
-        {
-            if (SelectedObserver != null)
+            if (_selectedObserver == value)
             {
-                Observers.Remove(SelectedObserver);
-                SelectedObserver = null;
+                return;
             }
+
+            _selectedObserver = value;
+            OnPropertyChanged();
+            _ = LoadObserverDataAsync();
+        }
+    }
+
+    private string _filePath = string.Empty;
+    public string FilePath
+    {
+        get => _filePath;
+        set { _filePath = value; OnPropertyChanged(); }
+    }
+
+    private string _contents = string.Empty;
+    public string Contents
+    {
+        get => _contents;
+        set { _contents = value; OnPropertyChanged(); }
+    }
+
+    private string _imageNames = string.Empty;
+    public string ImageNames
+    {
+        get => _imageNames;
+        set { _imageNames = value; OnPropertyChanged(); }
+    }
+
+    private bool _sendAllImages;
+    public bool SendAllImages
+    {
+        get => _sendAllImages;
+        set { _sendAllImages = value; OnPropertyChanged(); }
+    }
+
+    private bool _sendFirstXEnabled;
+    public bool SendFirstXEnabled
+    {
+        get => _sendFirstXEnabled;
+        set { _sendFirstXEnabled = value; OnPropertyChanged(); }
+    }
+
+    private string _sendXCount = "10";
+    public string SendXCount
+    {
+        get => _sendXCount;
+        set { _sendXCount = value; OnPropertyChanged(); }
+    }
+
+    private bool _sendTcpCommandEnabled;
+    public bool SendTcpCommandEnabled
+    {
+        get => _sendTcpCommandEnabled;
+        set { _sendTcpCommandEnabled = value; OnPropertyChanged(); }
+    }
+
+    private string _tcpCommand = string.Empty;
+    public string TcpCommand
+    {
+        get => _tcpCommand;
+        set { _tcpCommand = value; OnPropertyChanged(); }
+    }
+
+    public ICommand AddObserverCommand { get; }
+    public ICommand RemoveObserverCommand { get; }
+    public ICommand BrowseCommand { get; }
+    public ICommand SaveCommand { get; }
+
+    private readonly SaveConfirmationHelper _saveHelper;
+    private readonly IFileSearchService _fileSearchService;
+    private readonly IFileObserverService _fileObserverService;
+
+    public FileObserverViewModel(
+        SaveConfirmationHelper saveHelper,
+        IFileSearchService fileSearchService,
+        IFileObserverService fileObserverService)
+    {
+        _saveHelper = saveHelper ?? throw new ArgumentNullException(nameof(saveHelper));
+        _fileSearchService = fileSearchService ?? throw new ArgumentNullException(nameof(fileSearchService));
+        _fileObserverService = fileObserverService ?? throw new ArgumentNullException(nameof(fileObserverService));
+
+        AddObserverCommand = new RelayCommand(AddObserver);
+        RemoveObserverCommand = new RelayCommand(RemoveObserver);
+        BrowseCommand = new AsyncRelayCommand(BrowseFilePathAsync);
+        SaveCommand = new RelayCommand(Save);
+
+        _fileObserverService.FileChanged += OnFileChanged;
+        Observers.Add(new FileObserver { Name = "Observer1" });
+    }
+
+    private async Task LoadObserverDataAsync()
+    {
+        var observer = SelectedObserver;
+        if (observer is null)
+        {
+            ResetFields();
+            await _fileObserverService.StopAsync().ConfigureAwait(false);
+            return;
         }
 
-        private async Task BrowseFilePathAsync()
-        {
-            var dialog = new Microsoft.Win32.OpenFileDialog();
-            if (dialog.ShowDialog() == true)
-            {
-                FilePath = dialog.FileName;
+        FilePath = observer.FilePath;
+        Contents = observer.Contents;
+        ImageNames = observer.ImageNames;
+        SendAllImages = observer.SendAll;
+        SendFirstXEnabled = observer.SendFirstX;
+        SendXCount = observer.XCount.ToString();
+        SendTcpCommandEnabled = observer.SendTcp;
+        TcpCommand = observer.TcpString;
 
-                var directory = Path.GetDirectoryName(FilePath);
-                if (!string.IsNullOrEmpty(directory))
+        OnPropertyChanged(null);
+        await ConfigureObserverServiceAsync(observer).ConfigureAwait(false);
+    }
+
+    private void ResetFields()
+    {
+        FilePath = string.Empty;
+        Contents = string.Empty;
+        ImageNames = string.Empty;
+        SendAllImages = false;
+        SendFirstXEnabled = false;
+        SendXCount = "10";
+        SendTcpCommandEnabled = false;
+        TcpCommand = string.Empty;
+        OnPropertyChanged(null);
+    }
+
+    private void AddObserver()
+    {
+        var observer = new FileObserver { Name = $"Observer{Observers.Count + 1}" };
+        Observers.Add(observer);
+        SelectedObserver = observer;
+    }
+
+    private void RemoveObserver()
+    {
+        if (SelectedObserver is null)
+        {
+            return;
+        }
+
+        Observers.Remove(SelectedObserver);
+        SelectedObserver = null;
+        _ = _fileObserverService.StopAsync();
+    }
+
+    private async Task BrowseFilePathAsync()
+    {
+        var dialog = new Microsoft.Win32.OpenFileDialog();
+        if (dialog.ShowDialog() == true)
+        {
+            FilePath = dialog.FileName;
+
+            var directory = System.IO.Path.GetDirectoryName(FilePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                try
                 {
-                    try
-                    {
-                        var files = await _fileSearchService.GetFilesAsync(directory, "*", CancellationToken.None).ConfigureAwait(false);
-                        ImageNames = string.Join(",", files.Select(Path.GetFileName));
-                    }
-                    catch
-                    {
-                        ImageNames = string.Empty;
-                    }
+                    var files = await _fileSearchService
+                        .GetFilesAsync(directory, "*", CancellationToken.None)
+                        .ConfigureAwait(false);
+                    ImageNames = string.Join(",", files.Select(System.IO.Path.GetFileName));
+                }
+                catch
+                {
+                    ImageNames = string.Empty;
                 }
             }
+
+            if (SelectedObserver is not null)
+            {
+                SelectedObserver.FilePath = FilePath;
+                await ConfigureObserverServiceAsync(SelectedObserver).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private void Save() => _saveHelper.Show();
+
+    private async Task ConfigureObserverServiceAsync(FileObserver observer)
+    {
+        var options = new FileObserverServiceOptions
+        {
+            FilePath = observer.FilePath,
+            ImageNames = observer.ImageNames,
+            SendAllImages = observer.SendAll,
+            SendFirstX = observer.SendFirstX,
+            XCount = observer.XCount,
+            SendTcpCommand = observer.SendTcp,
+            TcpCommand = observer.TcpString
+        };
+
+        await _fileObserverService.ConfigureAsync(observer.Name, options).ConfigureAwait(false);
+        await _fileObserverService.StartAsync().ConfigureAwait(false);
+        var snapshot = await _fileObserverService.GetSnapshotAsync().ConfigureAwait(false);
+
+        if (!string.IsNullOrWhiteSpace(snapshot.Contents))
+        {
+            observer.Contents = snapshot.Contents;
+            Contents = snapshot.Contents;
         }
 
-        private void Save() => _saveHelper.Show();
-
-        // OnPropertyChanged inherited from ViewModelBase
+        if (snapshot.ImageNames.Length > 0 && string.IsNullOrWhiteSpace(observer.ImageNames))
+        {
+            observer.ImageNames = string.Join(",", snapshot.ImageNames);
+            ImageNames = observer.ImageNames;
+        }
     }
 
-    public class FileObserver
+    private void OnFileChanged(object? sender, FileObserverChangedEventArgs e)
     {
-        public string Name { get; set; } = string.Empty;
-        public string FilePath { get; set; } = string.Empty;
-        public string Contents { get; set; } = string.Empty;
-        public string ImageNames { get; set; } = string.Empty;
-        public bool SendAll { get; set; }
-        public bool SendFirstX { get; set; }
-        public int XCount { get; set; } = 10;
-        public bool SendTcp { get; set; }
-        public string TcpString { get; set; } = string.Empty;
+        Application.Current?.Dispatcher?.Invoke(() =>
+        {
+            if (SelectedObserver is not null)
+            {
+                SelectedObserver.Contents = e.Contents;
+            }
+
+            Contents = e.Contents;
+        });
     }
+}
+
+public class FileObserver
+{
+    public string Name { get; set; } = string.Empty;
+    public string FilePath { get; set; } = string.Empty;
+    public string Contents { get; set; } = string.Empty;
+    public string ImageNames { get; set; } = string.Empty;
+    public bool SendAll { get; set; }
+    public bool SendFirstX { get; set; }
+    public int XCount { get; set; } = 10;
+    public bool SendTcp { get; set; }
+    public string TcpString { get; set; } = string.Empty;
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Heartbeat/HeartbeatViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Heartbeat/HeartbeatViewModel.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using System.Windows;
+using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Heartbeat
@@ -51,26 +52,26 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Heartbeat
         public ICommand SaveCommand { get; }
 
         private readonly SaveConfirmationHelper _saveHelper;
+        private readonly IHeartbeatService _heartbeatService;
 
-        public HeartbeatViewModel(SaveConfirmationHelper saveHelper)
+        public HeartbeatViewModel(SaveConfirmationHelper saveHelper, IHeartbeatService heartbeatService)
         {
             _saveHelper = saveHelper;
+            _heartbeatService = heartbeatService ?? throw new ArgumentNullException(nameof(heartbeatService));
             BuildCommand = new RelayCommand(BuildMessage);
             SaveCommand = new RelayCommand(Save);
         }
 
         private void BuildMessage()
         {
-            var msg = BaseMessage;
-            if (IncludePing)
+            var options = new HeartbeatServiceOptions
             {
-                msg += " | PING";
-            }
-            if (IncludeStatus)
-            {
-                msg += " | STATUS";
-            }
-            FinalMessage = msg;
+                BaseMessage = BaseMessage,
+                IncludePing = IncludePing,
+                IncludeStatus = IncludeStatus
+            };
+
+            FinalMessage = _heartbeatService.BuildHeartbeatMessage(options);
         }
 
         private void Save() => _saveHelper.Show();

--- a/DesktopApplicationTemplate.UI/ViewModels/Http/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Http/HttpServiceViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Windows.Input;
 using System.Threading.Tasks;
 using System.Windows;
@@ -10,6 +9,7 @@ using System.IO;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.Core.Services.Protocols.Http;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Http
 {
@@ -137,10 +137,12 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
         public HttpMessageHandler? MessageHandler { get; set; }
 
         private readonly SaveConfirmationHelper _saveHelper;
+        private readonly IHttpClientService _httpClientService;
 
-        public HttpServiceViewModel(SaveConfirmationHelper saveHelper)
+        public HttpServiceViewModel(SaveConfirmationHelper saveHelper, IHttpClientService httpClientService)
         {
             _saveHelper = saveHelper;
+            _httpClientService = httpClientService ?? throw new ArgumentNullException(nameof(httpClientService));
             SendCommand = new AsyncRelayCommand(SendRequestAsync);
             AddHeaderCommand = new RelayCommand(() => Headers.Add(new HeaderItem()));
             RemoveHeaderCommand = new RelayCommand(() =>
@@ -167,30 +169,37 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
 
             Logger?.Log("Starting HTTP request", LogLevel.Debug);
 
-            using HttpClient client = MessageHandler != null ? new HttpClient(MessageHandler) : new HttpClient();
             try
             {
                 Logger?.Log($"Preparing {SelectedMethod} request to {Url}", LogLevel.Debug);
-                var request = new HttpRequestMessage(new HttpMethod(SelectedMethod), Url);
+                var request = new HttpExecutionRequest
+                {
+                    RequestUri = new Uri(Url),
+                    Method = new HttpMethod(SelectedMethod),
+                    MessageHandler = MessageHandler
+                };
 
                 foreach (var h in Headers)
                 {
                     if (!string.IsNullOrWhiteSpace(h.Key))
-                        request.Headers.TryAddWithoutValidation(h.Key, h.Value);
+                    {
+                        request.Headers[h.Key] = h.Value;
+                    }
                 }
+
+                if (SelectedMethod != "GET" && SelectedMethod != "DELETE")
+                {
+                    request.Body = RequestBody ?? string.Empty;
+                    Logger?.Log($"Request Body: {RequestBody}", LogLevel.Debug);
+                }
+
                 var headerSummary = string.Join(", ", Headers.Where(h => !string.IsNullOrWhiteSpace(h.Key)).Select(h => $"{h.Key}:{h.Value}"));
                 if (!string.IsNullOrWhiteSpace(headerSummary))
                     Logger?.Log($"Headers: {headerSummary}", LogLevel.Debug);
 
-                if (SelectedMethod != "GET" && SelectedMethod != "DELETE")
-                {
-                    request.Content = new StringContent(RequestBody ?? string.Empty, Encoding.UTF8, "application/json");
-                    Logger?.Log($"Request Body: {RequestBody}", LogLevel.Debug);
-                }
-
-                HttpResponseMessage response = await client.SendAsync(request);
-                StatusCode = (int)response.StatusCode;
-                ResponseBody = await response.Content.ReadAsStringAsync();
+                HttpExecutionResult result = await _httpClientService.ExecuteAsync(request).ConfigureAwait(false);
+                StatusCode = (int)result.StatusCode;
+                ResponseBody = result.Body;
                 Logger?.Log($"Received response with status {StatusCode}", LogLevel.Debug);
                 Logger?.Log($"Response Body: {ResponseBody}", LogLevel.Debug);
                 Logger?.Log("HTTP request completed", LogLevel.Debug);

--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptGlobals.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptGlobals.cs
@@ -1,6 +1,0 @@
-namespace DesktopApplicationTemplate.UI.ViewModels;
-
-public class ScriptGlobals
-{
-    public string Message { get; set; } = string.Empty;
-}

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using System.ComponentModel;
 using System.Threading.Tasks;
@@ -11,11 +10,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
-using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.Views;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Scripting;
-using Microsoft.CodeAnalysis.Scripting;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 {
@@ -93,7 +88,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private readonly IMessageRoutingService _routing;
         private TcpServiceOptions _options = new();
-
+        private TcpRuntimeContext? _runtimeContext;
+        
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
 
@@ -171,10 +167,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         /// <summary>Whether UDP mode is enabled.</summary>
         public bool IsUdp { get; private set; }
 
-        public TcpServiceMessagesViewModel(ServiceMessageTableViewModel messageTable, IMessageRoutingService routing)
+        private readonly ITcpRuntime _tcpRuntime;
+
+        public TcpServiceMessagesViewModel(ServiceMessageTableViewModel messageTable, IMessageRoutingService routing, ITcpRuntime tcpRuntime)
         {
             MessageTable = messageTable ?? throw new ArgumentNullException(nameof(messageTable));
             _routing = routing ?? throw new ArgumentNullException(nameof(routing));
+            _tcpRuntime = tcpRuntime ?? throw new ArgumentNullException(nameof(tcpRuntime));
 
             Messages.CollectionChanged += (_, _) =>
             {
@@ -201,14 +200,24 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 ? ScriptEditorViewModel.DefaultScript
                 : _options.Script;
             OutputMessage = _options.OutputMessage;
-            _ = RunInitialScriptAsync();
+            _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
+            _ = InitializeRuntimeAsync();
         }
 
-        private async Task RunInitialScriptAsync()
+        private async Task InitializeRuntimeAsync()
         {
+            if (_runtimeContext is null)
+            {
+                return;
+            }
+
             try
             {
-                OutputMessage = await RunScriptAsync().ConfigureAwait(false);
+                var state = await _tcpRuntime.InitializeAsync(_runtimeContext).ConfigureAwait(false);
+                Script = state.Script;
+                TestMessage = state.TestMessage;
+                OutputMessage = state.OutputMessage;
+                _options.OutputMessage = state.OutputMessage;
                 Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
             }
             catch (Exception ex)
@@ -216,7 +225,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 OutputMessage = ex.ToString();
                 Logger?.Log($"Script execution failed: {ex}", LogLevel.Error);
             }
-            _options.OutputMessage = OutputMessage;
         }
 
         /// <summary>Updates network and scripting settings.</summary>
@@ -255,12 +263,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         /// <summary>Saves the current test message to options and routing.</summary>
         public async Task SaveAsync()
         {
-            _options.LastTestMessage = TestMessage;
-            _options.Script = Script;
-            _routing.UpdateMessage(ServiceType, ServiceName, TestMessage);
+            if (_runtimeContext is null)
+            {
+                return;
+            }
+
             try
             {
-                OutputMessage = await RunScriptAsync().ConfigureAwait(false);
+                var result = await _tcpRuntime.ExecuteAsync(new TcpRuntimeExecutionRequest(_runtimeContext, Script, TestMessage)).ConfigureAwait(false);
+                Script = result.Script;
+                TestMessage = result.TestMessage;
+                OutputMessage = result.OutputMessage;
+                _options.OutputMessage = result.OutputMessage;
                 Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
             }
             catch (Exception ex)
@@ -268,39 +282,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 OutputMessage = ex.ToString();
                 Logger?.Log($"Script execution failed: {ex}", LogLevel.Error);
             }
-            _options.OutputMessage = OutputMessage;
-        }
-
-        private async Task<string> RunScriptAsync()
-        {
-            var globals = new ScriptGlobals { Message = TestMessage };
-            var code = Script + "\nreturn Process(Message);";
-            var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(ScriptGlobals));
-            var diagnostics = script.Compile();
-            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-                return string.Join(Environment.NewLine, diagnostics.Select(d => d.ToString()));
-
-            var result = await script.RunAsync(globals).ConfigureAwait(false);
-            return result.ReturnValue ?? string.Empty;
         }
 
         private void InitializeTestMessage()
         {
             if (string.IsNullOrWhiteSpace(ServiceName))
+            {
                 return;
+            }
 
-            if (string.IsNullOrWhiteSpace(_options.LastTestMessage) &&
-                _routing.TryGetMessage(ServiceType, ServiceName, out var routed))
-            {
-                TestMessage = routed ?? string.Empty;
-            }
-            else
-            {
-                TestMessage = string.IsNullOrWhiteSpace(_options.LastTestMessage)
-                    ? $"{ServiceName}-PEAK-123456789"
-                    : _options.LastTestMessage;
-            }
-            _routing.UpdateMessage(ServiceType, ServiceName, TestMessage);
+            _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
+            _ = InitializeRuntimeAsync();
         }
 
         private async Task OpenScriptEditorAsync()


### PR DESCRIPTION
## Summary
- move HTTP request execution into a reusable Core `HttpClientService` and update the WPF view model to call it
- add a Roslyn-powered `TcpRuntime` plus heartbeat and file observer services under Core/Protocols and migrate the view models to those abstractions
- register the new protocol services for DI and extend the file observer/heartbeat workflows to use timer and watcher callbacks

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68def14a7fb4832698aeb1f26f18eae7