### PR TITLE
Align shared view namespaces

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Ftp/FTPServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Ftp/FTPServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:BooleanToBrushConverter x:Key="BooleanToBrushConverter" TrueBrush="Green" FalseBrush="Red"/>

--- a/DesktopApplicationTemplate.UI/Views/Http/HttpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Http/HttpServiceView.xaml
@@ -8,7 +8,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
 
-      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
 
       mc:Ignorable="d" Background="#f3f3f3">
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -9,7 +9,7 @@
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
 
-        xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views"
+        xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
         mc:Ignorable="d"
         Title="MainView"
         MinWidth="800" MinHeight="600" Height="600" Width="1200"

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
@@ -8,7 +8,7 @@
       xmlns:sys="clr-namespace:System;assembly=System.Runtime"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
     <Page.Resources>
         <ObjectDataProvider x:Key="QoSValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="DesktopApplicationTemplate.UI.Views.ServiceLogView"
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceLogView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
@@ -1,6 +1,6 @@
 using System.Windows.Controls;
 
-namespace DesktopApplicationTemplate.UI.Views
+namespace DesktopApplicationTemplate.UI.Views.Shared
 {
     /// <summary>
     /// Interaction logic for ServiceLogView.xaml

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="DesktopApplicationTemplate.UI.Views.ServiceMessageTableView"
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceMessageTableView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
@@ -2,7 +2,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 
-namespace DesktopApplicationTemplate.UI.Views
+namespace DesktopApplicationTemplate.UI.Views.Shared
 {
     /// <summary>
     /// Interaction logic for ServiceMessageTableView.xaml

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
         <Grid Margin="10">


### PR DESCRIPTION
## Summary
- move ServiceLogView and ServiceMessageTableView into the DesktopApplicationTemplate.UI.Views.Shared namespace
- update shared namespace mappings in views that embed the shared controls so designers resolve them consistently

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e00b096aac8326961b2f16e279b7ff