### PR TITLE
Fix configuration dependency and helper namespace resolution

### DIFF
--- a/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
+++ b/DesktopApplicationTemplate.Core/DesktopApplicationTemplate.Core.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
-        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers;assembly=DesktopApplicationTemplate.UI"
+        xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
 


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Configuration.Abstractions to the core project so IConfiguration-based loaders compile
- simplify the helpers XML namespace declaration so the NullToVisibilityConverter can be resolved during XAML compilation

## Testing
- not run (Windows-only WPF solution)

------
https://chatgpt.com/codex/tasks/task_e_68dfc3241b648326a1dbdbe5a37f64eb