### PR TITLE
Format service message displays and routing metadata

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
@@ -25,6 +25,15 @@ public interface IMessageRoutingService
     bool TryGetMessage(ServiceType serviceType, string serviceName, MessageRoutingDirection direction, out string? message);
 
     /// <summary>
+    /// Attempts to retrieve the latest message by service name without requiring the service type.
+    /// </summary>
+    /// <param name="serviceName">The unique name of the service.</param>
+    /// <param name="direction">Specifies whether to return the last input or output message.</param>
+    /// <param name="message">The resolved message, if available.</param>
+    /// <returns><c>true</c> when a message is available; otherwise, <c>false</c>.</returns>
+    bool TryGetMessage(string serviceName, MessageRoutingDirection direction, out string? message);
+
+    /// <summary>
     /// Resolves <c>{ServiceName.LastInputMessage}</c> and <c>{ServiceName.LastOutputMessage}</c> tokens within the provided template.
     /// </summary>
     /// <param name="template">The template containing message tokens.</param>

--- a/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
@@ -13,7 +13,7 @@ public interface IMessageRoutingService
     /// <param name="serviceType">The category of the service.</param>
     /// <param name="serviceName">The unique name of the service.</param>
     /// <param name="message">The message to store.</param>
-    void UpdateMessage(ServiceType serviceType, string serviceName, string message);
+    void UpdateMessage(ServiceType serviceType, string serviceName, string message, MessageRoutingDirection direction = MessageRoutingDirection.Input);
 
     /// <summary>
     /// Attempts to retrieve the latest message for the specified service.
@@ -22,10 +22,10 @@ public interface IMessageRoutingService
     /// <param name="serviceName">The unique name of the service.</param>
     /// <param name="message">The message, if found.</param>
     /// <returns><c>true</c> if a message exists for the service; otherwise, <c>false</c>.</returns>
-    bool TryGetMessage(ServiceType serviceType, string serviceName, out string? message);
+    bool TryGetMessage(ServiceType serviceType, string serviceName, MessageRoutingDirection direction, out string? message);
 
     /// <summary>
-    /// Resolves <c>{ServiceType.ServiceName.Message}</c> tokens within the provided template.
+    /// Resolves <c>{ServiceName.LastInputMessage}</c> and <c>{ServiceName.LastOutputMessage}</c> tokens within the provided template.
     /// </summary>
     /// <param name="template">The template containing message tokens.</param>
     /// <returns>The template with tokens replaced by their corresponding messages.</returns>

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingDirection.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingDirection.cs
@@ -1,0 +1,14 @@
+namespace DesktopApplicationTemplate.Core.Services
+{
+    /// <summary>
+    /// Indicates whether a routed message represents inbound or outbound data.
+    /// </summary>
+    public enum MessageRoutingDirection
+    {
+        /// <summary>Represents the last inbound message for a service.</summary>
+        Input,
+
+        /// <summary>Represents the last outbound message for a service.</summary>
+        Output
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
@@ -1,0 +1,95 @@
+using System;
+using DesktopApplicationTemplate.Models;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DesktopApplicationTemplate.Core.Services;
+
+/// <summary>
+/// Rewrites script snippets to inline message routing tokens as literal values.
+/// </summary>
+public static class MessageRoutingScriptTransformer
+{
+    private static readonly CSharpParseOptions ScriptParseOptions = new(kind: SourceCodeKind.Script);
+
+    /// <summary>
+    /// Rewrites <c>{ServiceName}.LastInputMessage</c> and <c>{ServiceName}.LastOutputMessage</c> member access
+    /// expressions into string literals backed by the routing service.
+    /// </summary>
+    /// <param name="script">The user provided script.</param>
+    /// <param name="routingService">Routing service supplying the latest message snapshots.</param>
+    /// <returns>The rewritten script text.</returns>
+    public static string InjectRoutingLiterals(string? script, IMessageRoutingService routingService)
+    {
+        if (string.IsNullOrWhiteSpace(script))
+        {
+            return string.Empty;
+        }
+
+        if (routingService is null)
+        {
+            throw new ArgumentNullException(nameof(routingService));
+        }
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(script, ScriptParseOptions);
+        var rewriter = new RoutingTokenRewriter(routingService);
+        var rewritten = rewriter.Visit(syntaxTree.GetRoot());
+        return rewritten.ToFullString();
+    }
+
+    private sealed class RoutingTokenRewriter : CSharpSyntaxRewriter
+    {
+        private readonly IMessageRoutingService _routingService;
+
+        public RoutingTokenRewriter(IMessageRoutingService routingService)
+        {
+            _routingService = routingService;
+        }
+
+        public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            if (node is null)
+            {
+                return null;
+            }
+
+            var visited = (MemberAccessExpressionSyntax?)base.VisitMemberAccessExpression(node);
+            if (visited?.Expression is not IdentifierNameSyntax identifier)
+            {
+                return visited;
+            }
+
+            if (!TryGetDirection(visited.Name.Identifier.ValueText, out var direction))
+            {
+                return visited;
+            }
+
+            if (!_routingService.TryGetMessage(identifier.Identifier.ValueText, direction, out var message) || message is null)
+            {
+                message = string.Empty;
+            }
+
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(message));
+        }
+
+        private static bool TryGetDirection(string identifier, out MessageRoutingDirection direction)
+        {
+            if (string.Equals(identifier, "LastInputMessage", StringComparison.Ordinal))
+            {
+                direction = MessageRoutingDirection.Input;
+                return true;
+            }
+
+            if (string.Equals(identifier, "LastOutputMessage", StringComparison.Ordinal))
+            {
+                direction = MessageRoutingDirection.Output;
+                return true;
+            }
+
+            direction = MessageRoutingDirection.Input;
+            return false;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
@@ -1,5 +1,5 @@
 using System;
-using DesktopApplicationTemplate.Models;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
@@ -74,6 +74,25 @@ public class MessageRoutingService : IMessageRoutingService
     }
 
     /// <inheritdoc />
+    public bool TryGetMessage(string serviceName, MessageRoutingDirection direction, out string? message)
+    {
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            message = null;
+            return false;
+        }
+
+        if (_messagesByName.TryGetValue(serviceName.Trim(), out var entry))
+        {
+            message = entry.Get(direction);
+            return true;
+        }
+
+        message = null;
+        return false;
+    }
+
+    /// <inheritdoc />
     public string ResolveTokens(string template)
     {
         if (template is null)

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
@@ -10,9 +10,11 @@ namespace DesktopApplicationTemplate.Core.Services;
 /// </summary>
 public class MessageRoutingService : IMessageRoutingService
 {
-    private readonly ConcurrentDictionary<(ServiceType, string), string> _messages = new();
+    private readonly ConcurrentDictionary<(ServiceType, string), RoutingMessageEntry> _messages = new();
+    private readonly ConcurrentDictionary<string, RoutingMessageEntry> _messagesByName = new(StringComparer.OrdinalIgnoreCase);
     private readonly ILoggingService? _logger;
-    private static readonly Regex TokenRegex = new(@"\{([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
+    private static readonly Regex NewTokenRegex = new(@"\{([A-Za-z0-9_]+)\.(LastInputMessage|LastOutputMessage)\}", RegexOptions.Compiled);
+    private static readonly Regex LegacyTokenRegex = new(@"\{([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MessageRoutingService"/> class.
@@ -24,19 +26,52 @@ public class MessageRoutingService : IMessageRoutingService
     }
 
     /// <inheritdoc />
-    public void UpdateMessage(ServiceType serviceType, string serviceName, string message)
+    public void UpdateMessage(ServiceType serviceType, string serviceName, string message, MessageRoutingDirection direction = MessageRoutingDirection.Input)
     {
         if (string.IsNullOrWhiteSpace(serviceName))
             throw new ArgumentException("Service name cannot be null or whitespace.", nameof(serviceName));
 
-        _logger?.Log($"Updating message for {serviceType}.{serviceName}", LogLevel.Debug);
-        _messages.AddOrUpdate((serviceType, serviceName), _ => message ?? string.Empty, (_, _) => message ?? string.Empty);
-        _logger?.Log($"Message for {serviceType}.{serviceName} updated", LogLevel.Debug);
+        var normalizedName = serviceName.Trim();
+        var payload = message ?? string.Empty;
+
+        _logger?.Log($"Updating {direction} message for {serviceType}.{normalizedName}", LogLevel.Debug);
+
+        var entry = _messages.AddOrUpdate(
+            (serviceType, normalizedName),
+            _ => CreateEntry(direction, payload),
+            (_, existing) =>
+            {
+                existing.Update(direction, payload);
+                return existing;
+            });
+
+        _messagesByName.AddOrUpdate(normalizedName, _ => entry, (_, existing) =>
+        {
+            existing.Update(direction, payload);
+            return existing;
+        });
+
+        _logger?.Log($"{direction} message for {serviceType}.{normalizedName} updated", LogLevel.Debug);
     }
 
     /// <inheritdoc />
-    public bool TryGetMessage(ServiceType serviceType, string serviceName, out string? message)
-        => _messages.TryGetValue((serviceType, serviceName), out message);
+    public bool TryGetMessage(ServiceType serviceType, string serviceName, MessageRoutingDirection direction, out string? message)
+    {
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            message = null;
+            return false;
+        }
+
+        if (_messages.TryGetValue((serviceType, serviceName.Trim()), out var entry))
+        {
+            message = entry.Get(direction);
+            return true;
+        }
+
+        message = null;
+        return false;
+    }
 
     /// <inheritdoc />
     public string ResolveTokens(string template)
@@ -45,16 +80,78 @@ public class MessageRoutingService : IMessageRoutingService
             throw new ArgumentNullException(nameof(template));
 
         _logger?.Log($"Resolving tokens in '{template}'", LogLevel.Debug);
-        string result = TokenRegex.Replace(template, m =>
+        var result = NewTokenRegex.Replace(template, m =>
+        {
+            var name = m.Groups[1].Value;
+            var direction = string.Equals(m.Groups[2].Value, nameof(RoutingMessageEntry.LastInputMessage), StringComparison.Ordinal)
+                ? MessageRoutingDirection.Input
+                : MessageRoutingDirection.Output;
+
+            return TryGetMessageByName(name, direction, out var replacement)
+                ? replacement
+                : string.Empty;
+        });
+
+        result = LegacyTokenRegex.Replace(result, m =>
         {
             var typeStr = m.Groups[1].Value;
             var name = m.Groups[2].Value;
-            return Enum.TryParse<ServiceType>(typeStr, out var type) &&
-                   _messages.TryGetValue((type, name), out var msg)
-                ? msg
-                : string.Empty;
+            if (Enum.TryParse<ServiceType>(typeStr, out var type) &&
+                _messages.TryGetValue((type, name), out var entry))
+            {
+                return entry.LastInputMessage;
+            }
+
+            return string.Empty;
         });
         _logger?.Log($"Resolved template to '{result}'", LogLevel.Debug);
         return result;
+    }
+
+    private static RoutingMessageEntry CreateEntry(MessageRoutingDirection direction, string payload)
+    {
+        var entry = new RoutingMessageEntry();
+        entry.Update(direction, payload);
+        return entry;
+    }
+
+    private bool TryGetMessageByName(string serviceName, MessageRoutingDirection direction, out string replacement)
+    {
+        var key = serviceName.Trim();
+
+        if (_messagesByName.TryGetValue(key, out var entry))
+        {
+            replacement = entry.Get(direction);
+            return true;
+        }
+
+        replacement = string.Empty;
+        return false;
+    }
+
+    private sealed class RoutingMessageEntry
+    {
+        private string _lastInputMessage = string.Empty;
+        private string _lastOutputMessage = string.Empty;
+
+        public string LastInputMessage => _lastInputMessage;
+        public string LastOutputMessage => _lastOutputMessage;
+
+        public void Update(MessageRoutingDirection direction, string payload)
+        {
+            if (direction == MessageRoutingDirection.Input)
+            {
+                _lastInputMessage = payload ?? string.Empty;
+            }
+            else
+            {
+                _lastOutputMessage = payload ?? string.Empty;
+            }
+        }
+
+        public string Get(MessageRoutingDirection direction)
+        {
+            return direction == MessageRoutingDirection.Input ? _lastInputMessage : _lastOutputMessage;
+        }
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
@@ -120,8 +120,9 @@ public sealed class TcpRuntime : ITcpRuntime
 
     private async Task<string> ExecuteScriptInternalAsync(string script, string message, CancellationToken cancellationToken)
     {
+        var rewrittenScript = MessageRoutingScriptTransformer.InjectRoutingLiterals(script, _routingService);
         var globals = new TcpScriptGlobals { Message = message ?? string.Empty };
-        var code = (script ?? string.Empty) + "\nreturn Process(Message);";
+        var code = rewrittenScript + "\nreturn Process(Message);";
         var compiled = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(TcpScriptGlobals));
         var diagnostics = compiled.Compile();
 

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
@@ -71,7 +71,8 @@ public sealed class TcpRuntime : ITcpRuntime
         options.LastTestMessage = testMessage;
         options.OutputMessage = output;
 
-        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, testMessage);
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, testMessage, MessageRoutingDirection.Input);
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, output, MessageRoutingDirection.Output);
 
         return new TcpRuntimeState(script, testMessage, output);
     }
@@ -95,7 +96,8 @@ public sealed class TcpRuntime : ITcpRuntime
         context.Options.LastTestMessage = request.TestMessage;
         context.Options.OutputMessage = output;
 
-        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, request.TestMessage);
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, request.TestMessage, MessageRoutingDirection.Input);
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, output, MessageRoutingDirection.Output);
 
         return new TcpRuntimeState(request.Script, request.TestMessage, output);
     }
@@ -106,7 +108,7 @@ public sealed class TcpRuntime : ITcpRuntime
         var serviceName = context.ServiceName;
 
         if (string.IsNullOrWhiteSpace(options.LastTestMessage) &&
-            _routingService.TryGetMessage(context.ServiceType, serviceName, out var routed))
+            _routingService.TryGetMessage(context.ServiceType, serviceName, MessageRoutingDirection.Input, out var routed))
         {
             return routed ?? string.Empty;
         }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
@@ -37,6 +37,21 @@ public class TcpServiceOptions
     public int Port { get; set; }
 
     /// <summary>
+    /// Remote host name or address used when the service is configured to send messages.
+    /// </summary>
+    public string DestinationHost { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Remote port used when the service is configured to send messages.
+    /// </summary>
+    public int DestinationPort { get; set; }
+
+    /// <summary>
+    /// Gateway associated with the remote destination.
+    /// </summary>
+    public string DestinationGateway { get; set; } = string.Empty;
+
+    /// <summary>
     /// Indicates whether UDP should be used instead of TCP.
     /// </summary>
     public bool UseUdp { get; set; }

--- a/DesktopApplicationTemplate.UI/Helpers/MessageDisplayFormatter.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/MessageDisplayFormatter.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using DesktopApplicationTemplate.Models;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    /// <summary>
+    /// Provides helpers for presenting service messages with readable control characters and
+    /// standardized service references.
+    /// </summary>
+    public static class MessageDisplayFormatter
+    {
+        private static readonly IReadOnlyDictionary<char, string> ControlCharacterTokens = new Dictionary<char, string>
+        {
+            ['\0'] = "<NUL>",
+            ['\u0001'] = "<SOH>",
+            ['\u0002'] = "<STX>",
+            ['\u0003'] = "<ETX>",
+            ['\u0004'] = "<EOT>",
+            ['\u0005'] = "<ENQ>",
+            ['\u0006'] = "<ACK>",
+            ['\a'] = "<BEL>",
+            ['\b'] = "<BS>",
+            ['\t'] = "<HT>",
+            ['\n'] = "<LF>",
+            ['\u000B'] = "<VT>",
+            ['\f'] = "<FF>",
+            ['\r'] = "<CR>",
+            ['\u000E'] = "<SO>",
+            ['\u000F'] = "<SI>",
+            ['\u0010'] = "<DLE>",
+            ['\u0011'] = "<DC1>",
+            ['\u0012'] = "<DC2>",
+            ['\u0013'] = "<DC3>",
+            ['\u0014'] = "<DC4>",
+            ['\u0015'] = "<NAK>",
+            ['\u0016'] = "<SYN>",
+            ['\u0017'] = "<ETB>",
+            ['\u0018'] = "<CAN>",
+            ['\u0019'] = "<EM>",
+            ['\u001A'] = "<SUB>",
+            ['\u001B'] = "<ESC>",
+            ['\u001C'] = "<FS>",
+            ['\u001D'] = "<GS>",
+            ['\u001E'] = "<RS>",
+            ['\u001F'] = "<US>",
+            ['\u007F'] = "<DEL>"
+        };
+
+        /// <summary>
+        /// Converts ASCII control characters to their readable token form.
+        /// </summary>
+        /// <param name="message">The message that may contain control characters.</param>
+        /// <returns>A string where control characters are replaced with their symbolic names.</returns>
+        public static string FormatControlCharacters(string? message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder(message.Length);
+            foreach (var ch in message)
+            {
+                if (ControlCharacterTokens.TryGetValue(ch, out var token))
+                {
+                    builder.Append(token);
+                }
+                else
+                {
+                    builder.Append(ch);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Formats a message for display using the standardized service reference conventions.
+        /// </summary>
+        /// <param name="message">The message text to format.</param>
+        /// <param name="isIncoming">Indicates whether the message represents incoming data.</param>
+        /// <param name="serviceType">The type of service producing the message.</param>
+        /// <param name="serviceName">The name of the service producing the message.</param>
+        /// <returns>A formatted string suitable for UI presentation.</returns>
+        public static string FormatForService(string? message, bool isIncoming, ServiceType serviceType, string serviceName)
+        {
+            var formatted = FormatControlCharacters(message);
+            if (string.IsNullOrEmpty(formatted))
+            {
+                return string.Empty;
+            }
+
+            if (!ShouldUseServiceReference(serviceType) || string.IsNullOrWhiteSpace(serviceName))
+            {
+                return formatted;
+            }
+
+            var propertyName = isIncoming ? "LastInputMessage" : "LastOutputMessage";
+            return string.Create(serviceName.Length + propertyName.Length + formatted.Length + 2, (serviceName, propertyName, formatted),
+                (span, state) =>
+                {
+                    var (svcName, prop, content) = state;
+                    var index = 0;
+                    svcName.AsSpan().CopyTo(span);
+                    index += svcName.Length;
+                    span[index++] = '.';
+                    prop.AsSpan().CopyTo(span[index..]);
+                    index += prop.Length;
+                    span[index++] = ':';
+                    span[index++] = ' ';
+                    content.AsSpan().CopyTo(span[index..]);
+                });
+        }
+
+        private static bool ShouldUseServiceReference(ServiceType serviceType)
+        {
+            return serviceType is not ServiceType.Csv
+                and not ServiceType.Ftp
+                and not ServiceType.FileObserver
+                and not ServiceType.Scp;
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -52,6 +52,9 @@ namespace DesktopApplicationTemplate.Persistence
                         AlternateDns = s.TcpOptions.AlternateDns,
                         Mode = s.TcpOptions.Mode,
                         ConnectionRole = s.TcpOptions.ConnectionRole,
+                        DestinationHost = s.TcpOptions.DestinationHost,
+                        DestinationPort = s.TcpOptions.DestinationPort,
+                        DestinationGateway = s.TcpOptions.DestinationGateway,
                         InputMessage = s.TcpOptions.InputMessage,
                         Script = s.TcpOptions.Script,
                         OutputMessage = s.TcpOptions.OutputMessage,
@@ -287,6 +290,9 @@ namespace DesktopApplicationTemplate.Persistence
                             value.AlternateDns = info.TcpOptions.AlternateDns;
                             value.Mode = info.TcpOptions.Mode;
                             value.ConnectionRole = info.TcpOptions.ConnectionRole;
+                            value.DestinationHost = info.TcpOptions.DestinationHost;
+                            value.DestinationPort = info.TcpOptions.DestinationPort;
+                            value.DestinationGateway = info.TcpOptions.DestinationGateway;
                             value.InputMessage = info.TcpOptions.InputMessage;
                             value.Script = info.TcpOptions.Script;
                             value.OutputMessage = info.TcpOptions.OutputMessage;

--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -4,11 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Media;
+using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.Core.Services;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.VisualStudio.Threading;
-using DesktopApplicationTemplate.UI.Helpers;
 
 namespace DesktopApplicationTemplate.UI.ViewModels;
 
@@ -23,6 +24,7 @@ public class ScriptEditorViewModel : ViewModelBase
     private string _outputMessage = string.Empty;
     private Brush _outputBrush = Brushes.Black;
     private string _lastTestMessage = string.Empty;
+    private IMessageRoutingService? _routingService;
 
     public string ScriptText
     {
@@ -83,6 +85,21 @@ public class ScriptEditorViewModel : ViewModelBase
     public event Action<IEnumerable<Diagnostic>>? ErrorsChanged;
     public event Action<string>? OutputGenerated;
 
+    public IMessageRoutingService? RoutingService
+    {
+        get => _routingService;
+        set
+        {
+            if (_routingService == value)
+            {
+                return;
+            }
+
+            _routingService = value;
+            OnPropertyChanged();
+        }
+    }
+
     public ScriptEditorViewModel()
     {
         RunCommand = new AsyncRelayCommand(RunAsync);
@@ -92,7 +109,10 @@ public class ScriptEditorViewModel : ViewModelBase
     private async Task RunAsync()
     {
         var globals = new Globals { Message = TestMessage };
-        var code = ScriptText + "\nreturn Process(Message);";
+        var scriptBody = _routingService is null
+            ? ScriptText
+            : MessageRoutingScriptTransformer.InjectRoutingLiterals(ScriptText, _routingService);
+        var code = scriptBody + "\nreturn Process(Message);";
         var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(Globals));
         var diagnostics = script.Compile();
         await _jtf.SwitchToMainThreadAsync();

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -17,6 +17,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 using WpfBrush = System.Windows.Media.Brush;
 using WpfBrushes = System.Windows.Media.Brushes;
@@ -393,7 +394,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private static string NormalizeLatestMessage(string? message)
         {
-            return string.IsNullOrWhiteSpace(message) ? string.Empty : message.Trim();
+            return string.IsNullOrWhiteSpace(message)
+                ? string.Empty
+                : MessageDisplayFormatter.FormatControlCharacters(message.Trim());
         }
 
         private static string NormalizePersistedMessage(string message)
@@ -403,16 +406,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return string.Empty;
             }
 
-            if (message.Length > TimestampLength && message[TimestampLength] == ' ')
+            var trimmed = message.Trim();
+
+            if (trimmed.Length > TimestampLength && trimmed[TimestampLength] == ' ')
             {
-                var timestampCandidate = message.Substring(0, TimestampLength);
+                var timestampCandidate = trimmed.Substring(0, TimestampLength);
                 if (DateTime.TryParseExact(timestampCandidate, TimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
                 {
-                    return message[(TimestampLength + 1)..].Trim();
+                    var withoutTimestamp = trimmed[(TimestampLength + 1)..].Trim();
+                    return MessageDisplayFormatter.FormatControlCharacters(withoutTimestamp);
                 }
             }
 
-            return message.Trim();
+            return MessageDisplayFormatter.FormatControlCharacters(trimmed);
         }
 
         private static WpfBrush ParseBrush(string? color, WpfBrush fallback)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
@@ -18,12 +20,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// Adds a new message row and inserts it at the top to maintain
         /// descending timestamp order.
         /// </summary>
-        public void AddMessage(string incoming, string outgoing, string destination)
+        public void AddMessage(ServiceType serviceType, string serviceName, string incoming, string outgoing, string destination)
         {
+            var resolvedServiceName = serviceName ?? string.Empty;
+            var incomingDisplay = MessageDisplayFormatter.FormatForService(incoming, true, serviceType, resolvedServiceName);
+            var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoing, false, serviceType, resolvedServiceName);
+
             Messages.Insert(0, new ServiceMessageRow
             {
-                IncomingMessage = incoming ?? string.Empty,
-                OutgoingMessage = outgoing ?? string.Empty,
+                IncomingMessage = incomingDisplay,
+                OutgoingMessage = outgoingDisplay,
                 Destination = destination ?? string.Empty,
                 Timestamp = DateTime.Now
             });

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -20,6 +20,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private string _subnetMask = string.Empty;
     private string _primaryDns = string.Empty;
     private string _alternateDns = string.Empty;
+    private string _destinationHost = string.Empty;
+    private int _destinationPort;
+    private string _destinationGateway = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpCreateServiceViewModel"/> class.
@@ -138,7 +141,22 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     public TcpServiceMode Mode
     {
         get => _mode;
-        set { _mode = value; OnPropertyChanged(); }
+        set
+        {
+            if (_mode == value)
+            {
+                return;
+            }
+
+            _mode = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsSendingEnabled));
+            if (!IsSendingEnabled)
+            {
+                ClearErrors(nameof(DestinationHost));
+                ClearErrors(nameof(DestinationPort));
+            }
+        }
     }
 
     /// <summary>
@@ -147,9 +165,88 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
     /// <summary>
+    /// Indicates whether the service should expose sending configuration fields.
+    /// </summary>
+    public bool IsSendingEnabled => Mode != TcpServiceMode.Listening;
+
+    /// <summary>
     /// Available TCP connection roles.
     /// </summary>
     public TcpConnectionRole[] ConnectionRoles { get; } = (TcpConnectionRole[])Enum.GetValues(typeof(TcpConnectionRole));
+
+    /// <summary>
+    /// Remote host used when sending messages.
+    /// </summary>
+    public string DestinationHost
+    {
+        get => _destinationHost;
+        set
+        {
+            _destinationHost = value ?? string.Empty;
+            if (IsSendingEnabled)
+            {
+                var error = Rule.ValidateRequired(_destinationHost, "Destination Host");
+                if (error is not null)
+                {
+                    AddError(nameof(DestinationHost), error);
+                }
+                else
+                {
+                    ClearErrors(nameof(DestinationHost));
+                }
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationHost));
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Remote port used when sending messages.
+    /// </summary>
+    public int DestinationPort
+    {
+        get => _destinationPort;
+        set
+        {
+            _destinationPort = value;
+            if (IsSendingEnabled)
+            {
+                var error = Rule.ValidatePort(value);
+                if (error is not null)
+                {
+                    AddError(nameof(DestinationPort), error);
+                }
+                else
+                {
+                    ClearErrors(nameof(DestinationPort));
+                }
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationPort));
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gateway associated with the remote destination.
+    /// </summary>
+    public string DestinationGateway
+    {
+        get => _destinationGateway;
+        set
+        {
+            _destinationGateway = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationGateway, nameof(DestinationGateway), "Destination Gateway");
+            OnPropertyChanged();
+        }
+    }
 
     /// <summary>
     /// Selected TCP connection role.
@@ -195,6 +292,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         options.AlternateDns = AlternateDns;
         options.Mode = Mode;
         options.ConnectionRole = ConnectionRole;
+        options.DestinationHost = DestinationHost;
+        options.DestinationPort = DestinationPort;
+        options.DestinationGateway = DestinationGateway;
     }
 
     private void ValidateOptionalIpAddress(string value, string propertyName, string? displayName = null)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -22,6 +22,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     private string _subnetMask = string.Empty;
     private string _primaryDns = string.Empty;
     private string _alternateDns = string.Empty;
+    private string _destinationHost = string.Empty;
+    private int _destinationPort;
+    private string _destinationGateway = string.Empty;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpEditServiceViewModel"/> class.
@@ -47,6 +50,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         SubnetMask = _options.SubnetMask;
         PrimaryDns = _options.PrimaryDns;
         AlternateDns = _options.AlternateDns;
+        DestinationHost = _options.DestinationHost;
+        DestinationPort = _options.DestinationPort;
+        DestinationGateway = _options.DestinationGateway;
         if (ConnectionRole == TcpConnectionRole.Server)
         {
             _serverHost = _options.Host;
@@ -118,7 +124,22 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     public TcpServiceMode Mode
     {
         get => _mode;
-        set { _mode = value; OnPropertyChanged(); }
+        set
+        {
+            if (_mode == value)
+            {
+                return;
+            }
+
+            _mode = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsSendingEnabled));
+            if (!IsSendingEnabled)
+            {
+                ClearErrors(nameof(DestinationHost));
+                ClearErrors(nameof(DestinationPort));
+            }
+        }
     }
 
     /// <summary>
@@ -169,9 +190,88 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
     /// <summary>
+    /// Indicates whether the service should expose sending configuration fields.
+    /// </summary>
+    public bool IsSendingEnabled => Mode != TcpServiceMode.Listening;
+
+    /// <summary>
     /// Available TCP connection roles.
     /// </summary>
     public TcpConnectionRole[] ConnectionRoles { get; } = (TcpConnectionRole[])Enum.GetValues(typeof(TcpConnectionRole));
+
+    /// <summary>
+    /// Remote host used when sending messages.
+    /// </summary>
+    public string DestinationHost
+    {
+        get => _destinationHost;
+        set
+        {
+            _destinationHost = value ?? string.Empty;
+            if (IsSendingEnabled)
+            {
+                var error = Rule.ValidateRequired(_destinationHost, "Destination Host");
+                if (error is not null)
+                {
+                    AddError(nameof(DestinationHost), error);
+                }
+                else
+                {
+                    ClearErrors(nameof(DestinationHost));
+                }
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationHost));
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Remote port used when sending messages.
+    /// </summary>
+    public int DestinationPort
+    {
+        get => _destinationPort;
+        set
+        {
+            _destinationPort = value;
+            if (IsSendingEnabled)
+            {
+                var error = Rule.ValidatePort(value);
+                if (error is not null)
+                {
+                    AddError(nameof(DestinationPort), error);
+                }
+                else
+                {
+                    ClearErrors(nameof(DestinationPort));
+                }
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationPort));
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Gateway associated with the remote destination.
+    /// </summary>
+    public string DestinationGateway
+    {
+        get => _destinationGateway;
+        set
+        {
+            _destinationGateway = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationGateway, nameof(DestinationGateway), "Destination Gateway");
+            OnPropertyChanged();
+        }
+    }
 
     /// <summary>
     /// Selected TCP connection role.
@@ -227,6 +327,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         _options.AlternateDns = AlternateDns;
         _options.Mode = Mode;
         _options.ConnectionRole = ConnectionRole;
+        _options.DestinationHost = DestinationHost;
+        _options.DestinationPort = DestinationPort;
+        _options.DestinationGateway = DestinationGateway;
         RaiseServiceSaved(_options);
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -386,16 +386,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 tasks.Add(RunServerLoopAsync(token));
             }
 
-            if (hasClientReceiver)
+            if (hasClientReceiver && clientReceiveEndpoint is TcpEndpoint receiveEndpoint)
             {
-                Logger?.Log($"Starting TCP client to {clientReceiveEndpoint.Value.Host}:{clientReceiveEndpoint.Value.Port} ({protocol}) for receiving", LogLevel.Information);
-                tasks.Add(RunClientLoopAsync(clientReceiveEndpoint.Value, TcpClientOperation.Receive, token));
+                Logger?.Log($"Starting TCP client to {receiveEndpoint.Host}:{receiveEndpoint.Port} ({protocol}) for receiving", LogLevel.Information);
+                tasks.Add(RunClientLoopAsync(receiveEndpoint, TcpClientOperation.Receive, token));
             }
 
-            if (hasClientSender)
+            if (hasClientSender && clientSendEndpoint is TcpEndpoint sendEndpoint)
             {
-                Logger?.Log($"Starting TCP client to {clientSendEndpoint.Value.Host}:{clientSendEndpoint.Value.Port} ({protocol}) for sending", LogLevel.Information);
-                tasks.Add(RunClientLoopAsync(clientSendEndpoint.Value, TcpClientOperation.Send, token));
+                Logger?.Log($"Starting TCP client to {sendEndpoint.Host}:{sendEndpoint.Port} ({protocol}) for sending", LogLevel.Information);
+                tasks.Add(RunClientLoopAsync(sendEndpoint, TcpClientOperation.Send, token));
             }
 
             _networkLoopTask = Task.WhenAll(tasks);

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -252,6 +252,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 TestMessage = state.TestMessage;
                 OutputMessage = state.OutputMessage;
                 _options.OutputMessage = state.OutputMessage;
+                _routing.UpdateMessage(ServiceType, ServiceName, state.TestMessage, MessageRoutingDirection.Input);
+                _routing.UpdateMessage(ServiceType, ServiceName, state.OutputMessage, MessageRoutingDirection.Output);
                 Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
             }
             catch (Exception ex)
@@ -499,14 +501,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                         }
 
                         var incoming = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-                        Logger?.Log($"Received message from {endpoint}: {incoming}", LogLevel.Information);
+                        var formattedIncoming = MessageDisplayFormatter.FormatControlCharacters(incoming);
+                        Logger?.Log($"{ServiceName}.LastInputMessage from {endpoint}: {formattedIncoming}", LogLevel.Information);
+                        _routing.UpdateMessage(ServiceType, ServiceName, incoming, MessageRoutingDirection.Input);
                         await AppendMessageAsync(incoming, _options.OutputMessage, endpoint).ConfigureAwait(false);
 
                         if (!string.IsNullOrWhiteSpace(_options.OutputMessage))
                         {
                             var response = Encoding.UTF8.GetBytes(_options.OutputMessage);
                             await stream.WriteAsync(response.AsMemory(0, response.Length), cancellationToken).ConfigureAwait(false);
-                            Logger?.Log($"Sent response to {endpoint}: {_options.OutputMessage}", LogLevel.Debug);
+                            var formattedOutgoing = MessageDisplayFormatter.FormatControlCharacters(_options.OutputMessage);
+                            Logger?.Log($"{ServiceName}.LastOutputMessage to {endpoint}: {formattedOutgoing}", LogLevel.Debug);
+                            _routing.UpdateMessage(ServiceType, ServiceName, _options.OutputMessage, MessageRoutingDirection.Output);
                         }
                     }
                 }
@@ -564,16 +570,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             var incomingMessage = incoming ?? string.Empty;
             var outgoingMessage = outgoing ?? string.Empty;
             var destination = endpoint ?? string.Empty;
+            var incomingDisplay = MessageDisplayFormatter.FormatForService(incomingMessage, true, ServiceType, ServiceName);
+            var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoingMessage, false, ServiceType, ServiceName);
 
             return RunOnUiThreadAsync(() =>
             {
                 Messages.Insert(0, new TcpMessageRow
                 {
-                    IncomingMessage = incomingMessage,
+                    IncomingMessage = incomingDisplay,
                     IncomingIp = destination,
-                    OutgoingMessage = outgoingMessage,
+                    OutgoingMessage = outgoingDisplay,
                     ConnectedService = destination,
-                    Result = string.IsNullOrWhiteSpace(outgoingMessage) ? string.Empty : outgoingMessage
+                    Result = string.IsNullOrEmpty(outgoingDisplay) ? string.Empty : outgoingDisplay
                 });
 
                 while (Messages.Count > MaxTcpMessageRows)
@@ -581,7 +589,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                     Messages.RemoveAt(Messages.Count - 1);
                 }
 
-                MessageTable.AddMessage(incomingMessage, outgoingMessage, destination);
+                MessageTable.AddMessage(ServiceType, ServiceName, incomingMessage, outgoingMessage, destination);
 
                 OnPropertyChanged(nameof(IncomingData));
                 OnPropertyChanged(nameof(OutgoingResults));
@@ -900,6 +908,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 TestMessage = result.TestMessage;
                 OutputMessage = result.OutputMessage;
                 _options.OutputMessage = result.OutputMessage;
+                _routing.UpdateMessage(ServiceType, ServiceName, result.TestMessage, MessageRoutingDirection.Input);
+                _routing.UpdateMessage(ServiceType, ServiceName, result.OutputMessage, MessageRoutingDirection.Output);
                 Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
             }
             catch (Exception ex)
@@ -935,7 +945,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 OutputMessage = _options.OutputMessage = output;
                 TestMessage = svm.TestMessage;
                 _options.LastTestMessage = svm.TestMessage;
-                _routing.UpdateMessage(ServiceType, ServiceName, svm.TestMessage);
+                _routing.UpdateMessage(ServiceType, ServiceName, svm.TestMessage, MessageRoutingDirection.Input);
+                _routing.UpdateMessage(ServiceType, ServiceName, output, MessageRoutingDirection.Output);
             }
 
             void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -499,14 +499,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
             var host = ResolveDestinationHost();
             var port = ResolveDestinationPort();
-            if (string.IsNullOrWhiteSpace(host) || port <= 0)
+            if (string.IsNullOrWhiteSpace(host) || port is null)
             {
                 Logger?.Log("TCP client destination is not configured; skipping client startup.", LogLevel.Warning);
                 LogConnectionIssues("TCP client configuration", null, LogLevel.Warning);
                 return false;
             }
 
-            endpoint = new TcpEndpoint(host, port);
+            endpoint = new TcpEndpoint(host, port.Value);
             return true;
         }
 
@@ -731,9 +731,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         {
             var incomingMessage = incoming ?? string.Empty;
             var outgoingMessage = outgoing ?? string.Empty;
+            var incomingEndpoint = endpoint ?? string.Empty;
             var destination = string.IsNullOrWhiteSpace(outgoingMessage)
                 ? string.Empty
-                : endpoint ?? string.Empty;
+                : incomingEndpoint;
             var incomingDisplay = MessageDisplayFormatter.FormatForService(incomingMessage, true, ServiceType, ServiceName);
             var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoingMessage, false, ServiceType, ServiceName);
 
@@ -742,7 +743,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 Messages.Insert(0, new TcpMessageRow
                 {
                     IncomingMessage = incomingDisplay,
-                    IncomingIp = destination,
+                    IncomingIp = incomingEndpoint,
                     OutgoingMessage = outgoingDisplay,
                     ConnectedService = destination,
                     Result = string.IsNullOrEmpty(outgoingDisplay) ? string.Empty : outgoingDisplay
@@ -1044,13 +1045,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private string ResolveDestinationHost()
         {
             return string.IsNullOrWhiteSpace(_options.DestinationHost)
-                ? _options.Host
+                ? string.Empty
                 : _options.DestinationHost;
         }
 
-        private int ResolveDestinationPort()
+        private int? ResolveDestinationPort()
         {
-            return _options.DestinationPort > 0 ? _options.DestinationPort : _options.Port;
+            return _options.DestinationPort > 0 ? _options.DestinationPort : null;
         }
 
         private void ClearLogs()

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -264,7 +264,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
             var config = _networkConfiguration ?? new NetworkConfiguration();
 
-            if (!string.IsNullOrWhiteSpace(config.IpAddress))
+            if (_options.ConnectionRole == TcpConnectionRole.Server && !string.IsNullOrWhiteSpace(config.IpAddress))
             {
                 _options.Host = config.IpAddress;
             }
@@ -350,23 +350,28 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         {
             StopNetwork();
 
-            if (_options.Port <= 0)
+            var hasListener = ShouldStartServerListener();
+            if (hasListener && _options.Port <= 0)
             {
-                Logger?.Log("TCP port is not configured; skipping network startup.", LogLevel.Warning);
+                Logger?.Log("TCP port is not configured; skipping listener startup.", LogLevel.Warning);
+                hasListener = false;
+            }
+
+            var hasClientReceiver = TryGetClientReceiveEndpoint(out var clientReceiveEndpoint);
+            var hasClientSender = TryGetClientSendEndpoint(out var clientSendEndpoint);
+
+            if (!hasListener && !hasClientReceiver && !hasClientSender)
+            {
+                Logger?.Log("TCP service is not configured to listen or send; network startup skipped.", LogLevel.Warning);
                 return;
             }
 
-            var pingSucceeded = await PingRemoteAsync().ConfigureAwait(false);
+            var pingSucceeded = await EnsureRemoteHostsReachableAsync(
+                hasClientReceiver ? clientReceiveEndpoint : null,
+                hasClientSender ? clientSendEndpoint : null).ConfigureAwait(false);
+
             if (!pingSucceeded)
             {
-                var targetHost = _options.Mode == TcpServiceMode.Listening
-                    ? _options.Host
-                    : ResolveDestinationHost();
-                if (!string.IsNullOrWhiteSpace(targetHost))
-                {
-                    var role = _options.ConnectionRole == TcpConnectionRole.Server ? "listener" : "client";
-                    Logger?.Log($"Cannot start TCP {role} because {targetHost} did not respond to ping.", LogLevel.Error);
-                }
                 return;
             }
 
@@ -375,31 +380,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             var protocol = _options.UseUdp ? "UDP" : "TCP";
 
             var tasks = new List<Task>();
-            if (_options.Mode is TcpServiceMode.Listening or TcpServiceMode.ReceiveAndSend)
+            if (hasListener)
             {
                 Logger?.Log($"Starting TCP listener on {_options.Host}:{_options.Port} ({protocol})", LogLevel.Information);
                 tasks.Add(RunServerLoopAsync(token));
             }
 
-            if (_options.Mode is TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend)
+            if (hasClientReceiver)
             {
-                var targetHost = ResolveDestinationHost();
-                var targetPort = ResolveDestinationPort();
-                if (string.IsNullOrWhiteSpace(targetHost) || targetPort <= 0)
-                {
-                    Logger?.Log("TCP client configuration incomplete; skipping client startup.", LogLevel.Warning);
-                }
-                else
-                {
-                    Logger?.Log($"Starting TCP client to {targetHost}:{targetPort} ({protocol})", LogLevel.Information);
-                    tasks.Add(RunClientLoopAsync(token));
-                }
+                Logger?.Log($"Starting TCP client to {clientReceiveEndpoint.Value.Host}:{clientReceiveEndpoint.Value.Port} ({protocol}) for receiving", LogLevel.Information);
+                tasks.Add(RunClientLoopAsync(clientReceiveEndpoint.Value, TcpClientOperation.Receive, token));
             }
 
-            if (tasks.Count == 0)
+            if (hasClientSender)
             {
-                Logger?.Log("TCP service is not configured to listen or send; network startup skipped.", LogLevel.Warning);
-                return;
+                Logger?.Log($"Starting TCP client to {clientSendEndpoint.Value.Host}:{clientSendEndpoint.Value.Port} ({protocol}) for sending", LogLevel.Information);
+                tasks.Add(RunClientLoopAsync(clientSendEndpoint.Value, TcpClientOperation.Send, token));
             }
 
             _networkLoopTask = Task.WhenAll(tasks);
@@ -463,6 +459,128 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             Logger?.Log("TCP network loop stopped", LogLevel.Debug);
         }
 
+        private bool ShouldStartServerListener()
+        {
+            return _options.ConnectionRole == TcpConnectionRole.Server &&
+                   _options.Mode is TcpServiceMode.Listening or TcpServiceMode.ReceiveAndSend;
+        }
+
+        private bool TryGetClientReceiveEndpoint(out TcpEndpoint? endpoint)
+        {
+            endpoint = null;
+            if (_options.ConnectionRole != TcpConnectionRole.Client)
+            {
+                return false;
+            }
+
+            if (_options.Mode is not (TcpServiceMode.Listening or TcpServiceMode.ReceiveAndSend))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.Host) || _options.Port <= 0)
+            {
+                Logger?.Log("TCP client listening host or port is not configured; skipping client startup.", LogLevel.Warning);
+                LogConnectionIssues("TCP client configuration", null, LogLevel.Warning);
+                return false;
+            }
+
+            endpoint = new TcpEndpoint(_options.Host, _options.Port);
+            return true;
+        }
+
+        private bool TryGetClientSendEndpoint(out TcpEndpoint? endpoint)
+        {
+            endpoint = null;
+            if (_options.Mode is not (TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend))
+            {
+                return false;
+            }
+
+            var host = ResolveDestinationHost();
+            var port = ResolveDestinationPort();
+            if (string.IsNullOrWhiteSpace(host) || port <= 0)
+            {
+                Logger?.Log("TCP client destination is not configured; skipping client startup.", LogLevel.Warning);
+                LogConnectionIssues("TCP client configuration", null, LogLevel.Warning);
+                return false;
+            }
+
+            endpoint = new TcpEndpoint(host, port);
+            return true;
+        }
+
+        private async Task<bool> EnsureRemoteHostsReachableAsync(TcpEndpoint? receiveEndpoint, TcpEndpoint? sendEndpoint)
+        {
+            var hostsToPing = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (receiveEndpoint is { } receive)
+            {
+                hostsToPing.TryAdd(receive.Host, "listening client");
+            }
+
+            if (sendEndpoint is { } send)
+            {
+                hostsToPing.TryAdd(send.Host, "client");
+            }
+
+            foreach (var pair in hostsToPing)
+            {
+                if (await PingHostAsync(pair.Key).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
+                Logger?.Log($"Cannot start TCP {pair.Value} because {pair.Key} did not respond to ping.", LogLevel.Error);
+                return false;
+            }
+
+            return true;
+        }
+
+        private async Task<bool> PingHostAsync(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host) || string.Equals(host, "0.0.0.0", StringComparison.Ordinal))
+            {
+                Logger?.Log("Ping skipped because no remote host is configured.", LogLevel.Debug);
+                return true;
+            }
+
+            if (IsLocalHost(host))
+            {
+                Logger?.Log($"Ping skipped for local host {host}.", LogLevel.Debug);
+                return true;
+            }
+
+            try
+            {
+                using var ping = new Ping();
+                var reply = await ping.SendPingAsync(host, (int)PingTimeout.TotalMilliseconds).ConfigureAwait(false);
+                if (reply.Status == IPStatus.Success)
+                {
+                    Logger?.Log($"Ping to {host} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
+                    return true;
+                }
+
+                Logger?.Log($"Ping to {host} failed with status {reply.Status}", LogLevel.Error);
+                LogConnectionIssues($"TCP ping to {host}", null, LogLevel.Error);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                LogConnectionIssues($"TCP ping to {host}", ex);
+                return false;
+            }
+        }
+
+        private enum TcpClientOperation
+        {
+            Receive,
+            Send
+        }
+
+        private readonly record struct TcpEndpoint(string Host, int Port);
+
         private async Task RunServerLoopAsync(CancellationToken cancellationToken)
         {
             TcpListener? listener = null;
@@ -513,51 +631,39 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
-        private async Task RunClientLoopAsync(CancellationToken cancellationToken)
+        private async Task RunClientLoopAsync(TcpEndpoint endpoint, TcpClientOperation operation, CancellationToken cancellationToken)
         {
-            if (_options.Mode == TcpServiceMode.Listening)
-            {
-                Logger?.Log("TCP client loop skipped because the service is configured for listening only.", LogLevel.Debug);
-                return;
-            }
-
-            var targetHost = ResolveDestinationHost();
-            var targetPort = ResolveDestinationPort();
-            if (string.IsNullOrWhiteSpace(targetHost) || targetPort <= 0)
-            {
-                Logger?.Log("TCP client destination is not configured.", LogLevel.Warning);
-                LogConnectionIssues("TCP client configuration", null, LogLevel.Warning);
-                return;
-            }
+            var operationLabel = operation == TcpClientOperation.Receive ? "listening endpoint" : "destination";
 
             try
             {
                 using var client = new TcpClient();
-                await client.ConnectAsync(targetHost, targetPort, cancellationToken).ConfigureAwait(false);
-                Logger?.Log($"Connected to {targetHost}:{targetPort}", LogLevel.Information);
+                await client.ConnectAsync(endpoint.Host, endpoint.Port, cancellationToken).ConfigureAwait(false);
+                Logger?.Log($"Connected to {operationLabel} {endpoint.Host}:{endpoint.Port}", LogLevel.Information);
 
                 using var stream = client.GetStream();
                 var message = _options.InputMessage ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(message))
+                var shouldSendMessage = operation == TcpClientOperation.Send && !string.IsNullOrWhiteSpace(message);
+                if (shouldSendMessage)
                 {
                     var payload = Encoding.UTF8.GetBytes(message);
                     await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
-                    Logger?.Log($"Sent message to {targetHost}:{targetPort}: {message}", LogLevel.Information);
+                    Logger?.Log($"Sent message to {operationLabel} {endpoint.Host}:{endpoint.Port}: {message}", LogLevel.Information);
                 }
 
                 var buffer = new byte[4096];
                 var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
-                var endpoint = $"{targetHost}:{targetPort}";
+                var endpointDisplay = $"{endpoint.Host}:{endpoint.Port}";
                 if (bytesRead > 0)
                 {
                     var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-                    Logger?.Log($"Received response from {endpoint}: {response}", LogLevel.Information);
-                    await AppendMessageAsync(message, response, endpoint).ConfigureAwait(false);
+                    Logger?.Log($"Received response from {endpointDisplay}: {response}", LogLevel.Information);
+                    await AppendMessageAsync(message, response, endpointDisplay).ConfigureAwait(false);
                 }
                 else
                 {
-                    await AppendMessageAsync(message, string.Empty, endpoint).ConfigureAwait(false);
-                    Logger?.Log($"No response received from {endpoint}", LogLevel.Warning);
+                    await AppendMessageAsync(message, string.Empty, endpointDisplay).ConfigureAwait(false);
+                    Logger?.Log($"No response received from {endpointDisplay}", LogLevel.Warning);
                 }
             }
             catch (OperationCanceledException)
@@ -566,7 +672,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
             catch (Exception ex)
             {
-                LogConnectionIssues("TCP client connection", ex);
+                LogConnectionIssues($"TCP client connection to {endpoint.Host}:{endpoint.Port}", ex);
             }
         }
 
@@ -618,47 +724,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 {
                     Logger?.Log($"Client disconnected: {endpoint}", LogLevel.Information);
                 }
-            }
-        }
-
-        private async Task<bool> PingRemoteAsync()
-        {
-            if (_options.Mode == TcpServiceMode.Listening)
-            {
-                Logger?.Log("Ping skipped because service is not configured to send.", LogLevel.Debug);
-                return true;
-            }
-
-            var targetHost = ResolveDestinationHost();
-            if (string.IsNullOrWhiteSpace(targetHost) || string.Equals(targetHost, "0.0.0.0", StringComparison.Ordinal))
-            {
-                Logger?.Log("Ping skipped because no remote host is configured.", LogLevel.Debug);
-                return true;
-            }
-
-            if (IsLocalHost(targetHost))
-            {
-                Logger?.Log($"Ping skipped for local host {targetHost}.", LogLevel.Debug);
-                return true;
-            }
-
-            try
-            {
-                using var ping = new Ping();
-                var reply = await ping.SendPingAsync(targetHost, (int)PingTimeout.TotalMilliseconds).ConfigureAwait(false);
-                if (reply.Status == IPStatus.Success)
-                {
-                    Logger?.Log($"Ping to {targetHost} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
-                    return true;
-                }
-                Logger?.Log($"Ping to {targetHost} failed with status {reply.Status}", LogLevel.Error);
-                LogConnectionIssues("TCP ping", null, LogLevel.Error);
-                return false;
-            }
-            catch (Exception ex)
-            {
-                LogConnectionIssues("TCP ping", ex);
-                return false;
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -18,14 +19,16 @@ using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.Views;
+using DesktopApplicationTemplate.Core.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 {
     /// <summary>
     /// View model for displaying TCP service messages and associated logs.
     /// </summary>
-    public class TcpServiceMessagesViewModel : ViewModelBase, ILoggingViewModel
+    public class TcpServiceMessagesViewModel : ViewModelBase, ILoggingViewModel, INetworkAwareViewModel
     {
         private LogLevel _logLevelFilter = LogLevel.Debug;
 
@@ -105,6 +108,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private readonly List<Task> _activeClientTasks = new();
         private readonly object _clientTasksLock = new();
         private bool _isApplicationExitHooked;
+        private NetworkConfiguration _networkConfiguration = new();
 
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
@@ -227,12 +231,62 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 : _options.Script;
             OutputMessage = _options.OutputMessage;
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
+            ApplyNetworkConfiguration(restartIfActive: false);
             Messages.Clear();
             MessageTable.Messages.Clear();
             OnPropertyChanged(nameof(IncomingData));
             OnPropertyChanged(nameof(OutgoingResults));
             _ = InitializeRuntimeAsync();
             if (_service.IsActive)
+            {
+                _ = StartNetworkAsync();
+            }
+        }
+
+        /// <inheritdoc />
+        public void UpdateNetworkConfiguration(NetworkConfiguration configuration)
+        {
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            _networkConfiguration = configuration;
+            ApplyNetworkConfiguration(restartIfActive: true);
+        }
+
+        private void ApplyNetworkConfiguration(bool restartIfActive)
+        {
+            if (_options is null)
+            {
+                return;
+            }
+
+            var config = _networkConfiguration ?? new NetworkConfiguration();
+
+            if (!string.IsNullOrWhiteSpace(config.IpAddress))
+            {
+                _options.Host = config.IpAddress;
+            }
+
+            _options.SubnetMask = config.SubnetMask ?? string.Empty;
+            _options.PrimaryDns = config.DnsPrimary ?? string.Empty;
+            _options.AlternateDns = config.DnsSecondary ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(_options.DestinationGateway))
+            {
+                _options.DestinationGateway = config.Gateway ?? string.Empty;
+            }
+
+            UpdateNetworkSettings(
+                _options.Host,
+                _options.Port > 0 ? _options.Port.ToString(CultureInfo.InvariantCulture) : string.Empty,
+                _options.DestinationHost,
+                _options.DestinationGateway,
+                _options.DestinationPort > 0 ? _options.DestinationPort.ToString(CultureInfo.InvariantCulture) : string.Empty,
+                _options.UseUdp);
+
+            if (restartIfActive && _service?.IsActive == true)
             {
                 _ = StartNetworkAsync();
             }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -305,10 +305,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             var pingSucceeded = await PingRemoteAsync().ConfigureAwait(false);
             if (!pingSucceeded)
             {
-                if (!string.IsNullOrWhiteSpace(_options.Host))
+                var targetHost = _options.Mode == TcpServiceMode.Listening
+                    ? _options.Host
+                    : ResolveDestinationHost();
+                if (!string.IsNullOrWhiteSpace(targetHost))
                 {
                     var role = _options.ConnectionRole == TcpConnectionRole.Server ? "listener" : "client";
-                    Logger?.Log($"Cannot start TCP {role} because {_options.Host} did not respond to ping.", LogLevel.Error);
+                    Logger?.Log($"Cannot start TCP {role} because {targetHost} did not respond to ping.", LogLevel.Error);
                 }
                 return;
             }
@@ -316,11 +319,36 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             _networkLoopCancellation = new CancellationTokenSource();
             var token = _networkLoopCancellation.Token;
             var protocol = _options.UseUdp ? "UDP" : "TCP";
-            Logger?.Log($"Starting TCP {_options.ConnectionRole} on {_options.Host}:{_options.Port} ({protocol})", LogLevel.Information);
 
-            _networkLoopTask = _options.ConnectionRole == TcpConnectionRole.Server
-                ? RunServerLoopAsync(token)
-                : RunClientLoopAsync(token);
+            var tasks = new List<Task>();
+            if (_options.Mode is TcpServiceMode.Listening or TcpServiceMode.ReceiveAndSend)
+            {
+                Logger?.Log($"Starting TCP listener on {_options.Host}:{_options.Port} ({protocol})", LogLevel.Information);
+                tasks.Add(RunServerLoopAsync(token));
+            }
+
+            if (_options.Mode is TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend)
+            {
+                var targetHost = ResolveDestinationHost();
+                var targetPort = ResolveDestinationPort();
+                if (string.IsNullOrWhiteSpace(targetHost) || targetPort <= 0)
+                {
+                    Logger?.Log("TCP client configuration incomplete; skipping client startup.", LogLevel.Warning);
+                }
+                else
+                {
+                    Logger?.Log($"Starting TCP client to {targetHost}:{targetPort} ({protocol})", LogLevel.Information);
+                    tasks.Add(RunClientLoopAsync(token));
+                }
+            }
+
+            if (tasks.Count == 0)
+            {
+                Logger?.Log("TCP service is not configured to listen or send; network startup skipped.", LogLevel.Warning);
+                return;
+            }
+
+            _networkLoopTask = Task.WhenAll(tasks);
         }
 
         private void StopNetwork()
@@ -433,9 +461,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private async Task RunClientLoopAsync(CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(_options.Host))
+            if (_options.Mode == TcpServiceMode.Listening)
             {
-                Logger?.Log("TCP client host is not configured.", LogLevel.Warning);
+                Logger?.Log("TCP client loop skipped because the service is configured for listening only.", LogLevel.Debug);
+                return;
+            }
+
+            var targetHost = ResolveDestinationHost();
+            var targetPort = ResolveDestinationPort();
+            if (string.IsNullOrWhiteSpace(targetHost) || targetPort <= 0)
+            {
+                Logger?.Log("TCP client destination is not configured.", LogLevel.Warning);
                 LogConnectionIssues("TCP client configuration", null, LogLevel.Warning);
                 return;
             }
@@ -443,8 +479,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             try
             {
                 using var client = new TcpClient();
-                await client.ConnectAsync(_options.Host, _options.Port, cancellationToken).ConfigureAwait(false);
-                Logger?.Log($"Connected to {_options.Host}:{_options.Port}", LogLevel.Information);
+                await client.ConnectAsync(targetHost, targetPort, cancellationToken).ConfigureAwait(false);
+                Logger?.Log($"Connected to {targetHost}:{targetPort}", LogLevel.Information);
 
                 using var stream = client.GetStream();
                 var message = _options.InputMessage ?? string.Empty;
@@ -452,12 +488,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 {
                     var payload = Encoding.UTF8.GetBytes(message);
                     await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
-                    Logger?.Log($"Sent message to {_options.Host}:{_options.Port}: {message}", LogLevel.Information);
+                    Logger?.Log($"Sent message to {targetHost}:{targetPort}: {message}", LogLevel.Information);
                 }
 
                 var buffer = new byte[4096];
                 var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
-                var endpoint = $"{_options.Host}:{_options.Port}";
+                var endpoint = $"{targetHost}:{targetPort}";
                 if (bytesRead > 0)
                 {
                     var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
@@ -533,28 +569,35 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private async Task<bool> PingRemoteAsync()
         {
-            if (string.IsNullOrWhiteSpace(_options.Host) || string.Equals(_options.Host, "0.0.0.0", StringComparison.Ordinal))
+            if (_options.Mode == TcpServiceMode.Listening)
+            {
+                Logger?.Log("Ping skipped because service is not configured to send.", LogLevel.Debug);
+                return true;
+            }
+
+            var targetHost = ResolveDestinationHost();
+            if (string.IsNullOrWhiteSpace(targetHost) || string.Equals(targetHost, "0.0.0.0", StringComparison.Ordinal))
             {
                 Logger?.Log("Ping skipped because no remote host is configured.", LogLevel.Debug);
                 return true;
             }
 
-            if (IsLocalHost(_options.Host))
+            if (IsLocalHost(targetHost))
             {
-                Logger?.Log($"Ping skipped for local host {_options.Host}.", LogLevel.Debug);
+                Logger?.Log($"Ping skipped for local host {targetHost}.", LogLevel.Debug);
                 return true;
             }
 
             try
             {
                 using var ping = new Ping();
-                var reply = await ping.SendPingAsync(_options.Host, (int)PingTimeout.TotalMilliseconds).ConfigureAwait(false);
+                var reply = await ping.SendPingAsync(targetHost, (int)PingTimeout.TotalMilliseconds).ConfigureAwait(false);
                 if (reply.Status == IPStatus.Success)
                 {
-                    Logger?.Log($"Ping to {_options.Host} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
+                    Logger?.Log($"Ping to {targetHost} succeeded in {reply.RoundtripTime} ms", LogLevel.Information);
                     return true;
                 }
-                Logger?.Log($"Ping to {_options.Host} failed with status {reply.Status}", LogLevel.Error);
+                Logger?.Log($"Ping to {targetHost} failed with status {reply.Status}", LogLevel.Error);
                 LogConnectionIssues("TCP ping", null, LogLevel.Error);
                 return false;
             }
@@ -569,7 +612,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         {
             var incomingMessage = incoming ?? string.Empty;
             var outgoingMessage = outgoing ?? string.Empty;
-            var destination = endpoint ?? string.Empty;
+            var destination = string.IsNullOrWhiteSpace(outgoingMessage)
+                ? string.Empty
+                : endpoint ?? string.Empty;
             var incomingDisplay = MessageDisplayFormatter.FormatForService(incomingMessage, true, ServiceType, ServiceName);
             var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoingMessage, false, ServiceType, ServiceName);
 
@@ -877,6 +922,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
+        private string ResolveDestinationHost()
+        {
+            return string.IsNullOrWhiteSpace(_options.DestinationHost)
+                ? _options.Host
+                : _options.DestinationHost;
+        }
+
+        private int ResolveDestinationPort()
+        {
+            return _options.DestinationPort > 0 ? _options.DestinationPort : _options.Port;
+        }
+
         private void ClearLogs()
         {
             Logs.Clear();
@@ -939,6 +996,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             if (!string.IsNullOrWhiteSpace(Script))
                 svm.ScriptText = Script;
             svm.TestMessage = TestMessage;
+            svm.RoutingService = _routing;
 
             void OnOutputGenerated(string output)
             {

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -9,6 +9,7 @@
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Page.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -26,6 +27,9 @@
                 <RowDefinition Height="Auto" /> <!-- Alternate DNS -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
                 <RowDefinition Height="Auto" /> <!-- Mode -->
+                <RowDefinition Height="Auto" /> <!-- Destination Host -->
+                <RowDefinition Height="Auto" /> <!-- Destination Port -->
+                <RowDefinition Height="Auto" /> <!-- Destination Gateway -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
 
@@ -133,7 +137,61 @@
             <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="9" Grid.ColumnSpan="2"
+            <TextBlock Grid.Row="9" Grid.Column="0" Text="Destination Host" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="9" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBox x:Name="DestinationHostBox" Text="{Binding DestinationHost, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="10.0.0.50" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationHostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="10" Grid.Column="0" Text="Destination Port" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="10" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBox x:Name="DestinationPortBox" Text="{Binding DestinationPort, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="5021" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="11" Grid.Column="0" Text="Destination Gateway" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="11" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBox x:Name="DestinationGatewayBox" Text="{Binding DestinationGateway, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="192.168.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <views:EditorButtonBar Grid.Row="12" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -9,6 +9,7 @@
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </Page.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -26,6 +27,9 @@
                 <RowDefinition Height="Auto" /> <!-- Alternate DNS -->
                 <RowDefinition Height="Auto" /> <!-- Use UDP -->
                 <RowDefinition Height="Auto" /> <!-- Mode -->
+                <RowDefinition Height="Auto" /> <!-- Destination Host -->
+                <RowDefinition Height="Auto" /> <!-- Destination Port -->
+                <RowDefinition Height="Auto" /> <!-- Destination Gateway -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
 
@@ -133,7 +137,61 @@
             <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="9" Grid.ColumnSpan="2"
+            <TextBlock Grid.Row="9" Grid.Column="0" Text="Destination Host" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="9" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBox x:Name="DestinationHostBox" Text="{Binding DestinationHost, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="10.0.0.50" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationHostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="10" Grid.Column="0" Text="Destination Port" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="10" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBox x:Name="DestinationPortBox" Text="{Binding DestinationPort, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="5021" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="11" Grid.Column="0" Text="Destination Gateway" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="11" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBox x:Name="DestinationGatewayBox" Text="{Binding DestinationGateway, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="192.168.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <views:EditorButtonBar Grid.Row="12" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveAutomationName="Save TCP Service"


### PR DESCRIPTION
## Summary
- add a shared formatter that exposes control characters and applies the {ServiceName}.LastInputMessage/LastOutputMessage labels
- update the TCP service view model and message table to use the new formatting, log readable payloads, and push both incoming and outgoing values into the routing service
- extend the routing infrastructure with direction-aware storage, a public enum, and support for the new token syntax while preserving legacy tokens

## Testing
- ⚠️ `dotnet build DesktopApplicationTemplate.sln` *(dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e535a556b88326b50ed85494d84cb4