### PR TITLE
Fix script persistence and improve service log aggregation

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -125,7 +125,13 @@ public class ScriptEditorViewModel : ViewModelBase
         }
     }
 
-    private void Save() => RequestClose?.Invoke(this, new ScriptSavedEventArgs(ScriptText, _lastTestMessage));
+    private void Save()
+    {
+        var messageToPersist = string.IsNullOrWhiteSpace(_lastTestMessage)
+            ? TestMessage
+            : _lastTestMessage;
+        RequestClose?.Invoke(this, new ScriptSavedEventArgs(ScriptText, messageToPersist));
+    }
 }
 
 public class Globals

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.Models;
@@ -25,6 +28,8 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly ILogger<MainView>? _logger;
         private readonly IServiceUiRegistry<ServiceListModel, Page> _serviceRegistry;
         private readonly IServiceProvider _serviceProvider;
+        private readonly Dictionary<ServiceListModel, Action<LogEntry>> _serviceLogHandlers = new();
+        private readonly BrushConverter _brushConverter = new();
 
         public MainView(
             MainViewModel viewModel,
@@ -41,11 +46,13 @@ namespace DesktopApplicationTemplate.UI.Views
             }
             DataContext = _viewModel;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
+            _viewModel.Services.CollectionChanged += Services_CollectionChanged;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
             CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
             Closing += (_, _) => _logger?.LogInformation("MainView closing");
             ShowHome();
+            PreloadServicePages();
         }
 
         public void ShowHome()
@@ -99,20 +106,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
             if (svc.ServicePage != null)
             {
-                if (svc.ServicePage.DataContext is ILoggingViewModel vm && vm.Logger is not null)
+                if (svc.ServicePage.DataContext is ILoggingViewModel vm)
                 {
-                    if (svc.Type == ServiceType.Mqtt)
-                    {
-                        vm.Logger.LogAdded += entry => _viewModel.OnServiceLogAdded(svc, entry);
-                    }
-                    else
-                    {
-                        vm.Logger.LogAdded += entry =>
-                        {
-                            var brush = (Brush?)new BrushConverter().ConvertFromString(entry.Color);
-                            svc.AddLog(entry.Message, brush, entry.Level);
-                        };
-                    }
+                    AttachServiceLogger(svc, vm);
                 }
 
                 if (svc.ServicePage.DataContext is INetworkAwareViewModel navm)
@@ -124,10 +120,99 @@ namespace DesktopApplicationTemplate.UI.Views
                 {
                     logHost.SetServiceContext(svc);
                 }
-
             }
 
             return svc.ServicePage;
+        }
+
+        private void AttachServiceLogger(ServiceListModel svc, ILoggingViewModel vm)
+        {
+            if (vm.Logger is null || _serviceLogHandlers.ContainsKey(svc))
+            {
+                return;
+            }
+
+            Action<LogEntry> handler;
+
+            if (svc.Type == ServiceType.Mqtt)
+            {
+                handler = entry => _viewModel.OnServiceLogAdded(svc, entry);
+            }
+            else
+            {
+                handler = entry =>
+                {
+                    Brush? brush = null;
+                    try
+                    {
+                        brush = _brushConverter.ConvertFromString(entry.Color) as Brush;
+                    }
+                    catch
+                    {
+                        brush = null;
+                    }
+
+                    svc.AddLog(entry.Message, brush ?? Brushes.Black, entry.Level);
+                };
+            }
+
+            vm.Logger.LogAdded += handler;
+            _serviceLogHandlers[svc] = handler;
+
+            if (svc.Logs.Count == 0)
+            {
+                vm.Logger.Reload();
+            }
+        }
+
+        private void DetachServiceLogger(ServiceListModel svc)
+        {
+            if (!_serviceLogHandlers.TryGetValue(svc, out var handler))
+            {
+                return;
+            }
+
+            if (svc.ServicePage?.DataContext is ILoggingViewModel vm && vm.Logger is not null)
+            {
+                vm.Logger.LogAdded -= handler;
+            }
+
+            _serviceLogHandlers.Remove(svc);
+        }
+
+        private void Services_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
+            {
+                foreach (ServiceListModel svc in e.OldItems?.OfType<ServiceListModel>() ?? Enumerable.Empty<ServiceListModel>())
+                {
+                    DetachServiceLogger(svc);
+                }
+            }
+
+            if (e.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Replace)
+            {
+                foreach (ServiceListModel svc in e.NewItems?.OfType<ServiceListModel>() ?? Enumerable.Empty<ServiceListModel>())
+                {
+                    GetOrCreateServicePage(svc);
+                }
+            }
+
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var svc in _serviceLogHandlers.Keys.ToList())
+                {
+                    DetachServiceLogger(svc);
+                }
+            }
+        }
+
+        private void PreloadServicePages()
+        {
+            foreach (var svc in _viewModel.Services)
+            {
+                GetOrCreateServicePage(svc);
+            }
         }
 
         private void AddService_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
@@ -29,7 +29,7 @@
         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
             <Button Content="Connect" Command="{Binding ConnectCommand}" Width="80" AutomationProperties.Name="Connect MQTT"/>
             <Ellipse Width="10" Height="10" Margin="5,0,0,0" Fill="{Binding IsConnected, Converter={StaticResource BoolToBrush}}"/>
-            <TextBox Text="{Binding NewTopic}" Width="200" Margin="10,0,0,0" x:Name="NewTopicBox" ToolTip="Topic to subscribe"
+            <TextBox Text="{Binding NewTopic, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="10,0,0,0" x:Name="NewTopicBox" ToolTip="Topic to subscribe"
                      behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
             <ComboBox Width="100" Margin="5,0,0,0"
                       ItemsSource="{Binding Source={StaticResource QoSValues}}"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -5,8 +5,8 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <Grid Margin="20">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+        <Grid Margin="10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>


### PR DESCRIPTION
## Summary
- keep the last test message when saving a script so TCP services retain their input and output text
- preload service pages once and subscribe to their loggers only once so the MainView log fills with current service output without duplicating entries
- enable horizontal scrolling in the TCP service view and reduce its margin to keep the window within the desktop bounds
- update the MQTT topic text box to push changes immediately so the add button enables while typing

## Testing
- not run (Windows-only solution, rely on CI)


------
https://chatgpt.com/codex/tasks/task_e_68dfd09631048326b816703e290121f5