### PR TITLE
Improve TCP logging, persistence, and connection roles

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/NetworkUtilities.cs
+++ b/DesktopApplicationTemplate.Core/Services/NetworkUtilities.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Net;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 
 namespace DesktopApplicationTemplate.Core.Services
 {
@@ -17,6 +18,28 @@ namespace DesktopApplicationTemplate.Core.Services
                 count += Convert.ToString(b, 2).Count(c => c == '1');
             }
             return count;
+        }
+
+        public static string GetLocalIpAddress()
+        {
+            try
+            {
+                var addresses = Dns.GetHostAddresses(Dns.GetHostName())
+                    .Where(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a))
+                    .Select(a => a.ToString())
+                    .ToList();
+
+                if (addresses.Count > 0)
+                {
+                    return addresses[0];
+                }
+            }
+            catch
+            {
+                // ignore lookup failures and fall back to loopback
+            }
+
+            return IPAddress.Loopback.ToString();
         }
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/NetworkUtilities.cs
+++ b/DesktopApplicationTemplate.Core/Services/NetworkUtilities.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using DesktopApplicationTemplate.Core.Models;
 
 namespace DesktopApplicationTemplate.Core.Services
 {
@@ -40,6 +43,67 @@ namespace DesktopApplicationTemplate.Core.Services
             }
 
             return IPAddress.Loopback.ToString();
+        }
+
+        public static NetworkConfiguration GetLocalNetworkConfiguration()
+        {
+            var configuration = new NetworkConfiguration
+            {
+                IpAddress = GetLocalIpAddress()
+            };
+
+            try
+            {
+                foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    if (networkInterface.OperationalStatus != OperationalStatus.Up ||
+                        networkInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    {
+                        continue;
+                    }
+
+                    var properties = networkInterface.GetIPProperties();
+                    var unicast = properties.UnicastAddresses
+                        .FirstOrDefault(a => a.Address.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a.Address));
+
+                    if (unicast is null)
+                    {
+                        continue;
+                    }
+
+                    configuration = new NetworkConfiguration
+                    {
+                        IpAddress = unicast.Address.ToString(),
+                        SubnetMask = unicast.IPv4Mask?.ToString() ?? string.Empty,
+                        Gateway = properties.GatewayAddresses.FirstOrDefault()?.Address.ToString() ?? string.Empty,
+                        DnsPrimary = GetDnsAddress(properties.DnsAddresses, 0),
+                        DnsSecondary = GetDnsAddress(properties.DnsAddresses, 1)
+                    };
+
+                    break;
+                }
+            }
+            catch
+            {
+                // ignore failures and return whatever was discovered so far
+            }
+
+            return configuration;
+        }
+
+        private static string GetDnsAddress(IEnumerable<IPAddress> addresses, int index)
+        {
+            if (addresses is null)
+            {
+                return string.Empty;
+            }
+
+            var ipv4Addresses = addresses
+                .Where(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a))
+                .Select(a => a.ToString())
+                .ToList();
+
+            return index >= 0 && index < ipv4Addresses.Count ? ipv4Addresses[index] : string.Empty;
         }
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
@@ -42,6 +42,21 @@ public class TcpServiceOptions
     public bool UseUdp { get; set; }
 
     /// <summary>
+    /// Subnet mask associated with the connection.
+    /// </summary>
+    public string SubnetMask { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Primary DNS server used for resolving host names.
+    /// </summary>
+    public string PrimaryDns { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Alternate DNS server used for resolving host names.
+    /// </summary>
+    public string AlternateDns { get; set; } = string.Empty;
+
+    /// <summary>
     /// Operating mode for the service.
     /// </summary>
     public TcpServiceMode Mode { get; set; } = TcpServiceMode.Listening;

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
@@ -13,6 +13,15 @@ public enum TcpServiceMode
 }
 
 /// <summary>
+/// Indicates whether the TCP service should behave as a client or server.
+/// </summary>
+public enum TcpConnectionRole
+{
+    Server,
+    Client
+}
+
+/// <summary>
 /// Configuration options for creating a TCP service.
 /// </summary>
 public class TcpServiceOptions
@@ -36,6 +45,11 @@ public class TcpServiceOptions
     /// Operating mode for the service.
     /// </summary>
     public TcpServiceMode Mode { get; set; } = TcpServiceMode.Listening;
+
+    /// <summary>
+    /// Role of the TCP connection (client or server).
+    /// </summary>
+    public TcpConnectionRole ConnectionRole { get; set; } = TcpConnectionRole.Server;
 
     /// <summary>
     /// Sample message used for testing script transformations.

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -820,18 +820,15 @@ namespace DesktopApplicationTemplate.UI
             }
 
             KeyboardSimulator.Reset();
-            if (UiThreadTaskFactory is not null)
+            if (UiThreadTaskFactory is null)
             {
-                await UiThreadTaskFactory.SwitchToMainThreadAsync();
-                Current?.Shutdown();
+                logger?.LogWarning("Joinable task factory unavailable during domain exception; scheduling shutdown on dispatcher");
+                _ = Current?.Dispatcher?.BeginInvoke(new Action(() => Current?.Shutdown()));
                 return;
             }
 
-            var app = Current;
-            if (app is not null)
-            {
-                await app.Dispatcher.InvokeAsync(app.Shutdown);
-            }
+            await UiThreadTaskFactory.SwitchToMainThreadAsync();
+            Current?.Shutdown();
         }
 
         protected override void OnStartup(StartupEventArgs e)

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -830,13 +830,20 @@ namespace DesktopApplicationTemplate.UI
             var app = Current;
             if (app is not null)
             {
-                await app.Dispatcher.InvokeAsync(static application => application.Shutdown(), app);
+                await app.Dispatcher.InvokeAsync(app.Shutdown);
             }
         }
 
-        protected override async void OnStartup(StartupEventArgs e)
+        protected override void OnStartup(StartupEventArgs e)
         {
-            ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            UiThreadTaskFactory.Run(() => OnStartupAsync());
+            base.OnStartup(e);
+        }
+
+        private static async Task OnStartupAsync()
+        {
+            var application = Current ?? throw new InvalidOperationException("Application.Current is unavailable.");
+            application.ShutdownMode = ShutdownMode.OnExplicitShutdown;
             await AppHost.StartAsync();
 
             var settings = AppHost.Services.GetRequiredService<SettingsViewModel>();
@@ -862,18 +869,21 @@ namespace DesktopApplicationTemplate.UI
             {
                 var logger = AppHost.Services.GetService<ILogger<App>>();
                 logger?.LogWarning("MainView service missing; skipping window creation.");
-            }
-            else
-            {
-                MainWindow = mainWindow;
-                mainWindow.Show();
-                ShutdownMode = ShutdownMode.OnMainWindowClose;
+                return;
             }
 
-            base.OnStartup(e);
+            application.MainWindow = mainWindow;
+            mainWindow.Show();
+            application.ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
 
-        protected override async void OnExit(ExitEventArgs e)
+        protected override void OnExit(ExitEventArgs e)
+        {
+            UiThreadTaskFactory.Run(OnExitAsync);
+            base.OnExit(e);
+        }
+
+        private static async Task OnExitAsync()
         {
             var logger = AppHost.Services.GetService<Microsoft.Extensions.Logging.ILogger<App>>();
             var vm = AppHost.Services.GetService<MainViewModel>();
@@ -889,9 +899,8 @@ namespace DesktopApplicationTemplate.UI
             var hid = AppHost.Services.GetService<HidViewModel>();
             hid?.Dispose();
 
-            await AppHost.StopAsync();
+            await AppHost.StopAsync().ConfigureAwait(false);
             AppHost.Dispose();
-            base.OnExit(e);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -822,8 +822,17 @@ namespace DesktopApplicationTemplate.UI
             KeyboardSimulator.Reset();
             if (UiThreadTaskFactory is null)
             {
-                logger?.LogWarning("Joinable task factory unavailable during domain exception; scheduling shutdown on dispatcher");
-                _ = Current?.Dispatcher?.BeginInvoke(new Action(() => Current?.Shutdown()));
+                logger?.LogWarning("Joinable task factory unavailable during domain exception; scheduling shutdown on dispatcher context");
+                if (Current?.Dispatcher is { } dispatcher)
+                {
+                    var dispatcherContext = new DispatcherSynchronizationContext(dispatcher);
+                    dispatcherContext.Post(_ => Current?.Shutdown(), null);
+                }
+                else
+                {
+                    Current?.Shutdown();
+                }
+
                 return;
             }
 

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -140,7 +140,7 @@ namespace DesktopApplicationTemplate.UI
                 .Build();
         }
 
-        private void ConfigureServices(IConfiguration configuration, IServiceCollection services)
+        private static void ConfigureServices(IConfiguration configuration, IServiceCollection services)
         {
             services.AddServiceModules();
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, (sp, _) => new MqttEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<MqttEditServiceHandler>>()));
@@ -163,6 +163,7 @@ namespace DesktopApplicationTemplate.UI
                         handlers[type] = handler;
                     }
                 }
+
                 return handlers;
             });
             services.AddSingleton<MainView>();
@@ -212,8 +213,7 @@ namespace DesktopApplicationTemplate.UI
                 var catalog = sp.GetRequiredService<IServiceCatalog>();
                 return new ServiceUiRegistry<ServiceListModel, Page>(
                     catalog,
-                    new[]
-                    {
+                    [
                         BuildCsvRegistration(),
                         BuildFileObserverRegistration(),
                         BuildHeartbeatRegistration(),
@@ -223,7 +223,7 @@ namespace DesktopApplicationTemplate.UI
                         BuildScpRegistration(),
                         BuildTcpRegistration(),
                         BuildFtpRegistration(),
-                    });
+                    ]);
             });
             services.AddTransient<SplashWindow>();
             services.AddTransient<CreateServicePage>();
@@ -807,8 +807,7 @@ namespace DesktopApplicationTemplate.UI
             _ = OnAppDomainUnhandledExceptionAsync(sender, e);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD001:Use SwitchToMainThreadAsync to switch to the UI thread", Justification = "Dispatcher is sufficient for shutdown")]
-        internal async Task OnAppDomainUnhandledExceptionAsync(object? sender, UnhandledExceptionEventArgs e)
+        internal static async Task OnAppDomainUnhandledExceptionAsync(object? sender, UnhandledExceptionEventArgs e)
         {
             var logger = AppHost.Services.GetService<ILogger<App>>();
             if (e.ExceptionObject is Exception ex)
@@ -821,13 +820,20 @@ namespace DesktopApplicationTemplate.UI
             }
 
             KeyboardSimulator.Reset();
-            if (Current is not null)
+            if (UiThreadTaskFactory is not null)
             {
-                await Current.Dispatcher.InvokeAsync(() => Current.Shutdown());
+                await UiThreadTaskFactory.SwitchToMainThreadAsync();
+                Current?.Shutdown();
+                return;
+            }
+
+            var app = Current;
+            if (app is not null)
+            {
+                await app.Dispatcher.InvokeAsync(static application => application.Shutdown(), app);
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Startup event")]
         protected override async void OnStartup(StartupEventArgs e)
         {
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
@@ -867,7 +873,6 @@ namespace DesktopApplicationTemplate.UI
             base.OnStartup(e);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Application shutdown")]
         protected override async void OnExit(ExitEventArgs e)
         {
             var logger = AppHost.Services.GetService<Microsoft.Extensions.Logging.ILogger<App>>();

--- a/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/AsyncRelayCommand.cs
@@ -10,15 +10,10 @@ namespace DesktopApplicationTemplate.UI.Helpers
     /// <summary>
     /// An <see cref="ICommand"/> implementation that executes asynchronous delegates.
     /// </summary>
-    public class AsyncRelayCommand : ICommand
+    public class AsyncRelayCommand(Func<Task> execute, Func<bool>? canExecute = null) : ICommand
     {
-        private readonly Func<Task> _execute;
-        private readonly Func<bool>? _canExecute;
-        public AsyncRelayCommand(Func<Task> execute, Func<bool>? canExecute = null)
-        {
-            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
-            _canExecute = canExecute;
-        }
+        private readonly Func<Task> _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        private readonly Func<bool>? _canExecute = canExecute;
 
         public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
 
@@ -47,18 +42,10 @@ namespace DesktopApplicationTemplate.UI.Helpers
     /// An <see cref="ICommand"/> implementation that executes asynchronous delegates with a parameter.
     /// </summary>
     /// <typeparam name="T">Type of parameter passed to the command.</typeparam>
-    public class AsyncRelayCommand<T> : ICommand
+    public class AsyncRelayCommand<T>(Func<T?, Task> execute, Predicate<T?>? canExecute = null) : ICommand
     {
-        private readonly Func<T?, Task> _execute;
-        private readonly Predicate<T?>? _canExecute;
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AsyncRelayCommand{T}"/> class.
-        /// </summary>
-        public AsyncRelayCommand(Func<T?, Task> execute, Predicate<T?>? canExecute = null)
-        {
-            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
-            _canExecute = canExecute;
-        }
+        private readonly Func<T?, Task> _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        private readonly Predicate<T?>? _canExecute = canExecute;
 
         /// <inheritdoc />
         public bool CanExecute(object? parameter) => _canExecute?.Invoke((T?)parameter) ?? true;

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Core.Services;
@@ -13,6 +14,7 @@ namespace DesktopApplicationTemplate.UI.Services
         private readonly IRichTextLogger _richTextLogger;
         private readonly string _logFilePath;
         private readonly List<LogEntry> _logEntries = new();
+        private readonly SemaphoreSlim _fileWriteLock = new(1, 1);
 
         private LogLevel _minimumLevel = LogLevel.Debug;
         public LogLevel MinimumLevel
@@ -76,7 +78,7 @@ namespace DesktopApplicationTemplate.UI.Services
 
             LogAdded?.Invoke(entry);
 
-            _ = WriteToFileAsync(entry.Message + Environment.NewLine);
+            _ = AppendToLogFileAsync(entry.Message + Environment.NewLine);
         }
 
         private static string LevelToColor(LogLevel level) => level switch
@@ -149,19 +151,21 @@ namespace DesktopApplicationTemplate.UI.Services
             _ = _richTextLogger.SetEntriesAsync(_logEntries.Where(e => e.Level >= MinimumLevel));
         }
 
-        private Task WriteToFileAsync(string text)
+        private async Task AppendToLogFileAsync(string text)
         {
-            return Task.Run(async () =>
+            try
             {
-                try
-                {
-                    await File.AppendAllTextAsync(_logFilePath, text).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // ignore logging errors
-                }
-            });
+                await _fileWriteLock.WaitAsync().ConfigureAwait(false);
+                await File.AppendAllTextAsync(_logFilePath, text).ConfigureAwait(false);
+            }
+            catch
+            {
+                // ignore logging errors
+            }
+            finally
+            {
+                _fileWriteLock.Release();
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DesktopApplicationTemplate.Core.Services;
@@ -45,6 +46,7 @@ namespace DesktopApplicationTemplate.Persistence
                         Port = s.TcpOptions.Port,
                         UseUdp = s.TcpOptions.UseUdp,
                         Mode = s.TcpOptions.Mode,
+                        ConnectionRole = s.TcpOptions.ConnectionRole,
                         InputMessage = s.TcpOptions.InputMessage,
                         Script = s.TcpOptions.Script,
                         OutputMessage = s.TcpOptions.OutputMessage,
@@ -150,7 +152,16 @@ namespace DesktopApplicationTemplate.Persistence
                     HidOptions = hid,
                     ScpOptions = scp,
                     TotalExecutionTimeMs = s.TotalExecutionTimeMs,
-                    ExecutionCount = s.ExecutionCount
+                    ExecutionCount = s.ExecutionCount,
+                    Logs = s.Logs
+                        .Take(ServiceListModel.MaxLogEntries)
+                        .Select(l => new LogEntry
+                        {
+                            Level = l.Level,
+                            Message = l.Message,
+                            Color = l.Color
+                        })
+                        .ToList()
                 });
             }
 
@@ -208,6 +219,20 @@ namespace DesktopApplicationTemplate.Persistence
             }
             try
             {
+                try
+                {
+                    var current = JsonSerializer.Deserialize<List<ServiceInfo>>(json);
+                    if (current is { Count: > 0 })
+                    {
+                        logger?.Log($"Loaded {current.Count} services", LogLevel.Debug);
+                        return current;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // fall back to legacy parsing below
+                }
+
                 var legacy = JsonSerializer.Deserialize<List<LegacyServiceInfo>>(json) ?? new List<LegacyServiceInfo>();
                 var result = new List<ServiceInfo>();
                 foreach (var info in legacy)
@@ -231,7 +256,8 @@ namespace DesktopApplicationTemplate.Persistence
                             HidOptions = info.HidOptions,
                             ScpOptions = info.ScpOptions,
                             TotalExecutionTimeMs = info.TotalExecutionTimeMs,
-                            ExecutionCount = info.ExecutionCount
+                            ExecutionCount = info.ExecutionCount,
+                            Logs = info.Logs ?? new List<LogEntry>()
                         });
                     }
                     else
@@ -252,6 +278,7 @@ namespace DesktopApplicationTemplate.Persistence
                             value.Port = info.TcpOptions.Port;
                             value.UseUdp = info.TcpOptions.UseUdp;
                             value.Mode = info.TcpOptions.Mode;
+                            value.ConnectionRole = info.TcpOptions.ConnectionRole;
                             value.InputMessage = info.TcpOptions.InputMessage;
                             value.Script = info.TcpOptions.Script;
                             value.OutputMessage = info.TcpOptions.OutputMessage;
@@ -365,6 +392,7 @@ namespace DesktopApplicationTemplate.Persistence
         public ScpServiceOptions? ScpOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
+        public List<LogEntry> Logs { get; set; } = new();
     }
 
     internal class LegacyServiceInfo
@@ -385,5 +413,6 @@ namespace DesktopApplicationTemplate.Persistence
         public ScpServiceOptions? ScpOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
+        public List<LogEntry> Logs { get; set; } = new();
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -45,6 +45,9 @@ namespace DesktopApplicationTemplate.Persistence
                         Host = s.TcpOptions.Host,
                         Port = s.TcpOptions.Port,
                         UseUdp = s.TcpOptions.UseUdp,
+                        SubnetMask = s.TcpOptions.SubnetMask,
+                        PrimaryDns = s.TcpOptions.PrimaryDns,
+                        AlternateDns = s.TcpOptions.AlternateDns,
                         Mode = s.TcpOptions.Mode,
                         ConnectionRole = s.TcpOptions.ConnectionRole,
                         InputMessage = s.TcpOptions.InputMessage,
@@ -277,6 +280,9 @@ namespace DesktopApplicationTemplate.Persistence
                             value.Host = info.TcpOptions.Host;
                             value.Port = info.TcpOptions.Port;
                             value.UseUdp = info.TcpOptions.UseUdp;
+                            value.SubnetMask = info.TcpOptions.SubnetMask;
+                            value.PrimaryDns = info.TcpOptions.PrimaryDns;
+                            value.AlternateDns = info.TcpOptions.AlternateDns;
                             value.Mode = info.TcpOptions.Mode;
                             value.ConnectionRole = info.TcpOptions.ConnectionRole;
                             value.InputMessage = info.TcpOptions.InputMessage;

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -519,14 +519,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
             LogViewModel.RefreshLogs();
 
-            if (_activatingServices.Contains(svc) && entry.Level >= LogLevel.Error)
+            if (entry.Level >= LogLevel.Error)
             {
-                _activatingServices.Remove(svc);
-                svc.SetRuntimeState(ServiceRuntimeState.Error);
-                svc.IsActive = false;
-                if (!Services.Any(s => s.IsActive) && _activatingServices.Count == 0)
+                var wasActivating = _activatingServices.Remove(svc);
+                if (svc.RuntimeState != ServiceRuntimeState.Error)
                 {
-                    ServicesRunning = false;
+                    svc.SetRuntimeState(ServiceRuntimeState.Error);
+                }
+
+                if (wasActivating)
+                {
+                    if (svc.IsActive)
+                    {
+                        svc.IsActive = false;
+                    }
+
+                    if (!Services.Any(s => s.IsActive) && _activatingServices.Count == 0)
+                    {
+                        ServicesRunning = false;
+                    }
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -431,6 +431,30 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
+        public async Task ShutdownServicesAsync()
+        {
+            if (!Services.Any(s => s.IsActive) && _activatingServices.Count == 0)
+            {
+                return;
+            }
+
+            while (IsServiceProcessBusy)
+            {
+                await Task.Delay(50);
+            }
+
+            IsServiceProcessBusy = true;
+            try
+            {
+                await StopServicesAsync();
+                ServicesRunning = false;
+            }
+            finally
+            {
+                IsServiceProcessBusy = false;
+            }
+        }
+
         private async Task StartServicesAsync()
         {
             foreach (var svc in Services)

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -297,6 +297,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 };
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);
+                svc.LoadPersistedLogs(info.Logs ?? new List<LogEntry>());
                 var normalizedName = NormalizeDisplayName(svc.Type, svc.DisplayName);
                 if (Services.Any(existing => existing.DisplayName.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {
@@ -310,6 +311,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 if (svc.Type != ServiceType.Csv)
                     _csvService.EnsureColumnsForService(svc.DisplayName);
                 Services.Add(svc);
+                foreach (var log in svc.Logs.Reverse())
+                {
+                    AllLogs.Insert(0, log);
+                }
                 _logger?.Log($"Loaded service {svc.DisplayName}", LogLevel.Debug);
             }
             OnPropertyChanged(nameof(ServicesCreated));
@@ -340,7 +345,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             var codePrefix = type.ToCode();
             if (!string.Equals(codePrefix, baseName, StringComparison.OrdinalIgnoreCase) &&
-                trimmed.StartsWith(codePrefix, StringComparison.OrdinalIgnoreCase))
+                trimmed.StartsWith(codePrefix, StringComparison.OrdinalIgnoreCase) &&
+                !trimmed.StartsWith(baseName, StringComparison.OrdinalIgnoreCase))
             {
                 trimmed = baseName + trimmed[codePrefix.Length..];
             }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Windows.Controls;
@@ -28,6 +30,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
     public class ServiceListModel : ViewModelBase
     {
+        internal const int MaxLogEntries = 200;
+
         public string DisplayName { get; set; } = string.Empty;
         public ServiceType Type { get; set; }
         [JsonIgnore] public Page? Page { get; set; }
@@ -249,10 +253,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug, bool checkReference = true)
         {
-            LastInputMessage = message;
             var ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
             var entry = new LogEntry { Message = $"{ts} {message}", Color = (color ?? WpfBrushes.Black).ToString(), Level = level };
+            LastInputMessage = entry.Message;
             Logs.Insert(0, entry);
+            if (Logs.Count > MaxLogEntries)
+            {
+                Logs.RemoveAt(Logs.Count - 1);
+            }
             LogAdded?.Invoke(this, entry);
             if (checkReference)
             {
@@ -261,6 +269,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (checkReference)
             {
                 HandleReference(message, color ?? WpfBrushes.Black, level);
+            }
+        }
+
+        public void LoadPersistedLogs(IEnumerable<LogEntry> entries)
+        {
+            var materialized = entries?.Where(e => !string.IsNullOrWhiteSpace(e.Message)).Take(MaxLogEntries).ToList() ?? new List<LogEntry>();
+            Logs = new ObservableCollection<LogEntry>(materialized);
+            OnPropertyChanged(nameof(Logs));
+            if (Logs.FirstOrDefault() is { } latest)
+            {
+                LastInputMessage = latest.Message;
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -17,6 +18,7 @@ using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Services;
 using WpfBrush = System.Windows.Media.Brush;
 using WpfBrushes = System.Windows.Media.Brushes;
+using WpfBrushConverter = System.Windows.Media.BrushConverter;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -58,8 +60,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private int _executionCount;
         private TimeSpan _lastExecutionDuration;
         private string _lastInputMessage = string.Empty;
+        private WpfBrush _lastInputBrush = WpfBrushes.Black;
         private int _incomingMessageCount;
         private int _outgoingMessageCount;
+        private static readonly WpfBrushConverter BrushConverter = new();
+        private const string TimestampFormat = "MM.dd.yyyy - HH:mm:ss.fffffff";
+        private const int TimestampLength = 29;
 
         /// <summary>
         /// Gets the average execution time in milliseconds for operations performed by this service.
@@ -127,6 +133,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 _lastInputMessage = value;
                 OnPropertyChanged();
+            }
+        }
+
+        public WpfBrush LastInputBrush
+        {
+            get => _lastInputBrush;
+            private set
+            {
+                if (!Equals(_lastInputBrush, value))
+                {
+                    _lastInputBrush = value;
+                    OnPropertyChanged();
+                }
             }
         }
 
@@ -253,9 +272,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug, bool checkReference = true)
         {
-            var ts = DateTime.Now.ToString("MM.dd.yyyy - HH:mm:ss.fffffff");
+            var normalizedMessage = NormalizeLatestMessage(message);
+            LastInputMessage = normalizedMessage;
+            LastInputBrush = color ?? WpfBrushes.Black;
+            var ts = DateTime.Now.ToString(TimestampFormat, CultureInfo.InvariantCulture);
             var entry = new LogEntry { Message = $"{ts} {message}", Color = (color ?? WpfBrushes.Black).ToString(), Level = level };
-            LastInputMessage = entry.Message;
             Logs.Insert(0, entry);
             if (Logs.Count > MaxLogEntries)
             {
@@ -279,7 +300,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             OnPropertyChanged(nameof(Logs));
             if (Logs.FirstOrDefault() is { } latest)
             {
-                LastInputMessage = latest.Message;
+                LastInputMessage = NormalizePersistedMessage(latest.Message);
+                LastInputBrush = ParseBrush(latest.Color);
             }
         }
 
@@ -351,6 +373,54 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
 
             return false;
+        }
+
+        private static string NormalizeLatestMessage(string? message)
+        {
+            return string.IsNullOrWhiteSpace(message) ? string.Empty : message.Trim();
+        }
+
+        private static string NormalizePersistedMessage(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return string.Empty;
+            }
+
+            if (message.Length > TimestampLength && message[TimestampLength] == ' ')
+            {
+                var timestampCandidate = message.Substring(0, TimestampLength);
+                if (DateTime.TryParseExact(timestampCandidate, TimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+                {
+                    return message[(TimestampLength + 1)..].Trim();
+                }
+            }
+
+            return message.Trim();
+        }
+
+        private static WpfBrush ParseBrush(string? color)
+        {
+            if (string.IsNullOrWhiteSpace(color))
+            {
+                return WpfBrushes.Black;
+            }
+
+            try
+            {
+                if (BrushConverter.ConvertFromString(color) is WpfBrush parsed)
+                {
+                    return parsed;
+                }
+            }
+            catch (FormatException)
+            {
+            }
+            catch (NotSupportedException)
+            {
+            }
+
+            return WpfBrushes.Black;
         }
 
         public void SetColorsByType()

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 
@@ -16,6 +17,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private TcpConnectionRole _connectionRole = TcpConnectionRole.Server;
     private string _serverHost = NetworkUtilities.GetLocalIpAddress();
     private string _clientHost = string.Empty;
+    private string _subnetMask = string.Empty;
+    private string _primaryDns = string.Empty;
+    private string _alternateDns = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpCreateServiceViewModel"/> class.
@@ -23,7 +27,14 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     public TcpCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
         : base(rule, logger: logger)
     {
+        var configuration = NetworkUtilities.GetLocalNetworkConfiguration();
+        _serverHost = string.IsNullOrWhiteSpace(configuration.IpAddress)
+            ? NetworkUtilities.GetLocalIpAddress()
+            : configuration.IpAddress;
         Host = _serverHost;
+        SubnetMask = configuration.SubnetMask;
+        PrimaryDns = configuration.DnsPrimary;
+        AlternateDns = configuration.DnsSecondary;
     }
 
     /// <summary>
@@ -66,6 +77,48 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
                 AddError(nameof(Port), error);
             else
                 ClearErrors(nameof(Port));
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Subnet mask associated with the connection.
+    /// </summary>
+    public string SubnetMask
+    {
+        get => _subnetMask;
+        set
+        {
+            _subnetMask = value ?? string.Empty;
+            ValidateOptionalIpAddress(_subnetMask, nameof(SubnetMask), "Subnet");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Primary DNS server used for resolving host names.
+    /// </summary>
+    public string PrimaryDns
+    {
+        get => _primaryDns;
+        set
+        {
+            _primaryDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_primaryDns, nameof(PrimaryDns), "Primary DNS");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Alternate DNS server used for resolving host names.
+    /// </summary>
+    public string AlternateDns
+    {
+        get => _alternateDns;
+        set
+        {
+            _alternateDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_alternateDns, nameof(AlternateDns), "Alternate DNS");
             OnPropertyChanged();
         }
     }
@@ -137,7 +190,28 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         options.Host = Host;
         options.Port = Port;
         options.UseUdp = UseUdp;
+        options.SubnetMask = SubnetMask;
+        options.PrimaryDns = PrimaryDns;
+        options.AlternateDns = AlternateDns;
         options.Mode = Mode;
         options.ConnectionRole = ConnectionRole;
+    }
+
+    private void ValidateOptionalIpAddress(string value, string propertyName, string? displayName = null)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            ClearErrors(propertyName);
+            return;
+        }
+
+        if (IPAddress.TryParse(value, out _))
+        {
+            ClearErrors(propertyName);
+            return;
+        }
+
+        var label = displayName ?? propertyName;
+        AddError(propertyName, $"{label} must be a valid IPv4 address");
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -13,6 +13,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private int _port;
     private bool _useUdp;
     private TcpServiceMode _mode;
+    private TcpConnectionRole _connectionRole = TcpConnectionRole.Server;
+    private string _serverHost = NetworkUtilities.GetLocalIpAddress();
+    private string _clientHost = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpCreateServiceViewModel"/> class.
@@ -20,6 +23,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     public TcpCreateServiceViewModel(IServiceRule rule, ILoggingService? logger = null)
         : base(rule, logger: logger)
     {
+        Host = _serverHost;
     }
 
     /// <summary>
@@ -37,6 +41,14 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
             else
                 ClearErrors(nameof(Host));
             OnPropertyChanged();
+            if (_connectionRole == TcpConnectionRole.Server)
+            {
+                _serverHost = value;
+            }
+            else
+            {
+                _clientHost = value;
+            }
         }
     }
 
@@ -81,6 +93,44 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
+    /// <summary>
+    /// Available TCP connection roles.
+    /// </summary>
+    public TcpConnectionRole[] ConnectionRoles { get; } = (TcpConnectionRole[])Enum.GetValues(typeof(TcpConnectionRole));
+
+    /// <summary>
+    /// Selected TCP connection role.
+    /// </summary>
+    public TcpConnectionRole ConnectionRole
+    {
+        get => _connectionRole;
+        set
+        {
+            if (_connectionRole == value)
+            {
+                return;
+            }
+
+            _connectionRole = value;
+            OnPropertyChanged();
+            if (_connectionRole == TcpConnectionRole.Server)
+            {
+                _clientHost = _host;
+                if (string.IsNullOrWhiteSpace(_serverHost))
+                {
+                    _serverHost = NetworkUtilities.GetLocalIpAddress();
+                }
+                Host = _serverHost;
+            }
+            else
+            {
+                _serverHost = _host;
+                Host = _clientHost;
+            }
+            Logger?.Log($"TCP connection role set to {_connectionRole}", LogLevel.Debug);
+        }
+    }
+
     /// <inheritdoc />
     protected override void ApplyOptions(TcpServiceOptions options)
     {
@@ -88,5 +138,6 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         options.Port = Port;
         options.UseUdp = UseUdp;
         options.Mode = Mode;
+        options.ConnectionRole = ConnectionRole;
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -14,6 +14,10 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     private int _port;
     private bool _useUdp;
     private TcpServiceMode _mode;
+    private TcpConnectionRole _connectionRole = TcpConnectionRole.Server;
+    private string _serverHost = NetworkUtilities.GetLocalIpAddress();
+    private string _clientHost = string.Empty;
+    private bool _suppressRoleHostUpdate;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpEditServiceViewModel"/> class.
@@ -30,10 +34,21 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         ServiceName = serviceName ?? throw new ArgumentNullException(nameof(serviceName));
+        _suppressRoleHostUpdate = true;
+        ConnectionRole = _options.ConnectionRole;
         Host = _options.Host;
         Port = _options.Port;
         UseUdp = _options.UseUdp;
         Mode = _options.Mode;
+        if (ConnectionRole == TcpConnectionRole.Server)
+        {
+            _serverHost = _options.Host;
+        }
+        else
+        {
+            _clientHost = _options.Host;
+        }
+        _suppressRoleHostUpdate = false;
     }
 
 
@@ -52,6 +67,14 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
             else
                 ClearErrors(nameof(Host));
             OnPropertyChanged();
+            if (_connectionRole == TcpConnectionRole.Server)
+            {
+                _serverHost = value;
+            }
+            else
+            {
+                _clientHost = value;
+            }
         }
     }
 
@@ -96,6 +119,49 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
+    /// <summary>
+    /// Available TCP connection roles.
+    /// </summary>
+    public TcpConnectionRole[] ConnectionRoles { get; } = (TcpConnectionRole[])Enum.GetValues(typeof(TcpConnectionRole));
+
+    /// <summary>
+    /// Selected TCP connection role.
+    /// </summary>
+    public TcpConnectionRole ConnectionRole
+    {
+        get => _connectionRole;
+        set
+        {
+            if (_connectionRole == value)
+            {
+                return;
+            }
+
+            _connectionRole = value;
+            OnPropertyChanged();
+            if (_suppressRoleHostUpdate)
+            {
+                return;
+            }
+
+            if (_connectionRole == TcpConnectionRole.Server)
+            {
+                _clientHost = _host;
+                if (string.IsNullOrWhiteSpace(_serverHost))
+                {
+                    _serverHost = NetworkUtilities.GetLocalIpAddress();
+                }
+                Host = _serverHost;
+            }
+            else
+            {
+                _serverHost = _host;
+                Host = _clientHost;
+            }
+            Logger?.Log($"TCP connection role set to {_connectionRole}", LogLevel.Debug);
+        }
+    }
+
     /// <inheritdoc />
     protected override void OnSave()
     {
@@ -108,6 +174,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         _options.Port = Port;
         _options.UseUdp = UseUdp;
         _options.Mode = Mode;
+        _options.ConnectionRole = ConnectionRole;
         RaiseServiceSaved(_options);
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 
@@ -18,6 +19,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     private string _serverHost = NetworkUtilities.GetLocalIpAddress();
     private string _clientHost = string.Empty;
     private bool _suppressRoleHostUpdate;
+    private string _subnetMask = string.Empty;
+    private string _primaryDns = string.Empty;
+    private string _alternateDns = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpEditServiceViewModel"/> class.
@@ -40,6 +44,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         Port = _options.Port;
         UseUdp = _options.UseUdp;
         Mode = _options.Mode;
+        SubnetMask = _options.SubnetMask;
+        PrimaryDns = _options.PrimaryDns;
+        AlternateDns = _options.AlternateDns;
         if (ConnectionRole == TcpConnectionRole.Server)
         {
             _serverHost = _options.Host;
@@ -115,6 +122,48 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     }
 
     /// <summary>
+    /// Subnet mask associated with the connection.
+    /// </summary>
+    public string SubnetMask
+    {
+        get => _subnetMask;
+        set
+        {
+            _subnetMask = value ?? string.Empty;
+            ValidateOptionalIpAddress(_subnetMask, nameof(SubnetMask), "Subnet");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Primary DNS server used for resolving host names.
+    /// </summary>
+    public string PrimaryDns
+    {
+        get => _primaryDns;
+        set
+        {
+            _primaryDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_primaryDns, nameof(PrimaryDns), "Primary DNS");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Alternate DNS server used for resolving host names.
+    /// </summary>
+    public string AlternateDns
+    {
+        get => _alternateDns;
+        set
+        {
+            _alternateDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_alternateDns, nameof(AlternateDns), "Alternate DNS");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
     /// Available service modes.
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
@@ -173,6 +222,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         _options.Host = Host;
         _options.Port = Port;
         _options.UseUdp = UseUdp;
+        _options.SubnetMask = SubnetMask;
+        _options.PrimaryDns = PrimaryDns;
+        _options.AlternateDns = AlternateDns;
         _options.Mode = Mode;
         _options.ConnectionRole = ConnectionRole;
         RaiseServiceSaved(_options);
@@ -185,6 +237,24 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     protected override void OnAdvancedConfig()
     {
         // Advanced configuration removed.
+    }
+
+    private void ValidateOptionalIpAddress(string value, string propertyName, string? displayName = null)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            ClearErrors(propertyName);
+            return;
+        }
+
+        if (IPAddress.TryParse(value, out _))
+        {
+            ClearErrors(propertyName);
+            return;
+        }
+
+        var label = displayName ?? propertyName;
+        AddError(propertyName, $"{label} must be a valid IPv4 address");
     }
 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
@@ -103,6 +104,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private static readonly TimeSpan PingTimeout = TimeSpan.FromSeconds(2);
         private readonly List<Task> _activeClientTasks = new();
         private readonly object _clientTasksLock = new();
+        private bool _isApplicationExitHooked;
 
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
@@ -199,6 +201,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
             OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
             OpenScriptEditorCommand = new AsyncRelayCommand(OpenScriptEditorAsync);
+
+            EnsureApplicationExitHooked();
         }
 
         /// <summary>Associates the view model with a service and its TCP options.</summary>
@@ -207,6 +211,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
             StopNetwork();
+            EnsureApplicationExitHooked();
             if (_service is not null)
             {
                 _service.ActiveChanged -= OnServiceActiveChanged;
@@ -295,6 +300,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 return;
             }
 
+            var pingSucceeded = await PingRemoteAsync().ConfigureAwait(false);
+            if (_options.ConnectionRole == TcpConnectionRole.Client && !pingSucceeded)
+            {
+                Logger?.Log($"Skipping TCP client start because {_options.Host} did not respond to ping.", LogLevel.Warning);
+                return;
+            }
+
             _networkLoopCancellation = new CancellationTokenSource();
             var token = _networkLoopCancellation.Token;
             var protocol = _options.UseUdp ? "UDP" : "TCP";
@@ -303,11 +315,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             _networkLoopTask = _options.ConnectionRole == TcpConnectionRole.Server
                 ? RunServerLoopAsync(token)
                 : RunClientLoopAsync(token);
-
-            if (_options.ConnectionRole == TcpConnectionRole.Server && !string.IsNullOrWhiteSpace(_options.Host))
-            {
-                await PingRemoteAsync().ConfigureAwait(false);
-            }
         }
 
         private void StopNetwork()
@@ -348,6 +355,23 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 }, TaskScheduler.Default);
             }
 
+            List<Task> clientTasks;
+            lock (_clientTasksLock)
+            {
+                clientTasks = _activeClientTasks.ToList();
+            }
+
+            if (clientTasks.Count > 0)
+            {
+                _ = Task.WhenAll(clientTasks).ContinueWith(t =>
+                {
+                    if (t.IsFaulted && Logger is not null)
+                    {
+                        Logger.Log($"One or more TCP client handlers faulted during shutdown: {t.Exception?.GetBaseException().Message}", LogLevel.Error);
+                    }
+                }, TaskScheduler.Default);
+            }
+
             Logger?.Log("TCP network loop stopped", LogLevel.Debug);
         }
 
@@ -356,12 +380,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             TcpListener? listener = null;
             try
             {
-                var listenAddress = ResolveListenAddress(_options.Host);
-                if (!string.IsNullOrWhiteSpace(_options.Host) &&
-                    !IPAddress.TryParse(_options.Host, out _) &&
-                    !string.Equals(_options.Host, "0.0.0.0", StringComparison.Ordinal) &&
-                    listenAddress.Equals(IPAddress.Any))
+                var listenAddress = ResolveListenAddress(_options.Host, out var fallbackToAny);
+                if (fallbackToAny && !string.IsNullOrWhiteSpace(_options.Host))
                 {
+                    Logger?.Log($"Requested listen address '{_options.Host}' is not assigned to this machine; listening on all interfaces instead.", LogLevel.Warning);
                     LogConnectionIssues("TCP listener address resolution", null, LogLevel.Warning);
                 }
 
@@ -499,29 +521,40 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
-        private async Task PingRemoteAsync()
+        private async Task<bool> PingRemoteAsync()
         {
-            if (string.IsNullOrWhiteSpace(_options.Host))
+            if (string.IsNullOrWhiteSpace(_options.Host) || string.Equals(_options.Host, "0.0.0.0", StringComparison.Ordinal))
             {
-                return;
+                Logger?.Log("Ping skipped because no remote host is configured.", LogLevel.Debug);
+                return true;
+            }
+
+            if (IsLocalHost(_options.Host))
+            {
+                Logger?.Log($"Ping skipped for local host {_options.Host}.", LogLevel.Debug);
+                return true;
             }
 
             try
             {
                 using var ping = new Ping();
-                var reply = await ping.SendPingAsync(_options.Host, (int)PingTimeout.TotalMilliseconds);
+                var reply = await ping.SendPingAsync(_options.Host, (int)PingTimeout.TotalMilliseconds).ConfigureAwait(false);
                 if (reply.Status == IPStatus.Success)
                 {
                     Logger?.Log($"Ping to {_options.Host} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
+                    return true;
                 }
                 else
                 {
                     Logger?.Log($"Ping to {_options.Host} failed with status {reply.Status}", LogLevel.Warning);
+                    LogConnectionIssues("TCP ping", null, LogLevel.Warning);
+                    return false;
                 }
             }
             catch (Exception ex)
             {
                 LogConnectionIssues("TCP ping", ex);
+                return false;
             }
         }
 
@@ -596,9 +629,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 return "Host: not configured";
             }
 
-            if (IPAddress.TryParse(_options.Host, out _))
+            if (IPAddress.TryParse(_options.Host, out var parsedAddress))
             {
-                return $"Host: {_options.Host}";
+                var locality = IsLocalAddress(parsedAddress) ? "local" : "remote";
+                return $"Host: {_options.Host} ({locality})";
             }
 
             try
@@ -712,8 +746,26 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
-        private static IPAddress ResolveListenAddress(string host)
+        private void EnsureApplicationExitHooked()
         {
+            if (_isApplicationExitHooked || Application.Current is null)
+            {
+                return;
+            }
+
+            Application.Current.Exit += OnApplicationExit;
+            _isApplicationExitHooked = true;
+        }
+
+        private void OnApplicationExit(object? sender, ExitEventArgs e)
+        {
+            StopNetwork();
+        }
+
+        private static IPAddress ResolveListenAddress(string host, out bool fallbackToAny)
+        {
+            fallbackToAny = false;
+
             if (string.IsNullOrWhiteSpace(host) || string.Equals(host, "0.0.0.0", StringComparison.Ordinal))
             {
                 return IPAddress.Any;
@@ -721,16 +773,98 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
             if (IPAddress.TryParse(host, out var address))
             {
-                return address;
+                if (IsLocalAddress(address))
+                {
+                    return address;
+                }
+
+                fallbackToAny = true;
+                return IPAddress.Any;
             }
 
             try
             {
-                return Dns.GetHostAddresses(host).FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork) ?? IPAddress.Any;
+                var resolved = Dns.GetHostAddresses(host)
+                    .Where(a => a.AddressFamily == AddressFamily.InterNetwork)
+                    .FirstOrDefault(IsLocalAddress);
+
+                if (resolved is not null)
+                {
+                    return resolved;
+                }
             }
             catch
             {
-                return IPAddress.Any;
+                // ignore resolution failures and fall back to any address
+            }
+
+            fallbackToAny = true;
+            return IPAddress.Any;
+        }
+
+        private static bool IsLocalAddress(IPAddress address)
+        {
+            if (address.Equals(IPAddress.Any) || IPAddress.IsLoopback(address))
+            {
+                return true;
+            }
+
+            try
+            {
+                foreach (var networkInterface in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    if (networkInterface.OperationalStatus != OperationalStatus.Up)
+                    {
+                        continue;
+                    }
+
+                    foreach (var unicast in networkInterface.GetIPProperties().UnicastAddresses)
+                    {
+                        if (unicast.Address.AddressFamily != AddressFamily.InterNetwork)
+                        {
+                            continue;
+                        }
+
+                        if (address.Equals(unicast.Address))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // ignore adapter enumeration failures
+            }
+
+            return false;
+        }
+
+        private static bool IsLocalHost(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                return false;
+            }
+
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (IPAddress.TryParse(host, out var address))
+            {
+                return IsLocalAddress(address);
+            }
+
+            try
+            {
+                return Dns.GetHostAddresses(host)
+                    .Any(a => a.AddressFamily == AddressFamily.InterNetwork && IsLocalAddress(a));
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -357,6 +357,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             try
             {
                 var listenAddress = ResolveListenAddress(_options.Host);
+                if (!string.IsNullOrWhiteSpace(_options.Host) &&
+                    !IPAddress.TryParse(_options.Host, out _) &&
+                    !string.Equals(_options.Host, "0.0.0.0", StringComparison.Ordinal) &&
+                    listenAddress.Equals(IPAddress.Any))
+                {
+                    LogConnectionIssues("TCP listener address resolution", null, LogLevel.Warning);
+                }
+
                 listener = new TcpListener(listenAddress, _options.Port);
                 listener.Start();
                 Logger?.Log($"Listening on {listenAddress}:{_options.Port}", LogLevel.Information);
@@ -379,7 +387,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
             catch (Exception ex)
             {
-                Logger?.Log($"TCP listener failed: {ex.Message}", LogLevel.Error);
+                LogConnectionIssues("TCP listener", ex);
             }
             finally
             {
@@ -400,6 +408,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             if (string.IsNullOrWhiteSpace(_options.Host))
             {
                 Logger?.Log("TCP client host is not configured.", LogLevel.Warning);
+                LogConnectionIssues("TCP client configuration", null, LogLevel.Warning);
                 return;
             }
 
@@ -439,7 +448,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
             catch (Exception ex)
             {
-                Logger?.Log($"TCP client error: {ex.Message}", LogLevel.Error);
+                LogConnectionIssues("TCP client connection", ex);
             }
         }
 
@@ -512,7 +521,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
             catch (Exception ex)
             {
-                Logger?.Log($"Ping to {_options.Host} failed: {ex.Message}", LogLevel.Error);
+                LogConnectionIssues("TCP ping", ex);
             }
         }
 
@@ -543,6 +552,114 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 OnPropertyChanged(nameof(IncomingData));
                 OnPropertyChanged(nameof(OutgoingResults));
             });
+        }
+
+        private void LogConnectionIssues(string stage, Exception? exception, LogLevel? summaryLevel = null)
+        {
+            if (Logger is null)
+            {
+                return;
+            }
+
+            if (exception is not null)
+            {
+                Logger.Log($"{stage} failed: {exception.Message}", LogLevel.Error);
+                if (exception is SocketException socketException)
+                {
+                    Logger.Log($"Socket error: {socketException.SocketErrorCode}", LogLevel.Error);
+                }
+            }
+            else if (summaryLevel is LogLevel level)
+            {
+                Logger.Log($"{stage} has configuration issues.", level);
+            }
+
+            foreach (var detail in BuildConnectionDiagnostics())
+            {
+                Logger.Log(detail, LogLevel.Warning);
+            }
+        }
+
+        private IEnumerable<string> BuildConnectionDiagnostics()
+        {
+            yield return BuildHostDiagnostic();
+            yield return BuildPortDiagnostic();
+            yield return BuildSubnetDiagnostic();
+            yield return BuildDnsDiagnostic(_options.PrimaryDns, "Primary DNS");
+            yield return BuildDnsDiagnostic(_options.AlternateDns, "Alternate DNS");
+        }
+
+        private string BuildHostDiagnostic()
+        {
+            if (string.IsNullOrWhiteSpace(_options.Host))
+            {
+                return "Host: not configured";
+            }
+
+            if (IPAddress.TryParse(_options.Host, out _))
+            {
+                return $"Host: {_options.Host}";
+            }
+
+            try
+            {
+                var addresses = Dns.GetHostAddresses(_options.Host)
+                    .Where(a => a.AddressFamily == AddressFamily.InterNetwork)
+                    .Select(a => a.ToString())
+                    .ToArray();
+
+                if (addresses.Length == 0)
+                {
+                    return $"Host: DNS lookup returned no IPv4 addresses for '{_options.Host}'";
+                }
+
+                var preview = string.Join(", ", addresses.Take(2));
+                if (addresses.Length > 2)
+                {
+                    preview += ", ...";
+                }
+
+                return $"Host: resolved to {preview}";
+            }
+            catch (SocketException ex)
+            {
+                return $"Host: DNS resolution failed ({ex.SocketErrorCode})";
+            }
+            catch (Exception ex)
+            {
+                return $"Host: resolution failed ({ex.Message})";
+            }
+        }
+
+        private string BuildPortDiagnostic()
+        {
+            return _options.Port is >= 1 and <= 65535
+                ? $"Port: {_options.Port}"
+                : $"Port: invalid ({_options.Port})";
+        }
+
+        private string BuildSubnetDiagnostic()
+        {
+            if (string.IsNullOrWhiteSpace(_options.SubnetMask))
+            {
+                return "Subnet: not configured";
+            }
+
+            return IPAddress.TryParse(_options.SubnetMask, out _)
+                ? $"Subnet: {_options.SubnetMask}"
+                : $"Subnet: invalid ({_options.SubnetMask})";
+        }
+
+        private static string BuildDnsDiagnostic(string value, string label)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return $"{label}: not configured";
+            }
+
+            return IPAddress.TryParse(value, out _)
+                ? $"{label}: {value}"
+                : $"{label}: invalid ({value})";
         }
 
         private static Task RunOnUiThreadAsync(Action action)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -301,9 +301,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
 
             var pingSucceeded = await PingRemoteAsync().ConfigureAwait(false);
-            if (_options.ConnectionRole == TcpConnectionRole.Client && !pingSucceeded)
+            if (!pingSucceeded)
             {
-                Logger?.Log($"Skipping TCP client start because {_options.Host} did not respond to ping.", LogLevel.Warning);
+                if (!string.IsNullOrWhiteSpace(_options.Host))
+                {
+                    var role = _options.ConnectionRole == TcpConnectionRole.Server ? "listener" : "client";
+                    Logger?.Log($"Cannot start TCP {role} because {_options.Host} did not respond to ping.", LogLevel.Error);
+                }
                 return;
             }
 
@@ -544,12 +548,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                     Logger?.Log($"Ping to {_options.Host} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
                     return true;
                 }
-                else
-                {
-                    Logger?.Log($"Ping to {_options.Host} failed with status {reply.Status}", LogLevel.Warning);
-                    LogConnectionIssues("TCP ping", null, LogLevel.Warning);
-                    return false;
-                }
+                Logger?.Log($"Ping to {_options.Host} failed with status {reply.Status}", LogLevel.Error);
+                LogConnectionIssues("TCP ping", null, LogLevel.Error);
+                return false;
             }
             catch (Exception ex)
             {

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -339,7 +339,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             if (task != null)
             {
                 _networkLoopTask = null;
-                task.ContinueWith(t =>
+                _ = task.ContinueWith(t =>
                 {
                     if (t.IsFaulted && Logger is not null)
                     {

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -14,6 +14,7 @@ using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Views;
@@ -99,8 +100,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private ServiceListModel? _service;
         private CancellationTokenSource? _networkLoopCancellation;
         private Task? _networkLoopTask;
-        private readonly SynchronizationContext? _uiContext;
         private static readonly TimeSpan PingTimeout = TimeSpan.FromSeconds(2);
+        private readonly List<Task> _activeClientTasks = new();
+        private readonly object _clientTasksLock = new();
 
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
@@ -186,8 +188,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             MessageTable = messageTable ?? throw new ArgumentNullException(nameof(messageTable));
             _routing = routing ?? throw new ArgumentNullException(nameof(routing));
             _tcpRuntime = tcpRuntime ?? throw new ArgumentNullException(nameof(tcpRuntime));
-            _uiContext = SynchronizationContext.Current;
-
             Messages.CollectionChanged += (_, _) =>
             {
                 OnPropertyChanged(nameof(IncomingData));
@@ -373,7 +373,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                         break;
                     }
 
-                    _ = HandleClientAsync(client, cancellationToken);
+                    var clientTask = HandleClientAsync(client, cancellationToken);
+                    TrackClientTask(clientTask);
                 }
             }
             catch (Exception ex)
@@ -424,11 +425,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 {
                     var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
                     Logger?.Log($"Received response from {endpoint}: {response}", LogLevel.Information);
-                    AppendMessage(message, response, endpoint);
+                    await AppendMessageAsync(message, response, endpoint).ConfigureAwait(false);
                 }
                 else
                 {
-                    AppendMessage(message, string.Empty, endpoint);
+                    await AppendMessageAsync(message, string.Empty, endpoint).ConfigureAwait(false);
                     Logger?.Log($"No response received from {endpoint}", LogLevel.Warning);
                 }
             }
@@ -464,7 +465,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
                         var incoming = Encoding.UTF8.GetString(buffer, 0, bytesRead);
                         Logger?.Log($"Received message from {endpoint}: {incoming}", LogLevel.Information);
-                        AppendMessage(incoming, _options.OutputMessage, endpoint);
+                        await AppendMessageAsync(incoming, _options.OutputMessage, endpoint).ConfigureAwait(false);
 
                         if (!string.IsNullOrWhiteSpace(_options.OutputMessage))
                         {
@@ -515,17 +516,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
-        private void AppendMessage(string incoming, string outgoing, string endpoint)
+        private Task AppendMessageAsync(string? incoming, string? outgoing, string? endpoint)
         {
-            RunOnUiThread(() =>
+            var incomingMessage = incoming ?? string.Empty;
+            var outgoingMessage = outgoing ?? string.Empty;
+            var destination = endpoint ?? string.Empty;
+
+            return RunOnUiThreadAsync(() =>
             {
                 Messages.Insert(0, new TcpMessageRow
                 {
-                    IncomingMessage = incoming ?? string.Empty,
-                    IncomingIp = endpoint ?? string.Empty,
-                    OutgoingMessage = outgoing ?? string.Empty,
-                    ConnectedService = endpoint ?? string.Empty,
-                    Result = string.IsNullOrWhiteSpace(outgoing) ? string.Empty : outgoing
+                    IncomingMessage = incomingMessage,
+                    IncomingIp = destination,
+                    OutgoingMessage = outgoingMessage,
+                    ConnectedService = destination,
+                    Result = string.IsNullOrWhiteSpace(outgoingMessage) ? string.Empty : outgoingMessage
                 });
 
                 while (Messages.Count > MaxTcpMessageRows)
@@ -533,23 +538,61 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                     Messages.RemoveAt(Messages.Count - 1);
                 }
 
-                MessageTable.AddMessage(incoming, outgoing, endpoint);
+                MessageTable.AddMessage(incomingMessage, outgoingMessage, destination);
 
                 OnPropertyChanged(nameof(IncomingData));
                 OnPropertyChanged(nameof(OutgoingResults));
             });
         }
 
-        private void RunOnUiThread(Action action)
+        private static Task RunOnUiThreadAsync(Action action)
         {
-            if (_uiContext is null || SynchronizationContext.Current == _uiContext)
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            if (App.UiThreadTaskFactory is null)
             {
                 action();
+                return Task.CompletedTask;
             }
-            else
+
+            return App.UiThreadTaskFactory.RunAsync(async () =>
             {
-                _uiContext.Post(_ => action(), null);
+                await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
+                action();
+            }).Task;
+        }
+
+        private void TrackClientTask(Task clientTask)
+        {
+            if (clientTask is null)
+            {
+                throw new ArgumentNullException(nameof(clientTask));
             }
+
+            lock (_clientTasksLock)
+            {
+                _activeClientTasks.Add(clientTask);
+            }
+
+            _ = clientTask.ContinueWith(t =>
+            {
+                lock (_clientTasksLock)
+                {
+                    _activeClientTasks.Remove(t);
+                }
+
+                if (t.IsFaulted && Logger is not null)
+                {
+                    var baseException = t.Exception?.GetBaseException();
+                    if (baseException is not null)
+                    {
+                        Logger.Log($"TCP client handler faulted: {baseException.Message}", LogLevel.Error);
+                    }
+                }
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
         private static IPAddress ResolveListenAddress(string host)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -1,9 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.ComponentModel;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
@@ -90,7 +95,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private readonly IMessageRoutingService _routing;
         private TcpServiceOptions _options = new();
         private TcpRuntimeContext? _runtimeContext;
-        
+        private const int MaxTcpMessageRows = 50;
+        private ServiceListModel? _service;
+        private CancellationTokenSource? _networkLoopCancellation;
+        private Task? _networkLoopTask;
+        private readonly SynchronizationContext? _uiContext;
+        private static readonly TimeSpan PingTimeout = TimeSpan.FromSeconds(2);
+
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
 
@@ -175,6 +186,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             MessageTable = messageTable ?? throw new ArgumentNullException(nameof(messageTable));
             _routing = routing ?? throw new ArgumentNullException(nameof(routing));
             _tcpRuntime = tcpRuntime ?? throw new ArgumentNullException(nameof(tcpRuntime));
+            _uiContext = SynchronizationContext.Current;
 
             Messages.CollectionChanged += (_, _) =>
             {
@@ -194,6 +206,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         public void SetService(ServiceListModel service)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
+            StopNetwork();
+            if (_service is not null)
+            {
+                _service.ActiveChanged -= OnServiceActiveChanged;
+            }
+
+            _service = service;
+            _service.ActiveChanged += OnServiceActiveChanged;
             _options = service.TcpOptions ?? new TcpServiceOptions();
             ServiceType = service.Type;
             ServiceName = service.DisplayName;
@@ -202,7 +222,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 : _options.Script;
             OutputMessage = _options.OutputMessage;
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
+            Messages.Clear();
+            MessageTable.Messages.Clear();
+            OnPropertyChanged(nameof(IncomingData));
+            OnPropertyChanged(nameof(OutgoingResults));
             _ = InitializeRuntimeAsync();
+            if (_service.IsActive)
+            {
+                _ = StartNetworkAsync();
+            }
         }
 
         private async Task InitializeRuntimeAsync()
@@ -243,6 +271,307 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             OnPropertyChanged(nameof(ServerGateway));
             OnPropertyChanged(nameof(ServerPort));
             OnPropertyChanged(nameof(IsUdp));
+        }
+
+        private void OnServiceActiveChanged(bool isActive)
+        {
+            if (isActive)
+            {
+                _ = StartNetworkAsync();
+            }
+            else
+            {
+                StopNetwork();
+            }
+        }
+
+        private async Task StartNetworkAsync()
+        {
+            StopNetwork();
+
+            if (_options.Port <= 0)
+            {
+                Logger?.Log("TCP port is not configured; skipping network startup.", LogLevel.Warning);
+                return;
+            }
+
+            _networkLoopCancellation = new CancellationTokenSource();
+            var token = _networkLoopCancellation.Token;
+            var protocol = _options.UseUdp ? "UDP" : "TCP";
+            Logger?.Log($"Starting TCP {_options.ConnectionRole} on {_options.Host}:{_options.Port} ({protocol})", LogLevel.Information);
+
+            _networkLoopTask = _options.ConnectionRole == TcpConnectionRole.Server
+                ? RunServerLoopAsync(token)
+                : RunClientLoopAsync(token);
+
+            if (_options.ConnectionRole == TcpConnectionRole.Server && !string.IsNullOrWhiteSpace(_options.Host))
+            {
+                await PingRemoteAsync().ConfigureAwait(false);
+            }
+        }
+
+        private void StopNetwork()
+        {
+            var cts = _networkLoopCancellation;
+            var task = _networkLoopTask;
+            if (cts == null && task == null)
+            {
+                return;
+            }
+
+            if (cts != null)
+            {
+                _networkLoopCancellation = null;
+                try
+                {
+                    cts.Cancel();
+                }
+                catch
+                {
+                    // ignore cancellation errors
+                }
+                finally
+                {
+                    cts.Dispose();
+                }
+            }
+
+            if (task != null)
+            {
+                _networkLoopTask = null;
+                task.ContinueWith(t =>
+                {
+                    if (t.IsFaulted && Logger is not null)
+                    {
+                        Logger.Log($"TCP network loop faulted: {t.Exception?.GetBaseException().Message}", LogLevel.Error);
+                    }
+                }, TaskScheduler.Default);
+            }
+
+            Logger?.Log("TCP network loop stopped", LogLevel.Debug);
+        }
+
+        private async Task RunServerLoopAsync(CancellationToken cancellationToken)
+        {
+            TcpListener? listener = null;
+            try
+            {
+                var listenAddress = ResolveListenAddress(_options.Host);
+                listener = new TcpListener(listenAddress, _options.Port);
+                listener.Start();
+                Logger?.Log($"Listening on {listenAddress}:{_options.Port}", LogLevel.Information);
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    TcpClient client;
+                    try
+                    {
+                        client = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+
+                    _ = HandleClientAsync(client, cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger?.Log($"TCP listener failed: {ex.Message}", LogLevel.Error);
+            }
+            finally
+            {
+                try
+                {
+                    listener?.Stop();
+                }
+                catch
+                {
+                    // ignore errors during shutdown
+                }
+                Logger?.Log("TCP listener stopped", LogLevel.Debug);
+            }
+        }
+
+        private async Task RunClientLoopAsync(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(_options.Host))
+            {
+                Logger?.Log("TCP client host is not configured.", LogLevel.Warning);
+                return;
+            }
+
+            try
+            {
+                using var client = new TcpClient();
+                await client.ConnectAsync(_options.Host, _options.Port, cancellationToken).ConfigureAwait(false);
+                Logger?.Log($"Connected to {_options.Host}:{_options.Port}", LogLevel.Information);
+
+                using var stream = client.GetStream();
+                var message = _options.InputMessage ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    var payload = Encoding.UTF8.GetBytes(message);
+                    await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
+                    Logger?.Log($"Sent message to {_options.Host}:{_options.Port}: {message}", LogLevel.Information);
+                }
+
+                var buffer = new byte[4096];
+                var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                var endpoint = $"{_options.Host}:{_options.Port}";
+                if (bytesRead > 0)
+                {
+                    var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                    Logger?.Log($"Received response from {endpoint}: {response}", LogLevel.Information);
+                    AppendMessage(message, response, endpoint);
+                }
+                else
+                {
+                    AppendMessage(message, string.Empty, endpoint);
+                    Logger?.Log($"No response received from {endpoint}", LogLevel.Warning);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // graceful cancellation
+            }
+            catch (Exception ex)
+            {
+                Logger?.Log($"TCP client error: {ex.Message}", LogLevel.Error);
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+        {
+            using (client)
+            {
+                var endpoint = client.Client.RemoteEndPoint?.ToString() ?? "unknown";
+                Logger?.Log($"Client connected from {endpoint}", LogLevel.Information);
+
+                try
+                {
+                    using var stream = client.GetStream();
+                    var buffer = new byte[4096];
+
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                        if (bytesRead == 0)
+                        {
+                            break;
+                        }
+
+                        var incoming = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                        Logger?.Log($"Received message from {endpoint}: {incoming}", LogLevel.Information);
+                        AppendMessage(incoming, _options.OutputMessage, endpoint);
+
+                        if (!string.IsNullOrWhiteSpace(_options.OutputMessage))
+                        {
+                            var response = Encoding.UTF8.GetBytes(_options.OutputMessage);
+                            await stream.WriteAsync(response.AsMemory(0, response.Length), cancellationToken).ConfigureAwait(false);
+                            Logger?.Log($"Sent response to {endpoint}: {_options.OutputMessage}", LogLevel.Debug);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // graceful cancellation
+                }
+                catch (Exception ex)
+                {
+                    Logger?.Log($"Error handling client {endpoint}: {ex.Message}", LogLevel.Error);
+                }
+                finally
+                {
+                    Logger?.Log($"Client disconnected: {endpoint}", LogLevel.Information);
+                }
+            }
+        }
+
+        private async Task PingRemoteAsync()
+        {
+            if (string.IsNullOrWhiteSpace(_options.Host))
+            {
+                return;
+            }
+
+            try
+            {
+                using var ping = new Ping();
+                var reply = await ping.SendPingAsync(_options.Host, (int)PingTimeout.TotalMilliseconds);
+                if (reply.Status == IPStatus.Success)
+                {
+                    Logger?.Log($"Ping to {_options.Host} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
+                }
+                else
+                {
+                    Logger?.Log($"Ping to {_options.Host} failed with status {reply.Status}", LogLevel.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger?.Log($"Ping to {_options.Host} failed: {ex.Message}", LogLevel.Error);
+            }
+        }
+
+        private void AppendMessage(string incoming, string outgoing, string endpoint)
+        {
+            RunOnUiThread(() =>
+            {
+                Messages.Insert(0, new TcpMessageRow
+                {
+                    IncomingMessage = incoming ?? string.Empty,
+                    IncomingIp = endpoint ?? string.Empty,
+                    OutgoingMessage = outgoing ?? string.Empty,
+                    ConnectedService = endpoint ?? string.Empty,
+                    Result = string.IsNullOrWhiteSpace(outgoing) ? string.Empty : outgoing
+                });
+
+                while (Messages.Count > MaxTcpMessageRows)
+                {
+                    Messages.RemoveAt(Messages.Count - 1);
+                }
+
+                MessageTable.AddMessage(incoming, outgoing, endpoint);
+
+                OnPropertyChanged(nameof(IncomingData));
+                OnPropertyChanged(nameof(OutgoingResults));
+            });
+        }
+
+        private void RunOnUiThread(Action action)
+        {
+            if (_uiContext is null || SynchronizationContext.Current == _uiContext)
+            {
+                action();
+            }
+            else
+            {
+                _uiContext.Post(_ => action(), null);
+            }
+        }
+
+        private static IPAddress ResolveListenAddress(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host) || string.Equals(host, "0.0.0.0", StringComparison.Ordinal))
+            {
+                return IPAddress.Any;
+            }
+
+            if (IPAddress.TryParse(host, out var address))
+            {
+                return address;
+            }
+
+            try
+            {
+                return Dns.GetHostAddresses(host).FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork) ?? IPAddress.Any;
+            }
+            catch
+            {
+                return IPAddress.Any;
+            }
         }
 
         private void ClearLogs()

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -168,11 +168,12 @@
                                 <Border CornerRadius="8" BorderBrush="{Binding BorderColor}" Background="{Binding BackgroundColor}" BorderThickness="2" Padding="5" Margin="2"
                                         PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown" PreviewMouseMove="ServiceItem_PreviewMouseMove"
                                         AllowDrop="True" Drop="ServiceItem_Drop" MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown">
-                                    <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2">
+                                        <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2"
+                                                Tag="{Binding DataContext.EditServiceCommand, RelativeSource={RelativeSource AncestorType=ListBox}}">
                                         <Border.ContextMenu>
-                                            <ContextMenu>
+                                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
                                                 <MenuItem Header="Edit Service"
-                                                          Command="{Binding DataContext.EditServiceCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                                                          Command="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                                                           CommandParameter="{Binding}" />
                                                 <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
                                                 <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -190,7 +190,7 @@
                                             <StackPanel Grid.Column="1">
                                                 <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
                                                 <TextBlock Text="{Binding ExecutionTimeText}" />
-                                                <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" Foreground="{Binding LastInputBrush}" />
                                                 <TextBlock>
                                                     <Run Text="{Binding IncomingMessageCount, Mode=OneWay}"/>
                                                     <Run Text=" - incoming"/>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.ComponentModel;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
@@ -17,6 +18,7 @@ using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -54,10 +56,24 @@ namespace DesktopApplicationTemplate.UI.Views
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
             CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
-            Closing += (_, _) => _logger?.LogInformation("MainView closing");
+            Closing += MainView_Closing;
             Closed += (_, _) => _viewModel.ConfigurationChangeBlocked -= OnConfigurationChangeBlocked;
             ShowHome();
             PreloadServicePages();
+        }
+
+        private async void MainView_Closing(object? sender, CancelEventArgs e)
+        {
+            _logger?.LogInformation("MainView closing");
+
+            try
+            {
+                await _viewModel.ShutdownServicesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Failed to stop services during shutdown");
+            }
         }
 
         public void ShowHome()
@@ -151,16 +167,16 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            Action<LogEntry> handler;
-
-            if (svc.Type == ServiceType.Mqtt)
+            Action<LogEntry> handler = entry =>
             {
-                handler = entry => _viewModel.OnServiceLogAdded(svc, entry);
-            }
-            else
-            {
-                handler = entry =>
+                void ApplyLog()
                 {
+                    if (svc.Type == ServiceType.Mqtt)
+                    {
+                        _viewModel.OnServiceLogAdded(svc, entry);
+                        return;
+                    }
+
                     Brush? brush = null;
                     try
                     {
@@ -172,8 +188,17 @@ namespace DesktopApplicationTemplate.UI.Views
                     }
 
                     svc.AddLog(entry.Message, brush ?? Brushes.Black, entry.Level);
-                };
-            }
+                }
+
+                if (Dispatcher.CheckAccess())
+                {
+                    ApplyLog();
+                }
+                else
+                {
+                    _ = Dispatcher.InvokeAsync(ApplyLog, DispatcherPriority.Background);
+                }
+            };
 
             vm.Logger.LogAdded += handler;
             _serviceLogHandlers[svc] = handler;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -62,13 +62,16 @@ namespace DesktopApplicationTemplate.UI.Views
             PreloadServicePages();
         }
 
-        private async void MainView_Closing(object? sender, CancelEventArgs e)
+        private void MainView_Closing(object? sender, CancelEventArgs e)
         {
             _logger?.LogInformation("MainView closing");
 
             try
             {
-                await _viewModel.ShutdownServicesAsync();
+                App.UiThreadTaskFactory.Run(async () =>
+                {
+                    await _viewModel.ShutdownServicesAsync().ConfigureAwait(true);
+                });
             }
             catch (Exception ex)
             {
@@ -196,7 +199,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
                 else
                 {
-                    _ = Dispatcher.InvokeAsync(ApplyLog, DispatcherPriority.Background);
+                    App.UiThreadTaskFactory.Run(async () =>
+                    {
+                        await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
+                        ApplyLog();
+                    });
                 }
             };
 

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -18,6 +18,7 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" /> <!-- Service Name -->
+                <RowDefinition Height="Auto" /> <!-- Connection Role -->
                 <RowDefinition Height="Auto" /> <!-- Host -->
                 <RowDefinition Height="Auto" /> <!-- Port -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
@@ -41,8 +42,11 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="1" Grid.Column="1">
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="2" Grid.Column="1">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -57,8 +61,8 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="2" Grid.Column="1">
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="3" Grid.Column="1">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -73,12 +77,12 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="3" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -21,6 +21,9 @@
                 <RowDefinition Height="Auto" /> <!-- Connection Role -->
                 <RowDefinition Height="Auto" /> <!-- Host -->
                 <RowDefinition Height="Auto" /> <!-- Port -->
+                <RowDefinition Height="Auto" /> <!-- Subnet -->
+                <RowDefinition Height="Auto" /> <!-- Primary DNS -->
+                <RowDefinition Height="Auto" /> <!-- Alternate DNS -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
                 <RowDefinition Height="Auto" /> <!-- Mode -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
@@ -77,12 +80,60 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="4" Grid.Column="1">
+                <TextBox x:Name="SubnetBox" Text="{Binding SubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=SubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="5" Grid.Column="1">
+                <TextBox x:Name="PrimaryDnsBox" Text="{Binding PrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
-            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="6" Grid.Column="1">
+                <TextBox x:Name="AlternateDnsBox" Text="{Binding AlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="1.1.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=AlternateDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+
+            <views:EditorButtonBar Grid.Row="9" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -21,6 +21,9 @@
                 <RowDefinition Height="Auto" /> <!-- Connection Role -->
                 <RowDefinition Height="Auto" /> <!-- Host -->
                 <RowDefinition Height="Auto" /> <!-- Port -->
+                <RowDefinition Height="Auto" /> <!-- Subnet -->
+                <RowDefinition Height="Auto" /> <!-- Primary DNS -->
+                <RowDefinition Height="Auto" /> <!-- Alternate DNS -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
                 <RowDefinition Height="Auto" /> <!-- Mode -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
@@ -77,12 +80,60 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="4" Grid.Column="1">
+                <TextBox x:Name="SubnetBox" Text="{Binding SubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=SubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="5" Grid.Column="1">
+                <TextBox x:Name="PrimaryDnsBox" Text="{Binding PrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
 
-            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="6" Grid.Column="1">
+                <TextBox x:Name="AlternateDnsBox" Text="{Binding AlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="1.1.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=AlternateDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+
+            <views:EditorButtonBar Grid.Row="9" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveAutomationName="Save TCP Service"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -18,6 +18,7 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" /> <!-- Service Name -->
+                <RowDefinition Height="Auto" /> <!-- Connection Role -->
                 <RowDefinition Height="Auto" /> <!-- Host -->
                 <RowDefinition Height="Auto" /> <!-- Port -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
@@ -41,8 +42,11 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="1" Grid.Column="1">
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}" Style="{StaticResource FormField}"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="2" Grid.Column="1">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -57,8 +61,8 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="2" Grid.Column="1">
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="3" Grid.Column="1">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -73,12 +77,12 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="3" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <CheckBox Grid.Row="4" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="4" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
+            <ComboBox Grid.Row="5" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveAutomationName="Save TCP Service"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -65,7 +65,7 @@
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
                 <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
-                <shared:ServiceLogView Grid.Row="3" x:Name="LogView" />
+                <shared:ServiceLogView Grid.Row="3" x:Name="LogView" Height="250" />
             </Grid>
         </Grid>
     </ScrollViewer>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml.cs
@@ -1,5 +1,5 @@
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
-using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
@@ -11,10 +11,11 @@ namespace DesktopApplicationTemplate.UI.Views.Tcp
     /// </summary>
     public partial class TcpServiceMessagesView : Page, IServiceLogHost
     {
-        public TcpServiceMessagesView(TcpServiceMessagesViewModel viewModel)
+        public TcpServiceMessagesView(TcpServiceMessagesViewModel viewModel, ILoggingService logger)
         {
             InitializeComponent();
             DataContext = viewModel;
+            viewModel.Logger = logger;
         }
 
         public void SetServiceContext(ServiceListModel service)


### PR DESCRIPTION
## Summary
- persist per-service logs by capping entries, saving them with service metadata, and restoring them at startup while fixing the service list preview text
- add a TCP connection role option (server/client) with sensible host defaults in the view models, options, and XAML editors
- inject logging into the TCP messages view and implement listener/client loops that log connections, messages, and ping results when listening, while fixing service name normalization

## Testing
- dotnet build (fails: dotnet command not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e4148478dc8326a51db366e99b9deb