### PR TITLE
Add protocol facades and persist expanded service options

### DIFF
--- a/DesktopApplicationTemplate.Services/CommonServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Services/CommonServiceCollectionExtensions.cs
@@ -24,6 +24,8 @@ public static class CommonServiceCollectionExtensions
         services.AddTransient(typeof(IServiceScreen<>), typeof(ServiceScreen<>));
         services.AddSingleton<IFileSearchService, FileSearchService>();
         services.AddSingleton<IProtocolLogger, LoggingServiceProtocolLogger>();
+        services.AddSingleton<IProtocolEventPublisher, ProtocolEventPublisherFacade>();
+        services.AddSingleton<IProtocolLifecycleObserver, ProtocolLifecycleObserverFacade>();
         services.AddSingleton<IHttpClientService, HttpClientService>();
         services.AddTransient<ITcpRuntime, TcpRuntime>();
         services.AddTransient<IHeartbeatService, HeartbeatService>();

--- a/DesktopApplicationTemplate.Services/Protocols/ProtocolEventPublisherFacade.cs
+++ b/DesktopApplicationTemplate.Services/Protocols/ProtocolEventPublisherFacade.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+
+namespace DesktopApplicationTemplate.Services.Protocols;
+
+/// <summary>
+/// Publishes protocol events to the shared logging service.
+/// </summary>
+public sealed class ProtocolEventPublisherFacade : IProtocolEventPublisher
+{
+    private readonly ILoggingService _loggingService;
+
+    public ProtocolEventPublisherFacade(ILoggingService loggingService)
+    {
+        _loggingService = loggingService ?? throw new ArgumentNullException(nameof(loggingService));
+    }
+
+    /// <inheritdoc />
+    public Task PublishAsync(IProtocolEvent protocolEvent, CancellationToken cancellationToken = default)
+    {
+        if (protocolEvent is null)
+        {
+            throw new ArgumentNullException(nameof(protocolEvent));
+        }
+
+        var message = BuildMessage(protocolEvent);
+        _loggingService.Log(message, LogLevel.Information);
+        return Task.CompletedTask;
+    }
+
+    private static string BuildMessage(IProtocolEvent protocolEvent)
+    {
+        var metadataText = FormatMetadata(protocolEvent.Metadata);
+        return $"[{protocolEvent.Timestamp:u}] {protocolEvent.Name}: {metadataText}";
+    }
+
+    private static string FormatMetadata(IReadOnlyDictionary<string, object?> metadata)
+    {
+        if (metadata is null || metadata.Count == 0)
+        {
+            return "No metadata available.";
+        }
+
+        var parts = new List<string>(metadata.Count);
+        foreach (var kvp in metadata)
+        {
+            var value = kvp.Value switch
+            {
+                null => "<null>",
+                string text when string.IsNullOrWhiteSpace(text) => "<empty>",
+                _ => kvp.Value.ToString()
+            };
+            parts.Add($"{kvp.Key}: {value}");
+        }
+
+        return string.Join(", ", parts);
+    }
+}

--- a/DesktopApplicationTemplate.Services/Protocols/ProtocolLifecycleObserverFacade.cs
+++ b/DesktopApplicationTemplate.Services/Protocols/ProtocolLifecycleObserverFacade.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols;
+
+namespace DesktopApplicationTemplate.Services.Protocols;
+
+/// <summary>
+/// Logs protocol lifecycle transitions through the shared logging service.
+/// </summary>
+public sealed class ProtocolLifecycleObserverFacade : IProtocolLifecycleObserver
+{
+    private readonly ILoggingService _loggingService;
+
+    public ProtocolLifecycleObserverFacade(ILoggingService loggingService)
+    {
+        _loggingService = loggingService ?? throw new ArgumentNullException(nameof(loggingService));
+    }
+
+    /// <inheritdoc />
+    public Task OnStartingAsync(IProtocolService protocolService, CancellationToken cancellationToken = default)
+        => LogAsync(protocolService, "starting");
+
+    /// <inheritdoc />
+    public Task OnStartedAsync(IProtocolService protocolService, CancellationToken cancellationToken = default)
+        => LogAsync(protocolService, "started");
+
+    /// <inheritdoc />
+    public Task OnStoppingAsync(IProtocolService protocolService, CancellationToken cancellationToken = default)
+        => LogAsync(protocolService, "stopping");
+
+    /// <inheritdoc />
+    public Task OnStoppedAsync(IProtocolService protocolService, CancellationToken cancellationToken = default)
+        => LogAsync(protocolService, "stopped");
+
+    private Task LogAsync(IProtocolService protocolService, string stage)
+    {
+        if (protocolService is null)
+        {
+            throw new ArgumentNullException(nameof(protocolService));
+        }
+
+        var protocolName = string.IsNullOrWhiteSpace(protocolService.Name)
+            ? "UnknownProtocol"
+            : protocolService.Name;
+
+        _loggingService.Log($"[{protocolName}] Lifecycle {stage}", LogLevel.Information);
+        return Task.CompletedTask;
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -166,6 +166,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<IFileDialogService, FileDialogService>();
             services.AddSingleton<IScpClientFactory, ScpClientFactory>();
             services.AddSingleton<IScpUploadService, ScpService>();
+            // Register shared services and protocol facades from the Services layer.
             services.AddCommonServices();
             services.AddSingleton<SaveConfirmationHelper>();
             services.AddSingleton<CloseConfirmationHelper>();

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -8,11 +8,14 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.Core.Services.Protocols.Ftp;
 using DesktopApplicationTemplate.Core.Services.Protocols.Http;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
+using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
 using DesktopApplicationTemplate.UI;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.Persistence
 {
@@ -30,6 +33,10 @@ namespace DesktopApplicationTemplate.Persistence
                 CsvServiceOptions? csv = null;
                 FtpServerOptions? ftp = null;
                 HttpServiceOptions? http = null;
+                HeartbeatServiceOptions? heartbeat = null;
+                FileObserverServiceOptions? fileObserver = null;
+                HidServiceOptions? hid = null;
+                ScpServiceOptions? scp = null;
                 if (s.Type == ServiceType.Tcp && s.TcpOptions != null)
                 {
                     tcp = new TcpServiceOptions
@@ -77,6 +84,55 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
+                if (s.Type == ServiceType.Heartbeat && s.HeartbeatOptions != null)
+                {
+                    heartbeat = new HeartbeatServiceOptions
+                    {
+                        BaseMessage = s.HeartbeatOptions.BaseMessage,
+                        IncludePing = s.HeartbeatOptions.IncludePing,
+                        IncludeStatus = s.HeartbeatOptions.IncludeStatus
+                    };
+                }
+
+                if (s.Type == ServiceType.FileObserver && s.FileObserverOptions != null)
+                {
+                    fileObserver = new FileObserverServiceOptions
+                    {
+                        FilePath = s.FileObserverOptions.FilePath,
+                        ImageNames = s.FileObserverOptions.ImageNames,
+                        SendAllImages = s.FileObserverOptions.SendAllImages,
+                        SendFirstX = s.FileObserverOptions.SendFirstX,
+                        XCount = s.FileObserverOptions.XCount,
+                        SendTcpCommand = s.FileObserverOptions.SendTcpCommand,
+                        TcpCommand = s.FileObserverOptions.TcpCommand
+                    };
+                }
+
+                if (s.Type == ServiceType.Hid && s.HidOptions != null)
+                {
+                    hid = new HidServiceOptions
+                    {
+                        MessageTemplate = s.HidOptions.MessageTemplate,
+                        UsbProtocol = s.HidOptions.UsbProtocol,
+                        AttachedService = s.HidOptions.AttachedService,
+                        DebounceTimeMs = s.HidOptions.DebounceTimeMs,
+                        KeyDownTimeMs = s.HidOptions.KeyDownTimeMs
+                    };
+                }
+
+                if (s.Type == ServiceType.Scp && s.ScpOptions != null)
+                {
+                    scp = new ScpServiceOptions
+                    {
+                        Host = s.ScpOptions.Host,
+                        Port = s.ScpOptions.Port,
+                        Username = s.ScpOptions.Username,
+                        Password = s.ScpOptions.Password,
+                        LocalPath = s.ScpOptions.LocalPath,
+                        RemotePath = s.ScpOptions.RemotePath
+                    };
+                }
+
                 data.Add(new ServiceInfo
                 {
                     DisplayName = s.DisplayName,
@@ -89,6 +145,10 @@ namespace DesktopApplicationTemplate.Persistence
                     FtpOptions = ftp,
                     HttpOptions = http,
                     CsvOptions = csv,
+                    HeartbeatOptions = heartbeat,
+                    FileObserverOptions = fileObserver,
+                    HidOptions = hid,
+                    ScpOptions = scp,
                     TotalExecutionTimeMs = s.TotalExecutionTimeMs,
                     ExecutionCount = s.ExecutionCount
                 });
@@ -166,6 +226,10 @@ namespace DesktopApplicationTemplate.Persistence
                             FtpOptions = info.FtpOptions,
                             HttpOptions = info.HttpOptions,
                             CsvOptions = info.CsvOptions,
+                            HeartbeatOptions = info.HeartbeatOptions,
+                            FileObserverOptions = info.FileObserverOptions,
+                            HidOptions = info.HidOptions,
+                            ScpOptions = info.ScpOptions,
                             TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                             ExecutionCount = info.ExecutionCount
                         });
@@ -214,6 +278,62 @@ namespace DesktopApplicationTemplate.Persistence
                             // ignore missing options during tests or early startup
                         }
                     }
+                    if (info.ServiceType == ServiceType.Heartbeat && info.HeartbeatOptions != null)
+                    {
+                        var opt = App.AppHost?.Services.GetService<IOptions<HeartbeatServiceOptions>>();
+                        if (opt != null)
+                        {
+                            var value = opt.Value;
+                            value.BaseMessage = info.HeartbeatOptions.BaseMessage;
+                            value.IncludePing = info.HeartbeatOptions.IncludePing;
+                            value.IncludeStatus = info.HeartbeatOptions.IncludeStatus;
+                        }
+                    }
+
+                    if (info.ServiceType == ServiceType.FileObserver && info.FileObserverOptions != null)
+                    {
+                        var opt = App.AppHost?.Services.GetService<IOptions<FileObserverServiceOptions>>();
+                        if (opt != null)
+                        {
+                            var value = opt.Value;
+                            value.FilePath = info.FileObserverOptions.FilePath;
+                            value.ImageNames = info.FileObserverOptions.ImageNames;
+                            value.SendAllImages = info.FileObserverOptions.SendAllImages;
+                            value.SendFirstX = info.FileObserverOptions.SendFirstX;
+                            value.XCount = info.FileObserverOptions.XCount;
+                            value.SendTcpCommand = info.FileObserverOptions.SendTcpCommand;
+                            value.TcpCommand = info.FileObserverOptions.TcpCommand;
+                        }
+                    }
+
+                    if (info.ServiceType == ServiceType.Hid && info.HidOptions != null)
+                    {
+                        var opt = App.AppHost?.Services.GetService<IOptions<HidServiceOptions>>();
+                        if (opt != null)
+                        {
+                            var value = opt.Value;
+                            value.MessageTemplate = info.HidOptions.MessageTemplate;
+                            value.UsbProtocol = info.HidOptions.UsbProtocol;
+                            value.AttachedService = info.HidOptions.AttachedService;
+                            value.DebounceTimeMs = info.HidOptions.DebounceTimeMs;
+                            value.KeyDownTimeMs = info.HidOptions.KeyDownTimeMs;
+                        }
+                    }
+
+                    if (info.ServiceType == ServiceType.Scp && info.ScpOptions != null)
+                    {
+                        var opt = App.AppHost?.Services.GetService<IOptions<ScpServiceOptions>>();
+                        if (opt != null)
+                        {
+                            var value = opt.Value;
+                            value.Host = info.ScpOptions.Host;
+                            value.Port = info.ScpOptions.Port;
+                            value.Username = info.ScpOptions.Username;
+                            value.Password = info.ScpOptions.Password;
+                            value.LocalPath = info.ScpOptions.LocalPath;
+                            value.RemotePath = info.ScpOptions.RemotePath;
+                        }
+                    }
                 }
 
                 logger?.Log($"Loaded {result.Count} services", LogLevel.Debug);
@@ -239,6 +359,10 @@ namespace DesktopApplicationTemplate.Persistence
         public FtpServerOptions? FtpOptions { get; set; }
         public HttpServiceOptions? HttpOptions { get; set; }
         public CsvServiceOptions? CsvOptions { get; set; }
+        public HeartbeatServiceOptions? HeartbeatOptions { get; set; }
+        public FileObserverServiceOptions? FileObserverOptions { get; set; }
+        public HidServiceOptions? HidOptions { get; set; }
+        public ScpServiceOptions? ScpOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
     }
@@ -255,6 +379,10 @@ namespace DesktopApplicationTemplate.Persistence
         public FtpServerOptions? FtpOptions { get; set; }
         public HttpServiceOptions? HttpOptions { get; set; }
         public CsvServiceOptions? CsvOptions { get; set; }
+        public HeartbeatServiceOptions? HeartbeatOptions { get; set; }
+        public FileObserverServiceOptions? FileObserverOptions { get; set; }
+        public HidServiceOptions? HidOptions { get; set; }
+        public ScpServiceOptions? ScpOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -212,6 +212,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     FtpOptions = info.FtpOptions,
                     HttpOptions = info.HttpOptions,
                     CsvOptions = info.CsvOptions,
+                    HeartbeatOptions = info.HeartbeatOptions,
+                    FileObserverOptions = info.FileObserverOptions,
+                    HidOptions = info.HidOptions,
+                    ScpOptions = info.ScpOptions,
                     TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                     ExecutionCount = info.ExecutionCount
                 };


### PR DESCRIPTION
## Summary
- register Services-layer facades that publish protocol events and lifecycle logging through the shared logging service
- extend service persistence to round-trip heartbeat, file observer, HID, and SCP options and hydrate the UI view models accordingly

## Testing
- Not run (dotnet CLI unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfbf608dec832685143d39f6259242