### PR TITLE
Improve log interactions and TCP destination rules

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.Core.Services;
@@ -34,9 +35,34 @@ public interface IMessageRoutingService
     bool TryGetMessage(string serviceName, MessageRoutingDirection direction, out string? message);
 
     /// <summary>
-    /// Resolves <c>{ServiceName.LastInputMessage}</c> and <c>{ServiceName.LastOutputMessage}</c> tokens within the provided template.
+    /// Replaces <c>{ServiceName.LastInputMessage}</c> and <c>{ServiceName.LastOutputMessage}</c> tokens within the provided template.
     /// </summary>
     /// <param name="template">The template containing message tokens.</param>
+    /// <param name="referencingServiceName">
+    /// Optional service name that owns the template. When provided, routing dependencies are refreshed to
+    /// reflect the referenced services discovered in <paramref name="template"/>.
+    /// </param>
     /// <returns>The template with tokens replaced by their corresponding messages.</returns>
-    string ResolveTokens(string template);
+    string ResolveTokens(string template, string? referencingServiceName = null);
+
+    /// <summary>
+    /// Updates the routing dependencies for the specified service.
+    /// </summary>
+    /// <param name="referencingServiceName">The service that references other routed messages.</param>
+    /// <param name="references">The set of services and message directions referenced by the service.</param>
+    void SetReferences(string referencingServiceName, IEnumerable<MessageRoutingReference> references);
+
+    /// <summary>
+    /// Gets the services that currently reference the specified service's routed messages.
+    /// </summary>
+    /// <param name="serviceName">The name of the service being referenced.</param>
+    /// <returns>A read-only collection of service references formatted as <c>ServiceName.Property</c>.</returns>
+    IReadOnlyCollection<string> GetReferencingServices(string serviceName);
 }
+
+/// <summary>
+/// Describes a routed message dependency from one service to another.
+/// </summary>
+/// <param name="ServiceName">The referenced service name.</param>
+/// <param name="Direction">The message direction requested from the referenced service.</param>
+public readonly record struct MessageRoutingReference(string ServiceName, MessageRoutingDirection Direction);

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -19,7 +20,7 @@ public static class MessageRoutingScriptTransformer
     /// <param name="script">The user provided script.</param>
     /// <param name="routingService">Routing service supplying the latest message snapshots.</param>
     /// <returns>The rewritten script text.</returns>
-    public static string InjectRoutingLiterals(string? script, IMessageRoutingService routingService)
+    public static string InjectRoutingLiterals(string? script, IMessageRoutingService routingService, string? referencingServiceName = null)
     {
         if (string.IsNullOrWhiteSpace(script))
         {
@@ -34,17 +35,24 @@ public static class MessageRoutingScriptTransformer
         var syntaxTree = CSharpSyntaxTree.ParseText(script, ScriptParseOptions);
         var rewriter = new RoutingTokenRewriter(routingService);
         var rewritten = rewriter.Visit(syntaxTree.GetRoot());
+        if (!string.IsNullOrWhiteSpace(referencingServiceName))
+        {
+            routingService.SetReferences(referencingServiceName, rewriter.References);
+        }
         return rewritten.ToFullString();
     }
 
     private sealed class RoutingTokenRewriter : CSharpSyntaxRewriter
     {
         private readonly IMessageRoutingService _routingService;
+        private readonly List<MessageRoutingReference> _references = new();
 
         public RoutingTokenRewriter(IMessageRoutingService routingService)
         {
             _routingService = routingService;
         }
+
+        public IReadOnlyList<MessageRoutingReference> References => _references;
 
         public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
         {
@@ -64,6 +72,7 @@ public static class MessageRoutingScriptTransformer
                 return visited;
             }
 
+            _references.Add(new MessageRoutingReference(identifier.Identifier.ValueText, direction));
             if (!_routingService.TryGetMessage(identifier.Identifier.ValueText, direction, out var message) || message is null)
             {
                 message = string.Empty;

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using DesktopApplicationTemplate.Models;
 
@@ -12,6 +14,9 @@ public class MessageRoutingService : IMessageRoutingService
 {
     private readonly ConcurrentDictionary<(ServiceType, string), RoutingMessageEntry> _messages = new();
     private readonly ConcurrentDictionary<string, RoutingMessageEntry> _messagesByName = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, HashSet<MessageRoutingDirection>>> _referencesByService = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, HashSet<MessageRoutingDirection>>> _referencedByService = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _referencesLock = new();
     private readonly ILoggingService? _logger;
     private static readonly Regex NewTokenRegex = new(@"\{([A-Za-z0-9_]+)\.(LastInputMessage|LastOutputMessage)\}", RegexOptions.Compiled);
     private static readonly Regex LegacyTokenRegex = new(@"\{([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
@@ -93,18 +98,25 @@ public class MessageRoutingService : IMessageRoutingService
     }
 
     /// <inheritdoc />
-    public string ResolveTokens(string template)
+    public string ResolveTokens(string template, string? referencingServiceName = null)
     {
         if (template is null)
             throw new ArgumentNullException(nameof(template));
 
         _logger?.Log($"Resolving tokens in '{template}'", LogLevel.Debug);
+        var normalizedReferencing = NormalizeServiceName(referencingServiceName);
+        List<MessageRoutingReference>? references = normalizedReferencing is null ? null : new List<MessageRoutingReference>();
         var result = NewTokenRegex.Replace(template, m =>
         {
             var name = m.Groups[1].Value;
             var direction = string.Equals(m.Groups[2].Value, nameof(RoutingMessageEntry.LastInputMessage), StringComparison.Ordinal)
                 ? MessageRoutingDirection.Input
                 : MessageRoutingDirection.Output;
+
+            if (references is not null)
+            {
+                references.Add(new MessageRoutingReference(name, direction));
+            }
 
             return TryGetMessageByName(name, direction, out var replacement)
                 ? replacement
@@ -123,8 +135,181 @@ public class MessageRoutingService : IMessageRoutingService
 
             return string.Empty;
         });
+
+        if (normalizedReferencing is not null)
+        {
+            SetReferences(normalizedReferencing, references!);
+        }
+
         _logger?.Log($"Resolved template to '{result}'", LogLevel.Debug);
         return result;
+    }
+
+    /// <inheritdoc />
+    public void SetReferences(string referencingServiceName, IEnumerable<MessageRoutingReference> references)
+    {
+        var normalizedReferencing = NormalizeServiceName(referencingServiceName);
+        if (normalizedReferencing is null)
+        {
+            throw new ArgumentException("Referencing service name cannot be null or whitespace.", nameof(referencingServiceName));
+        }
+
+        var referenceMap = (references ?? Array.Empty<MessageRoutingReference>())
+            .Where(r => !string.IsNullOrWhiteSpace(r.ServiceName))
+            .GroupBy(r => NormalizeServiceName(r.ServiceName)!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => new HashSet<MessageRoutingDirection>(g.Select(r => r.Direction)),
+                StringComparer.OrdinalIgnoreCase);
+
+        lock (_referencesLock)
+        {
+            if (referenceMap.Count == 0)
+            {
+                if (_referencesByService.Remove(normalizedReferencing, out var previous))
+                {
+                    foreach (var referenced in previous.Keys)
+                    {
+                        RemoveReferencedByEntry(referenced, normalizedReferencing);
+                    }
+                }
+                else
+                {
+                    // Ensure we are removed from any referenced-by entries even if no previous entry was present.
+                    foreach (var referenced in _referencedByService.Keys.ToArray())
+                    {
+                        RemoveReferencedByEntry(referenced, normalizedReferencing);
+                    }
+                }
+
+                return;
+            }
+
+            if (!_referencesByService.TryGetValue(normalizedReferencing, out var currentReferences))
+            {
+                currentReferences = new Dictionary<string, HashSet<MessageRoutingDirection>>(StringComparer.OrdinalIgnoreCase);
+                _referencesByService[normalizedReferencing] = currentReferences;
+            }
+
+            var toRemove = currentReferences.Keys
+                .Where(key => !referenceMap.ContainsKey(key))
+                .ToList();
+            foreach (var removed in toRemove)
+            {
+                currentReferences.Remove(removed);
+                RemoveReferencedByEntry(removed, normalizedReferencing);
+            }
+
+            foreach (var pair in referenceMap)
+            {
+                if (!currentReferences.TryGetValue(pair.Key, out var directions))
+                {
+                    directions = new HashSet<MessageRoutingDirection>();
+                    currentReferences[pair.Key] = directions;
+                }
+                else
+                {
+                    directions.Clear();
+                }
+
+                foreach (var direction in pair.Value)
+                {
+                    directions.Add(direction);
+                }
+
+                if (!_referencedByService.TryGetValue(pair.Key, out var referencingMap))
+                {
+                    referencingMap = new Dictionary<string, HashSet<MessageRoutingDirection>>(StringComparer.OrdinalIgnoreCase);
+                    _referencedByService[pair.Key] = referencingMap;
+                }
+
+                if (!referencingMap.TryGetValue(normalizedReferencing, out var referencingDirections))
+                {
+                    referencingDirections = new HashSet<MessageRoutingDirection>();
+                    referencingMap[normalizedReferencing] = referencingDirections;
+                }
+                else
+                {
+                    referencingDirections.Clear();
+                }
+
+                foreach (var direction in pair.Value)
+                {
+                    referencingDirections.Add(direction);
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> GetReferencingServices(string serviceName)
+    {
+        var normalized = NormalizeServiceName(serviceName);
+        if (normalized is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        lock (_referencesLock)
+        {
+            if (!_referencedByService.TryGetValue(normalized, out var references) || references.Count == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            var results = new List<string>(references.Count);
+            foreach (var pair in references)
+            {
+                var formattedDirections = pair.Value
+                    .Select(ToPropertyName)
+                    .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                if (formattedDirections.Length == 0)
+                {
+                    results.Add(pair.Key);
+                }
+                else if (formattedDirections.Length == 1)
+                {
+                    results.Add($"{pair.Key}.{formattedDirections[0]}");
+                }
+                else
+                {
+                    results.Add($"{pair.Key}.{string.Join("/", formattedDirections)}");
+                }
+            }
+
+            results.Sort(StringComparer.OrdinalIgnoreCase);
+            return results.ToArray();
+        }
+    }
+
+    private void RemoveReferencedByEntry(string referencedService, string referencingService)
+    {
+        if (!_referencedByService.TryGetValue(referencedService, out var referencingMap))
+        {
+            return;
+        }
+
+        referencingMap.Remove(referencingService);
+        if (referencingMap.Count == 0)
+        {
+            _referencedByService.Remove(referencedService);
+        }
+    }
+
+    private static string? NormalizeServiceName(string? serviceName)
+    {
+        return string.IsNullOrWhiteSpace(serviceName)
+            ? null
+            : serviceName.Trim();
+    }
+
+    private static string ToPropertyName(MessageRoutingDirection direction)
+    {
+        return direction == MessageRoutingDirection.Input
+            ? nameof(RoutingMessageEntry.LastInputMessage)
+            : nameof(RoutingMessageEntry.LastOutputMessage);
     }
 
     private static RoutingMessageEntry CreateEntry(MessageRoutingDirection direction, string payload)

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
@@ -120,7 +120,8 @@ public sealed class TcpRuntime : ITcpRuntime
 
     private async Task<string> ExecuteScriptInternalAsync(string script, string message, CancellationToken cancellationToken)
     {
-        var rewrittenScript = MessageRoutingScriptTransformer.InjectRoutingLiterals(script, _routingService);
+        var referencingService = _context?.ServiceName;
+        var rewrittenScript = MessageRoutingScriptTransformer.InjectRoutingLiterals(script, _routingService, referencingService);
         var globals = new TcpScriptGlobals { Message = message ?? string.Empty };
         var code = rewrittenScript + "\nreturn Process(Message);";
         var compiled = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(TcpScriptGlobals));

--- a/DesktopApplicationTemplate.UI/Helpers/MessageDisplayFormatter.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/MessageDisplayFormatter.cs
@@ -98,7 +98,10 @@ namespace DesktopApplicationTemplate.UI.Helpers
             }
 
             var propertyName = isIncoming ? "LastInputMessage" : "LastOutputMessage";
-            return string.Create(serviceName.Length + propertyName.Length + formatted.Length + 2, (serviceName, propertyName, formatted),
+            const int separatorLength = 3; // '.', ':' and the following space
+            var requiredLength = serviceName.Length + propertyName.Length + formatted.Length + separatorLength;
+
+            return string.Create(requiredLength, (serviceName, propertyName, formatted),
                 (span, state) =>
                 {
                     var (svcName, prop, content) = state;

--- a/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ScriptEditorViewModel.cs
@@ -25,6 +25,7 @@ public class ScriptEditorViewModel : ViewModelBase
     private Brush _outputBrush = Brushes.Black;
     private string _lastTestMessage = string.Empty;
     private IMessageRoutingService? _routingService;
+    private string? _routingServiceName;
 
     public string ScriptText
     {
@@ -100,6 +101,21 @@ public class ScriptEditorViewModel : ViewModelBase
         }
     }
 
+    public string? RoutingServiceName
+    {
+        get => _routingServiceName;
+        set
+        {
+            if (_routingServiceName == value)
+            {
+                return;
+            }
+
+            _routingServiceName = value;
+            OnPropertyChanged();
+        }
+    }
+
     public ScriptEditorViewModel()
     {
         RunCommand = new AsyncRelayCommand(RunAsync);
@@ -111,7 +127,7 @@ public class ScriptEditorViewModel : ViewModelBase
         var globals = new Globals { Message = TestMessage };
         var scriptBody = _routingService is null
             ? ScriptText
-            : MessageRoutingScriptTransformer.InjectRoutingLiterals(ScriptText, _routingService);
+            : MessageRoutingScriptTransformer.InjectRoutingLiterals(ScriptText, _routingService, RoutingServiceName);
         var code = scriptBody + "\nreturn Process(Message);";
         var script = CSharpScript.Create<string>(code, ScriptOptions.Default, typeof(Globals));
         var diagnostics = script.Compile();

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -151,11 +151,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
             _mode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
-            if (!IsSendingEnabled)
-            {
-                ClearErrors(nameof(DestinationHost));
-                ClearErrors(nameof(DestinationPort));
-            }
+            UpdateDestinationValidationState();
         }
     }
 
@@ -164,10 +160,14 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     /// </summary>
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
+    private bool RequiresDestinationConfiguration =>
+        Mode == TcpServiceMode.Sending ||
+        (Mode == TcpServiceMode.ReceiveAndSend && ConnectionRole == TcpConnectionRole.Client);
+
     /// <summary>
     /// Indicates whether the service should expose sending configuration fields.
     /// </summary>
-    public bool IsSendingEnabled => Mode != TcpServiceMode.Listening;
+    public bool IsSendingEnabled => RequiresDestinationConfiguration;
 
     /// <summary>
     /// Available TCP connection roles.
@@ -183,23 +183,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         set
         {
             _destinationHost = value ?? string.Empty;
-            if (IsSendingEnabled)
-            {
-                var error = Rule.ValidateRequired(_destinationHost, "Destination Host");
-                if (error is not null)
-                {
-                    AddError(nameof(DestinationHost), error);
-                }
-                else
-                {
-                    ClearErrors(nameof(DestinationHost));
-                }
-            }
-            else
-            {
-                ClearErrors(nameof(DestinationHost));
-            }
-
+            ValidateDestinationHost();
             OnPropertyChanged();
         }
     }
@@ -213,23 +197,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         set
         {
             _destinationPort = value;
-            if (IsSendingEnabled)
-            {
-                var error = Rule.ValidatePort(value);
-                if (error is not null)
-                {
-                    AddError(nameof(DestinationPort), error);
-                }
-                else
-                {
-                    ClearErrors(nameof(DestinationPort));
-                }
-            }
-            else
-            {
-                ClearErrors(nameof(DestinationPort));
-            }
-
+            ValidateDestinationPort();
             OnPropertyChanged();
         }
     }
@@ -263,6 +231,8 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
 
             _connectionRole = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(IsSendingEnabled));
+            UpdateDestinationValidationState();
             if (_connectionRole == TcpConnectionRole.Server)
             {
                 _clientHost = _host;
@@ -313,5 +283,51 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
 
         var label = displayName ?? propertyName;
         AddError(propertyName, $"{label} must be a valid IPv4 address");
+    }
+
+    private void ValidateDestinationHost()
+    {
+        if (RequiresDestinationConfiguration)
+        {
+            var error = Rule.ValidateRequired(_destinationHost, "Destination Host");
+            if (error is not null)
+            {
+                AddError(nameof(DestinationHost), error);
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationHost));
+            }
+        }
+        else
+        {
+            ClearErrors(nameof(DestinationHost));
+        }
+    }
+
+    private void ValidateDestinationPort()
+    {
+        if (RequiresDestinationConfiguration)
+        {
+            var error = Rule.ValidatePort(_destinationPort);
+            if (error is not null)
+            {
+                AddError(nameof(DestinationPort), error);
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationPort));
+            }
+        }
+        else
+        {
+            ClearErrors(nameof(DestinationPort));
+        }
+    }
+
+    private void UpdateDestinationValidationState()
+    {
+        ValidateDestinationHost();
+        ValidateDestinationPort();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -134,11 +134,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
             _mode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
-            if (!IsSendingEnabled)
-            {
-                ClearErrors(nameof(DestinationHost));
-                ClearErrors(nameof(DestinationPort));
-            }
+            UpdateDestinationValidationState();
         }
     }
 
@@ -190,9 +186,14 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     public TcpServiceMode[] Modes { get; } = (TcpServiceMode[])Enum.GetValues(typeof(TcpServiceMode));
 
     /// <summary>
+    private bool RequiresDestinationConfiguration =>
+        Mode == TcpServiceMode.Sending ||
+        (Mode == TcpServiceMode.ReceiveAndSend && ConnectionRole == TcpConnectionRole.Client);
+
+    /// <summary>
     /// Indicates whether the service should expose sending configuration fields.
     /// </summary>
-    public bool IsSendingEnabled => Mode != TcpServiceMode.Listening;
+    public bool IsSendingEnabled => RequiresDestinationConfiguration;
 
     /// <summary>
     /// Available TCP connection roles.
@@ -208,23 +209,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         set
         {
             _destinationHost = value ?? string.Empty;
-            if (IsSendingEnabled)
-            {
-                var error = Rule.ValidateRequired(_destinationHost, "Destination Host");
-                if (error is not null)
-                {
-                    AddError(nameof(DestinationHost), error);
-                }
-                else
-                {
-                    ClearErrors(nameof(DestinationHost));
-                }
-            }
-            else
-            {
-                ClearErrors(nameof(DestinationHost));
-            }
-
+            ValidateDestinationHost();
             OnPropertyChanged();
         }
     }
@@ -238,23 +223,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         set
         {
             _destinationPort = value;
-            if (IsSendingEnabled)
-            {
-                var error = Rule.ValidatePort(value);
-                if (error is not null)
-                {
-                    AddError(nameof(DestinationPort), error);
-                }
-                else
-                {
-                    ClearErrors(nameof(DestinationPort));
-                }
-            }
-            else
-            {
-                ClearErrors(nameof(DestinationPort));
-            }
-
+            ValidateDestinationPort();
             OnPropertyChanged();
         }
     }
@@ -288,6 +257,8 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
 
             _connectionRole = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(IsSendingEnabled));
+            UpdateDestinationValidationState();
             if (_suppressRoleHostUpdate)
             {
                 return;
@@ -358,6 +329,52 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
 
         var label = displayName ?? propertyName;
         AddError(propertyName, $"{label} must be a valid IPv4 address");
+    }
+
+    private void ValidateDestinationHost()
+    {
+        if (RequiresDestinationConfiguration)
+        {
+            var error = Rule.ValidateRequired(_destinationHost, "Destination Host");
+            if (error is not null)
+            {
+                AddError(nameof(DestinationHost), error);
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationHost));
+            }
+        }
+        else
+        {
+            ClearErrors(nameof(DestinationHost));
+        }
+    }
+
+    private void ValidateDestinationPort()
+    {
+        if (RequiresDestinationConfiguration)
+        {
+            var error = Rule.ValidatePort(_destinationPort);
+            if (error is not null)
+            {
+                AddError(nameof(DestinationPort), error);
+            }
+            else
+            {
+                ClearErrors(nameof(DestinationPort));
+            }
+        }
+        else
+        {
+            ClearErrors(nameof(DestinationPort));
+        }
+    }
+
+    private void UpdateDestinationValidationState()
+    {
+        ValidateDestinationHost();
+        ValidateDestinationPort();
     }
 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -492,6 +492,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private bool TryGetClientSendEndpoint(out TcpEndpoint? endpoint)
         {
             endpoint = null;
+            if (_options.ConnectionRole != TcpConnectionRole.Client)
+            {
+                return false;
+            }
+
             if (_options.Mode is not (TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend))
             {
                 return false;
@@ -883,7 +888,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private IEnumerable<string> BuildDestinationDiagnostics()
         {
-            if (_options.Mode is TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend)
+            if (_options.ConnectionRole == TcpConnectionRole.Client &&
+                _options.Mode is TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend)
             {
                 var destinationHost = ResolveDestinationHost();
                 var destinationPort = ResolveDestinationPort();

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -732,9 +732,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             var incomingMessage = incoming ?? string.Empty;
             var outgoingMessage = outgoing ?? string.Empty;
             var incomingEndpoint = endpoint ?? string.Empty;
-            var destination = string.IsNullOrWhiteSpace(outgoingMessage)
-                ? string.Empty
-                : incomingEndpoint;
+            var referencingServices = _routing.GetReferencingServices(ServiceName);
+            var destination = string.Empty;
+            if (!string.IsNullOrWhiteSpace(outgoingMessage))
+            {
+                destination = incomingEndpoint;
+            }
+            else if (referencingServices.Count > 0)
+            {
+                destination = string.Join(", ", referencingServices);
+            }
             var incomingDisplay = MessageDisplayFormatter.FormatForService(incomingMessage, true, ServiceType, ServiceName);
             var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoingMessage, false, ServiceType, ServiceName);
 
@@ -794,6 +801,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             yield return BuildSubnetDiagnostic();
             yield return BuildDnsDiagnostic(_options.PrimaryDns, "Primary DNS");
             yield return BuildDnsDiagnostic(_options.AlternateDns, "Alternate DNS");
+            foreach (var destinationDetail in BuildDestinationDiagnostics())
+            {
+                yield return destinationDetail;
+            }
         }
 
         private string BuildHostDiagnostic()
@@ -868,6 +879,29 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             return IPAddress.TryParse(value, out _)
                 ? $"{label}: {value}"
                 : $"{label}: invalid ({value})";
+        }
+
+        private IEnumerable<string> BuildDestinationDiagnostics()
+        {
+            if (_options.Mode is TcpServiceMode.Sending or TcpServiceMode.ReceiveAndSend)
+            {
+                var destinationHost = ResolveDestinationHost();
+                var destinationPort = ResolveDestinationPort();
+                if (string.IsNullOrWhiteSpace(destinationHost) || destinationPort is null)
+                {
+                    yield return "Destination: not configured";
+                }
+                else
+                {
+                    yield return $"Destination: {destinationHost}:{destinationPort}";
+                }
+                yield break;
+            }
+
+            var referencing = _routing.GetReferencingServices(ServiceName);
+            yield return referencing.Count > 0
+                ? $"Destination references: {string.Join(", ", referencing)}"
+                : "Destination references: none";
         }
 
         private static Task RunOnUiThreadAsync(Action action)
@@ -1117,6 +1151,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 svm.ScriptText = Script;
             svm.TestMessage = TestMessage;
             svm.RoutingService = _routing;
+            svm.RoutingServiceName = ServiceName;
 
             void OnOutputGenerated(string output)
             {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -172,6 +172,11 @@
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                              SelectionChanged="ServiceList_SelectionChanged"
                              MouseDoubleClick="ServiceList_MouseDoubleClick">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <EventSetter Event="MouseDoubleClick" Handler="ServiceListItem_MouseDoubleClick" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" BorderBrush="{Binding BorderColor}" Background="{Binding BackgroundColor}" BorderThickness="2" Padding="5" Margin="2"

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -170,12 +170,13 @@
                              BorderThickness="0" HorizontalContentAlignment="Stretch"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             SelectionChanged="ServiceList_SelectionChanged">
+                             SelectionChanged="ServiceList_SelectionChanged"
+                             MouseDoubleClick="ServiceList_MouseDoubleClick">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <Border CornerRadius="8" BorderBrush="{Binding BorderColor}" Background="{Binding BackgroundColor}" BorderThickness="2" Padding="5" Margin="2"
                                         PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown" PreviewMouseMove="ServiceItem_PreviewMouseMove"
-                                        AllowDrop="True" Drop="ServiceItem_Drop" MouseLeftButtonDown="ServiceItem_MouseLeftButtonDown">
+                                        AllowDrop="True" Drop="ServiceItem_Drop">
                                         <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2"
                                                 Tag="{Binding DataContext.EditServiceCommand, RelativeSource={RelativeSource AncestorType=ListBox}}">
                                         <Border.ContextMenu>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -489,6 +489,27 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
+        private void ServiceList_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (e.OriginalSource is not DependencyObject source)
+            {
+                return;
+            }
+
+            var item = Helpers.VisualTreeHelperExtensions.FindParent<ListBoxItem>(source);
+            if (item?.DataContext is not ServiceListModel svc)
+            {
+                return;
+            }
+
+            _logger?.LogDebug("Service {Name} double-clicked", svc.DisplayName);
+            if (_viewModel.EditServiceCommand.CanExecute(svc))
+            {
+                _viewModel.EditServiceCommand.Execute(svc);
+                e.Handled = true;
+            }
+        }
+
         private void FilterButton_Click(object sender, RoutedEventArgs e)
         {
             if (FilterPopup != null)
@@ -636,21 +657,6 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
             }
 
-        }
-
-        private void ServiceItem_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            if (e.ClickCount < 2)
-                return;
-
-            if (sender is Border { DataContext: ServiceListModel svc })
-            {
-                _logger?.LogDebug("Service {Name} double-clicked", svc.DisplayName);
-                if (_viewModel.EditServiceCommand.CanExecute(svc))
-                {
-                    _viewModel.EditServiceCommand.Execute(svc);
-                }
-            }
         }
 
         private void OpenSettings_Click(object sender, RoutedEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -491,6 +491,11 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void ServiceList_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            if (e.Handled)
+            {
+                return;
+            }
+
             if (e.OriginalSource is not DependencyObject source)
             {
                 return;
@@ -503,6 +508,21 @@ namespace DesktopApplicationTemplate.UI.Views
             }
 
             _logger?.LogDebug("Service {Name} double-clicked", svc.DisplayName);
+            if (_viewModel.EditServiceCommand.CanExecute(svc))
+            {
+                _viewModel.EditServiceCommand.Execute(svc);
+                e.Handled = true;
+            }
+        }
+
+        private void ServiceListItem_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (sender is not ListBoxItem { DataContext: ServiceListModel svc })
+            {
+                return;
+            }
+
+            _logger?.LogDebug("Service {Name} double-clicked via item container", svc.DisplayName);
             if (_viewModel.EditServiceCommand.CanExecute(svc))
             {
                 _viewModel.EditServiceCommand.Execute(svc);

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -9,6 +9,11 @@
              d:DesignWidth="400"
              d:DataContext="{d:DesignInstance Type=viewModels:ServiceLogViewModel}"
              mc:Ignorable="d">
+    <UserControl.CommandBindings>
+        <CommandBinding Command="ApplicationCommands.Copy"
+                        CanExecute="CopyCommand_CanExecute"
+                        Executed="CopyCommand_Executed" />
+    </UserControl.CommandBindings>
     <Border Background="#E6E6E6" CornerRadius="5" Padding="10">
         <Grid>
             <Grid.RowDefinitions>
@@ -27,7 +32,16 @@
                 <Button Content="Export Log" Width="100" Margin="10,0,0,0" Command="{Binding ExportLogCommand}" Background="#CCCCFF"/>
                 <Button Content="Clear Log" Width="100" Margin="10,0,0,0" Command="{Binding ClearLogCommand}" Background="#FFCCCC"/>
             </StackPanel>
-            <ListBox Grid.Row="1" ItemsSource="{Binding DisplayLogs}" ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.VerticalScrollBarVisibility="Auto" MinHeight="150">
+            <ListBox x:Name="LogListBox"
+                     Grid.Row="1"
+                     ItemsSource="{Binding DisplayLogs}"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     MinHeight="150"
+                     SelectionMode="Extended">
+                <ListBox.InputBindings>
+                    <KeyBinding Key="C" Modifiers="Control" Command="ApplicationCommands.Copy" />
+                </ListBox.InputBindings>
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <TextBlock Text="{Binding Message}" Foreground="{Binding Color}" TextWrapping="Wrap" Margin="0,0,0,5" />

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Linq;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.Views.Shared
 {
@@ -10,6 +15,39 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
         public ServiceLogView()
         {
             InitializeComponent();
+        }
+
+        private void CopyCommand_CanExecute(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = LogListBox?.SelectedItems?.Count > 0;
+        }
+
+        private void CopyCommand_Executed(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (LogListBox?.SelectedItems is null || LogListBox.SelectedItems.Count == 0)
+            {
+                return;
+            }
+
+            var lines = LogListBox.SelectedItems
+                .OfType<LogEntry>()
+                .Select(entry => entry.Message)
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .ToArray();
+
+            if (lines.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                Clipboard.SetText(string.Join(Environment.NewLine, lines));
+            }
+            catch (Exception)
+            {
+                // Clipboard.SetText can throw if the clipboard is unavailable; ignore and leave command silent.
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- enable extended selection in the service log view and wire ctrl+c copying for the selected log entries
- treat a service-list double-click as an edit shortcut while keeping single-click navigation to the main page
- require TCP destinations only for client send scenarios so listening services run without destination values

## Testing
- Not run (dotnet CLI is not available in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5579f67148326adc916408dcc2762