### PR TITLE
Fix TCP service message table column layout

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -12,13 +12,30 @@
               IsReadOnly="True"
               HeadersVisibility="Column"
               RowHeaderWidth="0"
-                MaxHeight="200"
-                ScrollViewer.VerticalScrollBarVisibility="Auto">
+              MaxHeight="200"
+              ColumnWidth="*"
+              MinColumnWidth="100"
+              ScrollViewer.HorizontalScrollBarVisibility="Auto"
+              ScrollViewer.VerticalScrollBarVisibility="Auto">
+        <DataGrid.ColumnHeaderStyle>
+            <Style TargetType="DataGridColumnHeader">
+                <EventSetter Event="PreviewMouseDoubleClick"
+                             Handler="ColumnHeaderPreviewMouseDoubleClick" />
+            </Style>
+        </DataGrid.ColumnHeaderStyle>
         <DataGrid.Columns>
-            <DataGridTextColumn Header="Incoming" Binding="{Binding IncomingMessage}" Width="*"/>
-            <DataGridTextColumn Header="Outgoing" Binding="{Binding OutgoingMessage}" Width="*"/>
-            <DataGridTextColumn Header="Destination" Binding="{Binding Destination}" Width="*"/>
-            <DataGridTextColumn Header="Timestamp" Binding="{Binding Timestamp}" Width="Auto"/>
+            <DataGridTextColumn Header="Incoming"
+                                 Binding="{Binding IncomingMessage}"
+                                 Width="2*"
+                                 MinWidth="150" />
+            <DataGridTextColumn Header="Outgoing"
+                                 Binding="{Binding OutgoingMessage}"
+                                 Width="2*"
+                                 MinWidth="150" />
+            <DataGridTextColumn Header="Destination"
+                                 Binding="{Binding Destination}"
+                                 Width="*"
+                                 MinWidth="120" />
         </DataGrid.Columns>
     </DataGrid>
 </UserControl>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
@@ -1,4 +1,6 @@
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 
 namespace DesktopApplicationTemplate.UI.Views.Shared
 {
@@ -10,6 +12,21 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
         public ServiceMessageTableView()
         {
             InitializeComponent();
+        }
+
+        private void ColumnHeaderPreviewMouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is not DataGridColumnHeader header || header.Column is null)
+            {
+                return;
+            }
+
+            var column = header.Column;
+
+            column.Width = new DataGridLength(1, DataGridLengthUnitType.Auto);
+            column.Width = new DataGridLength(1, DataGridLengthUnitType.SizeToCells);
+
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the unused timestamp column from the TCP service message table and rebalance the column widths
- enable horizontal scrolling and add a column-header double-click handler so users can autosize columns when needed

## Testing
- Not Run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68dfd7c7b4b08326b63b548fea43efd7