### PR TITLE
Add plug-in export workflow and shared packaging helpers

### DIFF
--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Migration routine converts legacy service type names to `ServiceType` and logs unmapped values.
 - `IServiceModule` interface enables service-specific DI registration and modules are discovered and registered automatically at startup.
 - Static `ServiceTypeExtensions` maps service types to short codes for reuse in serialization and configuration.
+- Plug-in packaging utilities expose manifest validation helpers so import and export workflows share directory handling.
 
 #### Changed
 - Clarified environment instruction precedence in `AGENTS.md`.
@@ -53,6 +54,7 @@
 - Text inputs now automatically display tooltips derived from bound property names, guiding expected user input.
 - Reusable `AdvancedConfigViewModelBase<TOptions>` and `AdvancedConfigButtonBar` unify Save/Back logic across advanced configuration views.
 - Reusable `ServiceLogView` control and `ServiceLogViewModel` provide consistent log panels for the main window and services.
+- Main window adds an Export Plug-ins command and dialog so operators can bundle descriptors into `.peakiot` archives.
 - Reusable `ServiceMessageTableView` and `ServiceMessageTableViewModel` display recent service messages with default columns, integrated into the TCP service view.
 - Script editor window with Roslyn-based syntax highlighting and run/save commands.
 - TCP service messages view adds an Edit Script button for modifying scripts and test messages.

--- a/DesktopApplicationTemplate.Core/Modules/PluginLoader.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginLoader.cs
@@ -17,18 +17,7 @@ namespace DesktopApplicationTemplate.Core.Modules;
 /// </summary>
 public sealed class PluginLoader
 {
-    private const string ManifestFileName = "plugin.manifest.json";
-    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
-    {
-        AllowTrailingCommas = true,
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-    };
-
     private static readonly List<PluginLoadContext> ActiveContexts = new();
-    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
-        ? StringComparison.OrdinalIgnoreCase
-        : StringComparison.Ordinal;
     private static readonly HashSet<string> SupportedArchiveExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".peakiot",
@@ -123,20 +112,20 @@ public sealed class PluginLoader
     private void LoadFromArchive(string archivePath, ICollection<Assembly> assemblies)
     {
         using var archive = ZipFile.OpenRead(archivePath);
-        var manifestEntry = archive.GetEntry(ManifestFileName);
+        var manifestEntry = archive.GetEntry(PluginPackageUtilities.ManifestFileName);
         if (manifestEntry is null)
         {
-            logger.LogWarning("Plug-in archive {ArchivePath} does not contain {ManifestFileName}.", archivePath, ManifestFileName);
+            logger.LogWarning("Plug-in archive {ArchivePath} does not contain {ManifestFileName}.", archivePath, PluginPackageUtilities.ManifestFileName);
             return;
         }
 
         PluginManifest? manifest;
         using (var manifestStream = manifestEntry.Open())
         {
-            manifest = JsonSerializer.Deserialize<PluginManifest>(manifestStream, SerializerOptions);
+            manifest = JsonSerializer.Deserialize<PluginManifest>(manifestStream, PluginPackageUtilities.SerializerOptions);
         }
 
-        if (!TryValidateBasicManifest(manifest, archivePath, out var basicErrors))
+        if (!PluginPackageUtilities.TryValidateBasicManifest(manifest, archivePath, out var basicErrors))
         {
             foreach (var error in basicErrors)
             {
@@ -146,7 +135,7 @@ public sealed class PluginLoader
             return;
         }
 
-        var extractionPath = GetExtractionPath(manifest!);
+        var extractionPath = options.GetExtractionPath(manifest!);
         if (Directory.Exists(extractionPath))
         {
             Directory.Delete(extractionPath, recursive: true);
@@ -160,10 +149,10 @@ public sealed class PluginLoader
 
     private void LoadFromDirectory(string directoryPath, ICollection<Assembly> assemblies, string? origin = null)
     {
-        var manifestPath = Path.Combine(directoryPath, ManifestFileName);
+        var manifestPath = options.GetManifestPath(directoryPath);
         if (!File.Exists(manifestPath))
         {
-            logger.LogWarning("Plug-in folder {PluginDirectory} does not contain {ManifestFileName}.", directoryPath, ManifestFileName);
+            logger.LogWarning("Plug-in folder {PluginDirectory} does not contain {ManifestFileName}.", directoryPath, PluginPackageUtilities.ManifestFileName);
             return;
         }
 
@@ -171,7 +160,7 @@ public sealed class PluginLoader
         try
         {
             using var stream = File.OpenRead(manifestPath);
-            manifest = JsonSerializer.Deserialize<PluginManifest>(stream, SerializerOptions);
+            manifest = JsonSerializer.Deserialize<PluginManifest>(stream, PluginPackageUtilities.SerializerOptions);
         }
         catch (JsonException ex)
         {
@@ -179,7 +168,7 @@ public sealed class PluginLoader
             return;
         }
 
-        if (!TryValidateManifest(manifest, directoryPath, origin ?? manifestPath, out var errors))
+        if (!PluginPackageUtilities.TryValidateManifest(manifest, directoryPath, origin ?? manifestPath, out var errors))
         {
             foreach (var error in errors)
             {
@@ -189,14 +178,14 @@ public sealed class PluginLoader
             return;
         }
 
-        var manifestKey = CreateManifestKey(manifest!);
+        var manifestKey = PluginPackageUtilities.CreateManifestKey(manifest!);
         if (!loadedPlugins.Add(manifestKey))
         {
             logger.LogInformation("Plug-in {PluginId} version {PluginVersion} was already loaded. Skipping payload at {PluginDirectory}.", manifest!.Id, manifest.Version, directoryPath);
             return;
         }
 
-        var entryAssemblyPath = ResolvePath(directoryPath, manifest!.EntryAssembly);
+        var entryAssemblyPath = PluginPackageUtilities.ResolveRelativePath(directoryPath, manifest!.EntryAssembly);
         if (entryAssemblyPath is null)
         {
             logger.LogWarning("Entry assembly {EntryAssembly} for plug-in {PluginId} resolves outside of the plug-in directory.", manifest.EntryAssembly, manifest.Id);
@@ -212,7 +201,7 @@ public sealed class PluginLoader
 
         foreach (var assemblyReference in assemblyReferences)
         {
-            var assemblyPath = ResolvePath(directoryPath, assemblyReference);
+            var assemblyPath = PluginPackageUtilities.ResolveRelativePath(directoryPath, assemblyReference);
             if (assemblyPath is null || !File.Exists(assemblyPath))
             {
                 logger.LogWarning(
@@ -243,139 +232,6 @@ public sealed class PluginLoader
         }
     }
 
-    private static bool TryValidateBasicManifest(PluginManifest? manifest, string origin, out List<string> errors)
-    {
-        errors = new List<string>();
-        if (manifest is null)
-        {
-            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' could not be parsed."));
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(manifest.Id))
-        {
-            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'id'."));
-        }
-
-        if (string.IsNullOrWhiteSpace(manifest.Version))
-        {
-            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'version'."));
-        }
-        else if (!Version.TryParse(manifest.Version, out _))
-        {
-            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' specifies an invalid version '{manifest.Version}'."));
-        }
-
-        if (string.IsNullOrWhiteSpace(manifest.EntryAssembly))
-        {
-            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'entryAssembly'."));
-        }
-
-        return errors.Count == 0;
-    }
-
-    private static bool TryValidateManifest(PluginManifest? manifest, string pluginDirectory, string origin, out List<string> errors)
-    {
-        if (!TryValidateBasicManifest(manifest, origin, out errors))
-        {
-            return false;
-        }
-
-        if (manifest is null)
-        {
-            return false;
-        }
-
-        var entryAssembly = ResolvePath(pluginDirectory, manifest.EntryAssembly);
-        if (entryAssembly is null)
-        {
-            errors.Add(FormattableString.Invariant($"Entry assembly '{manifest.EntryAssembly}' resolves outside '{pluginDirectory}'."));
-        }
-        else if (!File.Exists(entryAssembly))
-        {
-            errors.Add(FormattableString.Invariant($"Entry assembly '{manifest.EntryAssembly}' was not found at '{entryAssembly}'."));
-        }
-
-        foreach (var assemblyReference in manifest.ServiceAssemblies)
-        {
-            var resolved = ResolvePath(pluginDirectory, assemblyReference);
-            if (resolved is null)
-            {
-                errors.Add(FormattableString.Invariant($"Service assembly '{assemblyReference}' resolves outside '{pluginDirectory}'."));
-                continue;
-            }
-
-            if (!File.Exists(resolved))
-            {
-                errors.Add(FormattableString.Invariant($"Service assembly '{assemblyReference}' was not found at '{resolved}'."));
-            }
-        }
-
-        foreach (var probingPath in manifest.ProbingPaths)
-        {
-            if (ResolvePath(pluginDirectory, probingPath) is null)
-            {
-                errors.Add(FormattableString.Invariant($"Probing path '{probingPath}' resolves outside '{pluginDirectory}'."));
-            }
-        }
-
-        return errors.Count == 0;
-    }
-
-    private static string CreateManifestKey(PluginManifest manifest)
-    {
-        return FormattableString.Invariant($"{manifest.Id.Trim()}|{manifest.Version.Trim()}");
-    }
-
-    private string GetExtractionPath(PluginManifest manifest)
-    {
-        var safeId = SanitizeSegment(manifest.Id);
-        var safeVersion = SanitizeSegment(manifest.Version);
-        return Path.Combine(options.ExtractionDirectory, safeId, safeVersion);
-    }
-
-    private static string? ResolvePath(string root, string relativePath)
-    {
-        if (string.IsNullOrWhiteSpace(relativePath))
-        {
-            return null;
-        }
-
-        var combined = Path.GetFullPath(Path.Combine(root, relativePath));
-        var rootPath = EnsureTrailingSeparator(Path.GetFullPath(root));
-        if (!combined.StartsWith(rootPath, PathComparison))
-        {
-            return null;
-        }
-
-        return combined;
-    }
-
-    private static string EnsureTrailingSeparator(string path)
-    {
-        if (!path.EndsWith(Path.DirectorySeparatorChar) && !path.EndsWith(Path.AltDirectorySeparatorChar))
-        {
-            path += Path.DirectorySeparatorChar;
-        }
-
-        return path;
-    }
-
-    private static string SanitizeSegment(string value)
-    {
-        var invalid = Path.GetInvalidFileNameChars();
-        var buffer = value.ToCharArray();
-        for (var i = 0; i < buffer.Length; i++)
-        {
-            if (invalid.Contains(buffer[i]))
-            {
-                buffer[i] = '_';
-            }
-        }
-
-        return new string(buffer);
-    }
-
     private sealed class PluginLoadContext : AssemblyLoadContext
     {
         private readonly AssemblyDependencyResolver resolver;
@@ -390,9 +246,9 @@ public sealed class PluginLoader
             }
 
             resolver = new AssemblyDependencyResolver(entryAssemblyPath);
-            var rootPath = EnsureTrailingSeparator(Path.GetFullPath(pluginDirectory));
+            var rootPath = PluginPackageUtilities.EnsureTrailingSeparator(Path.GetFullPath(pluginDirectory));
             this.probingPaths = probingPaths
-                .Select(path => ResolvePath(rootPath, path))
+                .Select(path => PluginPackageUtilities.ResolveRelativePath(rootPath, path))
                 .Where(path => path is not null)
                 .Cast<string>()
                 .Distinct(StringComparer.OrdinalIgnoreCase)

--- a/DesktopApplicationTemplate.Core/Modules/PluginLoaderOptions.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginLoaderOptions.cs
@@ -36,6 +36,39 @@ public sealed class PluginLoaderOptions
     public string ExtractionDirectory { get; }
 
     /// <summary>
+    /// Gets the full path for a package residing in the plug-in root directory.
+    /// Ensures the directory exists.
+    /// </summary>
+    /// <param name="fileName">The package file name.</param>
+    /// <returns>The absolute package path.</returns>
+    public string GetPackagePath(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("File name must be provided", nameof(fileName));
+        }
+
+        Directory.CreateDirectory(RootDirectory);
+        return Path.Combine(RootDirectory, fileName);
+    }
+
+    /// <summary>
+    /// Calculates the extraction path for the provided manifest.
+    /// </summary>
+    public string GetExtractionPath(PluginManifest manifest)
+    {
+        return PluginPackageUtilities.GetExtractionPath(this, manifest);
+    }
+
+    /// <summary>
+    /// Gets the manifest path for the specified plug-in directory.
+    /// </summary>
+    public string GetManifestPath(string pluginDirectory)
+    {
+        return PluginPackageUtilities.GetManifestPath(pluginDirectory);
+    }
+
+    /// <summary>
     /// Creates options using the provided configuration.
     /// </summary>
     /// <param name="configuration">The application configuration.</param>

--- a/DesktopApplicationTemplate.Core/Modules/PluginPackageUtilities.cs
+++ b/DesktopApplicationTemplate.Core/Modules/PluginPackageUtilities.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace DesktopApplicationTemplate.Core.Modules;
+
+/// <summary>
+/// Provides helper methods for working with plug-in package manifests and payloads.
+/// </summary>
+public static class PluginPackageUtilities
+{
+    /// <summary>
+    /// Gets the manifest file name used by plug-in packages.
+    /// </summary>
+    public const string ManifestFileName = "plugin.manifest.json";
+
+    /// <summary>
+    /// Gets the JSON serializer options used for manifests.
+    /// </summary>
+    public static JsonSerializerOptions SerializerOptions { get; } = new(JsonSerializerDefaults.Web)
+    {
+        AllowTrailingCommas = true,
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Builds a manifest path within the provided directory.
+    /// </summary>
+    public static string GetManifestPath(string pluginDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(pluginDirectory))
+        {
+            throw new ArgumentException("Directory must be provided", nameof(pluginDirectory));
+        }
+
+        return Path.Combine(pluginDirectory, ManifestFileName);
+    }
+
+    /// <summary>
+    /// Validates required manifest fields.
+    /// </summary>
+    public static bool TryValidateBasicManifest(PluginManifest? manifest, string origin, out List<string> errors)
+    {
+        errors = new List<string>();
+        if (manifest is null)
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' could not be parsed."));
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Id))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'id'."));
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Version))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'version'."));
+        }
+        else if (!Version.TryParse(manifest.Version, out _))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' specifies an invalid version '{manifest.Version}'."));
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.EntryAssembly))
+        {
+            errors.Add(FormattableString.Invariant($"Plug-in manifest in '{origin}' is missing 'entryAssembly'."));
+        }
+
+        return errors.Count == 0;
+    }
+
+    /// <summary>
+    /// Validates manifest entries that depend on the on-disk plug-in directory.
+    /// </summary>
+    public static bool TryValidateManifest(PluginManifest? manifest, string pluginDirectory, string origin, out List<string> errors)
+    {
+        if (!TryValidateBasicManifest(manifest, origin, out errors))
+        {
+            return false;
+        }
+
+        if (manifest is null)
+        {
+            return false;
+        }
+
+        var entryAssembly = ResolveRelativePath(pluginDirectory, manifest.EntryAssembly);
+        if (entryAssembly is null)
+        {
+            errors.Add(FormattableString.Invariant($"Entry assembly '{manifest.EntryAssembly}' resolves outside '{pluginDirectory}'."));
+        }
+        else if (!File.Exists(entryAssembly))
+        {
+            errors.Add(FormattableString.Invariant($"Entry assembly '{manifest.EntryAssembly}' was not found at '{entryAssembly}'."));
+        }
+
+        foreach (var assemblyReference in manifest.ServiceAssemblies)
+        {
+            var resolved = ResolveRelativePath(pluginDirectory, assemblyReference);
+            if (resolved is null)
+            {
+                errors.Add(FormattableString.Invariant($"Service assembly '{assemblyReference}' resolves outside '{pluginDirectory}'."));
+                continue;
+            }
+
+            if (!File.Exists(resolved))
+            {
+                errors.Add(FormattableString.Invariant($"Service assembly '{assemblyReference}' was not found at '{resolved}'."));
+            }
+        }
+
+        foreach (var probingPath in manifest.ProbingPaths)
+        {
+            if (ResolveRelativePath(pluginDirectory, probingPath) is null)
+            {
+                errors.Add(FormattableString.Invariant($"Probing path '{probingPath}' resolves outside '{pluginDirectory}'."));
+            }
+        }
+
+        return errors.Count == 0;
+    }
+
+    /// <summary>
+    /// Creates a stable key for identifying a manifest payload.
+    /// </summary>
+    public static string CreateManifestKey(PluginManifest manifest)
+    {
+        if (manifest is null)
+        {
+            throw new ArgumentNullException(nameof(manifest));
+        }
+
+        return FormattableString.Invariant($"{manifest.Id.Trim()}|{manifest.Version.Trim()}");
+    }
+
+    /// <summary>
+    /// Calculates the extraction path for a manifest using the configured options.
+    /// </summary>
+    public static string GetExtractionPath(PluginLoaderOptions options, PluginManifest manifest)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (manifest is null)
+        {
+            throw new ArgumentNullException(nameof(manifest));
+        }
+
+        var safeId = SanitizeSegment(manifest.Id);
+        var safeVersion = SanitizeSegment(manifest.Version);
+        return Path.Combine(options.ExtractionDirectory, safeId, safeVersion);
+    }
+
+    /// <summary>
+    /// Resolves a relative path inside a plug-in directory.
+    /// Returns null when the path escapes the root.
+    /// </summary>
+    public static string? ResolveRelativePath(string root, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            return null;
+        }
+
+        var combined = Path.GetFullPath(Path.Combine(root, relativePath));
+        var rootPath = EnsureTrailingSeparator(Path.GetFullPath(root));
+        if (!combined.StartsWith(rootPath, PathComparison))
+        {
+            return null;
+        }
+
+        return combined;
+    }
+
+    /// <summary>
+    /// Ensures a path ends with the system directory separator character.
+    /// </summary>
+    public static string EnsureTrailingSeparator(string path)
+    {
+        if (path.EndsWith(Path.DirectorySeparatorChar) || path.EndsWith(Path.AltDirectorySeparatorChar))
+        {
+            return path;
+        }
+
+        return path + Path.DirectorySeparatorChar;
+    }
+
+    /// <summary>
+    /// Replaces invalid file name characters with underscores.
+    /// </summary>
+    public static string SanitizeSegment(string value)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var buffer = value.ToCharArray();
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            if (invalid.Contains(buffer[i]))
+            {
+                buffer[i] = '_';
+            }
+        }
+
+        return new string(buffer);
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="candidate"/> is contained within <paramref name="root"/>.
+    /// </summary>
+    public static bool IsPathWithinRoot(string root, string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(root) || string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        var fullRoot = EnsureTrailingSeparator(Path.GetFullPath(root));
+        var fullCandidate = Path.GetFullPath(candidate);
+        return fullCandidate.StartsWith(fullRoot, PathComparison);
+    }
+
+    /// <summary>
+    /// Determines whether two paths reference the same location using platform-specific comparison rules.
+    /// </summary>
+    public static bool PathsEqual(string first, string second)
+    {
+        if (string.IsNullOrWhiteSpace(first) || string.IsNullOrWhiteSpace(second))
+        {
+            return false;
+        }
+
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), comparison);
+    }
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -154,6 +154,13 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<ServiceCatalog>(_ => new ServiceCatalog(descriptorSnapshot));
             services.AddSingleton<IServiceCatalog>(sp => sp.GetRequiredService<ServiceCatalog>());
 
+            var pluginOptions = PluginLoaderOptions.FromConfiguration(configuration);
+            services.AddSingleton(pluginOptions);
+            services.AddSingleton<IPluginImportService, PluginImportService>();
+            services.AddSingleton<IPluginExportService, PluginExportService>();
+            services.AddTransient<PluginExportViewModel>();
+            services.AddTransient<PluginExportWindow>();
+
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Mqtt, (sp, _) => new MqttEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<MqttEditServiceHandler>>()));
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Heartbeat, (sp, _) => new HeartbeatEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HeartbeatEditServiceHandler>>()));
             services.AddKeyedSingleton<IEditServiceHandler>(ServiceType.Hid, (sp, _) => new HidEditServiceHandler(() => sp.GetRequiredService<MainView>(), () => sp.GetRequiredService<MainViewModel>(), sp, sp.GetService<ILogger<HidEditServiceHandler>>()));

--- a/DesktopApplicationTemplate.UI/Services/IPluginExportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IPluginExportService.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.Services;
+
+/// <summary>
+/// Provides operations for packaging plug-in payloads.
+/// </summary>
+public interface IPluginExportService
+{
+    /// <summary>
+    /// Gets descriptors that can be exported from the current environment.
+    /// </summary>
+    IReadOnlyCollection<PluginDescriptorExportInfo> GetExportableDescriptors();
+
+    /// <summary>
+    /// Exports the selected descriptors into a plug-in package.
+    /// </summary>
+    Task<PluginExportResult> ExportAsync(PluginExportRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Provides descriptor metadata displayed in the export workflow.
+/// </summary>
+/// <param name="Id">The descriptor identifier.</param>
+/// <param name="DisplayName">The human-friendly display name.</param>
+/// <param name="Category">The descriptor category.</param>
+public sealed record PluginDescriptorExportInfo(string Id, string DisplayName, string Category);
+
+/// <summary>
+/// Describes export parameters supplied by the UI.
+/// </summary>
+/// <param name="PluginId">Unique identifier written to the manifest.</param>
+/// <param name="PluginName">Display name written to the manifest.</param>
+/// <param name="Version">Semantic version recorded in the manifest.</param>
+/// <param name="DescriptorIds">Descriptors that should be included.</param>
+/// <param name="DestinationPath">Optional destination path for the package.</param>
+public sealed record PluginExportRequest(
+    string PluginId,
+    string PluginName,
+    string Version,
+    IReadOnlyCollection<string> DescriptorIds,
+    string? DestinationPath);
+
+/// <summary>
+/// Represents the result of an export operation.
+/// </summary>
+/// <param name="Success">Indicates whether the export succeeded.</param>
+/// <param name="Message">User-friendly status message.</param>
+/// <param name="PackagePath">Path to the generated package when successful.</param>
+/// <param name="Descriptors">Descriptors included in the package.</param>
+public sealed record PluginExportResult(
+    bool Success,
+    string Message,
+    string? PackagePath,
+    IReadOnlyCollection<string> Descriptors);

--- a/DesktopApplicationTemplate.UI/Services/PluginExportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/PluginExportService.cs
@@ -1,0 +1,489 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.UI.Services;
+
+/// <summary>
+/// Creates plug-in packages from descriptors discovered at runtime.
+/// </summary>
+public sealed class PluginExportService : IPluginExportService
+{
+    private readonly PluginLoaderOptions _options;
+    private readonly IServiceCatalog _serviceCatalog;
+    private readonly ILogger<PluginExportService> _logger;
+
+    public PluginExportService(
+        PluginLoaderOptions options,
+        IServiceCatalog serviceCatalog,
+        ILogger<PluginExportService> logger)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _serviceCatalog = serviceCatalog ?? throw new ArgumentNullException(nameof(serviceCatalog));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public IReadOnlyCollection<PluginDescriptorExportInfo> GetExportableDescriptors()
+    {
+        var index = BuildModuleIndex();
+        return index.Values
+            .Select(context => new PluginDescriptorExportInfo(
+                context.Descriptor.Id,
+                context.Descriptor.DisplayName,
+                context.Descriptor.Category))
+            .OrderBy(info => info.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<PluginExportResult> ExportAsync(PluginExportRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            return await Task.Run(() => ExportInternal(request, cancellationToken), cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Plug-in export cancelled.");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export plug-in package for descriptors {Descriptors}.", string.Join(", ", request.DescriptorIds ?? Array.Empty<string>()));
+            return new PluginExportResult(false, "Export failed. Check logs for details.", null, request.DescriptorIds ?? Array.Empty<string>());
+        }
+    }
+
+    private PluginExportResult ExportInternal(PluginExportRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.PluginId))
+        {
+            return new PluginExportResult(false, "A plug-in id is required.", null, request.DescriptorIds ?? Array.Empty<string>());
+        }
+
+        if (string.IsNullOrWhiteSpace(request.PluginName))
+        {
+            return new PluginExportResult(false, "A plug-in name is required.", null, request.DescriptorIds ?? Array.Empty<string>());
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Version) || !Version.TryParse(request.Version, out _))
+        {
+            return new PluginExportResult(false, "Provide a semantic version (for example, 1.0.0).", null, request.DescriptorIds ?? Array.Empty<string>());
+        }
+
+        var descriptorIds = request.DescriptorIds ?? Array.Empty<string>();
+        if (descriptorIds.Count == 0)
+        {
+            return new PluginExportResult(false, "Select at least one descriptor to export.", null, descriptorIds);
+        }
+
+        var moduleIndex = BuildModuleIndex();
+        var selectedContexts = new List<ModuleExportContext>();
+        foreach (var descriptorId in descriptorIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!moduleIndex.TryGetValue(descriptorId, out var context))
+            {
+                return new PluginExportResult(false, $"Descriptor '{descriptorId}' is not available for export.", null, descriptorIds);
+            }
+
+            selectedContexts.Add(context);
+        }
+
+        if (selectedContexts.Count == 0)
+        {
+            return new PluginExportResult(false, "No descriptors matched the selection.", null, descriptorIds);
+        }
+
+        var filesToCopy = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var serviceAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var probingPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string? entryAssembly = null;
+
+        foreach (var context in selectedContexts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var moduleRelativePath = NormalizeRelativePath(context.PluginRoot, context.AssemblyPath);
+            AddFile(moduleRelativePath, context.AssemblyPath, filesToCopy);
+            serviceAssemblies.Add(moduleRelativePath);
+            entryAssembly ??= moduleRelativePath;
+
+            if (context.Manifest is not null)
+            {
+                IncludeFromManifest(context, filesToCopy, serviceAssemblies, probingPaths, cancellationToken);
+            }
+            else
+            {
+                IncludeDirectoryContents(Path.GetDirectoryName(context.AssemblyPath)!, context.PluginRoot, filesToCopy, cancellationToken);
+            }
+        }
+
+        if (filesToCopy.Count == 0)
+        {
+            return new PluginExportResult(false, "No assemblies were discovered for the selected descriptors.", null, descriptorIds);
+        }
+
+        entryAssembly ??= serviceAssemblies.First();
+        var manifest = BuildManifest(request, entryAssembly, serviceAssemblies, probingPaths);
+        if (!PluginPackageUtilities.TryValidateBasicManifest(manifest, "export", out var manifestErrors))
+        {
+            return new PluginExportResult(false, string.Join(Environment.NewLine, manifestErrors), null, descriptorIds);
+        }
+
+        var destination = ResolveDestinationPath(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var tempRoot = CreateTemporaryDirectory();
+        try
+        {
+            foreach (var kvp in filesToCopy)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var targetPath = Path.Combine(tempRoot, kvp.Key);
+                var targetDirectory = Path.GetDirectoryName(targetPath);
+                if (!string.IsNullOrEmpty(targetDirectory))
+                {
+                    Directory.CreateDirectory(targetDirectory);
+                }
+
+                File.Copy(kvp.Value, targetPath, overwrite: true);
+            }
+
+            var manifestPath = Path.Combine(tempRoot, PluginPackageUtilities.ManifestFileName);
+            using (var stream = File.Create(manifestPath))
+            {
+                JsonSerializer.Serialize(stream, manifest, PluginPackageUtilities.SerializerOptions);
+            }
+
+            var destinationDirectory = Path.GetDirectoryName(destination);
+            if (!string.IsNullOrEmpty(destinationDirectory))
+            {
+                Directory.CreateDirectory(destinationDirectory);
+            }
+
+            if (File.Exists(destination))
+            {
+                File.Delete(destination);
+            }
+
+            ZipFile.CreateFromDirectory(tempRoot, destination, CompressionLevel.Optimal, includeBaseDirectory: false);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempRoot);
+        }
+
+        var successMessage = selectedContexts.Count == 1
+            ? $"Exported descriptor '{selectedContexts[0].Descriptor.DisplayName}'."
+            : $"Exported {selectedContexts.Count} descriptors.";
+
+        _logger.LogInformation("{Message} Package: {PackagePath}.", successMessage, destination);
+        return new PluginExportResult(true, successMessage, destination, descriptorIds);
+    }
+
+    private void IncludeFromManifest(
+        ModuleExportContext context,
+        IDictionary<string, string> filesToCopy,
+        ISet<string> serviceAssemblies,
+        ISet<string> probingPaths,
+        CancellationToken cancellationToken)
+    {
+        var manifest = context.Manifest!;
+
+        var entryAssemblyPath = PluginPackageUtilities.ResolveRelativePath(context.PluginRoot, manifest.EntryAssembly);
+        if (entryAssemblyPath is not null && File.Exists(entryAssemblyPath))
+        {
+            var relative = NormalizeRelativePath(context.PluginRoot, entryAssemblyPath);
+            AddFile(relative, entryAssemblyPath, filesToCopy);
+            serviceAssemblies.Add(relative);
+        }
+
+        foreach (var assemblyReference in manifest.ServiceAssemblies)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var resolved = PluginPackageUtilities.ResolveRelativePath(context.PluginRoot, assemblyReference);
+            if (resolved is null || !File.Exists(resolved))
+            {
+                continue;
+            }
+
+            var relative = NormalizeRelativePath(context.PluginRoot, resolved);
+            AddFile(relative, resolved, filesToCopy);
+            serviceAssemblies.Add(relative);
+        }
+
+        foreach (var probingPath in manifest.ProbingPaths)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var resolved = PluginPackageUtilities.ResolveRelativePath(context.PluginRoot, probingPath);
+            if (resolved is null || !Directory.Exists(resolved))
+            {
+                continue;
+            }
+
+            var relativeDirectory = NormalizeRelativePath(context.PluginRoot, resolved);
+            probingPaths.Add(relativeDirectory);
+            IncludeDirectoryContents(resolved, context.PluginRoot, filesToCopy, cancellationToken);
+        }
+    }
+
+    private static void IncludeDirectoryContents(
+        string directory,
+        string pluginRoot,
+        IDictionary<string, string> filesToCopy,
+        CancellationToken cancellationToken)
+    {
+        foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.Equals(Path.GetFileName(file), PluginPackageUtilities.ManifestFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!PluginPackageUtilities.IsPathWithinRoot(pluginRoot, file))
+            {
+                continue;
+            }
+
+            var relative = NormalizeRelativePath(pluginRoot, file);
+            AddFile(relative, file, filesToCopy);
+        }
+    }
+
+    private static void AddFile(string relativePath, string sourcePath, IDictionary<string, string> filesToCopy)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            relativePath = Path.GetFileName(sourcePath);
+        }
+
+        if (filesToCopy.TryGetValue(relativePath, out var existing))
+        {
+            if (!PluginPackageUtilities.PathsEqual(existing, sourcePath))
+            {
+                throw new InvalidOperationException(FormattableString.Invariant($"Conflicting files map to '{relativePath}'."));
+            }
+
+            return;
+        }
+
+        filesToCopy[relativePath] = sourcePath;
+    }
+
+    private PluginManifest BuildManifest(
+        PluginExportRequest request,
+        string entryAssembly,
+        IEnumerable<string> serviceAssemblies,
+        IEnumerable<string> probingPaths)
+    {
+        var normalizedEntry = NormalizeForManifest(entryAssembly);
+        var services = serviceAssemblies
+            .Where(path => !string.Equals(path, entryAssembly, StringComparison.OrdinalIgnoreCase))
+            .Select(NormalizeForManifest)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var normalizedProbing = probingPaths
+            .Select(NormalizeForManifest)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new PluginManifest
+        {
+            Id = request.PluginId.Trim(),
+            Name = request.PluginName.Trim(),
+            Version = request.Version.Trim(),
+            EntryAssembly = normalizedEntry,
+            ServiceAssemblies = services,
+            ProbingPaths = normalizedProbing,
+        };
+    }
+
+    private string ResolveDestinationPath(PluginExportRequest request)
+    {
+        var destination = request.DestinationPath;
+        if (string.IsNullOrWhiteSpace(destination))
+        {
+            var safeId = PluginPackageUtilities.SanitizeSegment(request.PluginId.Trim());
+            var safeVersion = PluginPackageUtilities.SanitizeSegment(request.Version.Trim());
+            var fileName = FormattableString.Invariant($"{safeId}-{safeVersion}.peakiot");
+            return _options.GetPackagePath(fileName);
+        }
+
+        destination = destination.Trim();
+        var extension = Path.GetExtension(destination);
+        if (string.IsNullOrWhiteSpace(extension) || !extension.Equals(".peakiot", StringComparison.OrdinalIgnoreCase))
+        {
+            destination = Path.ChangeExtension(destination, ".peakiot");
+        }
+
+        return destination;
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "PluginExport", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures so export result is not hidden.
+        }
+    }
+
+    private IReadOnlyDictionary<string, ModuleExportContext> BuildModuleIndex()
+    {
+        var assemblies = PluginLoader.CombineWithDefaultAssemblies(AppDomain.CurrentDomain.GetAssemblies());
+        var modules = ServiceModuleDiscovery.InstantiateModules(assemblies);
+        var result = new Dictionary<string, ModuleExportContext>(StringComparer.Ordinal);
+        var availableIds = new HashSet<string>(_serviceCatalog.Descriptors.Select(d => d.Id), StringComparer.Ordinal);
+
+        foreach (var module in modules)
+        {
+            var moduleAssembly = module.GetType().Assembly;
+            var location = moduleAssembly.Location;
+            if (string.IsNullOrWhiteSpace(location))
+            {
+                continue;
+            }
+
+            if (!IsWithinManagedRoots(location))
+            {
+                continue;
+            }
+
+            var pluginRoot = FindPluginRoot(location);
+            if (pluginRoot is null)
+            {
+                continue;
+            }
+
+            PluginManifest? manifest = null;
+            var manifestPath = _options.GetManifestPath(pluginRoot);
+            if (File.Exists(manifestPath))
+            {
+                try
+                {
+                    using var manifestStream = File.OpenRead(manifestPath);
+                    manifest = JsonSerializer.Deserialize<PluginManifest>(manifestStream, PluginPackageUtilities.SerializerOptions);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to read plug-in manifest at {ManifestPath}.", manifestPath);
+                }
+            }
+
+            foreach (var descriptor in module.DescribeServices() ?? Array.Empty<IServiceDescriptor>())
+            {
+                if (descriptor is null)
+                {
+                    continue;
+                }
+
+                if (!availableIds.Contains(descriptor.Id))
+                {
+                    continue;
+                }
+
+                result[descriptor.Id] = new ModuleExportContext(module, descriptor, location, pluginRoot, manifest);
+            }
+        }
+
+        return result;
+    }
+
+    private bool IsWithinManagedRoots(string path)
+    {
+        return PluginPackageUtilities.IsPathWithinRoot(_options.ExtractionDirectory, path)
+            || PluginPackageUtilities.IsPathWithinRoot(_options.RootDirectory, path);
+    }
+
+    private string? FindPluginRoot(string assemblyPath)
+    {
+        var directory = Path.GetDirectoryName(assemblyPath);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return null;
+        }
+
+        var current = directory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            var manifestPath = _options.GetManifestPath(current);
+            if (File.Exists(manifestPath))
+            {
+                return current;
+            }
+
+            if (!IsWithinManagedRoots(current))
+            {
+                break;
+            }
+
+            var parent = Directory.GetParent(current)?.FullName;
+            if (string.IsNullOrEmpty(parent) || PluginPackageUtilities.PathsEqual(parent, current))
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return null;
+    }
+
+    private static string NormalizeRelativePath(string root, string path)
+    {
+        var relative = Path.GetRelativePath(root, path);
+        if (string.Equals(relative, ".", StringComparison.Ordinal))
+        {
+            return Path.GetFileName(path);
+        }
+
+        return relative;
+    }
+
+    private static string NormalizeForManifest(string relativePath)
+    {
+        return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private sealed record ModuleExportContext(
+        IServiceModule Module,
+        IServiceDescriptor Descriptor,
+        string AssemblyPath,
+        string PluginRoot,
+        PluginManifest? Manifest);
+}

--- a/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
@@ -58,11 +58,10 @@ public sealed class PluginImportService : IPluginImportService
 
         try
         {
-            Directory.CreateDirectory(_options.RootDirectory);
             var fileName = Path.GetFileName(sourcePath);
-            var destinationPath = Path.Combine(_options.RootDirectory, fileName);
+            var destinationPath = _options.GetPackagePath(fileName);
 
-            if (!PathsEqual(sourcePath, destinationPath))
+            if (!PluginPackageUtilities.PathsEqual(sourcePath, destinationPath))
             {
                 _logger.LogInformation("Copying plug-in package {Source} to {Destination}.", sourcePath, destinationPath);
                 File.Copy(sourcePath, destinationPath, overwrite: true);
@@ -114,9 +113,4 @@ public sealed class PluginImportService : IPluginImportService
         }
     }
 
-    private static bool PathsEqual(string first, string second)
-    {
-        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), comparison);
-    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -41,6 +41,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand RemoveServiceCommand { get; }
         public ICommand EditServiceCommand { get; }
         public ICommand ToggleServiceProcessCommand { get; }
+        public ICommand ExportPluginsCommand { get; }
         public int ServicesCreated => Services.Count;
         public int CurrentActiveServices => Services.Count(s => s.IsActive);
 
@@ -129,6 +130,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             RemoveServiceCommand = new AsyncRelayCommand(RemoveSelectedServiceAsync, () => SelectedService != null);
             EditServiceCommand = new RelayCommand<ServiceListModel?>(EditService, svc => svc != null);
             ToggleServiceProcessCommand = new AsyncRelayCommand(ToggleServiceProcessAsync, () => !IsServiceProcessBusy);
+            ExportPluginsCommand = new RelayCommand(OnExportPlugins);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
             Filters.PropertyChanged += (_, __) => ApplyFilters();
             LoadServices();
@@ -159,8 +161,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
+        private void OnExportPlugins()
+        {
+            ExportPluginsRequested?.Invoke(this, EventArgs.Empty);
+        }
+
         public event Action? AddServiceRequested;
         public event Action? ConfigurationChangeBlocked;
+        public event EventHandler? ExportPluginsRequested;
 
         public bool RequestConfigurationChange()
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/PluginDescriptorSelectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/PluginDescriptorSelectionViewModel.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// Represents a selectable descriptor in the export dialog.
+/// </summary>
+public sealed class PluginDescriptorSelectionViewModel : ViewModelBase
+{
+    private bool _isSelected;
+
+    public PluginDescriptorSelectionViewModel(string id, string displayName, string category)
+    {
+        Id = id;
+        DisplayName = displayName;
+        Category = category;
+    }
+
+    public string Id { get; }
+
+    public string DisplayName { get; }
+
+    public string Category { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (_isSelected != value)
+            {
+                _isSelected = value;
+                OnPropertyChanged();
+                SelectionChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public event EventHandler? SelectionChanged;
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/PluginExportViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/PluginExportViewModel.cs
@@ -245,40 +245,4 @@ public sealed class PluginExportViewModel : ViewModelBase, IDisposable
         _exportCommand.RaiseCanExecuteChanged();
     }
 
-    /// <summary>
-    /// Represents a selectable descriptor in the export dialog.
-    /// </summary>
-    public sealed class PluginDescriptorSelectionViewModel : ViewModelBase
-    {
-        private bool _isSelected;
-
-        public PluginDescriptorSelectionViewModel(string id, string displayName, string category)
-        {
-            Id = id;
-            DisplayName = displayName;
-            Category = category;
-        }
-
-        public string Id { get; }
-
-        public string DisplayName { get; }
-
-        public string Category { get; }
-
-        public bool IsSelected
-        {
-            get => _isSelected;
-            set
-            {
-                if (_isSelected != value)
-                {
-                    _isSelected = value;
-                    OnPropertyChanged();
-                    SelectionChanged?.Invoke(this, EventArgs.Empty);
-                }
-            }
-        }
-
-        public event EventHandler? SelectionChanged;
-    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/PluginExportViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/PluginExportViewModel.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Core.Modules;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Services;
+
+namespace DesktopApplicationTemplate.UI.ViewModels;
+
+/// <summary>
+/// View model that orchestrates plug-in export operations.
+/// </summary>
+public sealed class PluginExportViewModel : ViewModelBase, IDisposable
+{
+    private readonly IPluginExportService _exportService;
+    private readonly IServiceCatalog _serviceCatalog;
+    private readonly AsyncRelayCommand _exportCommand;
+    private readonly RelayCommand _cancelCommand;
+
+    private string _pluginId = "Custom.Plugin";
+    private string _pluginName = "Custom Plugin";
+    private string _version = "1.0.0";
+    private string _destinationPath = string.Empty;
+    private string _statusMessage = string.Empty;
+    private bool _isExporting;
+
+    public PluginExportViewModel(IPluginExportService exportService, IServiceCatalog serviceCatalog)
+    {
+        _exportService = exportService ?? throw new ArgumentNullException(nameof(exportService));
+        _serviceCatalog = serviceCatalog ?? throw new ArgumentNullException(nameof(serviceCatalog));
+
+        _exportCommand = new AsyncRelayCommand(ExportAsync, CanExport);
+        _cancelCommand = new RelayCommand(OnCancel);
+
+        Descriptors = new ObservableCollection<PluginDescriptorSelectionViewModel>();
+        RefreshDescriptors();
+        _serviceCatalog.DescriptorsChanged += OnDescriptorsChanged;
+    }
+
+    public ObservableCollection<PluginDescriptorSelectionViewModel> Descriptors { get; }
+
+    public ICommand ExportCommand => _exportCommand;
+
+    public ICommand CancelCommand => _cancelCommand;
+
+    public string PluginId
+    {
+        get => _pluginId;
+        set
+        {
+            if (_pluginId != value)
+            {
+                _pluginId = value ?? string.Empty;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(SuggestedFileName));
+            }
+        }
+    }
+
+    public string PluginName
+    {
+        get => _pluginName;
+        set
+        {
+            if (_pluginName != value)
+            {
+                _pluginName = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string Version
+    {
+        get => _version;
+        set
+        {
+            if (_version != value)
+            {
+                _version = value ?? string.Empty;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(SuggestedFileName));
+            }
+        }
+    }
+
+    public string DestinationPath
+    {
+        get => _destinationPath;
+        set
+        {
+            if (_destinationPath != value)
+            {
+                _destinationPath = value ?? string.Empty;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (_statusMessage != value)
+            {
+                _statusMessage = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public bool IsExporting
+    {
+        get => _isExporting;
+        private set
+        {
+            if (_isExporting != value)
+            {
+                _isExporting = value;
+                OnPropertyChanged();
+                UpdateCommandStates();
+            }
+        }
+    }
+
+    public bool HasDescriptors => Descriptors.Count > 0;
+
+    public string SuggestedFileName => FormattableString.Invariant($"{PluginPackageUtilities.SanitizeSegment(string.IsNullOrWhiteSpace(PluginId) ? "Plugin" : PluginId.Trim())}-{PluginPackageUtilities.SanitizeSegment(string.IsNullOrWhiteSpace(Version) ? "1.0.0" : Version.Trim())}.peakiot");
+
+    public event EventHandler<PluginExportResult>? ExportCompleted;
+
+    public event EventHandler? CancelRequested;
+
+    public void Dispose()
+    {
+        foreach (var descriptor in Descriptors)
+        {
+            descriptor.SelectionChanged -= DescriptorSelectionChanged;
+        }
+
+        _serviceCatalog.DescriptorsChanged -= OnDescriptorsChanged;
+    }
+
+    private bool CanExport()
+    {
+        return !IsExporting && Descriptors.Any(descriptor => descriptor.IsSelected);
+    }
+
+    private async Task ExportAsync()
+    {
+        if (IsExporting)
+        {
+            return;
+        }
+
+        IsExporting = true;
+        StatusMessage = "Exporting plug-in...";
+
+        try
+        {
+            var selected = Descriptors
+                .Where(descriptor => descriptor.IsSelected)
+                .Select(descriptor => descriptor.Id)
+                .ToArray();
+
+            var request = new PluginExportRequest(
+                PluginId,
+                PluginName,
+                Version,
+                selected,
+                string.IsNullOrWhiteSpace(DestinationPath) ? null : DestinationPath);
+
+            var result = await _exportService.ExportAsync(request).ConfigureAwait(true);
+            StatusMessage = result.Message;
+
+            if (result.Success && !string.IsNullOrWhiteSpace(result.PackagePath))
+            {
+                DestinationPath = result.PackagePath;
+            }
+
+            ExportCompleted?.Invoke(this, result);
+        }
+        finally
+        {
+            IsExporting = false;
+        }
+    }
+
+    private void OnCancel()
+    {
+        CancelRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnDescriptorsChanged(object? sender, EventArgs e)
+    {
+        if (App.UiThreadTaskFactory is null)
+        {
+            RefreshDescriptors();
+            return;
+        }
+
+        _ = App.UiThreadTaskFactory.RunAsync(async () =>
+        {
+            RefreshDescriptors();
+            await Task.CompletedTask;
+        });
+    }
+
+    private void RefreshDescriptors()
+    {
+        var previouslySelected = new HashSet<string>(Descriptors.Where(d => d.IsSelected).Select(d => d.Id), StringComparer.Ordinal);
+        foreach (var descriptor in Descriptors.ToList())
+        {
+            descriptor.SelectionChanged -= DescriptorSelectionChanged;
+        }
+
+        Descriptors.Clear();
+
+        foreach (var info in _exportService.GetExportableDescriptors())
+        {
+            var descriptor = new PluginDescriptorSelectionViewModel(info.Id, info.DisplayName, info.Category)
+            {
+                IsSelected = previouslySelected.Contains(info.Id),
+            };
+            descriptor.SelectionChanged += DescriptorSelectionChanged;
+            Descriptors.Add(descriptor);
+        }
+
+        OnPropertyChanged(nameof(HasDescriptors));
+        UpdateCommandStates();
+    }
+
+    private void DescriptorSelectionChanged(object? sender, EventArgs e)
+    {
+        UpdateCommandStates();
+    }
+
+    private void UpdateCommandStates()
+    {
+        _exportCommand.RaiseCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Represents a selectable descriptor in the export dialog.
+    /// </summary>
+    public sealed class PluginDescriptorSelectionViewModel : ViewModelBase
+    {
+        private bool _isSelected;
+
+        public PluginDescriptorSelectionViewModel(string id, string displayName, string category)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Category = category;
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public string Category { get; }
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                if (_isSelected != value)
+                {
+                    _isSelected = value;
+                    OnPropertyChanged();
+                    SelectionChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        public event EventHandler? SelectionChanged;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -94,6 +94,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <Button Grid.Column="0"
                     Background="Transparent"
@@ -115,8 +116,15 @@
                     Padding="20,6"
                     Height="40"
                     MinWidth="140"/>
-            <Button Grid.Column="3" Content="_" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.MinimizeWindowCommand"/>
-            <Button Grid.Column="4" Content="X" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.CloseWindowCommand"/>
+            <Button Grid.Column="3"
+                    Content="Export Plug-ins"
+                    Command="{Binding ExportPluginsCommand}"
+                    Margin="0,25,10,25"
+                    Padding="20,6"
+                    Height="40"
+                    MinWidth="140"/>
+            <Button Grid.Column="4" Content="_" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.MinimizeWindowCommand"/>
+            <Button Grid.Column="5" Content="X" Width="40" Height="40" Margin="0,25,10,25" Command="SystemCommands.CloseWindowCommand"/>
         </Grid>
 
         <!-- Main Content -->

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -56,12 +56,13 @@ namespace DesktopApplicationTemplate.UI.Views
             DataContext = _viewModel;
             _viewModel.ConfigurationChangeBlocked += OnConfigurationChangeBlocked;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
+            _viewModel.ExportPluginsRequested += OnExportPluginsRequested;
             _viewModel.Services.CollectionChanged += Services_CollectionChanged;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
             CommandBindings.Add(new CommandBinding(SystemCommands.MinimizeWindowCommand, MinimizeCommand_Executed));
             Closing += MainView_Closing;
-            Closed += (_, _) => _viewModel.ConfigurationChangeBlocked -= OnConfigurationChangeBlocked;
+            Closed += MainView_Closed;
             ShowHome();
             PreloadServicePages();
         }
@@ -81,6 +82,12 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 _logger?.LogError(ex, "Failed to stop services during shutdown");
             }
+        }
+
+        private void MainView_Closed(object? sender, EventArgs e)
+        {
+            _viewModel.ConfigurationChangeBlocked -= OnConfigurationChangeBlocked;
+            _viewModel.ExportPluginsRequested -= OnExportPluginsRequested;
         }
 
         public void ShowHome()
@@ -116,6 +123,18 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             _logger?.LogInformation("Minimize command invoked");
             SystemCommands.MinimizeWindow(this);
+        }
+
+        private void OnExportPluginsRequested(object? sender, EventArgs e)
+        {
+            if (_serviceProvider.GetService(typeof(PluginExportWindow)) is not PluginExportWindow exportWindow)
+            {
+                _logger?.LogWarning("Plugin export window could not be resolved from the service provider.");
+                return;
+            }
+
+            exportWindow.Owner = this;
+            exportWindow.ShowDialog();
         }
 
         private void HomeButton_Click(object sender, RoutedEventArgs e) => NavigateHome("Home button");

--- a/DesktopApplicationTemplate.UI/Views/PluginExportWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/PluginExportWindow.xaml
@@ -74,7 +74,7 @@
                           d:DataContext="{d:DesignInstance viewModels:PluginExportViewModel}"
                           BorderThickness="0">
                     <ListView.ItemTemplate>
-                        <DataTemplate DataType="{x:Type viewModels:PluginExportViewModel.PluginDescriptorSelectionViewModel}">
+                        <DataTemplate DataType="{x:Type viewModels:PluginDescriptorSelectionViewModel}">
                             <DockPanel>
                                 <CheckBox Content="{Binding DisplayName}"
                                           IsChecked="{Binding IsSelected, Mode=TwoWay}"

--- a/DesktopApplicationTemplate.UI/Views/PluginExportWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/PluginExportWindow.xaml
@@ -1,0 +1,126 @@
+<Window x:Class="DesktopApplicationTemplate.UI.Views.PluginExportWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
+        mc:Ignorable="d"
+        Title="Export Plug-in"
+        Width="520"
+        Height="620"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="CanResizeWithGrip"
+        Style="{DynamicResource BubblyWindowStyle}">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0"
+                   Text="Select the service descriptors to include in the plug-in package and confirm the manifest metadata."
+                   TextWrapping="Wrap" />
+
+        <Grid Grid.Row="1" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" Grid.Column="0" Text="Plug-in ID:" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding PluginId, UpdateSourceTrigger=PropertyChanged}"/>
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Display name:" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding PluginName, UpdateSourceTrigger=PropertyChanged}"/>
+
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Version:" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Version, UpdateSourceTrigger=PropertyChanged}"/>
+        </Grid>
+
+        <Grid Grid.Row="2" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox Grid.Column="0" Text="{Binding DestinationPath, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Grid.Column="1" Content="Browse..." Click="BrowseButton_Click" MinWidth="90" Margin="8,0,0,0"/>
+        </Grid>
+
+        <GroupBox Grid.Row="3" Header="Descriptors" Padding="8" Margin="0,12,0,0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <ListView Grid.Row="0"
+                          ItemsSource="{Binding Descriptors}"
+                          SelectionMode="Extended"
+                          d:DataContext="{d:DesignInstance viewModels:PluginExportViewModel}"
+                          BorderThickness="0">
+                    <ListView.ItemTemplate>
+                        <DataTemplate DataType="{x:Type viewModels:PluginExportViewModel.PluginDescriptorSelectionViewModel}">
+                            <DockPanel>
+                                <CheckBox Content="{Binding DisplayName}"
+                                          IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                          VerticalAlignment="Center"/>
+                                <TextBlock Text="{Binding Category}"
+                                           Foreground="Gray"
+                                           Margin="8,0,0,0"
+                                           DockPanel.Dock="Right"
+                                           VerticalAlignment="Center"/>
+                            </DockPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <TextBlock Grid.Row="1"
+                           Text="No plug-in descriptors are currently available."
+                           Foreground="Gray"
+                           HorizontalAlignment="Center"
+                           Margin="0,12,0,0">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasDescriptors}" Value="False">
+                                    <Setter Property="Visibility" Value="Visible"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
+        </GroupBox>
+
+        <TextBlock Grid.Row="4" Margin="0,12,0,0"
+                   Text="{Binding StatusMessage}"
+                   Foreground="Gray"
+                   TextWrapping="Wrap"/>
+
+        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Export"
+                    MinWidth="100"
+                    Command="{Binding ExportCommand}"/>
+            <Button Content="Cancel"
+                    MinWidth="100"
+                    Command="{Binding CancelCommand}"
+                    Margin="8,0,0,0"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/DesktopApplicationTemplate.UI/Views/PluginExportWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/PluginExportWindow.xaml.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Windows;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.Win32;
+
+namespace DesktopApplicationTemplate.UI.Views;
+
+/// <summary>
+/// Interaction logic for PluginExportWindow.xaml
+/// </summary>
+public partial class PluginExportWindow : Window
+{
+    private readonly PluginExportViewModel _viewModel;
+
+    public PluginExportWindow(PluginExportViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+        DataContext = _viewModel;
+        _viewModel.ExportCompleted += OnExportCompleted;
+        _viewModel.CancelRequested += OnCancelRequested;
+        Closed += OnClosed;
+    }
+
+    private void BrowseButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Filter = "Peak IoT Plug-in (*.peakiot)|*.peakiot|All files (*.*)|*.*",
+            FileName = string.IsNullOrWhiteSpace(_viewModel.DestinationPath)
+                ? _viewModel.SuggestedFileName
+                : _viewModel.DestinationPath,
+        };
+
+        if (dialog.ShowDialog(this) == true)
+        {
+            _viewModel.DestinationPath = dialog.FileName;
+        }
+    }
+
+    private void OnExportCompleted(object? sender, PluginExportResult result)
+    {
+        if (result.Success)
+        {
+            MessageBox.Show(this, result.Message, "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+            DialogResult = true;
+            Close();
+            return;
+        }
+
+        MessageBox.Show(this, result.Message, "Export Failed", MessageBoxButton.OK, MessageBoxImage.Warning);
+    }
+
+    private void OnCancelRequested(object? sender, EventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        _viewModel.ExportCompleted -= OnExportCompleted;
+        _viewModel.CancelRequested -= OnCancelRequested;
+        _viewModel.Dispose();
+        Closed -= OnClosed;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Dictionary-based edit handlers are registered for each `ServiceType` and injecte
 
 Dynamic DI modules are enabled by `services.AddServiceModules()`, which scans assemblies for `IServiceModule` implementations and calls their `RegisterServices` methods. Dropping a new module into the application automatically registers its services without manual wiring.
 
+### Plug-in packaging workflow
+
+1. Open the main window and choose **Export Plug-ins** from the navigation bar.
+2. Select the descriptors that should be packaged, then review the manifest metadata (plug-in id, name, and version).
+3. Optionally browse to a custom destination. Leaving the path blank writes the archive to the configured plug-in directory using the sanitized id and version.
+4. Click **Export** to generate a `.peakiot` archive. The package contains the selected assemblies plus a manifest compatible with the existing `PluginImportService`, so the file can be copied back into the plug-in directory or imported without additional steps.
+
 ### Adding a new service example
 
 1. Add a value to the `ServiceType` enum.


### PR DESCRIPTION
## Summary
- factor shared plug-in manifest helpers into `PluginPackageUtilities` and update the loader/import path to reuse them
- implement `PluginExportService` plus a dialog-driven workflow so operators can bundle selected descriptors into `.peakiot` archives
- document the export process and register the export/import services through the application host

## Testing
- Not run (environment lacks Windows Desktop support)

------
https://chatgpt.com/codex/tasks/task_e_68e51d3e31348326a2d2959b11e85ce4