### PR TITLE
Add design metadata for shared service views

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -1,10 +1,14 @@
 <UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceLogView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:services="clr-namespace:DesktopApplicationTemplate.Core.Services;assembly=DesktopApplicationTemplate.Core"
-             mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="400">
+             xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
+             d:DesignHeight="300"
+             d:DesignWidth="400"
+             d:DataContext="{d:DesignInstance Type=viewModels:ServiceLogViewModel}"
+             mc:Ignorable="d">
     <Border Background="#E6E6E6" CornerRadius="5" Padding="10">
         <Grid>
             <Grid.RowDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -3,6 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
+             d:DataContext="{d:DesignInstance Type=viewModels:ServiceMessageTableViewModel}"
              mc:Ignorable="d">
     <DataGrid ItemsSource="{Binding Messages}"
               AutoGenerateColumns="False"


### PR DESCRIPTION
## Summary
- add design-time metadata for ServiceLogView and ServiceMessageTableView so their generated classes stay aligned with DesktopApplicationTemplate.UI.Views.Shared
- confirmed each consumer view references the shared namespace via the shared: prefix (TcpServiceMessagesView, MainWindow, FTPServiceView, HttpServiceView, MqttTagSubscriptionsView)

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: `dotnet` is not available in the Linux container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0183049e48326bf2868448e4e8319