### PR TITLE
Improve TCP advanced access, service naming, and CSV outputs

### DIFF
--- a/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
@@ -83,5 +83,23 @@ public static class ServiceTypeExtensions
             ServiceType.Heartbeat => "Heartbeat",
             _ => type.ToCode()
         };
+
+    /// <summary>
+    /// Provides the default prefix used when generating service names.
+    /// </summary>
+    public static string ToBaseName(this ServiceType type) =>
+        type switch
+        {
+            ServiceType.Ftp => "FTP",
+            ServiceType.Mqtt => "MQTT",
+            ServiceType.Http => "HTTP",
+            ServiceType.Tcp => "TCP",
+            ServiceType.Hid => "HID",
+            ServiceType.Csv => "CSV",
+            ServiceType.FileObserver => "FileObserver",
+            ServiceType.Scp => "SCP",
+            ServiceType.Heartbeat => "Heartbeat",
+            _ => type.ToCode()
+        };
 }
 

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvConfiguration.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvConfiguration.cs
@@ -10,7 +10,7 @@ public class CsvConfiguration
     /// <summary>
     /// Gets or sets the file name pattern used when creating output files.
     /// </summary>
-    public string FileNamePattern { get; set; } = "output_{index}.csv";
+    public string FileNamePattern { get; set; } = "output_{timestamp}.csv";
 
     /// <summary>
     /// Gets or sets the directory where CSV files are written.

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -144,17 +145,56 @@ public class CsvService : ICsvService
 
     private static string BuildFileName(CsvConfiguration configuration, CsvServiceState state, ICsvOutput output)
     {
-        string pattern = configuration.FileNamePattern ?? string.Empty;
-        string fileName = pattern.Replace("{index}", state.FileIndex.ToString());
-        if (pattern.Contains("{index}", StringComparison.Ordinal))
+        if (state is null)
         {
-            state.FileIndex++;
+            throw new ArgumentNullException(nameof(state));
         }
 
-        string directory = configuration.OutputDirectory ?? string.Empty;
-        string path = Path.Combine(directory, fileName);
+        if (output is null)
+        {
+            throw new ArgumentNullException(nameof(output));
+        }
+
+        var directory = configuration.OutputDirectory ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(state.CurrentFileName))
+        {
+            var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+            state.CurrentFileName = ResolveFileName(configuration.FileNamePattern, timestamp);
+            state.HeaderWritten = false;
+        }
+
+        var path = Path.Combine(directory, state.CurrentFileName);
         output.EnsureDirectoryForFile(path);
         return path;
+    }
+
+    private static string ResolveFileName(string? pattern, string timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return $"output_{timestamp}.csv";
+        }
+
+        const string token = "{timestamp}";
+        var index = pattern.IndexOf(token, StringComparison.OrdinalIgnoreCase);
+        if (index >= 0)
+        {
+            return string.Concat(pattern.AsSpan(0, index), timestamp, pattern.AsSpan(index + token.Length));
+        }
+
+        var fileName = Path.GetFileNameWithoutExtension(pattern);
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            fileName = "output";
+        }
+
+        var extension = Path.GetExtension(pattern);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".csv";
+        }
+
+        return $"{fileName}_{timestamp}{extension}";
     }
 
     private static bool IsCsvService(string serviceName)

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvServiceState.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvServiceState.cs
@@ -16,11 +16,16 @@ public class CsvServiceState
     public bool HeaderWritten { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets the current file name used for CSV output.
+    /// </summary>
+    public string? CurrentFileName { get; set; }
+
+    /// <summary>
     /// Resets the state so the next write will create a fresh file and header.
     /// </summary>
     public void Reset()
     {
         HeaderWritten = false;
-        FileIndex++;
+        CurrentFileName = null;
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -323,7 +323,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     var newService = new ServiceListModel
                     {
-                        DisplayName = $"MQTT - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Mqtt,
                         IsActive = false
                     };
@@ -388,9 +388,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<MqttCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Mqtt,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Mqtt,
                             new ServiceFactoryOptions<MqttServiceOptions>(name, (MqttServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -417,7 +419,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"FTP Server - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Ftp,
                         IsActive = false,
                         FtpOptions = ctx.Options
@@ -440,9 +442,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<FtpServerCreateViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Ftp,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Ftp,
                             new ServiceFactoryOptions<CoreFtpServerOptions>(name, (CoreFtpServerOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<FtpServerCreateView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -469,7 +473,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.Http.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Http,
                         IsActive = false,
                         HttpOptions = ctx.Options
@@ -484,9 +488,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<HttpCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Http,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Http,
                             new ServiceFactoryOptions<HttpServiceOptions>(name, (HttpServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<HttpCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -513,7 +519,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.Tcp.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Tcp,
                         IsActive = false,
                         TcpOptions = ctx.Options
@@ -528,9 +534,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<TcpCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Tcp,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Tcp,
                             new ServiceFactoryOptions<TcpServiceOptions>(name, (TcpServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     return ActivatorUtilities.CreateInstance<TcpCreateServiceView>(provider, vm);
                 },
@@ -547,7 +555,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.Hid.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Hid,
                         IsActive = false,
                         HidOptions = ctx.Options
@@ -562,9 +570,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<HidCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Hid,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Hid,
                             new ServiceFactoryOptions<HidServiceOptions>(name, (HidServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<HidCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -591,7 +601,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.Scp.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Scp,
                         IsActive = false,
                         ScpOptions = ctx.Options
@@ -606,9 +616,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<ScpCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Scp,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Scp,
                             new ServiceFactoryOptions<ScpServiceOptions>(name, (ScpServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<ScpCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -635,7 +647,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.FileObserver.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.FileObserver,
                         IsActive = false,
                         FileObserverOptions = ctx.Options
@@ -650,9 +662,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<FileObserverCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.FileObserver,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.FileObserver,
                             new ServiceFactoryOptions<FileObserverServiceOptions>(name, (FileObserverServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<FileObserverCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>
@@ -679,7 +693,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.Csv.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Csv,
                         IsActive = false,
                         CsvOptions = ctx.Options
@@ -694,9 +708,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<CsvServiceEditorViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Csv,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Csv,
                             new ServiceFactoryOptions<CsvServiceOptions>(name, (CsvServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = provider.GetRequiredService<CsvServiceEditorView>();
                     view.Initialize(vm);
@@ -715,7 +731,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
-                        DisplayName = $"{ServiceType.Heartbeat.ToLegacyString()} - {ctx.Name}",
+                        DisplayName = ctx.Name,
                         Type = ServiceType.Heartbeat,
                         IsActive = false,
                         HeartbeatOptions = ctx.Options
@@ -730,9 +746,11 @@ namespace DesktopApplicationTemplate.UI
                     var vm = provider.GetRequiredService<HeartbeatCreateServiceViewModel>();
                     vm.ServiceName = defaultName;
                     var mainView = provider.GetRequiredService<MainView>();
-                    vm.ServiceSaved += (name, options) =>
-                        _ = mainView.AddServiceAsync(ServiceType.Heartbeat,
+                    vm.ServiceSaved += async (name, options) =>
+                    {
+                        await mainView.TryAddServiceAsync(ServiceType.Heartbeat,
                             new ServiceFactoryOptions<HeartbeatServiceOptions>(name, (HeartbeatServiceOptions)options));
+                    };
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     var view = ActivatorUtilities.CreateInstance<HeartbeatCreateServiceView>(provider, vm);
                     vm.AdvancedConfigRequested += opts =>

--- a/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -32,12 +33,20 @@ public class CsvEditServiceHandler : IEditServiceHandler
         var csvPage = mainView.GetOrCreateServicePage(service);
         var options = service.CsvOptions ?? new CsvServiceOptions();
         var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
-        vm.Load(service.DisplayName.Split(" - ").Last(), options);
+        vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<CsvServiceEditorView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"CSV Creator - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.CsvOptions = opts;
             if (csvPage != null)
                 mainView.ShowPage(csvPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -33,12 +34,20 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
         var mainViewModel = _getMainViewModel();
         var foPage = mainView.GetOrCreateServicePage(service);
         var options = service.FileObserverOptions ?? new FileObserverServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<FileObserverEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"File Observer - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.FileObserverOptions = opts;
             if (foPage != null)
                 mainView.ShowPage(foPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.Ftp;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -34,11 +35,19 @@ public class FtpEditServiceHandler : IEditServiceHandler
         var mainViewModel = _getMainViewModel();
         var ftpPage = mainView.GetOrCreateServicePage(service);
         var options = service.FtpOptions ?? new FtpServerOptions();
-        var vm = ActivatorUtilities.CreateInstance<FtpServerEditViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var vm = ActivatorUtilities.CreateInstance<FtpServerEditViewModel>(_services, service.DisplayName, options);
         var editView = ActivatorUtilities.CreateInstance<FtpServerEditView>(_services, vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"FTP Server - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.FtpOptions = opts;
             var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
             opt.Port = opts.Port;

--- a/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -33,12 +34,20 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
         var mainViewModel = _getMainViewModel();
         var hbPage = mainView.GetOrCreateServicePage(service);
         var options = service.HeartbeatOptions ?? new HeartbeatServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<HeartbeatEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var vm = ActivatorUtilities.CreateInstance<HeartbeatEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HeartbeatEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"Heartbeat - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.HeartbeatOptions = opts;
             if (hbPage != null)
                 mainView.ShowPage(hbPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Hid.Edit;
@@ -32,12 +33,20 @@ public class HidEditServiceHandler : IEditServiceHandler
         var mainViewModel = _getMainViewModel();
         var hidPage = mainView.GetOrCreateServicePage(service);
         var options = service.HidOptions ?? new HidServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<HidEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var vm = ActivatorUtilities.CreateInstance<HidEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HidEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"HID - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.HidOptions = opts;
             if (hidPage != null)
                 mainView.ShowPage(hidPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.Http;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -33,12 +34,20 @@ public class HttpEditServiceHandler : IEditServiceHandler
         var mainViewModel = _getMainViewModel();
         var httpPage = mainView.GetOrCreateServicePage(service);
         var options = service.HttpOptions ?? new HttpServiceOptions();
-        var vm = ActivatorUtilities.CreateInstance<HttpEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var vm = ActivatorUtilities.CreateInstance<HttpEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HttpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"HTTP - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.HttpOptions = opts;
             if (httpPage != null)
                 mainView.ShowPage(httpPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -34,12 +35,20 @@ public class MqttEditServiceHandler : IEditServiceHandler
         var mainViewModel = _getMainViewModel();
         var tagPage = mainView.GetOrCreateServicePage(service);
         var options = _services.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
-        var vm = ActivatorUtilities.CreateInstance<MqttEditServiceViewModel>(_services, service.DisplayName.Split(" - ").Last(), options);
+        var vm = ActivatorUtilities.CreateInstance<MqttEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<MqttEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"MQTT - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             if (tagPage != null)
                 mainView.ShowPage(tagPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Scp.Edit;
@@ -33,12 +34,20 @@ public class ScpEditServiceHandler : IEditServiceHandler
         var scpPage = mainView.GetOrCreateServicePage(service);
         var options = service.ScpOptions ?? new ScpServiceOptions();
         var vm = _services.GetRequiredService<ScpEditServiceViewModel>();
-        vm.Load(service.DisplayName.Split(" - ").Last(), options);
+        vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<ScpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"SCP - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.ScpOptions = opts;
             if (scpPage != null)
                 mainView.ShowPage(scpPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.UI.Views;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -34,12 +35,20 @@ public class TcpEditServiceHandler : IEditServiceHandler
         var options = service.TcpOptions ?? new TcpServiceOptions();
         var vm = _services.GetRequiredService<TcpEditServiceViewModel>();
         vm.ServiceType = service.Type;
-        vm.Load(service.DisplayName.Split(" - ").Last(), options);
+        vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<TcpEditServiceView>();
         editView.Initialize(vm);
         vm.ServiceSaved += (name, opts) =>
         {
-            service.DisplayName = $"{vm.ServiceType.ToLegacyString()} - {name}";
+            var trimmed = string.IsNullOrWhiteSpace(name)
+                ? mainViewModel.GenerateServiceName(service.Type)
+                : name.Trim();
+            if (mainViewModel.Services.Any(s => s != service && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                trimmed = mainViewModel.GenerateServiceName(service.Type);
+            }
+
+            service.DisplayName = trimmed;
             service.Type = vm.ServiceType;
             service.TcpOptions = opts;
             if (tcpPage != null)

--- a/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/CreateServiceViewModel.cs
@@ -22,18 +22,32 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public CreateServiceViewModel(IEnumerable<string>? existingNames = null)
         {
-            _existingNames = existingNames != null ? new HashSet<string>(existingNames) : new HashSet<string>();
+            _existingNames = existingNames != null
+                ? new HashSet<string>(existingNames, StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public string GenerateDefaultName(ServiceType serviceType)
         {
-            var typeName = serviceType.ToLegacyString();
+            var typeName = serviceType.ToBaseName();
             int index = 1;
             while (_existingNames.Contains($"{typeName}{index}"))
             {
                 index++;
             }
             return $"{typeName}{index}";
+        }
+
+        public void SetExistingNames(IEnumerable<string> names)
+        {
+            _existingNames.Clear();
+            foreach (var name in names)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    _existingNames.Add(name);
+                }
+            }
         }
         // OnPropertyChanged provided by ViewModelBase
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -107,7 +107,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             ServiceListModel.ResolveService = (type, name) =>
                 Services.FirstOrDefault(s =>
                     s.Type == type &&
-                    s.DisplayName.Split(" - ").Last().Equals(name, StringComparison.OrdinalIgnoreCase));
+                    s.DisplayName.Equals(name, StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrWhiteSpace(servicesFilePath))
             {
                 ServicePersistence.FilePath = servicesFilePath!;
@@ -196,12 +196,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         internal string GenerateServiceName(ServiceType serviceType)
         {
-            var typeName = serviceType.ToLegacyString();
+            var typeName = serviceType.ToBaseName();
             int index = 1;
             foreach (var svc in Services.Where(s => s.Type == serviceType))
             {
-                var namePart = svc.DisplayName.Split(" - ").Last();
-                if (namePart.StartsWith(typeName) &&
+                var namePart = svc.DisplayName;
+                if (namePart.StartsWith(typeName, StringComparison.OrdinalIgnoreCase) &&
                     int.TryParse(namePart.Substring(typeName.Length), out int n) && n >= index)
                 {
                     index = n + 1;
@@ -288,6 +288,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 };
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);
+                var normalizedName = NormalizeDisplayName(svc.Type, svc.DisplayName);
+                if (Services.Any(existing => existing.DisplayName.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    normalizedName = GenerateServiceName(svc.Type);
+                }
+                svc.DisplayName = normalizedName;
                 svc.SetColorsByType();
                 svc.SetRuntimeState(svc.IsActive ? ServiceRuntimeState.Active : ServiceRuntimeState.Inactive);
                 svc.LogAdded += OnServiceLogAdded;
@@ -299,6 +305,38 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
             OnPropertyChanged(nameof(ServicesCreated));
             OnPropertyChanged(nameof(CurrentActiveServices));
+        }
+
+        private static string NormalizeDisplayName(ServiceType type, string displayName)
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                return type.ToBaseName();
+            }
+
+            var trimmed = displayName.Trim();
+            var separatorIndex = trimmed.LastIndexOf(" - ", StringComparison.Ordinal);
+            if (separatorIndex >= 0)
+            {
+                trimmed = trimmed[(separatorIndex + 3)..];
+            }
+
+            var legacyPrefix = type.ToLegacyString();
+            var baseName = type.ToBaseName();
+            if (!string.Equals(legacyPrefix, baseName, StringComparison.OrdinalIgnoreCase) &&
+                trimmed.StartsWith(legacyPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = baseName + trimmed[legacyPrefix.Length..];
+            }
+
+            var codePrefix = type.ToCode();
+            if (!string.Equals(codePrefix, baseName, StringComparison.OrdinalIgnoreCase) &&
+                trimmed.StartsWith(codePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = baseName + trimmed[codePrefix.Length..];
+            }
+
+            return trimmed;
         }
 
         private void ApplyFilters()

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -196,7 +196,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             if (service == null) throw new ArgumentNullException(nameof(service));
             _options = service.TcpOptions ?? new TcpServiceOptions();
             ServiceType = service.Type;
-            ServiceName = service.DisplayName.Split(" - ").Last();
+            ServiceName = service.DisplayName;
             Script = string.IsNullOrWhiteSpace(_options.Script)
                 ? ScriptEditorViewModel.DefaultScript
                 : _options.Script;

--- a/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/CreateServicePage.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels;
@@ -19,6 +20,8 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel = viewModel;
             DataContext = _viewModel;
         }
+
+        public void SetExistingNames(IEnumerable<string> names) => _viewModel.SetExistingNames(names);
 
         private void ServiceType_Click(object sender, RoutedEventArgs e)
         {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -6,6 +6,8 @@ using System.Collections.Specialized;
 using System.Linq;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.ViewModels.Tcp;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Models;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
@@ -29,6 +31,7 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly IServiceUiRegistry<ServiceListModel, Page> _serviceRegistry;
         private readonly IServiceProvider _serviceProvider;
         private readonly Dictionary<ServiceListModel, Action<LogEntry>> _serviceLogHandlers = new();
+        private readonly Dictionary<ServiceListModel, EventHandler> _tcpAdvancedHandlers = new();
         private readonly BrushConverter _brushConverter = new();
 
         public MainView(
@@ -122,6 +125,11 @@ namespace DesktopApplicationTemplate.UI.Views
                     AttachServiceLogger(svc, vm);
                 }
 
+                if (svc.ServicePage.DataContext is TcpServiceMessagesViewModel tcpVm)
+                {
+                    AttachTcpAdvancedHandler(svc, tcpVm);
+                }
+
                 if (svc.ServicePage.DataContext is INetworkAwareViewModel navm)
                 {
                     navm.UpdateNetworkConfiguration(_viewModel.NetworkConfig.CurrentConfiguration);
@@ -176,6 +184,18 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
+        private void AttachTcpAdvancedHandler(ServiceListModel svc, TcpServiceMessagesViewModel vm)
+        {
+            if (_tcpAdvancedHandlers.TryGetValue(svc, out var existing))
+            {
+                vm.AdvancedSettingsRequested -= existing;
+            }
+
+            EventHandler handler = (_, _) => OpenTcpAdvancedSettings(svc);
+            vm.AdvancedSettingsRequested += handler;
+            _tcpAdvancedHandlers[svc] = handler;
+        }
+
         private void DetachServiceLogger(ServiceListModel svc)
         {
             if (!_serviceLogHandlers.TryGetValue(svc, out var handler))
@@ -189,6 +209,28 @@ namespace DesktopApplicationTemplate.UI.Views
             }
 
             _serviceLogHandlers.Remove(svc);
+            DetachTcpAdvancedHandler(svc);
+        }
+
+        private void DetachTcpAdvancedHandler(ServiceListModel svc)
+        {
+            if (!_tcpAdvancedHandlers.TryGetValue(svc, out var handler))
+            {
+                return;
+            }
+
+            if (svc.ServicePage?.DataContext is TcpServiceMessagesViewModel vm)
+            {
+                vm.AdvancedSettingsRequested -= handler;
+            }
+
+            _tcpAdvancedHandlers.Remove(svc);
+        }
+
+        private void OpenTcpAdvancedSettings(ServiceListModel svc)
+        {
+            var handler = _serviceProvider.GetKeyedService<IEditServiceHandler>(ServiceType.Tcp);
+            handler?.Edit(svc);
         }
 
         private void Services_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -214,6 +256,10 @@ namespace DesktopApplicationTemplate.UI.Views
                 foreach (var svc in _serviceLogHandlers.Keys.ToList())
                 {
                     DetachServiceLogger(svc);
+                }
+                foreach (var svc in _tcpAdvancedHandlers.Keys.ToList())
+                {
+                    DetachTcpAdvancedHandler(svc);
                 }
             }
         }
@@ -244,11 +290,20 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             var page = _serviceProvider.GetRequiredService<CreateServicePage>();
             _createServicePage = page;
+            page.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
             page.ServiceCreated += (name, type) =>
             {
+                var trimmed = string.IsNullOrWhiteSpace(name)
+                    ? _viewModel.GenerateServiceName(type)
+                    : name.Trim();
+                if (_viewModel.Services.Any(s => s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
+                {
+                    trimmed = _viewModel.GenerateServiceName(type);
+                }
+
                 var svc = new ServiceListModel
                 {
-                    DisplayName = $"{type.ToLegacyString()} - {name}",
+                    DisplayName = trimmed,
                     Type = type,
                     IsActive = false
                 };
@@ -263,6 +318,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (svc.ServicePage != null)
                     ShowPage(svc.ServicePage);
                 _ = _viewModel.SaveServicesAsync();
+                page.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
             };
             page.ServiceTypeSelected += NavigateTo;
             page.Cancelled += ShowHome;
@@ -273,7 +329,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void NavigateTo(ServiceType serviceType)
         {
-            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType.ToLegacyString();
+            var defaultName = _createServicePage?.GenerateDefaultName(serviceType) ?? serviceType.ToBaseName();
             if (_serviceRegistry.TryCreateNavigationPage(serviceType, _serviceProvider, defaultName, out var view) &&
                 view is not null)
             {
@@ -289,12 +345,29 @@ namespace DesktopApplicationTemplate.UI.Views
 
 
 
-        internal async Task AddServiceAsync(ServiceType type, object options)
+        internal async Task<bool> TryAddServiceAsync<TOptions>(ServiceType type, ServiceFactoryOptions<TOptions> context)
         {
-            if (!_serviceRegistry.TryCreateService(type, _serviceProvider, options, out var svc) || svc is null)
+            var sanitizedName = string.IsNullOrWhiteSpace(context.Name)
+                ? _viewModel.GenerateServiceName(type)
+                : context.Name.Trim();
+
+            if (_viewModel.Services.Any(s => s.DisplayName.Equals(sanitizedName, StringComparison.OrdinalIgnoreCase)))
             {
-                return;
+                MessageBox.Show(this,
+                    $"A service named '{sanitizedName}' already exists.",
+                    "Duplicate Service Name",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
+                return false;
             }
+
+            var normalizedContext = context with { Name = sanitizedName };
+
+            if (!_serviceRegistry.TryCreateService(type, _serviceProvider, normalizedContext, out var svc) || svc is null)
+            {
+                return false;
+            }
+
             svc.SetColorsByType();
             svc.LogAdded += _viewModel.OnServiceLogAdded;
             svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
@@ -306,9 +379,14 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.SelectedService = svc;
             ServiceList.ScrollIntoView(svc);
             if (svc.ServicePage != null)
+            {
                 ShowPage(svc.ServicePage);
+            }
+
             await _viewModel.SaveServicesAsync();
+            _createServicePage?.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
             _logger?.LogDebug("AddService workflow completed");
+            return true;
         }
 
 
@@ -371,6 +449,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     _viewModel.SelectedService = null;
                 }
                 await _viewModel.SaveServicesAsync();
+                _createServicePage?.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
             }
         }
 
@@ -388,13 +467,14 @@ namespace DesktopApplicationTemplate.UI.Views
                 string input = Microsoft.VisualBasic.Interaction.InputBox("Enter new service name:", "Rename Service", svc.DisplayName);
                 if (!string.IsNullOrWhiteSpace(input))
                 {
-                    var namePart = input.Contains(" - ") ? input.Split(" - ").Last() : input;
-                    if (_viewModel.Services.Any(s => s != svc && s.DisplayName.Split(" - ").Last().Equals(namePart, StringComparison.OrdinalIgnoreCase)))
+                    var trimmed = input.Trim();
+                    if (_viewModel.Services.Any(s => s != svc && s.DisplayName.Equals(trimmed, StringComparison.OrdinalIgnoreCase)))
                     {
-                        namePart = _viewModel.GenerateServiceName(svc.Type);
+                        trimmed = _viewModel.GenerateServiceName(svc.Type);
                     }
-                    svc.DisplayName = $"{svc.Type.ToLegacyString()} - {namePart}";
+                    svc.DisplayName = trimmed;
                     await _viewModel.SaveServicesAsync();
+                    _createServicePage?.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- wire the TCP advanced settings button to reuse the keyed edit handler and refresh create-page name tracking
- standardize service naming to sequential base names and prevent duplicates across create, edit, and rename workflows
- switch CSV creator outputs to timestamp-based file names that reopen existing files when present

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68e3e080976c83268024986fe30675f1