### PR TITLE
Refine startup behavior and service logging

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/ICsvOutput.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/ICsvOutput.cs
@@ -31,4 +31,10 @@ public interface ICsvOutput
     /// </summary>
     /// <param name="filePath">The destination file path.</param>
     void EnsureDirectoryForFile(string filePath);
+
+    /// <summary>
+    /// Deletes the specified file if it exists.
+    /// </summary>
+    /// <param name="filePath">The file path to delete.</param>
+    void DeleteFile(string filePath);
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -175,6 +175,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<IFileDialogService, FileDialogService>();
             services.AddSingleton<IScpClientFactory, ScpClientFactory>();
             services.AddSingleton<IScpUploadService, ScpService>();
+            services.AddSingleton<IStartupPreferencesService, StartupPreferencesDialogService>();
             // Register shared services and protocol facades from the Services layer.
             services.AddCommonServices();
             services.AddSingleton<SaveConfirmationHelper>();

--- a/DesktopApplicationTemplate.UI/Models/UserSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/UserSettings.cs
@@ -6,14 +6,8 @@ namespace DesktopApplicationTemplate.Models
         public bool AutoCheckUpdates { get; set; }
         public bool RunUIOnStartup { get; set; }
         public bool RunServicesOnStartup { get; set; }
-        public bool LogTcpMessages { get; set; } = true;
         public bool FirstRun { get; set; } = true;
         public bool SuppressSaveConfirmation { get; set; }
         public bool SuppressCloseConfirmation { get; set; }
-
-        /// <summary>
-        /// Preferred service category for new operations.
-        /// </summary>
-        public ServiceType PreferredServiceType { get; set; } = ServiceType.Tcp;
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/CsvServiceAdapter.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvServiceAdapter.cs
@@ -5,6 +5,8 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.UI.ViewModels.Csv;
 
+using ProtocolCsvService = DesktopApplicationTemplate.Core.Services.Protocols.Csv.ICsvService;
+
 namespace DesktopApplicationTemplate.UI.Services;
 
 /// <summary>
@@ -13,12 +15,12 @@ namespace DesktopApplicationTemplate.UI.Services;
 public class CsvServiceAdapter
 {
     private readonly CsvViewerViewModel _viewModel;
-    private readonly ICsvService _csvService;
+    private readonly ProtocolCsvService _csvService;
     private readonly ICsvOutput _output;
     private readonly CsvServiceState _state = new();
     private readonly ILoggingService? _logger;
 
-    public CsvServiceAdapter(CsvViewerViewModel viewModel, ICsvService csvService, ICsvOutput output, ILoggingService? logger = null)
+    public CsvServiceAdapter(CsvViewerViewModel viewModel, ProtocolCsvService csvService, ICsvOutput output, ILoggingService? logger = null)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _csvService = csvService ?? throw new ArgumentNullException(nameof(csvService));

--- a/DesktopApplicationTemplate.UI/Services/CsvServiceAdapter.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvServiceAdapter.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.UI.ViewModels.Csv;
 
@@ -14,12 +16,14 @@ public class CsvServiceAdapter
     private readonly ICsvService _csvService;
     private readonly ICsvOutput _output;
     private readonly CsvServiceState _state = new();
+    private readonly ILoggingService? _logger;
 
-    public CsvServiceAdapter(CsvViewerViewModel viewModel, ICsvService csvService, ICsvOutput output)
+    public CsvServiceAdapter(CsvViewerViewModel viewModel, ICsvService csvService, ICsvOutput output, ILoggingService? logger = null)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _csvService = csvService ?? throw new ArgumentNullException(nameof(csvService));
         _output = output ?? throw new ArgumentNullException(nameof(output));
+        _logger = logger;
     }
 
     public void EnsureColumnsForService(string serviceName)
@@ -32,15 +36,47 @@ public class CsvServiceAdapter
 
     public void RemoveColumnsForService(string serviceName)
     {
+        var existingPath = GetCurrentFilePath();
         if (_csvService.RemoveColumnsForService(Configuration, _state, serviceName))
         {
             _viewModel.Save();
+            if (!string.IsNullOrWhiteSpace(existingPath))
+            {
+                _output.DeleteFile(existingPath);
+                if (_output.FileExists(existingPath))
+                {
+                    _logger?.Log($"CSV service attempted to delete file '{existingPath}' for '{serviceName}', but it still exists.", LogLevel.Warning);
+                }
+                else
+                {
+                    _logger?.Log($"CSV service deleted file '{existingPath}' for '{serviceName}'.", LogLevel.Information);
+                }
+            }
         }
     }
 
     public void RecordLog(string serviceName, string message)
     {
+        var previousPath = GetCurrentFilePath();
+        var fileExisted = !string.IsNullOrWhiteSpace(previousPath) && _output.FileExists(previousPath);
+
         _csvService.RecordLog(Configuration, _state, _output, serviceName, message);
+
+        var currentPath = GetCurrentFilePath();
+        if (string.IsNullOrWhiteSpace(currentPath))
+        {
+            return;
+        }
+
+        if (!fileExisted && _output.FileExists(currentPath))
+        {
+            _logger?.Log($"CSV service created file '{currentPath}' for '{serviceName}'.", LogLevel.Information);
+        }
+
+        if (_output.FileExists(currentPath))
+        {
+            _logger?.Log($"CSV service updated file '{currentPath}' with entry from '{serviceName}'.", LogLevel.Information);
+        }
     }
 
     public void AppendRow(IEnumerable<string?> values)
@@ -49,4 +85,15 @@ public class CsvServiceAdapter
     }
 
     private CsvConfiguration Configuration => _viewModel.Configuration;
+
+    private string? GetCurrentFilePath()
+    {
+        if (string.IsNullOrWhiteSpace(_state.CurrentFileName))
+        {
+            return null;
+        }
+
+        var directory = Configuration.OutputDirectory ?? string.Empty;
+        return Path.Combine(directory, _state.CurrentFileName);
+    }
 }

--- a/DesktopApplicationTemplate.UI/Services/FileCsvOutput.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileCsvOutput.cs
@@ -42,4 +42,27 @@ public class FileCsvOutput : ICsvOutput
             Directory.CreateDirectory(directory);
         }
     }
+
+    /// <inheritdoc />
+    public void DeleteFile(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
+        if (!FileExists(filePath))
+        {
+            return;
+        }
+
+        try
+        {
+            File.Delete(filePath);
+        }
+        catch (IOException)
+        {
+            // Ignore deletion errors; callers log failures if needed.
+        }
+    }
 }

--- a/DesktopApplicationTemplate.UI/Services/StartupPreferencesDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/StartupPreferencesDialogService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Windows;
+using DesktopApplicationTemplate.UI.ViewModels;
+using DesktopApplicationTemplate.UI.Views;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    public interface IStartupPreferencesService
+    {
+        StartupPreferencesResult ShowDialog(bool runServicesOnStartup, bool runUiOnStartup);
+    }
+
+    public readonly record struct StartupPreferencesResult(bool Accepted, bool RunServicesOnStartup, bool RunUIOnStartup);
+
+    /// <summary>
+    /// Displays a dialog allowing the user to confirm startup behavior for services and UI.
+    /// </summary>
+    public sealed class StartupPreferencesDialogService : IStartupPreferencesService
+    {
+        public StartupPreferencesResult ShowDialog(bool runServicesOnStartup, bool runUiOnStartup)
+        {
+            var viewModel = new StartupPreferencesViewModel(runServicesOnStartup, runUiOnStartup);
+            var window = new StartupPreferencesWindow(viewModel)
+            {
+                Owner = GetActiveWindow()
+            };
+
+            var accepted = window.ShowDialog() == true;
+            return new StartupPreferencesResult(accepted, viewModel.RunServicesOnStartup, viewModel.RunUIOnStartup);
+        }
+
+        private static Window? GetActiveWindow()
+        {
+            if (Application.Current is null)
+            {
+                return null;
+            }
+
+            return Application.Current.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive) ?? Application.Current.MainWindow;
+        }
+    }
+}
+

--- a/DesktopApplicationTemplate.UI/Services/UserSettingsStorage.cs
+++ b/DesktopApplicationTemplate.UI/Services/UserSettingsStorage.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Services
+{
+    /// <summary>
+    /// Provides centralized serialization for user settings so multiple UI components
+    /// can load and persist preferences without duplicating file handling logic.
+    /// </summary>
+    internal static class UserSettingsStorage
+    {
+        internal static string FilePath { get; } =
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
+
+        /// <summary>
+        /// Loads settings from disk, returning a default instance when the file is missing
+        /// or cannot be read.
+        /// </summary>
+        internal static UserSettings Load(ILoggingService? logger)
+        {
+            if (!File.Exists(FilePath))
+            {
+                return new UserSettings();
+            }
+
+            try
+            {
+                var json = File.ReadAllText(FilePath);
+                return JsonSerializer.Deserialize<UserSettings>(json) ?? new UserSettings();
+            }
+            catch (IOException ex)
+            {
+                logger?.Log($"Failed to load settings from '{FilePath}'. Using default settings. Error: {ex}", LogLevel.Error);
+                return new UserSettings();
+            }
+        }
+
+        /// <summary>
+        /// Saves the provided settings to disk.
+        /// </summary>
+        internal static void Save(UserSettings settings, ILoggingService? logger)
+        {
+            if (settings is null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                ReferenceHandler = ReferenceHandler.IgnoreCycles,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            try
+            {
+                File.WriteAllText(FilePath, JsonSerializer.Serialize(settings, options));
+            }
+            catch (StackOverflowException)
+            {
+                var dumpOptions = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    ReferenceHandler = ReferenceHandler.Preserve
+                };
+                var dump = JsonSerializer.Serialize(settings, dumpOptions);
+                var temp = Path.Combine(Path.GetTempPath(), "settings_dump.json");
+                File.WriteAllText(temp, dump);
+                Environment.FailFast($"Stack overflow while saving settings. Dump written to {temp}");
+            }
+        }
+    }
+}
+

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -90,18 +90,27 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly ILoggingService? _logger;
         private readonly INetworkConfigurationService _networkService;
         private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
+        private readonly IStartupPreferencesService _startupPreferencesService;
         private readonly HashSet<ServiceListModel> _activatingServices = new();
         private static readonly TimeSpan ActivationConfirmationDelay = TimeSpan.FromMilliseconds(500);
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
-        public MainViewModel(CsvServiceAdapter csvService, NetworkConfigurationViewModel networkConfig, INetworkConfigurationService networkService, IDictionary<ServiceType, IEditServiceHandler> editHandlers, ILoggingService? logger = null, string? servicesFilePath = null)
+        public MainViewModel(
+            CsvServiceAdapter csvService,
+            NetworkConfigurationViewModel networkConfig,
+            INetworkConfigurationService networkService,
+            IDictionary<ServiceType, IEditServiceHandler> editHandlers,
+            IStartupPreferencesService startupPreferencesService,
+            ILoggingService? logger = null,
+            string? servicesFilePath = null)
         {
             _csvService = csvService;
             _networkService = networkService;
             _logger = logger;
             NetworkConfig = networkConfig;
             _editHandlers = editHandlers;
+            _startupPreferencesService = startupPreferencesService ?? throw new ArgumentNullException(nameof(startupPreferencesService));
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceListModel.ResolveService = (type, name) =>
@@ -387,6 +396,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     {
                         _logger?.Log("No services configured to start.", LogLevel.Warning);
                         return;
+                    }
+
+                    var currentSettings = UserSettingsStorage.Load(_logger);
+                    var preferenceResult = _startupPreferencesService.ShowDialog(currentSettings.RunServicesOnStartup, currentSettings.RunUIOnStartup);
+                    if (!preferenceResult.Accepted)
+                    {
+                        _logger?.Log("Start services cancelled from startup preferences dialog", LogLevel.Information);
+                        return;
+                    }
+
+                    if (preferenceResult.RunServicesOnStartup != currentSettings.RunServicesOnStartup ||
+                        preferenceResult.RunUIOnStartup != currentSettings.RunUIOnStartup)
+                    {
+                        currentSettings.RunServicesOnStartup = preferenceResult.RunServicesOnStartup;
+                        currentSettings.RunUIOnStartup = preferenceResult.RunUIOnStartup;
+                        UserSettingsStorage.Save(currentSettings, _logger);
                     }
 
                     ServicesRunning = true;

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -54,6 +54,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private int _executionCount;
         private TimeSpan _lastExecutionDuration;
         private string _lastInputMessage = string.Empty;
+        private int _incomingMessageCount;
+        private int _outgoingMessageCount;
 
         /// <summary>
         /// Gets the average execution time in milliseconds for operations performed by this service.
@@ -80,6 +82,36 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public string ExecutionTimeText => _executionCount == 0
             ? string.Empty
             : $"Last: {LastExecutionDuration.TotalMilliseconds:F0} ms (Avg: {AverageExecutionTimeMs:F0} ms)";
+
+        public int IncomingMessageCount
+        {
+            get => _incomingMessageCount;
+            private set
+            {
+                if (_incomingMessageCount == value)
+                {
+                    return;
+                }
+
+                _incomingMessageCount = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int OutgoingMessageCount
+        {
+            get => _outgoingMessageCount;
+            private set
+            {
+                if (_outgoingMessageCount == value)
+                {
+                    return;
+                }
+
+                _outgoingMessageCount = value;
+                OnPropertyChanged();
+            }
+        }
 
         /// <summary>
         /// Gets the last input message received by this service.
@@ -224,6 +256,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             LogAdded?.Invoke(this, entry);
             if (checkReference)
             {
+                UpdateMessageCounters(message);
+            }
+            if (checkReference)
+            {
                 HandleReference(message, color ?? WpfBrushes.Black, level);
             }
         }
@@ -265,6 +301,37 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     }
                 }
             }
+        }
+
+        private void UpdateMessageCounters(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            if (ContainsKeyword(message, "incoming", "received"))
+            {
+                IncomingMessageCount++;
+            }
+
+            if (ContainsKeyword(message, "outgoing", "sent", "sending"))
+            {
+                OutgoingMessageCount++;
+            }
+        }
+
+        private static bool ContainsKeyword(string message, params string[] keywords)
+        {
+            foreach (var keyword in keywords)
+            {
+                if (message.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public void SetColorsByType()

--- a/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/SettingsViewModel.cs
@@ -1,29 +1,23 @@
 using System;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.IO;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Services;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public class SettingsViewModel : ViewModelBase
     {
-        internal static string FilePath { get; set; } =
-            Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "userSettings.json");
+        internal static string FilePath => UserSettingsStorage.FilePath;
         private readonly ILoggingService? _logger;
         private bool _darkTheme;
         private bool _autoCheckUpdates;
         private bool _runUIOnStartup;
         private bool _runServicesOnStartup;
-        private bool _logTcpMessages = true;
         private bool _firstRun = true;
-        private ServiceType _preferredServiceType = ServiceType.Tcp;
         private static bool _suppressSaveConfirmation;
         private static bool _suppressCloseConfirmation;
         private bool _dirty;
 
-        public static bool TcpLoggingEnabled { get; private set; } = true;
         public static bool SaveConfirmationSuppressed
         {
             get => _suppressSaveConfirmation;
@@ -40,10 +34,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public bool AutoCheckUpdates { get => _autoCheckUpdates; set { _autoCheckUpdates = value; _dirty = true; OnPropertyChanged(); } }
         public bool RunUIOnStartup { get => _runUIOnStartup; set { _runUIOnStartup = value; _dirty = true; OnPropertyChanged(); } }
         public bool RunServicesOnStartup { get => _runServicesOnStartup; set { _runServicesOnStartup = value; _dirty = true; OnPropertyChanged(); } }
-        public bool LogTcpMessages { get => _logTcpMessages; set { _logTcpMessages = value; _dirty = true; OnPropertyChanged(); } }
         public bool FirstRun { get => _firstRun; set { _firstRun = value; _dirty = true; OnPropertyChanged(); } }
-        public ServiceType PreferredServiceType { get => _preferredServiceType; set { _preferredServiceType = value; _dirty = true; OnPropertyChanged(); } }
-        public ServiceType[] ServiceTypes { get; } = Enum.GetValues<ServiceType>();
         public bool HasUnsavedChanges => _dirty;
 
         public SettingsViewModel()
@@ -58,37 +49,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void Load()
         {
-            if (!File.Exists(FilePath))
-            {
-                return;
-            }
-
-            UserSettings? userSettings = null;
-
-            try
-            {
-                var json = File.ReadAllText(FilePath);
-                userSettings = JsonSerializer.Deserialize<UserSettings>(json);
-            }
-            catch (IOException ex)
-            {
-                _logger?.Log($"Failed to load settings from '{FilePath}'. Using default settings. Error: {ex}", LogLevel.Error);
-                return;
-            }
-
-            if (userSettings == null)
-            {
-                return;
-            }
+            var userSettings = UserSettingsStorage.Load(_logger);
 
             _darkTheme = userSettings.DarkTheme;
             _autoCheckUpdates = userSettings.AutoCheckUpdates;
             _runUIOnStartup = userSettings.RunUIOnStartup;
             _runServicesOnStartup = userSettings.RunServicesOnStartup;
-            _logTcpMessages = userSettings.LogTcpMessages;
             _firstRun = userSettings.FirstRun;
-            _preferredServiceType = userSettings.PreferredServiceType;
-            TcpLoggingEnabled = userSettings.LogTcpMessages;
             SaveConfirmationSuppressed = userSettings.SuppressSaveConfirmation;
             CloseConfirmationSuppressed = userSettings.SuppressCloseConfirmation;
         }
@@ -101,37 +68,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 AutoCheckUpdates = _autoCheckUpdates,
                 RunUIOnStartup = _runUIOnStartup,
                 RunServicesOnStartup = _runServicesOnStartup,
-                LogTcpMessages = _logTcpMessages,
                 FirstRun = _firstRun,
-                PreferredServiceType = _preferredServiceType,
                 SuppressSaveConfirmation = SaveConfirmationSuppressed,
                 SuppressCloseConfirmation = CloseConfirmationSuppressed
             };
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                ReferenceHandler = ReferenceHandler.IgnoreCycles,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            };
-
-            try
-            {
-                File.WriteAllText(FilePath, JsonSerializer.Serialize(data, options));
-                TcpLoggingEnabled = _logTcpMessages;
-                _dirty = false;
-            }
-            catch (StackOverflowException)
-            {
-                var dumpOptions = new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    ReferenceHandler = ReferenceHandler.Preserve
-                };
-                var dump = JsonSerializer.Serialize(data, dumpOptions);
-                var temp = Path.Combine(Path.GetTempPath(), "settings_dump.json");
-                File.WriteAllText(temp, dump);
-                Environment.FailFast($"Stack overflow while saving settings. Dump written to {temp}");
-            }
+            UserSettingsStorage.Save(data, _logger);
+            _dirty = false;
         }
 
         // OnPropertyChanged provided by ViewModelBase

--- a/DesktopApplicationTemplate.UI/ViewModels/StartupPreferencesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/StartupPreferencesViewModel.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Helpers;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public class StartupPreferencesViewModel : ViewModelBase
+    {
+        private bool _runServicesOnStartup;
+        private bool _runUiOnStartup;
+
+        public StartupPreferencesViewModel(bool runServicesOnStartup, bool runUiOnStartup)
+        {
+            _runServicesOnStartup = runServicesOnStartup;
+            _runUiOnStartup = runUiOnStartup;
+            ConfirmCommand = new RelayCommand(() => RequestClose?.Invoke(this, true));
+            CancelCommand = new RelayCommand(() => RequestClose?.Invoke(this, false));
+        }
+
+        public bool RunServicesOnStartup
+        {
+            get => _runServicesOnStartup;
+            set
+            {
+                if (_runServicesOnStartup == value)
+                {
+                    return;
+                }
+
+                _runServicesOnStartup = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool RunUIOnStartup
+        {
+            get => _runUiOnStartup;
+            set
+            {
+                if (_runUiOnStartup == value)
+                {
+                    return;
+                }
+
+                _runUiOnStartup = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ICommand ConfirmCommand { get; }
+
+        public ICommand CancelCommand { get; }
+
+        public event EventHandler<bool>? RequestClose;
+    }
+}
+

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -190,6 +190,14 @@
                                                 <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
                                                 <TextBlock Text="{Binding ExecutionTimeText}" />
                                                 <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock>
+                                                    <Run Text="{Binding IncomingMessageCount}"/>
+                                                    <Run Text=" - incoming"/>
+                                                </TextBlock>
+                                                <TextBlock>
+                                                    <Run Text="{Binding OutgoingMessageCount}"/>
+                                                    <Run Text=" - outgoing"/>
+                                                </TextBlock>
                                             </StackPanel>
                                         </Grid>
                                     </Border>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -191,11 +191,11 @@
                                                 <TextBlock Text="{Binding ExecutionTimeText}" />
                                                 <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" />
                                                 <TextBlock>
-                                                    <Run Text="{Binding IncomingMessageCount}"/>
+                                                    <Run Text="{Binding IncomingMessageCount, Mode=OneWay}"/>
                                                     <Run Text=" - incoming"/>
                                                 </TextBlock>
                                                 <TextBlock>
-                                                    <Run Text="{Binding OutgoingMessageCount}"/>
+                                                    <Run Text="{Binding OutgoingMessageCount, Mode=OneWay}"/>
                                                     <Run Text=" - outgoing"/>
                                                 </TextBlock>
                                             </StackPanel>

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
@@ -49,7 +49,7 @@ public partial class ScriptEditorWindow : Window
     {
         ClearErrorHighlights();
 
-        foreach (var diag in diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && !diag.Location.IsInMetadata))
+        foreach (var diag in diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && !d.Location.IsInMetadata))
         {
             var span = diag.Location.GetLineSpan();
             try

--- a/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/ScriptEditorWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
 using ICSharpCode.AvalonEdit.Document;
@@ -13,6 +14,7 @@ public partial class ScriptEditorWindow : Window
 {
     public string ScriptText { get; private set; } = string.Empty;
     public string LastTestMessage { get; private set; } = string.Empty;
+    private readonly List<DocumentColorizingTransformer> _errorTransformers = new();
 
     public ScriptEditorWindow()
     {
@@ -45,34 +47,75 @@ public partial class ScriptEditorWindow : Window
 
     private void HighlightErrors(IEnumerable<Diagnostic> diagnostics)
     {
-        Editor.TextArea.TextView.LineTransformers.Clear();
+        ClearErrorHighlights();
 
-        foreach (var diag in diagnostics)
+        foreach (var diag in diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error && !diag.Location.IsInMetadata))
         {
             var span = diag.Location.GetLineSpan();
-            var lineNumber = span.StartLinePosition.Line + 1;
-            Editor.TextArea.TextView.LineTransformers.Add(new LineHighlightTransformer(lineNumber, Colors.MistyRose));
+            try
+            {
+                var startOffset = Editor.Document.GetOffset(span.StartLinePosition.Line + 1, span.StartLinePosition.Character + 1);
+                var endOffset = Editor.Document.GetOffset(span.EndLinePosition.Line + 1, span.EndLinePosition.Character + 1);
+                var transformer = new ErrorUnderlineTransformer(startOffset, endOffset);
+                _errorTransformers.Add(transformer);
+                Editor.TextArea.TextView.LineTransformers.Add(transformer);
+            }
+            catch
+            {
+                // Ignore malformed spans.
+            }
         }
+
+        Editor.TextArea.TextView.Redraw();
     }
 
-    private sealed class LineHighlightTransformer : DocumentColorizingTransformer
+    private void ClearErrorHighlights()
     {
-        private readonly int _lineNumber;
-        private readonly SolidColorBrush _brush;
-
-        public LineHighlightTransformer(int lineNumber, Color color)
+        foreach (var transformer in _errorTransformers)
         {
-            _lineNumber = lineNumber;
-            _brush = new SolidColorBrush(color);
+            Editor.TextArea.TextView.LineTransformers.Remove(transformer);
+        }
+        _errorTransformers.Clear();
+    }
+
+    private sealed class ErrorUnderlineTransformer : DocumentColorizingTransformer
+    {
+        private readonly int _startOffset;
+        private readonly int _endOffset;
+
+        public ErrorUnderlineTransformer(int startOffset, int endOffset)
+        {
+            _startOffset = Math.Max(startOffset, 0);
+            _endOffset = Math.Max(endOffset, _startOffset);
         }
 
         protected override void ColorizeLine(DocumentLine line)
         {
-            if (line.LineNumber == _lineNumber)
+            var lineStart = Math.Max(line.Offset, _startOffset);
+            var lineEnd = Math.Min(line.EndOffset, _endOffset);
+            if (lineStart >= lineEnd)
             {
-                ChangeLinePart(line.Offset, line.EndOffset,
-                    element => element.TextRunProperties.SetBackgroundBrush(_brush));
+                return;
             }
+
+            ChangeLinePart(lineStart, lineEnd, element =>
+            {
+                var decorations = element.TextRunProperties.TextDecorations;
+                if (decorations is null || decorations.IsFrozen)
+                {
+                    decorations = decorations != null ? decorations.Clone() : new TextDecorationCollection();
+                }
+
+                var underline = new TextDecoration
+                {
+                    Location = TextDecorationLocation.Underline,
+                    Pen = new Pen(Brushes.Red, 1),
+                    PenThicknessUnit = TextDecorationUnit.FontRecommended
+                };
+
+                decorations.Add(underline);
+                element.TextRunProperties.SetTextDecorations(decorations);
+            });
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
+++ b/DesktopApplicationTemplate.UI/Views/SettingsPage.xaml
@@ -14,13 +14,6 @@
         <StackPanel Grid.Row="1" Margin="0,20,0,0">
             <CheckBox Content="Dark Theme" IsChecked="{Binding DarkTheme}"/>
             <CheckBox Content="Check for updates automatically" IsChecked="{Binding AutoCheckUpdates}"/>
-            <CheckBox Content="Run Application UI on startup" IsChecked="{Binding RunUIOnStartup}"/>
-            <CheckBox Content="Run background services on startup" IsChecked="{Binding RunServicesOnStartup}"/>
-            <CheckBox Content="Log TCP messages" IsChecked="{Binding LogTcpMessages}"/>
-            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                <TextBlock Text="Preferred Service:" Margin="0,0,5,0"/>
-                <ComboBox ItemsSource="{Binding ServiceTypes}" SelectedItem="{Binding PreferredServiceType}" Width="150"/>
-            </StackPanel>
             <Border Background="WhiteSmoke" CornerRadius="8" Padding="10" Margin="0,10,0,10">
                 <Grid x:Name="NetworkConfigGrid">
                     <Grid.RowDefinitions>

--- a/DesktopApplicationTemplate.UI/Views/StartupPreferencesWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/StartupPreferencesWindow.xaml
@@ -1,0 +1,40 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.StartupPreferencesWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Startup Preferences"
+        Height="200"
+        Width="360"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="Choose how the application should behave after startup."
+                   Margin="0,0,0,12"
+                   TextWrapping="Wrap"/>
+
+        <StackPanel Grid.Row="1" Margin="0,0,0,12">
+            <CheckBox Content="Run background services at startup"
+                      IsChecked="{Binding RunServicesOnStartup}"/>
+            <CheckBox Content="Run application UI at startup"
+                      Margin="0,8,0,0"
+                      IsChecked="{Binding RunUIOnStartup}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Cancel"
+                    Width="80"
+                    Margin="0,0,10,0"
+                    Command="{Binding CancelCommand}"/>
+            <Button Content="Continue"
+                    Width="100"
+                    Command="{Binding ConfirmCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>
+

--- a/DesktopApplicationTemplate.UI/Views/StartupPreferencesWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/StartupPreferencesWindow.xaml.cs
@@ -1,0 +1,23 @@
+using System.Windows;
+using DesktopApplicationTemplate.UI.ViewModels;
+
+namespace DesktopApplicationTemplate.UI.Views
+{
+    public partial class StartupPreferencesWindow : Window
+    {
+        public StartupPreferencesWindow(StartupPreferencesViewModel viewModel)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+            viewModel.RequestClose += OnRequestClose;
+            Closed += (_, _) => viewModel.RequestClose -= OnRequestClose;
+        }
+
+        private void OnRequestClose(object? sender, bool accepted)
+        {
+            DialogResult = accepted;
+            Close();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace startup configuration checkboxes with a modal prompt that appears when services start, persisting selections via shared settings storage
- always log service activity, track per-service message counts, and constrain CSV logging to file creation, updates, and deletions
- keep script editor formatting intact on Run and underline compilation errors while preserving syntax highlighting

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fefce86c8326ab0079ccff0c9e00