### PR TITLE
Improve TCP view layout and home navigation

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -43,7 +43,19 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Text="Peak Analytics IoT Application" FontSize="24" FontWeight="Bold" VerticalAlignment="Center" Margin="10,0,0,0"/>
+            <Button Grid.Column="0"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    Cursor="Hand"
+                    Padding="0"
+                    Margin="10,0,0,0"
+                    VerticalAlignment="Center"
+                    Click="AppTitle_Click">
+                <TextBlock Text="Peak Analytics IoT Application"
+                           FontSize="24"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"/>
+            </Button>
             <Button Grid.Column="2" Content="_" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.MinimizeWindowCommand"/>
             <Button Grid.Column="3" Content="X" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.CloseWindowCommand"/>
         </Grid>
@@ -62,19 +74,30 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,5">
-                    <TextBlock VerticalAlignment="Center" Margin="0,0,5,0">
-                        Active Services: <Run Text="{Binding CurrentActiveServices, Mode=OneWay}"/>/<Run Text="{Binding ServicesCreated, Mode=OneWay}"/>
-                    </TextBlock>
-                    <Button Content="+" Width="30" Click="AddService_Click" Background="#E6E6E6" Foreground="#333333"/>
-                    <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click" Background="#E6E6E6" Foreground="#333333"/>
-                    <Button x:Name="FilterButton" Content="☰" Width="30" Margin="5,0,0,0" Click="FilterButton_Click" Background="#E6E6E6" Foreground="#333333"/>
-                    <Popup x:Name="FilterPopup" PlacementTarget="{Binding ElementName=FilterButton}" Placement="Bottom" StaysOpen="False" DataContext="{Binding DataContext, ElementName=FilterButton}">
-                        <Border Background="White" CornerRadius="5" Padding="10">
-                            <views:FilterPanel DataContext="{Binding Filters}"/>
-                        </Border>
-                    </Popup>
-                </StackPanel>
+                <Grid Grid.Row="0" Margin="0,0,0,5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Button Grid.Column="0"
+                            Content="Home"
+                            Margin="0,0,10,0"
+                            Padding="12,6"
+                            Click="HomeButton_Click"/>
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <TextBlock VerticalAlignment="Center" Margin="0,0,5,0">
+                            Active Services: <Run Text="{Binding CurrentActiveServices, Mode=OneWay}"/>/<Run Text="{Binding ServicesCreated, Mode=OneWay}"/>
+                        </TextBlock>
+                        <Button Content="+" Width="30" Click="AddService_Click" Background="#E6E6E6" Foreground="#333333"/>
+                        <Button Content="-" Width="30" Margin="5,0,0,0" Click="RemoveService_Click" Background="#E6E6E6" Foreground="#333333"/>
+                        <Button x:Name="FilterButton" Content="☰" Width="30" Margin="5,0,0,0" Click="FilterButton_Click" Background="#E6E6E6" Foreground="#333333"/>
+                        <Popup x:Name="FilterPopup" PlacementTarget="{Binding ElementName=FilterButton}" Placement="Bottom" StaysOpen="False" DataContext="{Binding DataContext, ElementName=FilterButton}">
+                            <Border Background="White" CornerRadius="5" Padding="10">
+                                <views:FilterPanel DataContext="{Binding Filters}"/>
+                            </Border>
+                        </Popup>
+                    </StackPanel>
+                </Grid>
                 <Border Grid.Row="1" Background="#E6E6E6" CornerRadius="3" Padding="5">
                     <ListBox x:Name="ServiceList" ItemsSource="{Binding FilteredServices}" SelectedItem="{Binding SelectedService}"
                              BorderThickness="0" HorizontalContentAlignment="Stretch"

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -74,9 +74,17 @@ namespace DesktopApplicationTemplate.UI.Views
             SystemCommands.MinimizeWindow(this);
         }
 
-        private void HomeButton_Click(object sender, RoutedEventArgs e)
+        private void HomeButton_Click(object sender, RoutedEventArgs e) => NavigateHome("Home button");
+
+        private void AppTitle_Click(object sender, RoutedEventArgs e)
         {
-            _logger?.LogInformation("Home button clicked");
+            NavigateHome("Application title");
+            e.Handled = true;
+        }
+
+        private void NavigateHome(string source)
+        {
+            _logger?.LogInformation("{Source} clicked", source);
             _viewModel.SelectedService = null;
             ShowHome();
         }
@@ -365,11 +373,6 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
             }
 
-            if (_viewModel.SelectedService != null && !clickedListItem && !clickedFrame)
-            {
-                _viewModel.SelectedService = null;
-                ShowHome();
-            }
         }
 
         private void ServiceItem_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -20,12 +20,32 @@
 
                 <StackPanel Grid.Column="0">
                     <TextBlock Text="Incoming Data" FontWeight="Bold" Margin="0,0,0,5"/>
-                    <ListBox ItemsSource="{Binding IncomingData}"/>
+                    <ListBox ItemsSource="{Binding IncomingData}"
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             HorizontalContentAlignment="Stretch">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}"
+                                           TextWrapping="Wrap"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1">
                     <TextBlock Text="Outgoing Results" FontWeight="Bold" Margin="0,0,0,5"/>
-                    <ListBox ItemsSource="{Binding OutgoingResults}"/>
+                    <ListBox ItemsSource="{Binding OutgoingResults}"
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             HorizontalContentAlignment="Stretch">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}"
+                                           TextWrapping="Wrap"
+                                           TextTrimming="CharacterEllipsis"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </StackPanel>
             </Grid>
 


### PR DESCRIPTION
## Summary
- wrap TCP message lists so long entries no longer stretch the window
- add a header home button and make the title clickable for home navigation
- remove background clicks navigating home to avoid accidental exits

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfce1a42a88326bb3204a57f217841