### PR TITLE
Fix async relay command dispatcher and XAML references

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -28,8 +28,8 @@ namespace DesktopApplicationTemplate.UI.Helpers
         /// <summary>
         /// Executes the command asynchronously.
         /// </summary>
-        /// <param name="parameter">Unused parameter for signature compatibility.</param>
-        public async Task ExecuteAsync(object? parameter = null)
+        /// <param name="_">Unused parameter kept for signature compatibility.</param>
+        public async Task ExecuteAsync(object? _ = null)
         {
             await _execute().ConfigureAwait(false);
         }
@@ -82,6 +82,8 @@ namespace DesktopApplicationTemplate.UI.Helpers
 
     internal static class CommandDispatcher
     {
+        private static SynchronizationContext? _synchronizationContext = SynchronizationContext.Current;
+
         public static void RaiseCanExecuteChanged(EventHandler? handler, object sender)
         {
             if (handler is null)
@@ -89,16 +91,24 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 return;
             }
 
-            var dispatcher = Application.Current?.Dispatcher;
+            var context = _synchronizationContext ?? GetSynchronizationContext();
 
-            if (dispatcher is null || dispatcher.CheckAccess())
+            if (context is null || ReferenceEquals(SynchronizationContext.Current, context))
             {
                 handler(sender, EventArgs.Empty);
+                return;
             }
-            else
-            {
-                _ = dispatcher.BeginInvoke(new Action(() => handler(sender, EventArgs.Empty)), DispatcherPriority.Normal);
-            }
+
+            context.Post(_ => handler(sender, EventArgs.Empty), null);
+        }
+
+        private static SynchronizationContext? GetSynchronizationContext()
+        {
+            _synchronizationContext = Application.Current is null
+                ? SynchronizationContext.Current
+                : new DispatcherSynchronizationContext(Application.Current.Dispatcher);
+
+            return _synchronizationContext;
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
         <Grid Margin="10">


### PR DESCRIPTION
## Summary
- ensure `AsyncRelayCommand` raises `CanExecuteChanged` through a cached synchronization context instead of `Dispatcher.BeginInvoke`
- rename the unused async command parameter to a discard for analyzer compliance
- qualify the shared view namespace in the TCP service messages page so the designer can locate the controls

## Testing
- Not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dff875a19c8326872f65e49004d5c2