### PR TITLE
Document synchronization context capture in AsyncRelayCommand<T>

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -55,6 +55,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
     {
         private readonly Func<T?, Task> _execute;
         private readonly Predicate<T?>? _canExecute;
+        // Capture the synchronization context so UI notifications mirror the non-generic command.
         private readonly SynchronizationContext? _synchronizationContext;
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.


### PR DESCRIPTION
## Summary
- note that the generic async relay command captures the synchronization context so event notifications mirror the non-generic implementation

## Testing
- dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e011a155748326a61a1a9b8ad5c68c