### PR TITLE
Use CommandDispatcher.RaiseCanExecuteChanged in RelayCommand

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/RelayCommand.Generic.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/RelayCommand.Generic.cs
@@ -37,7 +37,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public void RaiseCanExecuteChanged()
         {
-            CommandDispatcher.FireAndForget(SynchronizationContext.Current, CanExecuteChanged, this);
+            CommandDispatcher.RaiseCanExecuteChanged(SynchronizationContext.Current, CanExecuteChanged, this);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/RelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/RelayCommand.cs
@@ -24,7 +24,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void RaiseCanExecuteChanged()
         {
-            CommandDispatcher.FireAndForget(SynchronizationContext.Current, CanExecuteChanged, this);
+            CommandDispatcher.RaiseCanExecuteChanged(SynchronizationContext.Current, CanExecuteChanged, this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- update RelayCommand and RelayCommand<T> to invoke CommandDispatcher.RaiseCanExecuteChanged with the current synchronization context

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0113cd3048326bc2eb1a7ed518539