### PR TITLE
Fix TextBoxHintBehavior namespace in MainWindow

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
-        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors;assembly=DesktopApplicationTemplate.UI"
+        xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
 
         xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
         mc:Ignorable="d"


### PR DESCRIPTION
## Summary
- align MainWindow.xaml with other views by using the local behaviors namespace so the TextBoxHintBehavior.AutoToolTip property resolves correctly

## Testing
- not run (dotnet CLI is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfc7b056b48326b003a9ffb64bcd92