### PR TITLE
Annotate command dispatcher for Windows platform

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI;
@@ -86,6 +87,7 @@ namespace DesktopApplicationTemplate.UI.Helpers
         }
     }
 
+    [SupportedOSPlatform("windows")]
     internal static class CommandDispatcher
     {
         public static Task RaiseCanExecuteChanged(EventHandler? handler, object sender)


### PR DESCRIPTION
## Summary
1. Import `System.Runtime.Versioning` so platform attributes can be applied in the helper.
2. Decorate `CommandDispatcher` with `[SupportedOSPlatform("windows")]` to avoid CA1416 when the dispatcher uses the UI task factory.

## Testing
- Not run (dotnet CLI unavailable in the Linux container).

------
https://chatgpt.com/codex/tasks/task_e_68e02a150ad88326b96770fdd5eca1be