### PR TITLE
Improve MQTT subscription management UI

### DIFF
--- a/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
+++ b/DesktopApplicationTemplate.UI/Models/TagSubscription.cs
@@ -12,10 +12,9 @@ public class TagSubscription : INotifyPropertyChanged
 {
     private string _topic = string.Empty;
     private MqttQualityOfServiceLevel _qoS;
-    private string _endpoint = string.Empty;
     private string _outgoingMessage = string.Empty;
-    private string? _statusColor;
-    private string? _icon;
+    private bool _isSubscribed;
+    private string _statusMessage = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TagSubscription"/> class.
@@ -61,20 +60,6 @@ public class TagSubscription : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Gets or sets the endpoint for test publishing.
-    /// </summary>
-    public string Endpoint
-    {
-        get => _endpoint;
-        set
-        {
-            if (_endpoint == value) return;
-            _endpoint = value;
-            OnPropertyChanged();
-        }
-    }
-
-    /// <summary>
     /// Gets or sets the outgoing test message.
     /// </summary>
     public string OutgoingMessage
@@ -89,29 +74,29 @@ public class TagSubscription : INotifyPropertyChanged
     }
 
     /// <summary>
-    /// Gets or sets the status color for UI display.
+    /// Gets or sets a value indicating whether the subscription is active on the broker.
     /// </summary>
-    public string? StatusColor
+    public bool IsSubscribed
     {
-        get => _statusColor;
+        get => _isSubscribed;
         set
         {
-            if (_statusColor == value) return;
-            _statusColor = value;
+            if (_isSubscribed == value) return;
+            _isSubscribed = value;
             OnPropertyChanged();
         }
     }
 
     /// <summary>
-    /// Gets or sets the icon for UI display.
+    /// Gets or sets the status message describing the subscription state.
     /// </summary>
-    public string? Icon
+    public string StatusMessage
     {
-        get => _icon;
+        get => _statusMessage;
         set
         {
-            if (_icon == value) return;
-            _icon = value;
+            if (_statusMessage == value) return;
+            _statusMessage = value;
             OnPropertyChanged();
         }
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Advanced/MqttAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Advanced/MqttAdvancedConfigViewModel.cs
@@ -2,8 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
 using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt.Advanced;
@@ -14,6 +17,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt.Advanced;
 public class MqttAdvancedConfigViewModel : AdvancedConfigViewModelBase<MqttServiceOptions>
 {
     private readonly MqttServiceOptions _options;
+    private readonly IFileDialogService _fileDialogService;
     private string? _clientCertificatePath;
     private string? _willTopic;
     private string? _willPayload;
@@ -26,10 +30,11 @@ public class MqttAdvancedConfigViewModel : AdvancedConfigViewModelBase<MqttServi
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttAdvancedConfigViewModel"/> class.
     /// </summary>
-    public MqttAdvancedConfigViewModel(MqttServiceOptions options, ILoggingService? logger = null)
+    public MqttAdvancedConfigViewModel(MqttServiceOptions options, IFileDialogService fileDialogService, ILoggingService? logger = null)
         : base(logger)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _fileDialogService = fileDialogService ?? throw new ArgumentNullException(nameof(fileDialogService));
         _willTopic = options.WillTopic;
         _willPayload = options.WillPayload;
         _willQualityOfService = options.WillQualityOfService;
@@ -38,6 +43,7 @@ public class MqttAdvancedConfigViewModel : AdvancedConfigViewModelBase<MqttServi
         _cleanSession = options.CleanSession;
         _reconnectDelaySeconds = options.ReconnectDelay?.Seconds ?? 0;
         QoSLevels = Enum.GetValues(typeof(MqttQualityOfServiceLevel)).Cast<MqttQualityOfServiceLevel>().ToArray();
+        BrowseClientCertificateCommand = new RelayCommand(BrowseForClientCertificate);
     }
 
     /// <summary>
@@ -53,6 +59,11 @@ public class MqttAdvancedConfigViewModel : AdvancedConfigViewModelBase<MqttServi
         get => _clientCertificatePath;
         set { _clientCertificatePath = value; OnPropertyChanged(); }
     }
+
+    /// <summary>
+    /// Command that allows browsing for a client certificate file.
+    /// </summary>
+    public ICommand BrowseClientCertificateCommand { get; }
 
     /// <summary>
     /// Will topic published on unexpected disconnect.
@@ -142,5 +153,14 @@ public class MqttAdvancedConfigViewModel : AdvancedConfigViewModelBase<MqttServi
     protected override void OnBack()
     {
         Logger?.Log("MQTT advanced options back", LogLevel.Debug);
+    }
+
+    private void BrowseForClientCertificate()
+    {
+        var path = _fileDialogService.OpenFile();
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            ClientCertificatePath = path;
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,8 +26,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     private readonly MqttServiceOptions _options;
     private readonly AsyncRelayCommand _addTopicCommand;
     private readonly AsyncRelayCommand _removeTopicCommand;
-    private readonly AsyncRelayCommand _publishTestMessageCommand;
-    private readonly AsyncRelayCommand<TagSubscription> _testTagEndpointCommand;
+    private readonly AsyncRelayCommand<TagSubscription> _sendTestMessageCommand;
 
     private TagSubscription? _selectedSubscription;
     private string _newTopic = string.Empty;
@@ -43,16 +43,15 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
         Subscriptions = new ObservableCollection<TagSubscription>();
-        SubscriptionResults = new ObservableCollection<SubscriptionResult>();
+        Subscriptions.CollectionChanged += OnSubscriptionsChanged;
         LogEntries = new ObservableCollection<LogEntry>();
-        _clientService.ConnectionStateChanged += (_, c) => IsConnected = c;
+        _clientService.ConnectionStateChanged += OnConnectionStateChanged;
         IsConnected = _clientService.IsConnected;
 
         _addTopicCommand = new AsyncRelayCommand(AddTopicAsync, () => CanAddTopic);
         _removeTopicCommand = new AsyncRelayCommand(RemoveTopicAsync, () => SelectedSubscription != null);
-        _publishTestMessageCommand = new AsyncRelayCommand(PublishTestMessageAsync, CanPublishTestMessage);
         ConnectCommand = new AsyncRelayCommand(ConnectAsync);
-        _testTagEndpointCommand = new AsyncRelayCommand<TagSubscription>(TestTagEndpointAsync, CanTestTagEndpoint);
+        _sendTestMessageCommand = new AsyncRelayCommand<TagSubscription>(SendTestMessageAsync, CanSendTestMessage);
     }
 
     /// <inheritdoc />
@@ -80,11 +79,6 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     public ObservableCollection<TagSubscription> Subscriptions { get; }
 
     /// <summary>
-    /// Gets the results of subscription attempts for UI feedback.
-    /// </summary>
-    public ObservableCollection<SubscriptionResult> SubscriptionResults { get; }
-
-    /// <summary>
     /// Gets log entries from the logger.
     /// </summary>
     public ObservableCollection<LogEntry> LogEntries { get; }
@@ -95,7 +89,24 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     public bool IsConnected
     {
         get => _isConnected;
-        private set { _isConnected = value; OnPropertyChanged(); }
+        private set
+        {
+            if (_isConnected == value)
+                return;
+
+            _isConnected = value;
+            OnPropertyChanged();
+            _sendTestMessageCommand.RaiseCanExecuteChanged();
+
+            if (!value)
+            {
+                foreach (var subscription in Subscriptions)
+                {
+                    subscription.IsSubscribed = false;
+                    subscription.StatusMessage = "Disconnected";
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -137,21 +148,9 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         set
         {
             if (_selectedSubscription == value) return;
-
-            if (_selectedSubscription is not null)
-            {
-                _selectedSubscription.PropertyChanged -= SelectedSubscriptionOnPropertyChanged;
-            }
-
             _selectedSubscription = value;
             OnPropertyChanged();
             _removeTopicCommand.RaiseCanExecuteChanged();
-            _publishTestMessageCommand.RaiseCanExecuteChanged();
-
-            if (_selectedSubscription is not null)
-            {
-                _selectedSubscription.PropertyChanged += SelectedSubscriptionOnPropertyChanged;
-            }
         }
     }
 
@@ -166,19 +165,14 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     public ICommand RemoveTopicCommand => _removeTopicCommand;
 
     /// <summary>
-    /// Command to publish the selected subscription's test message.
-    /// </summary>
-    public ICommand PublishTestMessageCommand => _publishTestMessageCommand;
-
-    /// <summary>
     /// Command to connect to the MQTT broker.
     /// </summary>
         public ICommand ConnectCommand { get; }
 
     /// <summary>
-    /// Command to test publishing to a tag's endpoint.
+    /// Command to publish a test message for a subscription.
     /// </summary>
-    public ICommand TestTagEndpointCommand => _testTagEndpointCommand;
+    public ICommand SendTestMessageCommand => _sendTestMessageCommand;
 
     /// <summary>
     /// Raised when connection settings are invalid and need editing.
@@ -195,22 +189,26 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         if (!CanAddTopic)
             return;
 
-        var topic = NewTopic;
-        var sub = new TagSubscription(topic) { QoS = NewQoS };
-        Subscriptions.Add(sub);
+        var topic = NewTopic.Trim();
+        if (Subscriptions.Any(s => string.Equals(s.Topic, topic, StringComparison.OrdinalIgnoreCase)))
+        {
+            Logger?.Log($"MQTT topic '{topic}' already exists", LogLevel.Warning);
+            return;
+        }
 
-        try
+        var subscription = new TagSubscription(topic)
         {
-            await _clientService.SubscribeAsync(topic, NewQoS).ConfigureAwait(false);
-            SubscriptionResults.Add(new SubscriptionResult(topic, true, $"Subscribed to {topic}"));
-            NewTopic = string.Empty;
-        }
-        catch (Exception ex)
-        {
-            Logger?.Log($"MQTT subscribe failed for {topic}: {ex.Message}", LogLevel.Error);
-            SubscriptionResults.Add(new SubscriptionResult(topic, false, ex.Message));
-            Subscriptions.Remove(sub);
-        }
+            QoS = NewQoS,
+            StatusMessage = IsConnected ? "Subscribing..." : "Waiting for connection"
+        };
+
+        Subscriptions.Add(subscription);
+        NewTopic = string.Empty;
+
+        if (!IsConnected)
+            return;
+
+        await SubscribeTopicAsync(subscription);
     }
 
     private async Task RemoveTopicAsync()
@@ -220,7 +218,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
 
         try
         {
-            await _clientService.UnsubscribeAsync(SelectedSubscription.Topic).ConfigureAwait(false);
+            await _clientService.UnsubscribeAsync(SelectedSubscription.Topic);
         }
         catch
         {
@@ -233,30 +231,17 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         SelectedSubscription = null;
     }
 
-    private bool CanPublishTestMessage()
-        => SelectedSubscription is not null && !string.IsNullOrWhiteSpace(SelectedSubscription.OutgoingMessage);
+    private bool CanSendTestMessage(TagSubscription? subscription)
+        => subscription is not null && IsConnected && !string.IsNullOrWhiteSpace(subscription.OutgoingMessage);
 
-    private async Task PublishTestMessageAsync()
+    private async Task SendTestMessageAsync(TagSubscription? subscription)
     {
-        if (!CanPublishTestMessage())
+        if (!CanSendTestMessage(subscription))
             return;
 
-        Logger?.Log("MQTT test publish start", LogLevel.Debug);
-        await _clientService.PublishAsync(SelectedSubscription!.Topic, SelectedSubscription.OutgoingMessage).ConfigureAwait(false);
-        Logger?.Log("MQTT test publish finished", LogLevel.Debug);
-    }
-
-    private bool CanTestTagEndpoint(TagSubscription? sub)
-        => sub is not null && !string.IsNullOrWhiteSpace(sub.Endpoint) && !string.IsNullOrWhiteSpace(sub.OutgoingMessage);
-
-    private async Task TestTagEndpointAsync(TagSubscription? sub)
-    {
-        if (!CanTestTagEndpoint(sub))
-            return;
-
-        Logger?.Log("MQTT tag test publish start", LogLevel.Debug);
-        await _clientService.PublishAsync(sub!.Endpoint, sub.OutgoingMessage).ConfigureAwait(false);
-        Logger?.Log("MQTT tag test publish finished", LogLevel.Debug);
+        Logger?.Log("MQTT topic test publish start", LogLevel.Debug);
+        await _clientService.PublishAsync(subscription!.Topic, subscription.OutgoingMessage);
+        Logger?.Log("MQTT topic test publish finished", LogLevel.Debug);
     }
 
     public async Task ConnectAsync()
@@ -264,8 +249,9 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         Logger?.Log("MQTT connect start", LogLevel.Debug);
         try
         {
-            await _clientService.ConnectAsync(_options).ConfigureAwait(false);
+            await _clientService.ConnectAsync(_options);
             IsConnected = true;
+            await SubscribeAllAsync();
             Logger?.Log("MQTT connect finished", LogLevel.Debug);
         }
         catch (ArgumentException ex)
@@ -281,11 +267,94 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         }
     }
 
-    private void SelectedSubscriptionOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    private async Task SubscribeTopicAsync(TagSubscription subscription)
     {
-        if (e.PropertyName == nameof(TagSubscription.OutgoingMessage))
+        if (!IsConnected)
         {
-            _publishTestMessageCommand.RaiseCanExecuteChanged();
+            subscription.IsSubscribed = false;
+            subscription.StatusMessage = "Waiting for connection";
+            return;
+        }
+
+        subscription.StatusMessage = "Subscribing...";
+
+        try
+        {
+            await _clientService.SubscribeAsync(subscription.Topic, subscription.QoS);
+            subscription.IsSubscribed = true;
+            subscription.StatusMessage = "Subscribed";
+        }
+        catch (Exception ex)
+        {
+            subscription.IsSubscribed = false;
+            subscription.StatusMessage = $"Subscribe failed: {ex.Message}";
+            Logger?.Log($"MQTT subscribe failed for {subscription.Topic}: {ex.Message}", LogLevel.Error);
+        }
+    }
+
+    private async Task SubscribeAllAsync()
+    {
+        if (!IsConnected)
+            return;
+
+        foreach (var subscription in Subscriptions)
+        {
+            await SubscribeTopicAsync(subscription);
+        }
+    }
+
+    private void OnSubscriptionsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems is not null)
+        {
+            foreach (var item in e.NewItems.OfType<TagSubscription>())
+            {
+                item.PropertyChanged += OnSubscriptionPropertyChanged;
+            }
+        }
+
+        if (e.OldItems is not null)
+        {
+            foreach (var item in e.OldItems.OfType<TagSubscription>())
+            {
+                item.PropertyChanged -= OnSubscriptionPropertyChanged;
+            }
+        }
+
+        _sendTestMessageCommand.RaiseCanExecuteChanged();
+    }
+
+    private void OnSubscriptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is not TagSubscription subscription)
+            return;
+
+        switch (e.PropertyName)
+        {
+            case nameof(TagSubscription.OutgoingMessage):
+                _sendTestMessageCommand.RaiseCanExecuteChanged();
+                break;
+            case nameof(TagSubscription.QoS):
+                if (IsConnected)
+                {
+                    _ = SubscribeTopicAsync(subscription);
+                }
+                else
+                {
+                    subscription.StatusMessage = "Waiting for connection";
+                }
+
+                break;
+        }
+    }
+
+    private void OnConnectionStateChanged(object? sender, bool connected)
+    {
+        IsConnected = connected;
+
+        if (connected)
+        {
+            _ = SubscribeAllAsync();
         }
     }
 

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/Advanced/MqttAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/Advanced/MqttAdvancedConfigView.xaml
@@ -23,7 +23,20 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="0" Text="Client Certificate" Style="{StaticResource FormLabel}"/>
-        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ClientCertificatePath}" Style="{StaticResource FormField}"/>
+        <Grid Grid.Row="0" Grid.Column="1" Margin="0,0,0,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBox Grid.Column="0"
+                     Text="{Binding ClientCertificatePath}"
+                     Margin="0,0,5,0"
+                     Style="{StaticResource FormField}"/>
+            <Button Grid.Column="1"
+                    Content="Browse..."
+                    Padding="12,2"
+                    Command="{Binding BrowseClientCertificateCommand}"/>
+        </Grid>
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Will Topic" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding WillTopic}" Style="{StaticResource FormField}"/>

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
@@ -22,7 +22,6 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <!-- Connection bar -->
@@ -47,48 +46,45 @@
                   SelectedItem="{Binding SelectedSubscription}"
                   AutoGenerateColumns="False"
                   HeadersVisibility="Column"
-                  CanUserAddRows="False">
+                  CanUserAddRows="False"
+                  EnableRowVirtualization="False">
             <DataGrid.Columns>
+                <DataGridTemplateColumn Header="Status" Width="150">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="{x:Type models:TagSubscription}">
+                            <StackPanel Orientation="Horizontal">
+                                <Ellipse Width="10"
+                                         Height="10"
+                                         Fill="{Binding IsSubscribed, Converter={StaticResource BoolToBrush}}"
+                                         ToolTip="{Binding StatusMessage}"/>
+                                <TextBlock Text="{Binding StatusMessage}" Margin="6,0,0,0" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTextColumn Header="Topic" Binding="{Binding Topic}" IsReadOnly="True"/>
                 <DataGridComboBoxColumn Header="QoS"
-                                        SelectedItemBinding="{Binding QoS}"
+                                        SelectedItemBinding="{Binding QoS, Mode=TwoWay}"
                                         ItemsSource="{Binding Source={StaticResource QoSValues}}"/>
-                <DataGridTextColumn Header="Endpoint"
-                                    Binding="{Binding Endpoint, UpdateSourceTrigger=PropertyChanged}"/>
-                <DataGridTextColumn Header="Message"
-                                    Binding="{Binding OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridTemplateColumn Header="Message" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate DataType="{x:Type models:TagSubscription}">
+                            <TextBox Text="{Binding OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTemplateColumn Header="Test">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate DataType="{x:Type models:TagSubscription}">
                             <Button Content="Test" Width="50"
-                                    Command="{Binding DataContext.TestTagEndpointCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                    Command="{Binding DataContext.SendTestMessageCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
                                     CommandParameter="{Binding}"/>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
-        <!-- Test message bar -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,10,0,0">
-            <TextBox Text="{Binding SelectedSubscription.OutgoingMessage, UpdateSourceTrigger=PropertyChanged}"
-                     Width="200"
-                     x:Name="TestMessageBox"
-                     ToolTip="Message to send"
-                     behaviors:TextBoxHintBehavior.AutoToolTip="True"/>
-            <Button x:Name="SendButton"
-                    Content="Send"
-                    Command="{Binding PublishTestMessageCommand}"
-                    Width="60"
-                    Margin="5,0,0,0"
-                    AutomationProperties.Name="Send Test Message"/>
-            <Button Content="Test"
-                    Command="{Binding TestTagEndpointCommand}"
-                    CommandParameter="{Binding SelectedSubscription}"
-                    Width="60"
-                    Margin="5,0,0,0"/>
-        </StackPanel>
-
         <!-- Log entries -->
-        <shared:ServiceLogView Grid.Row="3" Margin="0,10,0,0" x:Name="LogView" />
+        <shared:ServiceLogView Grid.Row="2" Margin="0,10,0,0" x:Name="LogView" />
     </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- allow editing MQTT subscription messages directly in the grid, add status indicators, and resend test messages per topic
- ensure QoS updates resubscribe topics, preserve subscriptions when disconnected, and disable virtualization to prevent scroll loss
- add client certificate browsing support to the advanced MQTT configuration view

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfeb356ae08326b7f2492e9bdbc6d2