### PR TITLE
Fix Loaded handler binding on TCP service message view

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -64,7 +64,7 @@
                              IsReadOnly="True" Margin="10,0,0,0" Background="#EDEDED"/>
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
-                <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" Loaded="ServiceMessageTableView_Loaded" />
+                <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
                 <shared:ServiceLogView Grid.Row="3" x:Name="LogView" />
             </Grid>
         </Grid>


### PR DESCRIPTION
## Summary
- remove the invalid `Loaded` event handler reference from `TcpServiceMessagesView`
- unblock XAML parsing by relying on the view model binding without a code-behind handler

## Testing
- not run (WPF application build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfd91bf120832680b512f37e72e5e0