### PR TITLE
Refactor service orchestration to use descriptor-aware infrastructure

### DIFF
--- a/DesktopApplicationTemplate.Services/CommonServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Services/CommonServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols;
 using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
@@ -27,6 +28,9 @@ public static class CommonServiceCollectionExtensions
         services.AddTransient<ITcpRuntime, TcpRuntime>();
         services.AddTransient<IHeartbeatService, HeartbeatService>();
         services.AddTransient<IFileObserverService, FileObserverService>();
+        services.AddSingleton<IServiceCatalog>(_ => new ServiceCatalog(Array.Empty<IServiceDescriptor>()));
+        services.AddSingleton<IServiceRuntimeFactory, DescriptorRuntimeFactory>();
+        services.AddSingleton(typeof(ServiceManager<,>));
         return services;
     }
 }

--- a/DesktopApplicationTemplate.Services/Protocols/LoggingServiceProtocolLogger.cs
+++ b/DesktopApplicationTemplate.Services/Protocols/LoggingServiceProtocolLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols;
 
@@ -9,38 +10,83 @@ namespace DesktopApplicationTemplate.Services.Protocols;
 /// </summary>
 public sealed class LoggingServiceProtocolLogger : IProtocolLogger
 {
-    private readonly ILoggingService loggingService;
+    private readonly ILoggingService _loggingService;
+    private readonly IProtocolEventPublisher? _eventPublisher;
 
-    public LoggingServiceProtocolLogger(ILoggingService loggingService)
+    public LoggingServiceProtocolLogger(ILoggingService loggingService, IProtocolEventPublisher? eventPublisher = null)
     {
-        this.loggingService = loggingService ?? throw new ArgumentNullException(nameof(loggingService));
+        _loggingService = loggingService ?? throw new ArgumentNullException(nameof(loggingService));
+        _eventPublisher = eventPublisher;
     }
 
     /// <inheritdoc />
     public void LogInformation(IProtocolService protocolService, string message)
     {
-        Log(protocolService, message, LogLevel.Information);
+        Log(protocolService, message, LogLevel.Information, null);
     }
 
     /// <inheritdoc />
     public void LogWarning(IProtocolService protocolService, string message)
     {
-        Log(protocolService, message, LogLevel.Warning);
+        Log(protocolService, message, LogLevel.Warning, null);
     }
 
     /// <inheritdoc />
     public void LogError(IProtocolService protocolService, Exception exception, string message)
     {
-        var formattedMessage = FormatMessage(protocolService, message);
-        loggingService.Log($"{formattedMessage} - {exception}", LogLevel.Error);
+        if (exception is null)
+        {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        Log(protocolService, message, LogLevel.Error, exception);
     }
 
-    private void Log(IProtocolService protocolService, string message, LogLevel level)
+    private void Log(IProtocolService? protocolService, string message, LogLevel level, Exception? exception)
     {
-        loggingService.Log(FormatMessage(protocolService, message), level);
+        var formattedMessage = FormatMessage(protocolService, message);
+        if (exception is null)
+        {
+            _loggingService.Log(formattedMessage, level);
+        }
+        else
+        {
+            _loggingService.Log($"{formattedMessage} - {exception}", level);
+        }
+
+        PublishEvent(protocolService, level, formattedMessage, exception);
     }
 
-    private static string FormatMessage(IProtocolService protocolService, string message)
+    private void PublishEvent(IProtocolService? protocolService, LogLevel level, string message, Exception? exception)
+    {
+        if (_eventPublisher is null)
+        {
+            return;
+        }
+
+        var protocolName = protocolService?.Name ?? "UnknownProtocol";
+        var evt = new ProtocolLogEvent(protocolName, level, message, exception);
+        var task = _eventPublisher.PublishAsync(evt);
+
+        if (task.IsCompletedSuccessfully)
+        {
+            return;
+        }
+
+        task.ContinueWith(
+            completed =>
+            {
+                if (completed.IsFaulted)
+                {
+                    _loggingService.Log(
+                        $"Failed to publish protocol log event for {protocolName}: {completed.Exception?.GetBaseException().Message}",
+                        LogLevel.Warning);
+                }
+            },
+            TaskScheduler.Default);
+    }
+
+    private static string FormatMessage(IProtocolService? protocolService, string message)
     {
         var sourceName = protocolService?.Name ?? "UnknownProtocol";
         var safeMessage = string.IsNullOrWhiteSpace(message) ? "No message provided." : message;

--- a/DesktopApplicationTemplate.Services/Protocols/ProtocolEvents.cs
+++ b/DesktopApplicationTemplate.Services/Protocols/ProtocolEvents.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+
+namespace DesktopApplicationTemplate.Services.Protocols;
+
+/// <summary>
+/// Represents a lifecycle event emitted by a protocol service.
+/// </summary>
+public sealed class ProtocolLifecycleEvent : IProtocolEvent
+{
+    public ProtocolLifecycleEvent(
+        string protocolName,
+        string descriptorId,
+        string displayName,
+        ProtocolLifecycleStage stage,
+        IReadOnlyCollection<string> associatedServices)
+    {
+        ProtocolName = string.IsNullOrWhiteSpace(protocolName) ? "UnknownProtocol" : protocolName;
+        DescriptorId = descriptorId ?? throw new ArgumentNullException(nameof(descriptorId));
+        DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+        Stage = stage;
+        AssociatedServices = associatedServices ?? Array.Empty<string>();
+        Timestamp = DateTimeOffset.UtcNow;
+
+        var metadata = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Protocol"] = ProtocolName,
+            ["DescriptorId"] = DescriptorId,
+            ["DisplayName"] = DisplayName,
+            ["Stage"] = Stage.ToString(),
+            ["AssociatedServices"] = AssociatedServices
+        };
+
+        Metadata = new ReadOnlyDictionary<string, object?>(metadata);
+    }
+
+    public string ProtocolName { get; }
+
+    public string DescriptorId { get; }
+
+    public string DisplayName { get; }
+
+    public ProtocolLifecycleStage Stage { get; }
+
+    public IReadOnlyCollection<string> AssociatedServices { get; }
+
+    public string Name => Stage switch
+    {
+        ProtocolLifecycleStage.Starting => "ProtocolStarting",
+        ProtocolLifecycleStage.Started => "ProtocolStarted",
+        ProtocolLifecycleStage.Stopping => "ProtocolStopping",
+        ProtocolLifecycleStage.Stopped => "ProtocolStopped",
+        _ => "ProtocolLifecycle"
+    };
+
+    public DateTimeOffset Timestamp { get; }
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; }
+}
+
+/// <summary>
+/// Represents a log entry emitted by a protocol service.
+/// </summary>
+public sealed class ProtocolLogEvent : IProtocolEvent
+{
+    public ProtocolLogEvent(string protocolName, LogLevel level, string message, Exception? exception = null)
+    {
+        ProtocolName = string.IsNullOrWhiteSpace(protocolName) ? "UnknownProtocol" : protocolName;
+        Level = level;
+        Message = string.IsNullOrWhiteSpace(message) ? "No message provided." : message;
+        Exception = exception;
+        Timestamp = DateTimeOffset.UtcNow;
+
+        var metadata = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Protocol"] = ProtocolName,
+            ["Level"] = Level,
+            ["Message"] = Message
+        };
+
+        if (Exception is not null)
+        {
+            metadata["Exception"] = Exception.ToString();
+        }
+
+        Metadata = new ReadOnlyDictionary<string, object?>(metadata);
+    }
+
+    public string ProtocolName { get; }
+
+    public LogLevel Level { get; }
+
+    public string Message { get; }
+
+    public Exception? Exception { get; }
+
+    public string Name => "ProtocolLog";
+
+    public DateTimeOffset Timestamp { get; }
+
+    public IReadOnlyDictionary<string, object?> Metadata { get; }
+}
+
+/// <summary>
+/// Identifies the lifecycle stage represented by a <see cref="ProtocolLifecycleEvent"/>.
+/// </summary>
+public enum ProtocolLifecycleStage
+{
+    Starting,
+    Started,
+    Stopping,
+    Stopped
+}

--- a/DesktopApplicationTemplate.Services/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Services/ServiceManager.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+using DesktopApplicationTemplate.Services.Protocols;
+using Microsoft.Extensions.Logging;
+using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
+
+namespace DesktopApplicationTemplate.Services;
+
+/// <summary>
+/// Coordinates service descriptor runtimes and UI registrations.
+/// </summary>
+/// <typeparam name="TService">The UI service model type.</typeparam>
+/// <typeparam name="TPage">The UI navigation target type.</typeparam>
+public sealed class ServiceManager<TService, TPage> : IDisposable
+{
+    private readonly IServiceCatalog _serviceCatalog;
+    private readonly IServiceRuntimeFactory _runtimeFactory;
+    private readonly IServiceUiRegistry<TService, TPage> _uiRegistry;
+    private readonly IReadOnlyCollection<IProtocolLifecycleObserver> _lifecycleObservers;
+    private readonly IProtocolEventPublisher? _eventPublisher;
+    private readonly ILoggingService? _loggingService;
+    private readonly ILogger<ServiceManager<TService, TPage>>? _logger;
+    private readonly ConcurrentDictionary<IServiceRuntime, ServiceRuntimeContext> _runtimeContexts = new();
+    private bool _disposed;
+
+    public ServiceManager(
+        IServiceCatalog serviceCatalog,
+        IServiceRuntimeFactory runtimeFactory,
+        IServiceUiRegistry<TService, TPage> uiRegistry,
+        IEnumerable<IProtocolLifecycleObserver>? lifecycleObservers = null,
+        IProtocolEventPublisher? eventPublisher = null,
+        ILoggingService? loggingService = null,
+        ILogger<ServiceManager<TService, TPage>>? logger = null)
+    {
+        _serviceCatalog = serviceCatalog ?? throw new ArgumentNullException(nameof(serviceCatalog));
+        _runtimeFactory = runtimeFactory ?? throw new ArgumentNullException(nameof(runtimeFactory));
+        _uiRegistry = uiRegistry ?? throw new ArgumentNullException(nameof(uiRegistry));
+        _eventPublisher = eventPublisher;
+        _loggingService = loggingService;
+        _logger = logger;
+        _lifecycleObservers = (lifecycleObservers ?? Array.Empty<IProtocolLifecycleObserver>()).ToArray();
+        _serviceCatalog.DescriptorsChanged += OnDescriptorsChanged;
+    }
+
+    /// <summary>Gets the registry responsible for UI integration.</summary>
+    public IServiceUiRegistry<TService, TPage> UiRegistry => _uiRegistry;
+
+    /// <summary>Raised when the underlying service catalog reports descriptor changes.</summary>
+    public event EventHandler? DescriptorsChanged;
+
+    /// <summary>
+    /// Creates a runtime context for the specified descriptor identifier.
+    /// </summary>
+    public ServiceRuntimeContext CreateRuntimeContext(
+        string descriptorId,
+        string displayName,
+        IReadOnlyCollection<string> associatedServices,
+        object? payload = null)
+    {
+        if (descriptorId is null)
+        {
+            throw new ArgumentNullException(nameof(descriptorId));
+        }
+
+        if (!_serviceCatalog.TryGetById(descriptorId, out var descriptor))
+        {
+            throw new InvalidOperationException($"Descriptor '{descriptorId}' is not registered.");
+        }
+
+        return new ServiceRuntimeContext(descriptor, descriptorId, displayName, associatedServices, payload);
+    }
+
+    /// <summary>
+    /// Starts a runtime for the supplied context, coordinating lifecycle notifications.
+    /// </summary>
+    public async Task<IServiceRuntime> StartRuntimeAsync(ServiceRuntimeContext context, CancellationToken cancellationToken = default)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        Log($"Starting runtime for descriptor '{context.DescriptorId}'.", LogLevel.Information);
+
+        var runtime = _runtimeFactory.Create(context);
+
+        if (!_runtimeContexts.TryAdd(runtime, context))
+        {
+            _runtimeContexts[runtime] = context;
+        }
+
+        if (runtime is IProtocolService protocolService)
+        {
+            await NotifyLifecycleAsync(protocolService, o => o.OnStartingAsync(protocolService, cancellationToken), "starting").ConfigureAwait(false);
+            await PublishLifecycleEventAsync(context, protocolService, ProtocolLifecycleStage.Starting, cancellationToken).ConfigureAwait(false);
+        }
+
+        await runtime.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        if (runtime is IProtocolService startedProtocol)
+        {
+            await NotifyLifecycleAsync(startedProtocol, o => o.OnStartedAsync(startedProtocol, cancellationToken), "started").ConfigureAwait(false);
+            await PublishLifecycleEventAsync(context, startedProtocol, ProtocolLifecycleStage.Started, cancellationToken).ConfigureAwait(false);
+        }
+
+        Log($"Runtime for descriptor '{context.DescriptorId}' started.", LogLevel.Debug);
+
+        return runtime;
+    }
+
+    /// <summary>
+    /// Stops and disposes the supplied runtime.
+    /// </summary>
+    public async Task StopRuntimeAsync(IServiceRuntime runtime, CancellationToken cancellationToken = default)
+    {
+        if (runtime is null)
+        {
+            throw new ArgumentNullException(nameof(runtime));
+        }
+
+        _runtimeContexts.TryRemove(runtime, out var context);
+
+        if (runtime is IProtocolService protocolService && context is not null)
+        {
+            await NotifyLifecycleAsync(protocolService, o => o.OnStoppingAsync(protocolService, cancellationToken), "stopping").ConfigureAwait(false);
+            await PublishLifecycleEventAsync(context, protocolService, ProtocolLifecycleStage.Stopping, cancellationToken).ConfigureAwait(false);
+        }
+
+        await runtime.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        if (runtime is IProtocolService stoppedProtocol && context is not null)
+        {
+            await NotifyLifecycleAsync(stoppedProtocol, o => o.OnStoppedAsync(stoppedProtocol, cancellationToken), "stopped").ConfigureAwait(false);
+            await PublishLifecycleEventAsync(context, stoppedProtocol, ProtocolLifecycleStage.Stopped, cancellationToken).ConfigureAwait(false);
+        }
+
+        await runtime.DisposeAsync().ConfigureAwait(false);
+
+        var descriptorLabel = context?.DescriptorId ?? "unknown";
+        Log($"Runtime for descriptor '{descriptorLabel}' stopped.", LogLevel.Debug);
+    }
+
+    private async Task NotifyLifecycleAsync(
+        IProtocolService protocolService,
+        Func<IProtocolLifecycleObserver, Task> invokeAsync,
+        string stage)
+    {
+        foreach (var observer in _lifecycleObservers)
+        {
+            try
+            {
+                await invokeAsync(observer).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log($"Lifecycle observer failure during {stage} for '{protocolService.Name}': {ex.Message}", LogLevel.Warning);
+            }
+        }
+    }
+
+    private Task PublishLifecycleEventAsync(
+        ServiceRuntimeContext context,
+        IProtocolService protocolService,
+        ProtocolLifecycleStage stage,
+        CancellationToken cancellationToken)
+    {
+        if (_eventPublisher is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var associated = context.AssociatedServices ?? Array.Empty<string>();
+        var lifecycleEvent = new ProtocolLifecycleEvent(protocolService.Name, context.DescriptorId, context.DisplayName, stage, associated);
+        var publishTask = _eventPublisher.PublishAsync(lifecycleEvent, cancellationToken);
+
+        if (publishTask.IsCompletedSuccessfully)
+        {
+            return Task.CompletedTask;
+        }
+
+        return publishTask.ContinueWith(
+            task =>
+            {
+                if (task.IsFaulted)
+                {
+                    Log($"Failed to publish lifecycle event for '{context.DescriptorId}': {task.Exception?.GetBaseException().Message}", LogLevel.Warning);
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void OnDescriptorsChanged(object? sender, EventArgs e)
+    {
+        DescriptorsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void Log(string message, LogLevel level)
+    {
+        _loggingService?.Log(message, level);
+        _logger?.Log(MapLevel(level), message);
+    }
+
+    private static Microsoft.Extensions.Logging.LogLevel MapLevel(LogLevel level) => level switch
+    {
+        LogLevel.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
+        LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+        LogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
+        LogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
+        LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+        LogLevel.Critical => Microsoft.Extensions.Logging.LogLevel.Critical,
+        _ => Microsoft.Extensions.Logging.LogLevel.Information
+    };
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _serviceCatalog.DescriptorsChanged -= OnDescriptorsChanged;
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+}
+
+/// <summary>
+/// Resolves descriptor-backed runtime factories and runtime instances.
+/// </summary>
+public sealed class DescriptorRuntimeFactory : IServiceRuntimeFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public DescriptorRuntimeFactory(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    public IServiceRuntime Create(ServiceRuntimeContext context)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var descriptor = context.Descriptor ?? throw new InvalidOperationException("Descriptor must be provided in the runtime context.");
+
+        foreach (var binding in descriptor.Factories ?? Array.Empty<ServiceFactoryBinding>())
+        {
+            if (binding.Kind != ServiceFactoryKind.Runtime)
+            {
+                continue;
+            }
+
+            var resolved = binding.Resolver(_serviceProvider);
+
+            if (resolved is IServiceRuntimeFactory factory && binding.ContractType.IsInstanceOfType(factory))
+            {
+                return factory.Create(context);
+            }
+
+            if (resolved is IServiceRuntime runtime && binding.ContractType.IsInstanceOfType(runtime))
+            {
+                return runtime;
+            }
+        }
+
+        throw new InvalidOperationException($"Descriptor '{descriptor.Id}' does not expose a runtime binding.");
+    }
+}

--- a/DesktopApplicationTemplate.Services/ServiceUiRegistration.cs
+++ b/DesktopApplicationTemplate.Services/ServiceUiRegistration.cs
@@ -1,65 +1,144 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.Services;
 
+/// <summary>
+/// Describes how a service descriptor integrates with UI workflows.
+/// </summary>
+/// <typeparam name="TService">Type representing the UI service view model.</typeparam>
+/// <typeparam name="TPage">Type representing a navigation target.</typeparam>
 public sealed record ServiceUiRegistration<TService, TPage>(
-    ServiceType ServiceType,
+    string DescriptorId,
     Func<IServiceProvider, object, TService> CreateService,
     Func<IServiceProvider, TPage> CreateServicePage,
-    Func<IServiceProvider, string, TPage> CreateNavigationPage);
+    Func<IServiceProvider, string, TPage> CreateNavigationPage,
+    ServiceType? LegacyServiceType = null,
+    Action<TService, ServicePresentationMetadata>? ApplyPresentation = null);
 
-public interface IServiceUiRegistry<TService, TPage>
+public interface IServiceUiRegistry<TService, TPage> : IDisposable
 {
     IReadOnlyCollection<ServiceType> SupportedServices { get; }
 
+    IReadOnlyCollection<string> SupportedDescriptorIds { get; }
+
     bool TryCreateService(ServiceType serviceType, IServiceProvider provider, object options, out TService? service);
+
+    bool TryCreateService(string descriptorId, IServiceProvider provider, object options, out TService? service);
 
     bool TryCreateServicePage(ServiceType serviceType, IServiceProvider provider, out TPage? page);
 
+    bool TryCreateServicePage(string descriptorId, IServiceProvider provider, out TPage? page);
+
     bool TryCreateNavigationPage(ServiceType serviceType, IServiceProvider provider, string defaultName, out TPage? page);
+
+    bool TryCreateNavigationPage(string descriptorId, IServiceProvider provider, string defaultName, out TPage? page);
 }
 
+/// <summary>
+/// Resolves UI integrations for service descriptors and reacts to catalog updates.
+/// </summary>
+/// <typeparam name="TService">Type representing the UI service view model.</typeparam>
+/// <typeparam name="TPage">Type representing a navigation target.</typeparam>
 public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TService, TPage>
 {
-    private readonly IReadOnlyDictionary<ServiceType, ServiceUiRegistration<TService, TPage>> _registrations;
+    private readonly IServiceCatalog _serviceCatalog;
+    private readonly IReadOnlyDictionary<string, ServiceUiRegistration<TService, TPage>> _registrations;
+    private readonly Dictionary<ServiceType, string> _legacyMap = new();
+    private IReadOnlyCollection<ServiceType> _supportedServices = Array.Empty<ServiceType>();
+    private readonly IReadOnlyCollection<string> _supportedDescriptorIds;
+    private bool _disposed;
 
-    public ServiceUiRegistry(IEnumerable<ServiceUiRegistration<TService, TPage>> registrations)
+    public ServiceUiRegistry(IServiceCatalog serviceCatalog, IEnumerable<ServiceUiRegistration<TService, TPage>> registrations)
     {
+        _serviceCatalog = serviceCatalog ?? throw new ArgumentNullException(nameof(serviceCatalog));
         if (registrations is null)
         {
             throw new ArgumentNullException(nameof(registrations));
         }
 
-        var map = new Dictionary<ServiceType, ServiceUiRegistration<TService, TPage>>();
+        var map = new Dictionary<string, ServiceUiRegistration<TService, TPage>>(StringComparer.Ordinal);
         foreach (var registration in registrations)
         {
-            map[registration.ServiceType] = registration;
+            if (registration is null)
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(registration.DescriptorId))
+            {
+                throw new ArgumentException("DescriptorId must be provided for all registrations.", nameof(registrations));
+            }
+
+            map[registration.DescriptorId] = registration;
+            if (registration.LegacyServiceType is { } legacy)
+            {
+                _legacyMap[legacy] = registration.DescriptorId;
+            }
         }
 
-        _registrations = map;
-        SupportedServices = map.Keys.ToArray();
+        _registrations = new ReadOnlyDictionary<string, ServiceUiRegistration<TService, TPage>>(map);
+        _supportedDescriptorIds = _registrations.Keys.ToArray();
+        UpdateLegacyMappings();
+        _serviceCatalog.DescriptorsChanged += OnDescriptorsChanged;
     }
 
-    public IReadOnlyCollection<ServiceType> SupportedServices { get; }
+    public IReadOnlyCollection<ServiceType> SupportedServices => _supportedServices;
+
+    public IReadOnlyCollection<string> SupportedDescriptorIds => _supportedDescriptorIds;
 
     public bool TryCreateService(ServiceType serviceType, IServiceProvider provider, object options, out TService? service)
     {
-        if (!_registrations.TryGetValue(serviceType, out var registration))
+        if (!_legacyMap.TryGetValue(serviceType, out var descriptorId))
+        {
+            service = default;
+            return false;
+        }
+
+        return TryCreateService(descriptorId, provider, options, out service);
+    }
+
+    public bool TryCreateService(string descriptorId, IServiceProvider provider, object options, out TService? service)
+    {
+        if (provider is null)
+        {
+            throw new ArgumentNullException(nameof(provider));
+        }
+
+        if (!_registrations.TryGetValue(descriptorId, out var registration))
         {
             service = default;
             return false;
         }
 
         service = registration.CreateService(provider, options);
+        ApplyPresentationIfAvailable(service, registration);
         return true;
     }
 
     public bool TryCreateServicePage(ServiceType serviceType, IServiceProvider provider, out TPage? page)
     {
-        if (!_registrations.TryGetValue(serviceType, out var registration))
+        if (!_legacyMap.TryGetValue(serviceType, out var descriptorId))
+        {
+            page = default;
+            return false;
+        }
+
+        return TryCreateServicePage(descriptorId, provider, out page);
+    }
+
+    public bool TryCreateServicePage(string descriptorId, IServiceProvider provider, out TPage? page)
+    {
+        if (provider is null)
+        {
+            throw new ArgumentNullException(nameof(provider));
+        }
+
+        if (!_registrations.TryGetValue(descriptorId, out var registration))
         {
             page = default;
             return false;
@@ -71,7 +150,23 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
 
     public bool TryCreateNavigationPage(ServiceType serviceType, IServiceProvider provider, string defaultName, out TPage? page)
     {
-        if (!_registrations.TryGetValue(serviceType, out var registration))
+        if (!_legacyMap.TryGetValue(serviceType, out var descriptorId))
+        {
+            page = default;
+            return false;
+        }
+
+        return TryCreateNavigationPage(descriptorId, provider, defaultName, out page);
+    }
+
+    public bool TryCreateNavigationPage(string descriptorId, IServiceProvider provider, string defaultName, out TPage? page)
+    {
+        if (provider is null)
+        {
+            throw new ArgumentNullException(nameof(provider));
+        }
+
+        if (!_registrations.TryGetValue(descriptorId, out var registration))
         {
             page = default;
             return false;
@@ -79,5 +174,62 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
 
         page = registration.CreateNavigationPage(provider, defaultName);
         return true;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _serviceCatalog.DescriptorsChanged -= OnDescriptorsChanged;
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+
+    private void OnDescriptorsChanged(object? sender, EventArgs e) => UpdateLegacyMappings();
+
+    private void UpdateLegacyMappings()
+    {
+        var updated = new Dictionary<ServiceType, string>();
+
+        foreach (var registration in _registrations.Values)
+        {
+            if (registration.LegacyServiceType is { } legacy)
+            {
+                updated[legacy] = registration.DescriptorId;
+            }
+        }
+
+        foreach (var kvp in _serviceCatalog.LegacyMap)
+        {
+            if (_registrations.ContainsKey(kvp.Value))
+            {
+                updated[kvp.Key] = kvp.Value;
+            }
+        }
+
+        _legacyMap.Clear();
+        foreach (var kvp in updated)
+        {
+            _legacyMap[kvp.Key] = kvp.Value;
+        }
+
+        _supportedServices = _legacyMap.Keys.ToArray();
+    }
+
+    private void ApplyPresentationIfAvailable(TService? service, ServiceUiRegistration<TService, TPage> registration)
+    {
+        if (service is null || registration.ApplyPresentation is null)
+        {
+            return;
+        }
+
+        var presentation = _serviceCatalog.TryGetById(registration.DescriptorId, out var descriptor)
+            ? descriptor.Presentation
+            : ServicePresentationMetadata.Empty;
+
+        registration.ApplyPresentation(service, presentation);
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -196,19 +196,24 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CsvServiceAdapter>();
             services.AddSingleton<CsvServiceView>();
             services.AddSingleton<SettingsViewModel>();
-            services.AddSingleton<IServiceUiRegistry<ServiceListModel, Page>>(_ =>
-                new ServiceUiRegistry<ServiceListModel, Page>(new[]
-                {
-                    BuildCsvRegistration(),
-                    BuildFileObserverRegistration(),
-                    BuildHeartbeatRegistration(),
-                    BuildHidRegistration(),
-                    BuildHttpRegistration(),
-                    BuildMqttRegistration(),
-                    BuildScpRegistration(),
-                    BuildTcpRegistration(),
-                    BuildFtpRegistration(),
-                }));
+            services.AddSingleton<IServiceUiRegistry<ServiceListModel, Page>>(sp =>
+            {
+                var catalog = sp.GetRequiredService<IServiceCatalog>();
+                return new ServiceUiRegistry<ServiceListModel, Page>(
+                    catalog,
+                    new[]
+                    {
+                        BuildCsvRegistration(),
+                        BuildFileObserverRegistration(),
+                        BuildHeartbeatRegistration(),
+                        BuildHidRegistration(),
+                        BuildHttpRegistration(),
+                        BuildMqttRegistration(),
+                        BuildScpRegistration(),
+                        BuildTcpRegistration(),
+                        BuildFtpRegistration(),
+                    });
+            });
             services.AddTransient<SplashWindow>();
             services.AddTransient<CreateServicePage>();
             services.AddTransient<CreateServiceViewModel>();
@@ -302,7 +307,7 @@ namespace DesktopApplicationTemplate.UI
         private static ServiceUiRegistration<ServiceListModel, Page> BuildMqttRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Mqtt,
+                ServiceDescriptorIds.Mqtt,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<MqttServiceOptions>)optionsObj;
@@ -390,13 +395,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Mqtt);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildFtpRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Ftp,
+                ServiceDescriptorIds.Ftp,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<FtpServerOptions>)optionsObj;
@@ -441,13 +447,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Ftp);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildHttpRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Http,
+                ServiceDescriptorIds.Http,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<HttpServiceOptions>)optionsObj;
@@ -484,13 +491,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Http);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildTcpRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Tcp,
+                ServiceDescriptorIds.Tcp,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<TcpServiceOptions>)optionsObj;
@@ -517,13 +525,14 @@ namespace DesktopApplicationTemplate.UI
                             new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     return ActivatorUtilities.CreateInstance<TcpCreateServiceView>(provider, vm);
-                });
+                },
+                legacyServiceType: ServiceType.Tcp);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildHidRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Hid,
+                ServiceDescriptorIds.Hid,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<HidServiceOptions>)optionsObj;
@@ -560,13 +569,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Hid);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildScpRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Scp,
+                ServiceDescriptorIds.Scp,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<ScpServiceOptions>)optionsObj;
@@ -603,13 +613,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Scp);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildFileObserverRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.FileObserver,
+                ServiceDescriptorIds.FileObserver,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<FileObserverServiceOptions>)optionsObj;
@@ -646,13 +657,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.FileObserver);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildCsvRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Csv,
+                ServiceDescriptorIds.Csv,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<CsvServiceOptions>)optionsObj;
@@ -690,13 +702,14 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Csv);
         }
 
         private static ServiceUiRegistration<ServiceListModel, Page> BuildHeartbeatRegistration()
         {
             return new ServiceUiRegistration<ServiceListModel, Page>(
-                ServiceType.Heartbeat,
+                ServiceDescriptorIds.Heartbeat,
                 (provider, optionsObj) =>
                 {
                     var ctx = (ServiceFactoryOptions<HeartbeatServiceOptions>)optionsObj;
@@ -733,7 +746,8 @@ namespace DesktopApplicationTemplate.UI
                         mainView.ShowPage(advView);
                     };
                     return view;
-                });
+                },
+                legacyServiceType: ServiceType.Heartbeat);
         }
 
         internal void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)


### PR DESCRIPTION
## Summary
- add a descriptor-aware `ServiceManager` and runtime factory to coordinate lifecycle notifications
- publish protocol lifecycle/log events through shared logging infrastructure and the new protocol event types
- update the WPF service UI registrations to resolve descriptor IDs via the shared registry and catalog

## Testing
- Not run (environment lacks the Windows .NET tooling required for WPF builds)


------
https://chatgpt.com/codex/tasks/task_e_68def89014ec8326b58e5d9b32cb92bd