### PR TITLE
Ensure service modules expose descriptors and relax logging platform guard

### DIFF
--- a/DesktopApplicationTemplate.Core/Modules/IServiceModule.cs
+++ b/DesktopApplicationTemplate.Core/Modules/IServiceModule.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,4 +20,10 @@ public interface IServiceModule
     /// </summary>
     /// <param name="services">The service collection to register with.</param>
     void RegisterServices(IServiceCollection services);
+
+    /// <summary>
+    /// Describes services exposed by the module without registering them in the container.
+    /// </summary>
+    /// <returns>The descriptors defined by the module.</returns>
+    IEnumerable<IServiceDescriptor> DescribeServices();
 }

--- a/DesktopApplicationTemplate.Core/Services/LogLevel.cs
+++ b/DesktopApplicationTemplate.Core/Services/LogLevel.cs
@@ -1,11 +1,8 @@
-using System.Runtime.Versioning;
-
 namespace DesktopApplicationTemplate.Core.Services
 {
     /// <summary>
     /// Specifies logging severity levels.
     /// </summary>
-    [SupportedOSPlatform("windows")]
     public enum LogLevel
     {
         Debug = 0,

--- a/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
+++ b/DesktopApplicationTemplate.UI/Modules/UiServiceModule.cs
@@ -1,13 +1,16 @@
-using DesktopApplicationTemplate.Core.Modules;
-using DesktopApplicationTemplate.Core.Services;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DesktopApplicationTemplate.UI.Modules;
 
 public sealed class UiServiceModule : IServiceModule
 {
+    public ServiceType Type => throw new NotSupportedException("The UI module does not expose a service descriptor type.");
+
     public void RegisterServices(IServiceCollection services)
     {
         // Cross-cutting UI service registrations remain in App.xaml configuration for now.


### PR DESCRIPTION
## Summary
- add a DescribeServices contract to IServiceModule so service discovery can enumerate module descriptors
- implement the placeholder Type property for UiServiceModule while keeping its descriptor list empty
- remove the Windows-only attribute from LogLevel to eliminate CA1416 analyzer errors

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfc478aef88326a28f761437714a80