### PR TITLE
Avoid async void file observer handler

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverViewModel.cs
@@ -236,7 +236,9 @@ public class FileObserverViewModel : ViewModelBase
         }
     }
 
-    private async void OnFileChanged(object? sender, FileObserverChangedEventArgs e)
+    private void OnFileChanged(object? sender, FileObserverChangedEventArgs e) => _ = HandleFileChangedAsync(e);
+
+    private async Task HandleFileChangedAsync(FileObserverChangedEventArgs e)
     {
         var application = Application.Current;
         if (application?.Dispatcher is null)


### PR DESCRIPTION
## Summary
1. Replace the async void file change event handler with a synchronous entry point that dispatches to an async task.
2. Add a dedicated asynchronous helper to marshal updates onto the UI thread before applying file contents.

## Testing
- Not run (CI only environment).


------
https://chatgpt.com/codex/tasks/task_e_68dfcca312f4832681642d00ef9b9d0d