### PR TITLE
Refine command dispatcher can-execute notifications

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
@@ -37,7 +38,13 @@ namespace DesktopApplicationTemplate.UI.Helpers
 
         public event EventHandler? CanExecuteChanged;
 
-        public void RaiseCanExecuteChanged() => CommandDispatcher.RaiseCanExecuteChanged(_synchronizationContext, CanExecuteChanged, this);
+        public void RaiseCanExecuteChanged()
+        {
+            CommandDispatcher.FireAndForget(
+                _synchronizationContext,
+                CanExecuteChanged,
+                this);
+        }
     }
 
     /// <summary>
@@ -79,12 +86,18 @@ namespace DesktopApplicationTemplate.UI.Helpers
         /// <summary>
         /// Notifies that the ability to execute has changed.
         /// </summary>
-        public void RaiseCanExecuteChanged() => CommandDispatcher.RaiseCanExecuteChanged(_synchronizationContext, CanExecuteChanged, this);
+        public void RaiseCanExecuteChanged()
+        {
+            CommandDispatcher.FireAndForget(
+                _synchronizationContext,
+                CanExecuteChanged,
+                this);
+        }
     }
 
     internal static class CommandDispatcher
     {
-        public static void RaiseCanExecuteChanged(SynchronizationContext? synchronizationContext, EventHandler? handler, object sender)
+        public static async Task RaiseCanExecuteChanged(SynchronizationContext? synchronizationContext, EventHandler? handler, object sender)
         {
             if (handler is null)
             {
@@ -104,16 +117,41 @@ namespace DesktopApplicationTemplate.UI.Helpers
                 return;
             }
 
-            _ = joinableTaskFactory.RunAsync(async () =>
-            {
-                await joinableTaskFactory.SwitchToMainThreadAsync();
-                handler(sender, EventArgs.Empty);
-            });
+            await joinableTaskFactory.SwitchToMainThreadAsync();
+            handler(sender, EventArgs.Empty);
         }
 
-        public static void RaiseCanExecuteChanged(EventHandler? handler, object sender)
+        public static Task RaiseCanExecuteChanged(EventHandler? handler, object sender)
         {
-            RaiseCanExecuteChanged(SynchronizationContext.Current, handler, sender);
+            return RaiseCanExecuteChanged(SynchronizationContext.Current, handler, sender);
+        }
+
+        public static void FireAndForget(SynchronizationContext? synchronizationContext, EventHandler? handler, object sender)
+        {
+            var joinableTaskFactory = App.UiThreadTaskFactory;
+            var task = joinableTaskFactory is not null
+                ? joinableTaskFactory.RunAsync(() => RaiseCanExecuteChanged(synchronizationContext, handler, sender)).Task
+                : RaiseCanExecuteChanged(synchronizationContext, handler, sender);
+
+            ObserveFailure(task);
+        }
+
+        private static void ObserveFailure(Task task)
+        {
+            if (task.IsCompleted)
+            {
+                if (task.IsFaulted)
+                {
+                    _ = task.Exception;
+                }
+
+                return;
+            }
+
+            task.ContinueWith(static t =>
+            {
+                _ = t.Exception;
+            }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/RelayCommand.Generic.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/RelayCommand.Generic.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Helpers;
 
@@ -34,6 +35,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <summary>
         /// Raises the <see cref="CanExecuteChanged"/> event.
         /// </summary>
-        public void RaiseCanExecuteChanged() => CommandDispatcher.RaiseCanExecuteChanged(CanExecuteChanged, this);
+        public void RaiseCanExecuteChanged()
+        {
+            CommandDispatcher.FireAndForget(SynchronizationContext.Current, CanExecuteChanged, this);
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/RelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/RelayCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI.Helpers;
 
@@ -21,6 +22,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public event EventHandler? CanExecuteChanged;
 
-        public void RaiseCanExecuteChanged() => CommandDispatcher.RaiseCanExecuteChanged(CanExecuteChanged, this);
+        public void RaiseCanExecuteChanged()
+        {
+            CommandDispatcher.FireAndForget(SynchronizationContext.Current, CanExecuteChanged, this);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- refactor the command dispatcher to await UI thread switches when raising CanExecuteChanged
- add a fire-and-forget helper so AsyncRelayCommand and RelayCommand variants safely invoke the async dispatcher

## Testing
- dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00ef38a008326ac6159cb8d238f98