### PR TITLE
Use JoinableTaskFactory to marshal command updates

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -90,6 +90,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.Threading;
 using MQTTnet;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
@@ -99,6 +100,7 @@ using System.Windows.Controls;
 using System;
 using System.Windows.Threading;
 using System.Collections.Generic;
+using System.Threading;
 using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Services;
@@ -109,9 +111,15 @@ namespace DesktopApplicationTemplate.UI
     public partial class App : System.Windows.Application
     {
         public static IHost AppHost { get; private set; } = null!;
+        private static JoinableTaskContext UiThreadTaskContext { get; set; } = null!;
+        public static JoinableTaskFactory UiThreadTaskFactory { get; private set; } = null!;
 
         public App()
         {
+            var synchronizationContext = SynchronizationContext.Current ?? new DispatcherSynchronizationContext(Dispatcher);
+            UiThreadTaskContext = new JoinableTaskContext(Thread.CurrentThread, synchronizationContext);
+            UiThreadTaskFactory = UiThreadTaskContext.Factory;
+
             DispatcherUnhandledException += OnDispatcherUnhandledException;
             AppDomain.CurrentDomain.UnhandledException += HandleAppDomainUnhandledException;
 

--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -2,8 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using System.Windows;
-using System.Windows.Threading;
+using DesktopApplicationTemplate.UI;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
@@ -97,11 +96,23 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 return;
             }
 
-            synchronizationContext.Post(static state =>
+            var joinableTaskFactory = App.UiThreadTaskFactory;
+            if (joinableTaskFactory is null)
             {
-                var (callback, callbackSender) = ((EventHandler Handler, object Sender))state!;
-                callback(callbackSender, EventArgs.Empty);
-            }, (handler, sender));
+                handler(sender, EventArgs.Empty);
+                return;
+            }
+
+            _ = joinableTaskFactory.RunAsync(async () =>
+            {
+                await joinableTaskFactory.SwitchToMainThreadAsync();
+                handler(sender, EventArgs.Empty);
+            });
+        }
+
+        public static void RaiseCanExecuteChanged(EventHandler? handler, object sender)
+        {
+            RaiseCanExecuteChanged(SynchronizationContext.Current, handler, sender);
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose a UI-thread JoinableTaskFactory from `App.xaml.cs`
- switch `CommandDispatcher` to marshal to the UI thread via the shared JoinableTaskFactory
- drop obsolete WPF synchronization-context usings from the relay command helpers

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e00b07127083269758191f88500955