### PR TITLE
Fix log level mapping and FilterPanel namespace reference

### DIFF
--- a/DesktopApplicationTemplate.Services/ServiceManager.cs
+++ b/DesktopApplicationTemplate.Services/ServiceManager.cs
@@ -210,7 +210,6 @@ public sealed class ServiceManager<TService, TPage> : IDisposable
 
     private static Microsoft.Extensions.Logging.LogLevel MapLevel(LogLevel level) => level switch
     {
-        LogLevel.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
         LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
         LogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
         LogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+        xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
@@ -71,7 +71,7 @@
                     <Button x:Name="FilterButton" Content="☰" Width="30" Margin="5,0,0,0" Click="FilterButton_Click" Background="#E6E6E6" Foreground="#333333"/>
                     <Popup x:Name="FilterPopup" PlacementTarget="{Binding ElementName=FilterButton}" Placement="Bottom" StaysOpen="False" DataContext="{Binding DataContext, ElementName=FilterButton}">
                         <Border Background="White" CornerRadius="5" Padding="10">
-                            <local:FilterPanel DataContext="{Binding Filters}"/>
+                            <views:FilterPanel DataContext="{Binding Filters}"/>
                         </Border>
                     </Popup>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- update the service log level mapping to remove the unsupported Trace level value
- fix the main window XAML to reference the FilterPanel control via the project namespace

## Testing
- not run (requires Windows-specific .NET tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dfc612791c83268c86f6f84aa18eca