### PR TITLE
Add centralized service start/stop flow with status indicators

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -15,7 +15,6 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
-using DesktopApplicationTemplate.UI;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -41,8 +40,41 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand AddServiceCommand { get; }
         public ICommand RemoveServiceCommand { get; }
         public ICommand EditServiceCommand { get; }
+        public ICommand ToggleServiceProcessCommand { get; }
         public int ServicesCreated => Services.Count;
         public int CurrentActiveServices => Services.Count(s => s.IsActive);
+
+        private bool _servicesRunning;
+        public bool ServicesRunning
+        {
+            get => _servicesRunning;
+            private set
+            {
+                if (_servicesRunning != value)
+                {
+                    _servicesRunning = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(ServiceProcessButtonText));
+                }
+            }
+        }
+
+        private bool _isServiceProcessBusy;
+        public bool IsServiceProcessBusy
+        {
+            get => _isServiceProcessBusy;
+            private set
+            {
+                if (_isServiceProcessBusy != value)
+                {
+                    _isServiceProcessBusy = value;
+                    OnPropertyChanged();
+                    (ToggleServiceProcessCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        public string ServiceProcessButtonText => ServicesRunning ? "Stop Services" : "Start Services";
 
         public ServiceLogViewModel LogViewModel { get; }
 
@@ -58,6 +90,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly ILoggingService? _logger;
         private readonly INetworkConfigurationService _networkService;
         private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
+        private readonly HashSet<ServiceListModel> _activatingServices = new();
+        private static readonly TimeSpan ActivationConfirmationDelay = TimeSpan.FromMilliseconds(500);
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
@@ -82,9 +116,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             AddServiceCommand = new RelayCommand(AddService);
             RemoveServiceCommand = new AsyncRelayCommand(RemoveSelectedServiceAsync, () => SelectedService != null);
             EditServiceCommand = new RelayCommand<ServiceListModel?>(EditService, svc => svc != null);
+            ToggleServiceProcessCommand = new AsyncRelayCommand(ToggleServiceProcessAsync, () => !IsServiceProcessBusy);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
             Filters.PropertyChanged += (_, __) => ApplyFilters();
             LoadServices();
+            ServicesRunning = Services.Any(svc => svc.IsActive);
             ApplyFilters();
             LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs);
             LogViewModel.PropertyChanged += (s, e) =>
@@ -112,11 +148,29 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         public event Action? AddServiceRequested;
+        public event Action? ConfigurationChangeBlocked;
+
+        public bool RequestConfigurationChange()
+        {
+            if (IsServiceProcessBusy || ServicesRunning)
+            {
+                ConfigurationChangeBlocked?.Invoke();
+                return false;
+            }
+
+            return true;
+        }
+
         private void EditService(ServiceListModel? service)
         {
             var target = service ?? SelectedService;
             if (target == null)
                 return;
+
+            if (!RequestConfigurationChange())
+            {
+                return;
+            }
 
             if (_editHandlers.TryGetValue(target.Type, out var handler))
             {
@@ -130,6 +184,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void AddService()
         {
+            if (!RequestConfigurationChange())
+            {
+                return;
+            }
+
             _logger?.Log("AddService invoked", LogLevel.Debug);
             AddServiceRequested?.Invoke();
             _logger?.Log("AddService completed", LogLevel.Debug);
@@ -153,31 +212,39 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task RemoveSelectedServiceAsync()
         {
-            if (SelectedService != null)
+            if (SelectedService == null)
             {
-                _logger?.Log($"Removing service {SelectedService.DisplayName}", LogLevel.Debug);
-                var index = Services.IndexOf(SelectedService);
-                SelectedService.AddLog("Service removed", WpfBrushes.Red);
-                if (SelectedService.Type != ServiceType.Csv)
-                    _csvService.RemoveColumnsForService(SelectedService.DisplayName);
-                SelectedService.LogAdded -= OnServiceLogAdded;
-                SelectedService.ActiveChanged -= OnServiceActiveChanged;
-                Services.Remove(SelectedService);
-                if (Services.Count > 0)
-                {
-                    if (index >= Services.Count) index = Services.Count - 1;
-                    SelectedService = Services[index];
-                }
-                else
-                {
-                    SelectedService = null;
-                }
-                OnPropertyChanged(nameof(ServicesCreated));
-                OnPropertyChanged(nameof(CurrentActiveServices));
-                LogViewModel.RefreshLogs();
-                await SaveServicesAsync().ConfigureAwait(false);
-                _logger?.Log("Service removed", LogLevel.Debug);
+                return;
             }
+
+            if (!RequestConfigurationChange())
+            {
+                return;
+            }
+
+            _logger?.Log($"Removing service {SelectedService.DisplayName}", LogLevel.Debug);
+            var index = Services.IndexOf(SelectedService);
+            SelectedService.AddLog("Service removed", WpfBrushes.Red);
+            if (SelectedService.Type != ServiceType.Csv)
+                _csvService.RemoveColumnsForService(SelectedService.DisplayName);
+            _activatingServices.Remove(SelectedService);
+            SelectedService.LogAdded -= OnServiceLogAdded;
+            SelectedService.ActiveChanged -= OnServiceActiveChanged;
+            Services.Remove(SelectedService);
+            if (Services.Count > 0)
+            {
+                if (index >= Services.Count) index = Services.Count - 1;
+                SelectedService = Services[index];
+            }
+            else
+            {
+                SelectedService = null;
+            }
+            OnPropertyChanged(nameof(ServicesCreated));
+            OnPropertyChanged(nameof(CurrentActiveServices));
+            LogViewModel.RefreshLogs();
+            await SaveServicesAsync().ConfigureAwait(false);
+            _logger?.Log("Service removed", LogLevel.Debug);
         }
 
         public async Task SaveServicesAsync()
@@ -222,6 +289,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);
                 svc.SetColorsByType();
+                svc.SetRuntimeState(svc.IsActive ? ServiceRuntimeState.Active : ServiceRuntimeState.Inactive);
                 svc.LogAdded += OnServiceLogAdded;
                 svc.ActiveChanged += OnServiceActiveChanged;
                 if (svc.Type != ServiceType.Csv)
@@ -259,6 +327,89 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             FilteredServices.Refresh();
         }
 
+        private async Task ToggleServiceProcessAsync()
+        {
+            if (IsServiceProcessBusy)
+            {
+                return;
+            }
+
+            IsServiceProcessBusy = true;
+            try
+            {
+                if (ServicesRunning)
+                {
+                    _logger?.Log("Stopping services", LogLevel.Information);
+                    await StopServicesAsync();
+                    ServicesRunning = false;
+                }
+                else
+                {
+                    if (Services.Count == 0)
+                    {
+                        _logger?.Log("No services configured to start.", LogLevel.Warning);
+                        return;
+                    }
+
+                    ServicesRunning = true;
+                    _logger?.Log("Starting services", LogLevel.Information);
+                    await StartServicesAsync();
+                }
+            }
+            finally
+            {
+                IsServiceProcessBusy = false;
+            }
+        }
+
+        private async Task StartServicesAsync()
+        {
+            foreach (var svc in Services)
+            {
+                if (svc.IsActive)
+                {
+                    svc.SetRuntimeState(ServiceRuntimeState.Active);
+                    continue;
+                }
+
+                if (!_activatingServices.Add(svc))
+                {
+                    continue;
+                }
+
+                svc.SetRuntimeState(ServiceRuntimeState.Activating);
+                await Task.Yield();
+                svc.IsActive = true;
+                _ = CompleteActivationAsync(svc);
+            }
+        }
+
+        private async Task StopServicesAsync()
+        {
+            foreach (var svc in Services)
+            {
+                _activatingServices.Remove(svc);
+                if (!svc.IsActive)
+                {
+                    svc.SetRuntimeState(ServiceRuntimeState.Inactive);
+                    continue;
+                }
+
+                svc.IsActive = false;
+                await Task.Yield();
+            }
+        }
+
+        private async Task CompleteActivationAsync(ServiceListModel svc)
+        {
+            await Task.Delay(ActivationConfirmationDelay);
+            if (_activatingServices.Contains(svc) && svc.RuntimeState != ServiceRuntimeState.Error)
+            {
+                svc.SetRuntimeState(ServiceRuntimeState.Active);
+                _activatingServices.Remove(svc);
+            }
+        }
+
         public void OnServiceLogAdded(ServiceListModel svc, LogEntry entry)
         {
             AllLogs.Insert(0, entry);
@@ -274,6 +425,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 }
             }
             LogViewModel.RefreshLogs();
+
+            if (_activatingServices.Contains(svc) && entry.Level >= LogLevel.Error)
+            {
+                _activatingServices.Remove(svc);
+                svc.SetRuntimeState(ServiceRuntimeState.Error);
+                svc.IsActive = false;
+                if (!Services.Any(s => s.IsActive) && _activatingServices.Count == 0)
+                {
+                    ServicesRunning = false;
+                }
+            }
         }
 
         internal void OnServiceActiveChanged(bool _)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -18,6 +18,14 @@ using WpfBrushes = System.Windows.Media.Brushes;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
+    public enum ServiceRuntimeState
+    {
+        Inactive,
+        Activating,
+        Active,
+        Error
+    }
+
     public class ServiceListModel : ViewModelBase
     {
         public string DisplayName { get; set; } = string.Empty;
@@ -167,10 +175,37 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     _isActive = value;
                     OnPropertyChanged();
                     if (_isActive)
+                    {
                         AddLog("[Service Activated]", WpfBrushes.Green);
+                    }
                     else
+                    {
+                        if (RuntimeState != ServiceRuntimeState.Error)
+                        {
+                            RuntimeState = ServiceRuntimeState.Inactive;
+                        }
                         AddLog("[Service Deactivated]", WpfBrushes.Red);
+                    }
                     ActiveChanged?.Invoke(_isActive);
+                }
+            }
+        }
+
+        public void SetRuntimeState(ServiceRuntimeState state)
+        {
+            RuntimeState = state;
+        }
+
+        private ServiceRuntimeState _runtimeState = ServiceRuntimeState.Inactive;
+        public ServiceRuntimeState RuntimeState
+        {
+            get => _runtimeState;
+            private set
+            {
+                if (_runtimeState != value)
+                {
+                    _runtimeState = value;
+                    OnPropertyChanged();
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+        xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
@@ -24,6 +25,55 @@
                 <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+            <Style x:Key="ServiceStatusIndicatorStyle" TargetType="Ellipse">
+                <Setter Property="Width" Value="12" />
+                <Setter Property="Height" Value="12" />
+                <Setter Property="Margin" Value="0,0,8,0" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Stroke" Value="#FF4A4A4A" />
+                <Setter Property="StrokeThickness" Value="1" />
+                <Setter Property="Fill">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#FFD32F2F" />
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Active}">
+                        <Setter Property="Fill">
+                            <Setter.Value>
+                                <SolidColorBrush Color="#FF2E7D32" />
+                            </Setter.Value>
+                        </Setter>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Activating}">
+                        <Setter Property="Fill">
+                            <Setter.Value>
+                                <SolidColorBrush Color="#FFF9A825" />
+                            </Setter.Value>
+                        </Setter>
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Error}">
+                        <Setter Property="Fill">
+                            <Setter.Value>
+                                <SolidColorBrush Color="#FFD32F2F" />
+                            </Setter.Value>
+                        </Setter>
+                        <DataTrigger.EnterActions>
+                            <BeginStoryboard x:Name="ErrorFlashStoryboard">
+                                <Storyboard RepeatBehavior="Forever" FillBehavior="Stop">
+                                    <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)" Duration="0:0:0.8">
+                                        <DiscreteColorKeyFrame KeyTime="0:0:0" Value="#FFD32F2F" />
+                                        <DiscreteColorKeyFrame KeyTime="0:0:0.4" Value="#FF808080" />
+                                    </ColorAnimationUsingKeyFrames>
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </DataTrigger.EnterActions>
+                        <DataTrigger.ExitActions>
+                            <StopStoryboard BeginStoryboardName="ErrorFlashStoryboard" />
+                        </DataTrigger.ExitActions>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Window.Resources>
 
@@ -43,6 +93,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <Button Grid.Column="0"
                     Background="Transparent"
@@ -57,8 +108,15 @@
                            FontWeight="Bold"
                            VerticalAlignment="Center"/>
             </Button>
-            <Button Grid.Column="2" Content="_" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.MinimizeWindowCommand"/>
-            <Button Grid.Column="3" Content="X" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.CloseWindowCommand"/>
+            <Button Grid.Column="2"
+                    Content="{Binding ServiceProcessButtonText}"
+                    Command="{Binding ToggleServiceProcessCommand}"
+                    Margin="0,25,10,25"
+                    Padding="20,6"
+                    Height="40"
+                    MinWidth="140"/>
+            <Button Grid.Column="3" Content="_" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.MinimizeWindowCommand"/>
+            <Button Grid.Column="4" Content="X" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.CloseWindowCommand"/>
         </Grid>
 
         <!-- Main Content -->
@@ -123,15 +181,16 @@
                                         </Border.ContextMenu>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
                                                 <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
                                             </Grid.ColumnDefinitions>
-                                            <StackPanel>
+                                            <Ellipse Style="{StaticResource ServiceStatusIndicatorStyle}"
+                                                     ToolTip="{Binding RuntimeState}"/>
+                                            <StackPanel Grid.Column="1">
                                                 <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
                                                 <TextBlock Text="{Binding ExecutionTimeText}" />
                                                 <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" />
                                             </StackPanel>
-                                            <ToggleButton Grid.Column="1" IsChecked="{Binding IsActive, Mode=TwoWay}" Style="{StaticResource ToggleSwitchStyle}"/>
                                         </Grid>
                                     </Border>
                                 </Border>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -45,12 +45,14 @@ namespace DesktopApplicationTemplate.UI.Views
                 _logger = factory.CreateLogger<MainView>();
             }
             DataContext = _viewModel;
+            _viewModel.ConfigurationChangeBlocked += OnConfigurationChangeBlocked;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
             _viewModel.Services.CollectionChanged += Services_CollectionChanged;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
             CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
             Closing += (_, _) => _logger?.LogInformation("MainView closing");
+            Closed += (_, _) => _viewModel.ConfigurationChangeBlocked -= OnConfigurationChangeBlocked;
             ShowHome();
             PreloadServicePages();
         }
@@ -67,6 +69,15 @@ namespace DesktopApplicationTemplate.UI.Views
             HomeContentGrid.Visibility = Visibility.Collapsed;
             ContentFrame.Visibility = Visibility.Visible;
             ContentFrame.Content = page;
+        }
+
+        private void OnConfigurationChangeBlocked()
+        {
+            MessageBox.Show(this,
+                "Stop the active services before making any changes.",
+                "Services Running",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
         }
 
         private void CloseCommand_Executed(object sender, ExecutedRoutedEventArgs e)
@@ -342,6 +353,11 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (sender is MenuItem { DataContext: ServiceListModel svc })
             {
+                if (!_viewModel.RequestConfigurationChange())
+                {
+                    return;
+                }
+
                 var index = _viewModel.Services.IndexOf(svc);
                 svc.LogAdded -= _viewModel.OnServiceLogAdded;
                 _viewModel.Services.Remove(svc);
@@ -364,6 +380,11 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (sender is MenuItem { DataContext: ServiceListModel svc })
             {
+                if (!_viewModel.RequestConfigurationChange())
+                {
+                    return;
+                }
+
                 string input = Microsoft.VisualBasic.Interaction.InputBox("Enter new service name:", "Rename Service", svc.DisplayName);
                 if (!string.IsNullOrWhiteSpace(input))
                 {
@@ -384,6 +405,11 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (sender is MenuItem { DataContext: ServiceListModel svc })
             {
+                if (!_viewModel.RequestConfigurationChange())
+                {
+                    return;
+                }
+
                 var dlg = new ColorPickerWindow { Owner = this };
                 if (dlg.ShowDialog() == true)
                 {
@@ -477,6 +503,11 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void OpenSettings_Click(object sender, RoutedEventArgs e)
         {
+            if (!_viewModel.RequestConfigurationChange())
+            {
+                return;
+            }
+
             var page = _serviceProvider.GetRequiredService<SettingsPage>();
             ShowPage(page);
         }
@@ -509,6 +540,12 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             if (!e.Data.GetDataPresent(typeof(ServiceListModel)))
                 return;
+
+            if (!_viewModel.RequestConfigurationChange())
+            {
+                e.Handled = true;
+                return;
+            }
 
             var source = (ServiceListModel)e.Data.GetData(typeof(ServiceListModel))!;
             if (sender is not Border { DataContext: ServiceListModel target } || source == target)


### PR DESCRIPTION
## Summary
- add a Start/Stop Services control to the main window header and display service runtime status with a color-coded indicator in the list
- extend MainViewModel with centralized service activation management, runtime state tracking, and configuration-change safeguards while services are running
- warn users when they attempt to modify settings during active services and block list reordering or context menu edits until services stop

## Testing
- not run (environment lacks required Windows/.NET tooling)

------
https://chatgpt.com/codex/tasks/task_e_68dfe113bb6083268523022d8089f2ec