### PR TITLE
Fix analyzer warnings in AsyncRelayCommand

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -3,6 +3,7 @@ using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.UI;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.Helpers
 {
@@ -90,16 +91,18 @@ namespace DesktopApplicationTemplate.UI.Helpers
     [SupportedOSPlatform("windows")]
     internal static class CommandDispatcher
     {
-        public static Task RaiseCanExecuteChanged(EventHandler? handler, object sender)
+        private static readonly JoinableTaskFactory BackgroundTaskFactory = new(new JoinableTaskContext());
+
+        public static JoinableTask RaiseCanExecuteChangedAsync(EventHandler? handler, object sender)
         {
             if (handler is null)
             {
-                return Task.CompletedTask;
+                return BackgroundTaskFactory.RunAsync(static () => Task.CompletedTask);
             }
 
             if (App.UiThreadTaskFactory is null)
             {
-                return Task.CompletedTask;
+                return BackgroundTaskFactory.RunAsync(static () => Task.CompletedTask);
             }
 
             return App.UiThreadTaskFactory.RunAsync(async () =>
@@ -111,25 +114,26 @@ namespace DesktopApplicationTemplate.UI.Helpers
 
                 await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
                 handler(sender, EventArgs.Empty);
-            }).Task;
+            });
         }
 
         public static void FireAndForget(EventHandler? handler, object sender)
         {
-            _ = ObserveFailureAsync(RaiseCanExecuteChanged(handler, sender));
+            var joinableTask = RaiseCanExecuteChangedAsync(handler, sender);
+            _ = ObserveFailureAsync(joinableTask);
         }
 
-        private static async Task ObserveFailureAsync(Task task)
+        private static async Task ObserveFailureAsync(JoinableTask joinableTask)
         {
             try
             {
-                await task.ConfigureAwait(false);
+                await joinableTask.JoinAsync().ConfigureAwait(false);
             }
             catch
             {
-                if (task.IsFaulted)
+                if (joinableTask.Task.IsFaulted)
                 {
-                    _ = task.Exception;
+                    _ = joinableTask.Task.Exception;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- rename the dispatcher helper method to use the Async suffix and return a JoinableTask
- reuse a background JoinableTaskFactory to provide completed tasks when the UI factory is unavailable
- observe dispatcher failures by awaiting JoinableTask.JoinAsync instead of the Task property

## Testing
- Not run (Windows-only WPF build tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e28e8136a0832691f93856b845d301