### PR TITLE
Refine async failure observation in command dispatcher

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -114,25 +114,22 @@ namespace DesktopApplicationTemplate.UI.Helpers
 
         public static void FireAndForget(EventHandler? handler, object sender)
         {
-            ObserveFailure(RaiseCanExecuteChanged(handler, sender));
+            _ = ObserveFailureAsync(RaiseCanExecuteChanged(handler, sender));
         }
 
-        private static void ObserveFailure(Task task)
+        private static async Task ObserveFailureAsync(Task task)
         {
-            if (task.IsCompleted)
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch
             {
                 if (task.IsFaulted)
                 {
                     _ = task.Exception;
                 }
-
-                return;
             }
-
-            task.ContinueWith(static t =>
-            {
-                _ = t.Exception;
-            }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
     }
 }


### PR DESCRIPTION
## Summary
- observe `CommandDispatcher` fire-and-forget operations with an awaited helper so analyzer warnings are resolved

## Testing
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e01fe0a5bc8326ba6fdcd3c37ccf06