### PR TITLE
Fix dispatcher event raising and resolve shared view namespace

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -82,8 +81,6 @@ namespace DesktopApplicationTemplate.UI.Helpers
 
     internal static class CommandDispatcher
     {
-        private static SynchronizationContext? _synchronizationContext = SynchronizationContext.Current;
-
         public static void RaiseCanExecuteChanged(EventHandler? handler, object sender)
         {
             if (handler is null)
@@ -91,24 +88,15 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 return;
             }
 
-            var context = _synchronizationContext ?? GetSynchronizationContext();
+            var dispatcher = Application.Current?.Dispatcher;
 
-            if (context is null || ReferenceEquals(SynchronizationContext.Current, context))
+            if (dispatcher is null || dispatcher.CheckAccess())
             {
                 handler(sender, EventArgs.Empty);
                 return;
             }
 
-            context.Post(_ => handler(sender, EventArgs.Empty), null);
-        }
-
-        private static SynchronizationContext? GetSynchronizationContext()
-        {
-            _synchronizationContext = Application.Current is null
-                ? SynchronizationContext.Current
-                : new DispatcherSynchronizationContext(Application.Current.Dispatcher);
-
-            return _synchronizationContext;
+            _ = dispatcher.InvokeAsync(() => handler(sender, EventArgs.Empty), DispatcherPriority.Normal);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
         <Grid Margin="10">


### PR DESCRIPTION
## Summary
- ensure `AsyncRelayCommand` raises `CanExecuteChanged` on the WPF dispatcher to avoid threading analyzer warnings
- update the TCP service messages view to reference shared controls without an explicit assembly qualifier so XAML compilation succeeds

## Testing
- not run (Windows-only WPF build)


------
https://chatgpt.com/codex/tasks/task_e_68e001f4dcfc8326b9d720a2b9bbae84