### PR TITLE
Add TCP advanced configuration, sequential naming, and CSV file updates

### DIFF
--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -31,10 +31,12 @@
 - Replaced verbose `ServiceName` strings with `ServiceType` enum properties for log view models.
 - Service persistence now stores `ServiceType` as short codes and reads legacy string names.
 - Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
+- CSV service now derives filenames from `{date}` and `{time}` tokens and appends to existing files instead of incrementing index-based names for each row.
 - `ServiceManager` loads default services from configuration using `ServiceType` short codes and accepts legacy names.
 - `ServiceListModel` now exposes a `Type` enum property, removing string-based service comparisons.
 
 #### Fixed
+- TCP service messages view hooks the Advanced Settings button to a dedicated configuration page so network metadata updates persist.
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.
 - Removed unsupported `DisplayName` assignment from Windows service options to restore service build.
 - Service factories populate the `Type` property when creating service models.
@@ -72,6 +74,7 @@
 - MQTT create, edit, and subscription views follow design spacing with shared form styles and accessibility names.
 - Service creation flows now display within the main view, removing the separate Create Service window and placeholder navigation text.
 - Create service page limits options to TCP, MQTT, HTTP, FTP, SCP, and CSV services.
+- Service creation now assigns sequential base names (e.g., `TCP1`) and edit workflows ensure duplicate names fall back to the next available index.
 - Main window height constrained to the work area to prevent overlapping the taskbar.
 - MQTT create and edit views include tooltips on text fields to clarify expected input.
 - Create and edit service view models inject `IServiceRule` to validate required fields with XAML error tooltips.
@@ -109,6 +112,7 @@
 - Service views and view models reorganized into per-service subfolders with updated namespaces.
 
 #### Fixed
+- TCP create and edit views wire their Advanced buttons to open the advanced configuration screen.
 - TCP and SCP edit workflows now load existing options via `Load` methods, enabling DI-friendly construction.
 - Service list averages use one-way bindings to avoid runtime parse exceptions.
 - Main window declares behaviors namespace to prevent XAML parse errors.

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvConfiguration.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvConfiguration.cs
@@ -10,7 +10,7 @@ public class CsvConfiguration
     /// <summary>
     /// Gets or sets the file name pattern used when creating output files.
     /// </summary>
-    public string FileNamePattern { get; set; } = "output_{index}.csv";
+    public string FileNamePattern { get; set; } = "output_{date}_{time}.csv";
 
     /// <summary>
     /// Gets or sets the directory where CSV files are written.

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Globalization;
 using System.Linq;
 
 namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
@@ -144,16 +145,50 @@ public class CsvService : ICsvService
 
     private static string BuildFileName(CsvConfiguration configuration, CsvServiceState state, ICsvOutput output)
     {
-        string pattern = configuration.FileNamePattern ?? string.Empty;
-        string fileName = pattern.Replace("{index}", state.FileIndex.ToString());
-        if (pattern.Contains("{index}", StringComparison.Ordinal))
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (!string.IsNullOrWhiteSpace(state.CurrentFilePath))
         {
-            state.FileIndex++;
+            output.EnsureDirectoryForFile(state.CurrentFilePath);
+            return state.CurrentFilePath!;
+        }
+
+        var pattern = configuration.FileNamePattern ?? string.Empty;
+        var timestamp = state.FileTimestamp ?? DateTime.Now;
+        state.FileTimestamp = timestamp;
+
+        string fileName = pattern;
+        if (fileName.Contains("{datetime}", StringComparison.Ordinal))
+        {
+            fileName = fileName.Replace("{datetime}", timestamp.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture));
+        }
+
+        if (fileName.Contains("{date}", StringComparison.Ordinal))
+        {
+            fileName = fileName.Replace("{date}", timestamp.ToString("yyyyMMdd", CultureInfo.InvariantCulture));
+        }
+
+        if (fileName.Contains("{time}", StringComparison.Ordinal))
+        {
+            fileName = fileName.Replace("{time}", timestamp.ToString("HHmmss", CultureInfo.InvariantCulture));
+        }
+
+        if (fileName.Contains("{index}", StringComparison.Ordinal))
+        {
+            fileName = fileName.Replace("{index}", state.FileIndex.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = $"output_{timestamp:yyyyMMdd_HHmmss}.csv";
         }
 
         string directory = configuration.OutputDirectory ?? string.Empty;
         string path = Path.Combine(directory, fileName);
         output.EnsureDirectoryForFile(path);
+        state.CurrentFilePath = path;
         return path;
     }
 

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvServiceState.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvServiceState.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 
 /// <summary>
@@ -11,6 +13,16 @@ public class CsvServiceState
     public int FileIndex { get; set; } = 0;
 
     /// <summary>
+    /// Gets or sets the cached file path for the current output file.
+    /// </summary>
+    public string? CurrentFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp used when generating the current file name.
+    /// </summary>
+    public DateTime? FileTimestamp { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the header row has been written for the current file.
     /// </summary>
     public bool HeaderWritten { get; set; } = false;
@@ -21,6 +33,8 @@ public class CsvServiceState
     public void Reset()
     {
         HeaderWritten = false;
+        CurrentFilePath = null;
+        FileTimestamp = null;
         FileIndex++;
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
@@ -15,32 +15,57 @@ public enum TcpServiceMode
 /// <summary>
 /// Configuration options for creating a TCP service.
 /// </summary>
-public class TcpServiceOptions
-{
-    /// <summary>
-    /// Remote host name or address.
-    /// </summary>
-    public string Host { get; set; } = string.Empty;
+    public class TcpServiceOptions
+    {
+        /// <summary>
+        /// Remote host name or address.
+        /// </summary>
+        public string Host { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Port number used for the connection.
-    /// </summary>
-    public int Port { get; set; }
+        /// <summary>
+        /// Port number used for the connection.
+        /// </summary>
+        public int Port { get; set; }
 
-    /// <summary>
-    /// Indicates whether UDP should be used instead of TCP.
-    /// </summary>
-    public bool UseUdp { get; set; }
+        /// <summary>
+        /// Indicates whether UDP should be used instead of TCP.
+        /// </summary>
+        public bool UseUdp { get; set; }
 
-    /// <summary>
-    /// Operating mode for the service.
-    /// </summary>
-    public TcpServiceMode Mode { get; set; } = TcpServiceMode.Listening;
+        /// <summary>
+        /// Operating mode for the service.
+        /// </summary>
+        public TcpServiceMode Mode { get; set; } = TcpServiceMode.Listening;
 
-    /// <summary>
-    /// Sample message used for testing script transformations.
-    /// </summary>
-    public string InputMessage { get; set; } = string.Empty;
+        /// <summary>
+        /// Local computer IP address used for listening services.
+        /// </summary>
+        public string ComputerIp { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Local port displayed for listening services.
+        /// </summary>
+        public string ListeningPort { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Destination server IP address for outbound connections.
+        /// </summary>
+        public string ServerIp { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gateway associated with the destination server.
+        /// </summary>
+        public string ServerGateway { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Destination server port for outbound connections.
+        /// </summary>
+        public string ServerPort { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Sample message used for testing script transformations.
+        /// </summary>
+        public string InputMessage { get; set; } = string.Empty;
 
     /// <summary>
     /// Script applied to <see cref="InputMessage"/> to produce an output.

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -18,6 +18,7 @@ using DesktopApplicationTemplate.UI.ViewModels.Http.Advanced;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Create;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Edit;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp.Advanced;
 using DesktopApplicationTemplate.UI.ViewModels.Hid;
 using DesktopApplicationTemplate.UI.ViewModels.Hid.Create;
 using DesktopApplicationTemplate.UI.ViewModels.Hid.Edit;
@@ -52,6 +53,7 @@ using DesktopApplicationTemplate.UI.Views.Http.Advanced;
 using DesktopApplicationTemplate.UI.Views.Tcp;
 using DesktopApplicationTemplate.UI.Views.Tcp.Create;
 using DesktopApplicationTemplate.UI.Views.Tcp.Edit;
+using DesktopApplicationTemplate.UI.Views.Tcp.Advanced;
 using DesktopApplicationTemplate.UI.Views.Hid;
 using DesktopApplicationTemplate.UI.Views.Hid.Create;
 using DesktopApplicationTemplate.UI.Views.Hid.Edit;
@@ -183,6 +185,8 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<ServiceMessageTableViewModel>();
             services.AddSingleton<TcpServiceMessagesView>();
             services.AddTransient<TcpServiceMessagesViewModel>();
+            services.AddTransient<TcpAdvancedConfigView>();
+            services.AddTransient<TcpAdvancedConfigViewModel>();
             services.AddSingleton<HttpServiceView>();
             services.AddSingleton<HttpServiceViewModel>();
             services.AddSingleton<FileObserverView>();
@@ -388,9 +392,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<MqttCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Mqtt);
                         _ = mainView.AddServiceAsync(ServiceType.Mqtt,
-                            new ServiceFactoryOptions<MqttServiceOptions>(name, (MqttServiceOptions)options));
+                            new ServiceFactoryOptions<MqttServiceOptions>(finalName, (MqttServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -440,9 +448,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<FtpServerCreateViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Ftp);
                         _ = mainView.AddServiceAsync(ServiceType.Ftp,
-                            new ServiceFactoryOptions<CoreFtpServerOptions>(name, (CoreFtpServerOptions)options));
+                            new ServiceFactoryOptions<CoreFtpServerOptions>(finalName, (CoreFtpServerOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<FtpServerCreateView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -484,9 +496,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<HttpCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Http);
                         _ = mainView.AddServiceAsync(ServiceType.Http,
-                            new ServiceFactoryOptions<HttpServiceOptions>(name, (HttpServiceOptions)options));
+                            new ServiceFactoryOptions<HttpServiceOptions>(finalName, (HttpServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<HttpCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -528,11 +544,25 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<TcpCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Tcp);
                         _ = mainView.AddServiceAsync(ServiceType.Tcp,
-                            new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
+                            new ServiceFactoryOptions<TcpServiceOptions>(finalName, (TcpServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
-                    return ActivatorUtilities.CreateInstance<TcpCreateServiceView>(provider, vm);
+                    var view = ActivatorUtilities.CreateInstance<TcpCreateServiceView>(provider, vm);
+                    vm.AdvancedConfigRequested += opts =>
+                    {
+                        var advVm = ActivatorUtilities.CreateInstance<TcpAdvancedConfigViewModel>(provider, opts);
+                        var advView = provider.GetRequiredService<TcpAdvancedConfigView>();
+                        advView.Initialize(advVm);
+                        advVm.Saved += _ => mainView.ShowPage(view);
+                        advVm.BackRequested += () => mainView.ShowPage(view);
+                        mainView.ShowPage(advView);
+                    };
+                    return view;
                 },
                 LegacyServiceType: ServiceType.Tcp);
         }
@@ -562,9 +592,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<HidCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Hid);
                         _ = mainView.AddServiceAsync(ServiceType.Hid,
-                            new ServiceFactoryOptions<HidServiceOptions>(name, (HidServiceOptions)options));
+                            new ServiceFactoryOptions<HidServiceOptions>(finalName, (HidServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<HidCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -606,9 +640,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<ScpCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Scp);
                         _ = mainView.AddServiceAsync(ServiceType.Scp,
-                            new ServiceFactoryOptions<ScpServiceOptions>(name, (ScpServiceOptions)options));
+                            new ServiceFactoryOptions<ScpServiceOptions>(finalName, (ScpServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<ScpCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -650,9 +688,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<FileObserverCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.FileObserver);
                         _ = mainView.AddServiceAsync(ServiceType.FileObserver,
-                            new ServiceFactoryOptions<FileObserverServiceOptions>(name, (FileObserverServiceOptions)options));
+                            new ServiceFactoryOptions<FileObserverServiceOptions>(finalName, (FileObserverServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<FileObserverCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -694,9 +736,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<CsvServiceEditorViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Csv);
                         _ = mainView.AddServiceAsync(ServiceType.Csv,
-                            new ServiceFactoryOptions<CsvServiceOptions>(name, (CsvServiceOptions)options));
+                            new ServiceFactoryOptions<CsvServiceOptions>(finalName, (CsvServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = provider.GetRequiredService<CsvServiceEditorView>();
                     view.Initialize(vm);
@@ -730,9 +776,13 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<HeartbeatCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     vm.ServiceSaved += (name, options) =>
+                    {
+                        var finalName = mainViewModel.GenerateServiceName(ServiceType.Heartbeat);
                         _ = mainView.AddServiceAsync(ServiceType.Heartbeat,
-                            new ServiceFactoryOptions<HeartbeatServiceOptions>(name, (HeartbeatServiceOptions)options));
+                            new ServiceFactoryOptions<HeartbeatServiceOptions>(finalName, (HeartbeatServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<HeartbeatCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>

--- a/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
@@ -37,7 +37,8 @@ public class CsvEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"CSV Creator - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"CSV Creator - {finalName}";
             service.CsvOptions = opts;
             if (csvPage != null)
                 mainView.ShowPage(csvPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
@@ -38,7 +38,8 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"File Observer - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"File Observer - {finalName}";
             service.FileObserverOptions = opts;
             if (foPage != null)
                 mainView.ShowPage(foPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -38,7 +38,8 @@ public class FtpEditServiceHandler : IEditServiceHandler
         var editView = ActivatorUtilities.CreateInstance<FtpServerEditView>(_services, vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"FTP Server - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"FTP Server - {finalName}";
             service.FtpOptions = opts;
             var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
             opt.Port = opts.Port;

--- a/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
@@ -38,7 +38,8 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"Heartbeat - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"Heartbeat - {finalName}";
             service.HeartbeatOptions = opts;
             if (hbPage != null)
                 mainView.ShowPage(hbPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
@@ -37,7 +37,8 @@ public class HidEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"HID - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"HID - {finalName}";
             service.HidOptions = opts;
             if (hidPage != null)
                 mainView.ShowPage(hidPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
@@ -38,7 +38,8 @@ public class HttpEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"HTTP - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"HTTP - {finalName}";
             service.HttpOptions = opts;
             if (httpPage != null)
                 mainView.ShowPage(httpPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
@@ -39,7 +39,8 @@ public class MqttEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"MQTT - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"MQTT - {finalName}";
             if (tagPage != null)
                 mainView.ShowPage(tagPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
@@ -38,7 +38,8 @@ public class ScpEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"SCP - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"SCP - {finalName}";
             service.ScpOptions = opts;
             if (scpPage != null)
                 mainView.ShowPage(scpPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -3,7 +3,9 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Edit;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp.Advanced;
 using DesktopApplicationTemplate.UI.Views.Tcp.Edit;
+using DesktopApplicationTemplate.UI.Views.Tcp.Advanced;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,7 +41,8 @@ public class TcpEditServiceHandler : IEditServiceHandler
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
+            var finalName = mainViewModel.EnsureUniqueServiceName(service, name);
+            service.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {finalName}";
             service.Type = vm.ServiceType;
             service.TcpOptions = opts;
             if (tcpPage != null)
@@ -50,6 +53,15 @@ public class TcpEditServiceHandler : IEditServiceHandler
         {
             if (tcpPage != null)
                 mainView.ShowPage(tcpPage);
+        };
+        vm.AdvancedConfigRequested += opts =>
+        {
+            var advVm = ActivatorUtilities.CreateInstance<TcpAdvancedConfigViewModel>(_services, opts);
+            var advView = _services.GetRequiredService<TcpAdvancedConfigView>();
+            advView.Initialize(advVm);
+            advVm.Saved += _ => mainView.ShowPage(editView);
+            advVm.BackRequested += () => mainView.ShowPage(editView);
+            mainView.ShowPage(advView);
         };
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -45,6 +45,11 @@ namespace DesktopApplicationTemplate.Persistence
                         Port = s.TcpOptions.Port,
                         UseUdp = s.TcpOptions.UseUdp,
                         Mode = s.TcpOptions.Mode,
+                        ComputerIp = s.TcpOptions.ComputerIp,
+                        ListeningPort = s.TcpOptions.ListeningPort,
+                        ServerIp = s.TcpOptions.ServerIp,
+                        ServerGateway = s.TcpOptions.ServerGateway,
+                        ServerPort = s.TcpOptions.ServerPort,
                         InputMessage = s.TcpOptions.InputMessage,
                         Script = s.TcpOptions.Script,
                         OutputMessage = s.TcpOptions.OutputMessage,
@@ -252,6 +257,11 @@ namespace DesktopApplicationTemplate.Persistence
                             value.Port = info.TcpOptions.Port;
                             value.UseUdp = info.TcpOptions.UseUdp;
                             value.Mode = info.TcpOptions.Mode;
+                            value.ComputerIp = info.TcpOptions.ComputerIp;
+                            value.ListeningPort = info.TcpOptions.ListeningPort;
+                            value.ServerIp = info.TcpOptions.ServerIp;
+                            value.ServerGateway = info.TcpOptions.ServerGateway;
+                            value.ServerPort = info.TcpOptions.ServerPort;
                             value.InputMessage = info.TcpOptions.InputMessage;
                             value.Script = info.TcpOptions.Script;
                             value.OutputMessage = info.TcpOptions.OutputMessage;

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using DesktopApplicationTemplate.Models;
@@ -29,11 +30,27 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         {
             var typeName = serviceType.ToLegacyString();
             int index = 1;
-            while (_existingNames.Contains($"{typeName}{index}"))
+            foreach (var existing in _existingNames)
             {
-                index++;
+                if (existing.StartsWith(typeName, StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(existing[typeName.Length..], out int value) && value >= index)
+                {
+                    index = value + 1;
+                }
             }
             return $"{typeName}{index}";
+        }
+
+        public void SetExistingNames(IEnumerable<string> names)
+        {
+            _existingNames.Clear();
+            foreach (var name in names)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    _existingNames.Add(name);
+                }
+            }
         }
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -210,6 +210,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             return $"{typeName}{index}";
         }
 
+        internal string EnsureUniqueServiceName(ServiceListModel currentService, string desiredName)
+        {
+            if (currentService is null)
+            {
+                throw new ArgumentNullException(nameof(currentService));
+            }
+
+            var candidate = (desiredName ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                return GenerateServiceName(currentService.Type);
+            }
+
+            var duplicate = Services.Any(s => !ReferenceEquals(s, currentService) &&
+                s.DisplayName.Split(" - ").Last().Equals(candidate, StringComparison.OrdinalIgnoreCase));
+
+            return duplicate ? GenerateServiceName(currentService.Type) : candidate;
+        }
+
         private async Task RemoveSelectedServiceAsync()
         {
             if (SelectedService == null)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Advanced/TcpAdvancedConfigViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Advanced/TcpAdvancedConfigViewModel.cs
@@ -1,0 +1,135 @@
+using System;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+
+namespace DesktopApplicationTemplate.UI.ViewModels.Tcp.Advanced;
+
+/// <summary>
+/// View model for editing advanced TCP configuration values.
+/// </summary>
+public class TcpAdvancedConfigViewModel : AdvancedConfigViewModelBase<TcpServiceOptions>
+{
+    private readonly TcpServiceOptions _options;
+    private string _computerIp;
+    private string _listeningPort;
+    private string _serverIp;
+    private string _serverGateway;
+    private string _serverPort;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TcpAdvancedConfigViewModel"/> class.
+    /// </summary>
+    public TcpAdvancedConfigViewModel(TcpServiceOptions options, ILoggingService? logger = null)
+        : base(logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _computerIp = options.ComputerIp;
+        _listeningPort = options.ListeningPort;
+        _serverIp = options.ServerIp;
+        _serverGateway = options.ServerGateway;
+        _serverPort = options.ServerPort;
+    }
+
+    /// <summary>
+    /// Gets or sets the computer IP displayed in the TCP message view.
+    /// </summary>
+    public string ComputerIp
+    {
+        get => _computerIp;
+        set
+        {
+            if (_computerIp == value)
+            {
+                return;
+            }
+
+            _computerIp = value ?? string.Empty;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the listening port shown in the TCP message view.
+    /// </summary>
+    public string ListeningPort
+    {
+        get => _listeningPort;
+        set
+        {
+            if (_listeningPort == value)
+            {
+                return;
+            }
+
+            _listeningPort = value ?? string.Empty;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the destination server IP.
+    /// </summary>
+    public string ServerIp
+    {
+        get => _serverIp;
+        set
+        {
+            if (_serverIp == value)
+            {
+                return;
+            }
+
+            _serverIp = value ?? string.Empty;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the destination gateway.
+    /// </summary>
+    public string ServerGateway
+    {
+        get => _serverGateway;
+        set
+        {
+            if (_serverGateway == value)
+            {
+                return;
+            }
+
+            _serverGateway = value ?? string.Empty;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the destination server port.
+    /// </summary>
+    public string ServerPort
+    {
+        get => _serverPort;
+        set
+        {
+            if (_serverPort == value)
+            {
+                return;
+            }
+
+            _serverPort = value ?? string.Empty;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override TcpServiceOptions OnSave()
+    {
+        Logger?.Log("TCP advanced options start", LogLevel.Debug);
+        _options.ComputerIp = ComputerIp;
+        _options.ListeningPort = ListeningPort;
+        _options.ServerIp = ServerIp;
+        _options.ServerGateway = ServerGateway;
+        _options.ServerPort = ServerPort;
+        Logger?.Log("TCP advanced options finished", LogLevel.Debug);
+        return _options;
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -117,7 +117,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     /// <inheritdoc />
     protected override void OnAdvancedConfig()
     {
-        // Advanced configuration removed.
+        RaiseAdvancedConfigRequested(_options);
     }
 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -195,12 +195,23 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
             _options = service.TcpOptions ?? new TcpServiceOptions();
+            if (service.TcpOptions is null)
+            {
+                service.TcpOptions = _options;
+            }
             ServiceType = service.Type;
             ServiceName = service.DisplayName.Split(" - ").Last();
             Script = string.IsNullOrWhiteSpace(_options.Script)
                 ? ScriptEditorViewModel.DefaultScript
                 : _options.Script;
             OutputMessage = _options.OutputMessage;
+            UpdateNetworkSettings(
+                _options.ComputerIp,
+                _options.ListeningPort,
+                _options.ServerIp,
+                _options.ServerGateway,
+                _options.ServerPort,
+                _options.UseUdp);
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
             _ = InitializeRuntimeAsync();
         }
@@ -237,6 +248,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             ServerGateway = serverGateway ?? string.Empty;
             ServerPort = serverPort ?? string.Empty;
             IsUdp = isUdp;
+            _options.ComputerIp = ComputerIp;
+            _options.ListeningPort = ListeningPort;
+            _options.ServerIp = ServerIp;
+            _options.ServerGateway = ServerGateway;
+            _options.ServerPort = ServerPort;
+            _options.UseUdp = isUdp;
             OnPropertyChanged(nameof(ComputerIp));
             OnPropertyChanged(nameof(ListeningPort));
             OnPropertyChanged(nameof(ServerIp));

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -35,6 +37,14 @@ namespace DesktopApplicationTemplate.UI.Views
         }
 
         public string GenerateDefaultName(ServiceType type) => _viewModel.GenerateDefaultName(type);
+
+        public void SetExistingServiceNames(IEnumerable<ServiceListModel> services)
+        {
+            var names = services
+                .Select(s => s.DisplayName.Split(" - ").Last())
+                .ToList();
+            _viewModel.SetExistingNames(names);
+        }
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
         {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -6,6 +6,8 @@ using System.Collections.Specialized;
 using System.Linq;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp.Advanced;
 using DesktopApplicationTemplate.Models;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +17,8 @@ using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using DesktopApplicationTemplate.UI.Views.Tcp.Advanced;
+using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -29,6 +33,7 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly IServiceUiRegistry<ServiceListModel, Page> _serviceRegistry;
         private readonly IServiceProvider _serviceProvider;
         private readonly Dictionary<ServiceListModel, Action<LogEntry>> _serviceLogHandlers = new();
+        private readonly Dictionary<ServiceListModel, EventHandler> _tcpAdvancedHandlers = new();
         private readonly BrushConverter _brushConverter = new();
 
         public MainView(
@@ -127,6 +132,11 @@ namespace DesktopApplicationTemplate.UI.Views
                     navm.UpdateNetworkConfiguration(_viewModel.NetworkConfig.CurrentConfiguration);
                 }
 
+                if (svc.ServicePage.DataContext is TcpServiceMessagesViewModel tcpVm)
+                {
+                    AttachTcpAdvancedHandler(svc, tcpVm);
+                }
+
                 if (svc.ServicePage is IServiceLogHost logHost)
                 {
                     logHost.SetServiceContext(svc);
@@ -191,6 +201,65 @@ namespace DesktopApplicationTemplate.UI.Views
             _serviceLogHandlers.Remove(svc);
         }
 
+        private void AttachTcpAdvancedHandler(ServiceListModel svc, TcpServiceMessagesViewModel vm)
+        {
+            if (_tcpAdvancedHandlers.ContainsKey(svc))
+            {
+                return;
+            }
+
+            EventHandler handler = (_, _) =>
+            {
+                var options = svc.TcpOptions ?? new TcpServiceOptions();
+                svc.TcpOptions = options;
+                var advVm = ActivatorUtilities.CreateInstance<TcpAdvancedConfigViewModel>(_serviceProvider, options);
+                var advView = _serviceProvider.GetRequiredService<TcpAdvancedConfigView>();
+                advView.Initialize(advVm);
+                advVm.Saved += updatedOptions =>
+                {
+                    svc.TcpOptions = updatedOptions;
+                    vm.UpdateNetworkSettings(
+                        updatedOptions.ComputerIp,
+                        updatedOptions.ListeningPort,
+                        updatedOptions.ServerIp,
+                        updatedOptions.ServerGateway,
+                        updatedOptions.ServerPort,
+                        updatedOptions.UseUdp);
+                    if (svc.ServicePage is not null)
+                    {
+                        ShowPage(svc.ServicePage);
+                    }
+                    _ = _viewModel.SaveServicesAsync();
+                };
+                advVm.BackRequested += () =>
+                {
+                    if (svc.ServicePage is not null)
+                    {
+                        ShowPage(svc.ServicePage);
+                    }
+                };
+                ShowPage(advView);
+            };
+
+            vm.AdvancedSettingsRequested += handler;
+            _tcpAdvancedHandlers[svc] = handler;
+        }
+
+        private void DetachTcpAdvancedHandler(ServiceListModel svc)
+        {
+            if (!_tcpAdvancedHandlers.TryGetValue(svc, out var handler))
+            {
+                return;
+            }
+
+            if (svc.ServicePage?.DataContext is TcpServiceMessagesViewModel vm)
+            {
+                vm.AdvancedSettingsRequested -= handler;
+            }
+
+            _tcpAdvancedHandlers.Remove(svc);
+        }
+
         private void Services_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
@@ -198,6 +267,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 foreach (ServiceListModel svc in e.OldItems?.OfType<ServiceListModel>() ?? Enumerable.Empty<ServiceListModel>())
                 {
                     DetachServiceLogger(svc);
+                    DetachTcpAdvancedHandler(svc);
                 }
             }
 
@@ -214,6 +284,10 @@ namespace DesktopApplicationTemplate.UI.Views
                 foreach (var svc in _serviceLogHandlers.Keys.ToList())
                 {
                     DetachServiceLogger(svc);
+                }
+                foreach (var svc in _tcpAdvancedHandlers.Keys.ToList())
+                {
+                    DetachTcpAdvancedHandler(svc);
                 }
             }
         }
@@ -244,11 +318,13 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             var page = _serviceProvider.GetRequiredService<CreateServicePage>();
             _createServicePage = page;
+            page.SetExistingServiceNames(_viewModel.Services);
             page.ServiceCreated += (name, type) =>
             {
+                var finalName = _viewModel.GenerateServiceName(type);
                 var svc = new ServiceListModel
                 {
-                    DisplayName = $"{type.ToLegacyString()} - {name}",
+                    DisplayName = $"{type.ToLegacyString()} - {finalName}",
                     Type = type,
                     IsActive = false
                 };

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Advanced/TcpAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Advanced/TcpAdvancedConfigView.xaml
@@ -1,0 +1,44 @@
+<Page x:Class="DesktopApplicationTemplate.UI.Views.Tcp.Advanced.TcpAdvancedConfigView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
+      mc:Ignorable="d">
+    <Grid Margin="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="Computer IP" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding ComputerIp, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Listening Port" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding ListeningPort, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Server IP" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ServerIp, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Server Gateway" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding ServerGateway, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
+
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Server Port" Style="{StaticResource FormLabel}"/>
+        <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding ServerPort, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
+
+        <views:AdvancedConfigButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       BackCommand="{Binding BackCommand}"
+                                       SaveButtonText="Save Configuration"
+                                       SaveAutomationName="Save TCP Advanced Configuration"
+                                       BackAutomationName="Back from TCP Advanced Configuration" />
+    </Grid>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Advanced/TcpAdvancedConfigView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Advanced/TcpAdvancedConfigView.xaml.cs
@@ -1,0 +1,22 @@
+using System.Windows.Controls;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp.Advanced;
+
+namespace DesktopApplicationTemplate.UI.Views.Tcp.Advanced;
+
+public partial class TcpAdvancedConfigView : Page
+{
+    private readonly ILoggingService _logger;
+
+    public TcpAdvancedConfigView(ILoggingService logger)
+    {
+        InitializeComponent();
+        _logger = logger;
+    }
+
+    public void Initialize(TcpAdvancedConfigViewModel viewModel)
+    {
+        DataContext = viewModel;
+        viewModel.Logger = _logger;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -79,9 +79,11 @@
             <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
             <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"
+                                   AdvancedAutomationName="Open TCP Advanced Configuration"
                                    SaveAutomationName="Create TCP Service"
                                    CancelAutomationName="Cancel TCP Creation" />
         </Grid>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -79,8 +79,10 @@
             <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
             <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+                                   AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
+                                   AdvancedAutomationName="Open TCP Advanced Configuration"
                                    SaveAutomationName="Save TCP Service"
                                    CancelAutomationName="Cancel TCP Edit" />
         </Grid>


### PR DESCRIPTION
## Summary
- add a reusable TCP advanced configuration view model/view and wire the advanced button across create, edit, and messages workflows
- ensure service creation and edit flows assign sequential base names and avoid duplicate service names
- update CSV writer options and state to generate timestamped filenames, reopen existing files, and persist TCP network metadata

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e080976c83268024986fe30675f1