### PR TITLE
Refine TCP service logging display

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
@@ -52,6 +52,21 @@ public class TcpServiceOptions
     public string DestinationGateway { get; set; } = string.Empty;
 
     /// <summary>
+    /// Subnet mask associated with the remote destination.
+    /// </summary>
+    public string DestinationSubnetMask { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Primary DNS server used for resolving the remote destination.
+    /// </summary>
+    public string DestinationPrimaryDns { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Alternate DNS server used for resolving the remote destination.
+    /// </summary>
+    public string DestinationAlternateDns { get; set; } = string.Empty;
+
+    /// <summary>
     /// Indicates whether UDP should be used instead of TCP.
     /// </summary>
     public bool UseUdp { get; set; }

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -31,7 +31,6 @@ public class TcpEditServiceHandler : IEditServiceHandler
     {
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
-        var tcpPage = mainView.GetOrCreateServicePage(service);
         var options = service.TcpOptions ?? new TcpServiceOptions();
         var vm = _services.GetRequiredService<TcpEditServiceViewModel>();
         vm.ServiceType = service.Type;
@@ -51,14 +50,22 @@ public class TcpEditServiceHandler : IEditServiceHandler
             service.DisplayName = trimmed;
             service.Type = vm.ServiceType;
             service.TcpOptions = opts;
-            if (tcpPage != null)
-                mainView.ShowPage(tcpPage);
+            var page = mainView.GetOrCreateServicePage(service);
+            if (page != null)
+            {
+                mainView.ShowPage(page);
+            }
+            mainViewModel.SelectedService = service;
             _ = mainViewModel.SaveServicesAsync();
         };
         vm.EditCancelled += () =>
         {
-            if (tcpPage != null)
-                mainView.ShowPage(tcpPage);
+            var page = mainView.GetOrCreateServicePage(service);
+            if (page != null)
+            {
+                mainView.ShowPage(page);
+            }
+            mainViewModel.SelectedService = service;
         };
         mainView.ShowPage(editView);
         _logger?.LogDebug("Edit workflow completed for {Name}", service.DisplayName);

--- a/DesktopApplicationTemplate.UI/Helpers/MessageDisplayFormatter.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/MessageDisplayFormatter.cs
@@ -77,52 +77,21 @@ namespace DesktopApplicationTemplate.UI.Helpers
         }
 
         /// <summary>
-        /// Formats a message for display using the standardized service reference conventions.
+        /// Formats a message for display using readable control character tokens while keeping the
+        /// original payload intact. Service reference prefixes are intentionally omitted so the
+        /// displayed text mirrors the exact message that was transmitted or received.
         /// </summary>
         /// <param name="message">The message text to format.</param>
-        /// <param name="isIncoming">Indicates whether the message represents incoming data.</param>
-        /// <param name="serviceType">The type of service producing the message.</param>
-        /// <param name="serviceName">The name of the service producing the message.</param>
+        /// <param name="isIncoming">Unused. Present for backward compatibility with previous callers.</param>
+        /// <param name="serviceType">Unused. Present for backward compatibility with previous callers.</param>
+        /// <param name="serviceName">Unused. Present for backward compatibility with previous callers.</param>
         /// <returns>A formatted string suitable for UI presentation.</returns>
         public static string FormatForService(string? message, bool isIncoming, ServiceType serviceType, string serviceName)
         {
-            var formatted = FormatControlCharacters(message);
-            if (string.IsNullOrEmpty(formatted))
-            {
-                return string.Empty;
-            }
-
-            if (!ShouldUseServiceReference(serviceType) || string.IsNullOrWhiteSpace(serviceName))
-            {
-                return formatted;
-            }
-
-            var propertyName = isIncoming ? "LastInputMessage" : "LastOutputMessage";
-            const int separatorLength = 3; // '.', ':' and the following space
-            var requiredLength = serviceName.Length + propertyName.Length + formatted.Length + separatorLength;
-
-            return string.Create(requiredLength, (serviceName, propertyName, formatted),
-                (span, state) =>
-                {
-                    var (svcName, prop, content) = state;
-                    var index = 0;
-                    svcName.AsSpan().CopyTo(span);
-                    index += svcName.Length;
-                    span[index++] = '.';
-                    prop.AsSpan().CopyTo(span[index..]);
-                    index += prop.Length;
-                    span[index++] = ':';
-                    span[index++] = ' ';
-                    content.AsSpan().CopyTo(span[index..]);
-                });
-        }
-
-        private static bool ShouldUseServiceReference(ServiceType serviceType)
-        {
-            return serviceType is not ServiceType.Csv
-                and not ServiceType.Ftp
-                and not ServiceType.FileObserver
-                and not ServiceType.Scp;
+            _ = isIncoming;
+            _ = serviceType;
+            _ = serviceName;
+            return FormatControlCharacters(message);
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Models/ServiceMessageHistoryEntry.cs
+++ b/DesktopApplicationTemplate.UI/Models/ServiceMessageHistoryEntry.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace DesktopApplicationTemplate.UI.Models
+{
+    /// <summary>
+    /// Represents a persisted TCP message exchange for restoring UI state.
+    /// </summary>
+    public class ServiceMessageHistoryEntry
+    {
+        /// <summary>Incoming message content in its original form.</summary>
+        public string IncomingMessage { get; set; } = string.Empty;
+
+        /// <summary>Outgoing message content in its original form.</summary>
+        public string OutgoingMessage { get; set; } = string.Empty;
+
+        /// <summary>Associated destination for the outgoing payload.</summary>
+        public string Destination { get; set; } = string.Empty;
+
+        /// <summary>Timestamp when the exchange occurred.</summary>
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+    }
+}

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -14,6 +14,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.Core.Services.Protocols.Hid;
 using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
@@ -169,7 +170,8 @@ namespace DesktopApplicationTemplate.Persistence
                             Message = l.Message,
                             Color = l.Color
                         })
-                        .ToList()
+                        .ToList(),
+                    MessageHistory = s.GetMessageHistorySnapshot().ToList()
                 });
             }
 
@@ -407,6 +409,7 @@ namespace DesktopApplicationTemplate.Persistence
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
         public List<LogEntry> Logs { get; set; } = new();
+        public List<ServiceMessageHistoryEntry> MessageHistory { get; set; } = new();
     }
 
     internal class LegacyServiceInfo

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -56,6 +56,9 @@ namespace DesktopApplicationTemplate.Persistence
                         DestinationHost = s.TcpOptions.DestinationHost,
                         DestinationPort = s.TcpOptions.DestinationPort,
                         DestinationGateway = s.TcpOptions.DestinationGateway,
+                        DestinationSubnetMask = s.TcpOptions.DestinationSubnetMask,
+                        DestinationPrimaryDns = s.TcpOptions.DestinationPrimaryDns,
+                        DestinationAlternateDns = s.TcpOptions.DestinationAlternateDns,
                         InputMessage = s.TcpOptions.InputMessage,
                         Script = s.TcpOptions.Script,
                         OutputMessage = s.TcpOptions.OutputMessage,
@@ -295,6 +298,9 @@ namespace DesktopApplicationTemplate.Persistence
                             value.DestinationHost = info.TcpOptions.DestinationHost;
                             value.DestinationPort = info.TcpOptions.DestinationPort;
                             value.DestinationGateway = info.TcpOptions.DestinationGateway;
+                            value.DestinationSubnetMask = info.TcpOptions.DestinationSubnetMask;
+                            value.DestinationPrimaryDns = info.TcpOptions.DestinationPrimaryDns;
+                            value.DestinationAlternateDns = info.TcpOptions.DestinationAlternateDns;
                             value.InputMessage = info.TcpOptions.InputMessage;
                             value.Script = info.TcpOptions.Script;
                             value.OutputMessage = info.TcpOptions.OutputMessage;

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -11,6 +11,7 @@ using WpfBrushes = System.Windows.Media.Brushes;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Persistence;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
@@ -309,6 +310,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);
                 svc.LoadPersistedLogs(info.Logs ?? new List<LogEntry>());
+                svc.LoadMessageHistory(info.MessageHistory ?? new List<ServiceMessageHistoryEntry>());
                 var normalizedName = NormalizeDisplayName(svc.Type, svc.DisplayName);
                 if (Services.Any(existing => existing.DisplayName.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -18,6 +18,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.Services;
 using WpfBrush = System.Windows.Media.Brush;
 using WpfBrushes = System.Windows.Media.Brushes;
@@ -73,6 +74,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public ObservableCollection<string> AssociatedServices { get; } = new();
 
+        private readonly LinkedList<ServiceMessageHistoryEntry> _messageHistory = new();
         private double _totalExecutionTimeMs;
         private int _executionCount;
         private TimeSpan _lastExecutionDuration;
@@ -353,6 +355,54 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         /// <summary>
+        /// Rehydrates persisted message history so the service restores its last known exchanges.
+        /// </summary>
+        /// <param name="entries">The persisted message entries.</param>
+        public void LoadMessageHistory(IEnumerable<ServiceMessageHistoryEntry> entries)
+        {
+            _messageHistory.Clear();
+            LastInputMessage = string.Empty;
+            LastOutputMessage = string.Empty;
+            LastInputBrush = WpfBrushes.Black;
+            if (entries is null)
+            {
+                return;
+            }
+
+            foreach (var entry in entries
+                         .Where(e => e is not null)
+                         .OrderByDescending(e => e.Timestamp)
+                         .Take(ServiceMessageTableViewModel.MaxRows))
+            {
+                _messageHistory.AddLast(new ServiceMessageHistoryEntry
+                {
+                    IncomingMessage = entry.IncomingMessage ?? string.Empty,
+                    OutgoingMessage = entry.OutgoingMessage ?? string.Empty,
+                    Destination = entry.Destination ?? string.Empty,
+                    Timestamp = entry.Timestamp
+                });
+            }
+
+            foreach (var historyEntry in _messageHistory)
+            {
+                if (!string.IsNullOrEmpty(historyEntry.IncomingMessage))
+                {
+                    UpdateLastInputMessage(historyEntry.IncomingMessage);
+                    break;
+                }
+            }
+
+            foreach (var historyEntry in _messageHistory)
+            {
+                if (!string.IsNullOrEmpty(historyEntry.OutgoingMessage))
+                {
+                    UpdateLastOutputMessage(historyEntry.OutgoingMessage);
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
         /// Updates the last input message tracked for this service.
         /// </summary>
         /// <param name="message">The raw message text.</param>
@@ -376,6 +426,52 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var normalizedMessage = NormalizeLatestMessage(message);
             LastOutputMessage = normalizedMessage;
             return normalizedMessage;
+        }
+
+        /// <summary>
+        /// Records a message exchange for persistence and downstream bindings.
+        /// </summary>
+        public void RecordMessageHistory(string? incomingMessage, string? outgoingMessage, string? destination, DateTime timestamp)
+        {
+            var entry = new ServiceMessageHistoryEntry
+            {
+                IncomingMessage = incomingMessage ?? string.Empty,
+                OutgoingMessage = outgoingMessage ?? string.Empty,
+                Destination = destination ?? string.Empty,
+                Timestamp = timestamp
+            };
+
+            _messageHistory.AddFirst(entry);
+            while (_messageHistory.Count > ServiceMessageTableViewModel.MaxRows)
+            {
+                _messageHistory.RemoveLast();
+            }
+
+            if (!string.IsNullOrEmpty(incomingMessage))
+            {
+                UpdateLastInputMessage(incomingMessage);
+            }
+
+            if (!string.IsNullOrEmpty(outgoingMessage))
+            {
+                UpdateLastOutputMessage(outgoingMessage);
+            }
+        }
+
+        /// <summary>
+        /// Creates a snapshot of the current message history for persistence.
+        /// </summary>
+        public IReadOnlyList<ServiceMessageHistoryEntry> GetMessageHistorySnapshot()
+        {
+            return _messageHistory
+                .Select(entry => new ServiceMessageHistoryEntry
+                {
+                    IncomingMessage = entry.IncomingMessage,
+                    OutgoingMessage = entry.OutgoingMessage,
+                    Destination = entry.Destination,
+                    Timestamp = entry.Timestamp
+                })
+                .ToList();
         }
 
         /// <summary>

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -77,6 +77,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private int _executionCount;
         private TimeSpan _lastExecutionDuration;
         private string _lastInputMessage = string.Empty;
+        private string _lastOutputMessage = string.Empty;
         private WpfBrush _lastInputBrush = WpfBrushes.Black;
         private int _incomingMessageCount;
         private int _outgoingMessageCount;
@@ -148,7 +149,30 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _lastInputMessage;
             private set
             {
+                if (_lastInputMessage == value)
+                {
+                    return;
+                }
+
                 _lastInputMessage = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets the last outgoing message produced by this service.
+        /// </summary>
+        public string LastOutputMessage
+        {
+            get => _lastOutputMessage;
+            private set
+            {
+                if (_lastOutputMessage == value)
+                {
+                    return;
+                }
+
+                _lastOutputMessage = value;
                 OnPropertyChanged();
             }
         }
@@ -289,11 +313,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug, bool checkReference = true)
         {
-            var normalizedMessage = NormalizeLatestMessage(message);
-            LastInputMessage = normalizedMessage;
-            LastInputBrush = color ?? WpfBrushes.Black;
-            var ts = DateTime.Now.ToString(TimestampFormat, CultureInfo.InvariantCulture);
-            var entry = new LogEntry { Message = $"{ts} {message}", Color = (color ?? WpfBrushes.Black).ToString(), Level = level };
+            var brush = color ?? WpfBrushes.Black;
+            var normalizedMessage = UpdateLastInputMessage(message, brush);
+            var entryMessage = string.IsNullOrEmpty(normalizedMessage)
+                ? $"[{level}]"
+                : $"[{level}] {normalizedMessage}";
+            var entry = new LogEntry
+            {
+                Message = entryMessage,
+                Color = brush.ToString(),
+                Level = level
+            };
             Logs.Insert(0, entry);
             if (Logs.Count > MaxLogEntries)
             {
@@ -320,6 +350,32 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 LastInputMessage = NormalizePersistedMessage(latest.Message);
                 LastInputBrush = ParseBrush(latest.Color, WpfBrushes.Black);
             }
+        }
+
+        /// <summary>
+        /// Updates the last input message tracked for this service.
+        /// </summary>
+        /// <param name="message">The raw message text.</param>
+        /// <param name="brush">The brush used to display the message in the UI.</param>
+        /// <returns>The normalized message stored on the model.</returns>
+        public string UpdateLastInputMessage(string? message, WpfBrush? brush = null)
+        {
+            var normalizedMessage = NormalizeLatestMessage(message);
+            LastInputMessage = normalizedMessage;
+            LastInputBrush = brush ?? WpfBrushes.Black;
+            return normalizedMessage;
+        }
+
+        /// <summary>
+        /// Updates the last output message tracked for this service.
+        /// </summary>
+        /// <param name="message">The raw message text.</param>
+        /// <returns>The normalized message stored on the model.</returns>
+        public string UpdateLastOutputMessage(string? message)
+        {
+            var normalizedMessage = NormalizeLatestMessage(message);
+            LastOutputMessage = normalizedMessage;
+            return normalizedMessage;
         }
 
         /// <summary>
@@ -413,8 +469,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 var timestampCandidate = trimmed.Substring(0, TimestampLength);
                 if (DateTime.TryParseExact(timestampCandidate, TimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
                 {
-                    var withoutTimestamp = trimmed[(TimestampLength + 1)..].Trim();
-                    return MessageDisplayFormatter.FormatControlCharacters(withoutTimestamp);
+                    trimmed = trimmed[(TimestampLength + 1)..].Trim();
+                }
+            }
+
+            if (trimmed.StartsWith('[', StringComparison.Ordinal))
+            {
+                var levelEnd = trimmed.IndexOf(']');
+                if (levelEnd > 0)
+                {
+                    var candidate = trimmed.Substring(1, levelEnd - 1);
+                    if (Enum.TryParse(candidate, out LogLevel _))
+                    {
+                        trimmed = trimmed[(levelEnd + 1)..].TrimStart();
+                    }
                 }
             }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -473,7 +473,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 }
             }
 
-            if (trimmed.StartsWith('[', StringComparison.Ordinal))
+            if (trimmed.StartsWith("[", StringComparison.Ordinal))
             {
                 var levelEnd = trimmed.IndexOf(']');
                 if (levelEnd > 0)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -314,7 +314,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug, bool checkReference = true)
         {
             var brush = color ?? WpfBrushes.Black;
-            var normalizedMessage = UpdateLastInputMessage(message, brush);
+            var normalizedMessage = NormalizeLatestMessage(message);
             var entryMessage = string.IsNullOrEmpty(normalizedMessage)
                 ? $"[{level}]"
                 : $"[{level}] {normalizedMessage}";

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -450,9 +450,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private static string NormalizeLatestMessage(string? message)
         {
-            return string.IsNullOrWhiteSpace(message)
-                ? string.Empty
-                : MessageDisplayFormatter.FormatControlCharacters(message.Trim());
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = StripBracketedTimestamp(message.Trim());
+            trimmed = StripLogLevel(trimmed);
+
+            return MessageDisplayFormatter.FormatControlCharacters(trimmed);
         }
 
         private static string NormalizePersistedMessage(string message)
@@ -462,31 +468,69 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return string.Empty;
             }
 
-            var trimmed = message.Trim();
-
-            if (trimmed.Length > TimestampLength && trimmed[TimestampLength] == ' ')
-            {
-                var timestampCandidate = trimmed.Substring(0, TimestampLength);
-                if (DateTime.TryParseExact(timestampCandidate, TimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
-                {
-                    trimmed = trimmed[(TimestampLength + 1)..].Trim();
-                }
-            }
-
-            if (trimmed.StartsWith("[", StringComparison.Ordinal))
-            {
-                var levelEnd = trimmed.IndexOf(']');
-                if (levelEnd > 0)
-                {
-                    var candidate = trimmed.Substring(1, levelEnd - 1);
-                    if (Enum.TryParse(candidate, out LogLevel _))
-                    {
-                        trimmed = trimmed[(levelEnd + 1)..].TrimStart();
-                    }
-                }
-            }
+            var trimmed = StripPersistedTimestamp(message.Trim());
+            trimmed = StripBracketedTimestamp(trimmed);
+            trimmed = StripLogLevel(trimmed);
 
             return MessageDisplayFormatter.FormatControlCharacters(trimmed);
+        }
+
+        private static string StripPersistedTimestamp(string message)
+        {
+            if (message.Length > TimestampLength && message[TimestampLength] == ' ')
+            {
+                var timestampCandidate = message.Substring(0, TimestampLength);
+                if (DateTime.TryParseExact(timestampCandidate, TimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+                {
+                    return message[(TimestampLength + 1)..].TrimStart();
+                }
+            }
+
+            return message;
+        }
+
+        private static string StripBracketedTimestamp(string message)
+        {
+            if (message.Length == 0 || message[0] != '[')
+            {
+                return message;
+            }
+
+            var endIndex = message.IndexOf(']');
+            if (endIndex <= 1)
+            {
+                return message;
+            }
+
+            var candidate = message.Substring(1, endIndex - 1);
+            if (TimeSpan.TryParseExact(candidate, "hh\\:mm\\:ss", CultureInfo.InvariantCulture, out _))
+            {
+                return message[(endIndex + 1)..].TrimStart();
+            }
+
+            return message;
+        }
+
+        private static string StripLogLevel(string message)
+        {
+            if (!message.StartsWith("[", StringComparison.Ordinal))
+            {
+                return message;
+            }
+
+            var levelEnd = message.IndexOf(']');
+            if (levelEnd <= 0)
+            {
+                return message;
+            }
+
+            var candidate = message.Substring(1, levelEnd - 1);
+            if (Enum.TryParse(candidate, out LogLevel _))
+            {
+                return message[(levelEnd + 1)..].TrimStart();
+            }
+
+            return message;
         }
 
         private static WpfBrush ParseBrush(string? color, WpfBrush fallback)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
@@ -12,9 +13,30 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     public class ServiceMessageTableViewModel : ViewModelBase
     {
         private const int MaxRows = 5;
+        private readonly Dictionary<string, LinkedList<ServiceMessageRow>> _messagesByService = new(StringComparer.OrdinalIgnoreCase);
+        private string _activeServiceKey = string.Empty;
 
         /// <summary>Collection of service message rows.</summary>
         public ObservableCollection<ServiceMessageRow> Messages { get; } = new();
+
+        /// <summary>
+        /// Sets the active service whose messages should be surfaced to the UI.
+        /// </summary>
+        /// <param name="serviceType">The service type.</param>
+        /// <param name="serviceName">The service name.</param>
+        public void SetActiveService(ServiceType serviceType, string serviceName)
+        {
+            _activeServiceKey = BuildKey(serviceType, serviceName?.Trim() ?? string.Empty);
+            Messages.Clear();
+
+            if (_messagesByService.TryGetValue(_activeServiceKey, out var rows))
+            {
+                foreach (var row in rows)
+                {
+                    Messages.Add(row);
+                }
+            }
+        }
 
         /// <summary>
         /// Adds a new message row and inserts it at the top to maintain
@@ -22,20 +44,44 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public void AddMessage(ServiceType serviceType, string serviceName, string incoming, string outgoing, string destination)
         {
-            var resolvedServiceName = serviceName ?? string.Empty;
+            var resolvedServiceName = serviceName?.Trim() ?? string.Empty;
             var incomingDisplay = MessageDisplayFormatter.FormatForService(incoming, true, serviceType, resolvedServiceName);
             var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoing, false, serviceType, resolvedServiceName);
 
-            Messages.Insert(0, new ServiceMessageRow
+            var key = BuildKey(serviceType, resolvedServiceName);
+            if (!_messagesByService.TryGetValue(key, out var rows))
+            {
+                rows = new LinkedList<ServiceMessageRow>();
+                _messagesByService[key] = rows;
+            }
+
+            var row = new ServiceMessageRow
             {
                 IncomingMessage = incomingDisplay,
                 OutgoingMessage = outgoingDisplay,
                 Destination = destination ?? string.Empty,
                 Timestamp = DateTime.Now
-            });
+            };
 
-            if (Messages.Count > MaxRows)
-                Messages.RemoveAt(Messages.Count - 1);
+            rows.AddFirst(row);
+            while (rows.Count > MaxRows)
+            {
+                rows.RemoveLast();
+            }
+
+            if (string.Equals(key, _activeServiceKey, StringComparison.OrdinalIgnoreCase))
+            {
+                Messages.Insert(0, row);
+                if (Messages.Count > MaxRows)
+                {
+                    Messages.RemoveAt(Messages.Count - 1);
+                }
+            }
+        }
+
+        private static string BuildKey(ServiceType serviceType, string serviceName)
+        {
+            return $"{serviceType}:{serviceName}";
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -12,7 +12,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     /// </summary>
     public class ServiceMessageTableViewModel : ViewModelBase
     {
-        private const int MaxRows = 5;
+        public const int MaxRows = 5;
         private readonly Dictionary<string, LinkedList<ServiceMessageRow>> _messagesByService = new(StringComparer.OrdinalIgnoreCase);
         private string _activeServiceKey = string.Empty;
 
@@ -47,6 +47,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var resolvedServiceName = serviceName?.Trim() ?? string.Empty;
             var incomingDisplay = MessageDisplayFormatter.FormatForService(incoming, true, serviceType, resolvedServiceName);
             var outgoingDisplay = MessageDisplayFormatter.FormatForService(outgoing, false, serviceType, resolvedServiceName);
+            var timestamp = DateTime.Now;
 
             var key = BuildKey(serviceType, resolvedServiceName);
             if (!_messagesByService.TryGetValue(key, out var rows))
@@ -60,7 +61,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 IncomingMessage = incomingDisplay,
                 OutgoingMessage = outgoingDisplay,
                 Destination = destination ?? string.Empty,
-                Timestamp = DateTime.Now
+                Timestamp = timestamp
             };
 
             rows.AddFirst(row);
@@ -69,12 +70,65 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 rows.RemoveLast();
             }
 
+            if (ServiceListModel.ResolveService?.Invoke(serviceType, resolvedServiceName) is { } service)
+            {
+                service.RecordMessageHistory(incoming, outgoing, destination, timestamp);
+            }
+
             if (string.Equals(key, _activeServiceKey, StringComparison.OrdinalIgnoreCase))
             {
                 Messages.Insert(0, row);
                 if (Messages.Count > MaxRows)
                 {
                     Messages.RemoveAt(Messages.Count - 1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads persisted messages for a service so previously recorded exchanges reappear in the UI.
+        /// </summary>
+        public void LoadMessages(ServiceType serviceType, string serviceName, IEnumerable<ServiceMessageHistoryEntry> entries)
+        {
+            var resolvedServiceName = serviceName?.Trim() ?? string.Empty;
+            var key = BuildKey(serviceType, resolvedServiceName);
+            if (!_messagesByService.TryGetValue(key, out var rows))
+            {
+                rows = new LinkedList<ServiceMessageRow>();
+                _messagesByService[key] = rows;
+            }
+            else
+            {
+                rows.Clear();
+            }
+
+            if (entries is not null)
+            {
+                foreach (var entry in entries)
+                {
+                    if (entry is null)
+                    {
+                        continue;
+                    }
+
+                    var row = new ServiceMessageRow
+                    {
+                        IncomingMessage = MessageDisplayFormatter.FormatForService(entry.IncomingMessage, true, serviceType, resolvedServiceName),
+                        OutgoingMessage = MessageDisplayFormatter.FormatForService(entry.OutgoingMessage, false, serviceType, resolvedServiceName),
+                        Destination = entry.Destination ?? string.Empty,
+                        Timestamp = entry.Timestamp
+                    };
+
+                    rows.AddLast(row);
+                }
+            }
+
+            if (string.Equals(key, _activeServiceKey, StringComparison.OrdinalIgnoreCase))
+            {
+                Messages.Clear();
+                foreach (var row in rows)
+                {
+                    Messages.Add(row);
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -12,7 +12,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     /// </summary>
     public class ServiceMessageTableViewModel : ViewModelBase
     {
-        public const int MaxRows = 5;
+        public const int MaxRows = 100;
         private readonly Dictionary<string, LinkedList<ServiceMessageRow>> _messagesByService = new(StringComparer.OrdinalIgnoreCase);
         private string _activeServiceKey = string.Empty;
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -182,7 +182,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     /// <summary>
     /// Indicates whether subnet and DNS inputs should be shown for sending scenarios.
     /// </summary>
-    public bool ShowsNetworkProfileConfiguration => Mode == TcpServiceMode.Sending;
+    public bool ShowsNetworkProfileConfiguration => Mode != TcpServiceMode.Listening;
 
     /// <summary>
     /// Available TCP connection roles.

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -23,6 +23,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private string _destinationHost = string.Empty;
     private int _destinationPort;
     private string _destinationGateway = string.Empty;
+    private TcpConnectionRole _previousListeningRole = TcpConnectionRole.Server;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpCreateServiceViewModel"/> class.
@@ -38,6 +39,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         SubnetMask = configuration.SubnetMask;
         PrimaryDns = configuration.DnsPrimary;
         AlternateDns = configuration.DnsSecondary;
+        _previousListeningRole = _connectionRole;
     }
 
     /// <summary>
@@ -151,6 +153,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
             _mode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
+            OnPropertyChanged(nameof(ShowsListeningConfiguration));
+            OnPropertyChanged(nameof(ShowsNetworkProfileConfiguration));
+            EnsureConnectionRoleForMode();
             UpdateDestinationValidationState();
         }
     }
@@ -168,6 +173,16 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     /// Indicates whether the service should expose sending configuration fields.
     /// </summary>
     public bool IsSendingEnabled => RequiresDestinationConfiguration;
+
+    /// <summary>
+    /// Indicates whether listening configuration should be visible.
+    /// </summary>
+    public bool ShowsListeningConfiguration => Mode != TcpServiceMode.Sending;
+
+    /// <summary>
+    /// Indicates whether subnet and DNS inputs should be shown for sending scenarios.
+    /// </summary>
+    public bool ShowsNetworkProfileConfiguration => Mode == TcpServiceMode.Sending;
 
     /// <summary>
     /// Available TCP connection roles.
@@ -229,7 +244,17 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
                 return;
             }
 
+            if (Mode == TcpServiceMode.Sending && value != TcpConnectionRole.Client)
+            {
+                return;
+            }
+
             _connectionRole = value;
+            if (Mode != TcpServiceMode.Sending)
+            {
+                _previousListeningRole = value;
+            }
+
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
             UpdateDestinationValidationState();
@@ -248,6 +273,31 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
                 Host = _clientHost;
             }
             Logger?.Log($"TCP connection role set to {_connectionRole}", LogLevel.Debug);
+        }
+    }
+
+    private void EnsureConnectionRoleForMode()
+    {
+        if (Mode == TcpServiceMode.Sending)
+        {
+            if (_connectionRole != TcpConnectionRole.Client)
+            {
+                var previous = _connectionRole;
+                _previousListeningRole = previous == TcpConnectionRole.Client ? TcpConnectionRole.Server : previous;
+                _connectionRole = TcpConnectionRole.Client;
+                OnPropertyChanged(nameof(ConnectionRole));
+                OnPropertyChanged(nameof(IsSendingEnabled));
+                UpdateDestinationValidationState();
+                Host = _clientHost;
+            }
+        }
+        else if (_connectionRole == TcpConnectionRole.Client && _previousListeningRole != TcpConnectionRole.Client)
+        {
+            _connectionRole = _previousListeningRole;
+            OnPropertyChanged(nameof(ConnectionRole));
+            OnPropertyChanged(nameof(IsSendingEnabled));
+            UpdateDestinationValidationState();
+            Host = _connectionRole == TcpConnectionRole.Server ? _serverHost : _clientHost;
         }
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Create/TcpCreateServiceViewModel.cs
@@ -23,6 +23,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     private string _destinationHost = string.Empty;
     private int _destinationPort;
     private string _destinationGateway = string.Empty;
+    private string _destinationSubnetMask = string.Empty;
+    private string _destinationPrimaryDns = string.Empty;
+    private string _destinationAlternateDns = string.Empty;
     private TcpConnectionRole _previousListeningRole = TcpConnectionRole.Server;
 
     /// <summary>
@@ -153,8 +156,8 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
             _mode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
-            OnPropertyChanged(nameof(ShowsListeningConfiguration));
-            OnPropertyChanged(nameof(ShowsNetworkProfileConfiguration));
+            OnPropertyChanged(nameof(CanEditListeningConfiguration));
+            OnPropertyChanged(nameof(CanEditDestinationConfiguration));
             EnsureConnectionRoleForMode();
             UpdateDestinationValidationState();
         }
@@ -167,7 +170,7 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
 
     private bool RequiresDestinationConfiguration =>
         Mode == TcpServiceMode.Sending ||
-        (Mode == TcpServiceMode.ReceiveAndSend && ConnectionRole == TcpConnectionRole.Client);
+        Mode == TcpServiceMode.ReceiveAndSend;
 
     /// <summary>
     /// Indicates whether the service should expose sending configuration fields.
@@ -175,14 +178,14 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
     public bool IsSendingEnabled => RequiresDestinationConfiguration;
 
     /// <summary>
-    /// Indicates whether listening configuration should be visible.
+    /// Indicates whether the listening configuration can be modified.
     /// </summary>
-    public bool ShowsListeningConfiguration => Mode != TcpServiceMode.Sending;
+    public bool CanEditListeningConfiguration => Mode != TcpServiceMode.Sending;
 
     /// <summary>
-    /// Indicates whether subnet and DNS inputs should be shown for sending scenarios.
+    /// Indicates whether destination configuration can be modified.
     /// </summary>
-    public bool ShowsNetworkProfileConfiguration => Mode != TcpServiceMode.Listening;
+    public bool CanEditDestinationConfiguration => IsSendingEnabled;
 
     /// <summary>
     /// Available TCP connection roles.
@@ -227,6 +230,48 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         {
             _destinationGateway = value ?? string.Empty;
             ValidateOptionalIpAddress(_destinationGateway, nameof(DestinationGateway), "Destination Gateway");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Subnet mask for the configured destination.
+    /// </summary>
+    public string DestinationSubnetMask
+    {
+        get => _destinationSubnetMask;
+        set
+        {
+            _destinationSubnetMask = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationSubnetMask, nameof(DestinationSubnetMask), "Destination Subnet");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Primary DNS server for the configured destination.
+    /// </summary>
+    public string DestinationPrimaryDns
+    {
+        get => _destinationPrimaryDns;
+        set
+        {
+            _destinationPrimaryDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationPrimaryDns, nameof(DestinationPrimaryDns), "Destination Primary DNS");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Alternate DNS server for the configured destination.
+    /// </summary>
+    public string DestinationAlternateDns
+    {
+        get => _destinationAlternateDns;
+        set
+        {
+            _destinationAlternateDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationAlternateDns, nameof(DestinationAlternateDns), "Destination Alternate DNS");
             OnPropertyChanged();
         }
     }
@@ -315,6 +360,9 @@ public class TcpCreateServiceViewModel : ServiceCreateViewModelBase<TcpServiceOp
         options.DestinationHost = DestinationHost;
         options.DestinationPort = DestinationPort;
         options.DestinationGateway = DestinationGateway;
+        options.DestinationSubnetMask = DestinationSubnetMask;
+        options.DestinationPrimaryDns = DestinationPrimaryDns;
+        options.DestinationAlternateDns = DestinationAlternateDns;
     }
 
     private void ValidateOptionalIpAddress(string value, string propertyName, string? displayName = null)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -25,6 +25,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     private string _destinationHost = string.Empty;
     private int _destinationPort;
     private string _destinationGateway = string.Empty;
+    private string _destinationSubnetMask = string.Empty;
+    private string _destinationPrimaryDns = string.Empty;
+    private string _destinationAlternateDns = string.Empty;
     private TcpConnectionRole _previousListeningRole = TcpConnectionRole.Server;
 
     /// <summary>
@@ -54,6 +57,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         DestinationHost = _options.DestinationHost;
         DestinationPort = _options.DestinationPort;
         DestinationGateway = _options.DestinationGateway;
+        DestinationSubnetMask = _options.DestinationSubnetMask;
+        DestinationPrimaryDns = _options.DestinationPrimaryDns;
+        DestinationAlternateDns = _options.DestinationAlternateDns;
         if (ConnectionRole == TcpConnectionRole.Server)
         {
             _serverHost = _options.Host;
@@ -136,8 +142,8 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
             _mode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
-            OnPropertyChanged(nameof(ShowsListeningConfiguration));
-            OnPropertyChanged(nameof(ShowsNetworkProfileConfiguration));
+            OnPropertyChanged(nameof(CanEditListeningConfiguration));
+            OnPropertyChanged(nameof(CanEditDestinationConfiguration));
             EnsureConnectionRoleForMode();
             UpdateDestinationValidationState();
         }
@@ -193,7 +199,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     /// <summary>
     private bool RequiresDestinationConfiguration =>
         Mode == TcpServiceMode.Sending ||
-        (Mode == TcpServiceMode.ReceiveAndSend && ConnectionRole == TcpConnectionRole.Client);
+        Mode == TcpServiceMode.ReceiveAndSend;
 
     /// <summary>
     /// Indicates whether the service should expose sending configuration fields.
@@ -201,14 +207,14 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     public bool IsSendingEnabled => RequiresDestinationConfiguration;
 
     /// <summary>
-    /// Indicates whether listening-related configuration should be visible.
+    /// Indicates whether listening-related configuration can be modified.
     /// </summary>
-    public bool ShowsListeningConfiguration => Mode != TcpServiceMode.Sending;
+    public bool CanEditListeningConfiguration => Mode != TcpServiceMode.Sending;
 
     /// <summary>
-    /// Indicates whether network profile fields should be visible for sending scenarios.
+    /// Indicates whether destination configuration can be modified.
     /// </summary>
-    public bool ShowsNetworkProfileConfiguration => Mode != TcpServiceMode.Listening;
+    public bool CanEditDestinationConfiguration => IsSendingEnabled;
 
     /// <summary>
     /// Available TCP connection roles.
@@ -253,6 +259,48 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         {
             _destinationGateway = value ?? string.Empty;
             ValidateOptionalIpAddress(_destinationGateway, nameof(DestinationGateway), "Destination Gateway");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Subnet mask applied to the destination configuration.
+    /// </summary>
+    public string DestinationSubnetMask
+    {
+        get => _destinationSubnetMask;
+        set
+        {
+            _destinationSubnetMask = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationSubnetMask, nameof(DestinationSubnetMask), "Destination Subnet");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Primary DNS server applied to the destination configuration.
+    /// </summary>
+    public string DestinationPrimaryDns
+    {
+        get => _destinationPrimaryDns;
+        set
+        {
+            _destinationPrimaryDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationPrimaryDns, nameof(DestinationPrimaryDns), "Destination Primary DNS");
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Alternate DNS server applied to the destination configuration.
+    /// </summary>
+    public string DestinationAlternateDns
+    {
+        get => _destinationAlternateDns;
+        set
+        {
+            _destinationAlternateDns = value ?? string.Empty;
+            ValidateOptionalIpAddress(_destinationAlternateDns, nameof(DestinationAlternateDns), "Destination Alternate DNS");
             OnPropertyChanged();
         }
     }
@@ -351,6 +399,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
         _options.DestinationHost = DestinationHost;
         _options.DestinationPort = DestinationPort;
         _options.DestinationGateway = DestinationGateway;
+        _options.DestinationSubnetMask = DestinationSubnetMask;
+        _options.DestinationPrimaryDns = DestinationPrimaryDns;
+        _options.DestinationAlternateDns = DestinationAlternateDns;
         RaiseServiceSaved(_options);
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -208,7 +208,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     /// <summary>
     /// Indicates whether network profile fields should be visible for sending scenarios.
     /// </summary>
-    public bool ShowsNetworkProfileConfiguration => Mode == TcpServiceMode.Sending;
+    public bool ShowsNetworkProfileConfiguration => Mode != TcpServiceMode.Listening;
 
     /// <summary>
     /// Available TCP connection roles.

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/Edit/TcpEditServiceViewModel.cs
@@ -25,6 +25,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     private string _destinationHost = string.Empty;
     private int _destinationPort;
     private string _destinationGateway = string.Empty;
+    private TcpConnectionRole _previousListeningRole = TcpConnectionRole.Server;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpEditServiceViewModel"/> class.
@@ -62,6 +63,7 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
             _clientHost = _options.Host;
         }
         _suppressRoleHostUpdate = false;
+        _previousListeningRole = ConnectionRole == TcpConnectionRole.Client ? TcpConnectionRole.Server : ConnectionRole;
     }
 
 
@@ -134,6 +136,9 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
             _mode = value;
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
+            OnPropertyChanged(nameof(ShowsListeningConfiguration));
+            OnPropertyChanged(nameof(ShowsNetworkProfileConfiguration));
+            EnsureConnectionRoleForMode();
             UpdateDestinationValidationState();
         }
     }
@@ -196,6 +201,16 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
     public bool IsSendingEnabled => RequiresDestinationConfiguration;
 
     /// <summary>
+    /// Indicates whether listening-related configuration should be visible.
+    /// </summary>
+    public bool ShowsListeningConfiguration => Mode != TcpServiceMode.Sending;
+
+    /// <summary>
+    /// Indicates whether network profile fields should be visible for sending scenarios.
+    /// </summary>
+    public bool ShowsNetworkProfileConfiguration => Mode == TcpServiceMode.Sending;
+
+    /// <summary>
     /// Available TCP connection roles.
     /// </summary>
     public TcpConnectionRole[] ConnectionRoles { get; } = (TcpConnectionRole[])Enum.GetValues(typeof(TcpConnectionRole));
@@ -255,7 +270,17 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
                 return;
             }
 
+            if (Mode == TcpServiceMode.Sending && value != TcpConnectionRole.Client)
+            {
+                return;
+            }
+
             _connectionRole = value;
+            if (Mode != TcpServiceMode.Sending)
+            {
+                _previousListeningRole = value;
+            }
+
             OnPropertyChanged();
             OnPropertyChanged(nameof(IsSendingEnabled));
             UpdateDestinationValidationState();
@@ -279,6 +304,31 @@ public class TcpEditServiceViewModel : ServiceEditViewModelBase<TcpServiceOption
                 Host = _clientHost;
             }
             Logger?.Log($"TCP connection role set to {_connectionRole}", LogLevel.Debug);
+        }
+    }
+
+    private void EnsureConnectionRoleForMode()
+    {
+        if (Mode == TcpServiceMode.Sending)
+        {
+            if (_connectionRole != TcpConnectionRole.Client)
+            {
+                var previous = _connectionRole;
+                _previousListeningRole = previous == TcpConnectionRole.Client ? TcpConnectionRole.Server : previous;
+                _connectionRole = TcpConnectionRole.Client;
+                OnPropertyChanged(nameof(ConnectionRole));
+                OnPropertyChanged(nameof(IsSendingEnabled));
+                UpdateDestinationValidationState();
+                Host = _clientHost;
+            }
+        }
+        else if (_connectionRole == TcpConnectionRole.Client && _previousListeningRole != TcpConnectionRole.Client)
+        {
+            _connectionRole = _previousListeningRole;
+            OnPropertyChanged(nameof(ConnectionRole));
+            OnPropertyChanged(nameof(IsSendingEnabled));
+            UpdateDestinationValidationState();
+            Host = _connectionRole == TcpConnectionRole.Server ? _serverHost : _clientHost;
         }
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -39,10 +39,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         public ObservableCollection<TcpMessageRow> Messages { get; } = new();
 
         /// <summary>Incoming data extracted from <see cref="Messages"/>.</summary>
-        public IEnumerable<string> IncomingData => Messages.Select(m => $"{m.IncomingIp}: {m.IncomingMessage}");
+        public IEnumerable<string> IncomingData => Messages
+            .Select(m => m.IncomingMessage)
+            .Where(message => !string.IsNullOrWhiteSpace(message));
 
         /// <summary>Outgoing results extracted from <see cref="Messages"/>.</summary>
-        public IEnumerable<string> OutgoingResults => Messages.Select(m => $"{m.ConnectedService}: {m.Result}");
+        public IEnumerable<string> OutgoingResults => Messages
+            .Select(m => m.Result)
+            .Where(result => !string.IsNullOrWhiteSpace(result));
 
         /// <summary>Collection of log entries.</summary>
         public ObservableCollection<LogEntry> Logs { get; } = new();
@@ -703,7 +707,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
                         var incoming = Encoding.UTF8.GetString(buffer, 0, bytesRead);
                         var formattedIncoming = MessageDisplayFormatter.FormatControlCharacters(incoming);
-                        Logger?.Log($"{ServiceName}.LastInputMessage from {endpoint}: {formattedIncoming}", LogLevel.Information);
+                        Logger?.Log($"Incoming message from {endpoint}: {formattedIncoming}", LogLevel.Information);
                         _routing.UpdateMessage(ServiceType, ServiceName, incoming, MessageRoutingDirection.Input);
                         await AppendMessageAsync(incoming, _options.OutputMessage, endpoint).ConfigureAwait(false);
 
@@ -712,7 +716,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                             var response = Encoding.UTF8.GetBytes(_options.OutputMessage);
                             await stream.WriteAsync(response.AsMemory(0, response.Length), cancellationToken).ConfigureAwait(false);
                             var formattedOutgoing = MessageDisplayFormatter.FormatControlCharacters(_options.OutputMessage);
-                            Logger?.Log($"{ServiceName}.LastOutputMessage to {endpoint}: {formattedOutgoing}", LogLevel.Debug);
+                            Logger?.Log($"Outgoing message to {endpoint}: {formattedOutgoing}", LogLevel.Debug);
                             _routing.UpdateMessage(ServiceType, ServiceName, _options.OutputMessage, MessageRoutingDirection.Output);
                         }
                     }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -51,6 +51,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         /// <summary>Collection of log entries.</summary>
         public ObservableCollection<LogEntry> Logs { get; } = new();
 
+        /// <summary>Latest incoming message text for the associated service.</summary>
+        public string LastInputMessage => _service?.LastInputMessage ?? string.Empty;
+
+        /// <summary>Latest outgoing message text for the associated service.</summary>
+        public string LastOutputMessage => _service?.LastOutputMessage ?? string.Empty;
+
         /// <inheritdoc />
         private ILoggingService? _logger;
         public ILoggingService? Logger
@@ -224,10 +230,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             if (_service is not null)
             {
                 _service.ActiveChanged -= OnServiceActiveChanged;
+                _service.PropertyChanged -= OnServicePropertyChanged;
             }
 
             _service = service;
             _service.ActiveChanged += OnServiceActiveChanged;
+            _service.PropertyChanged += OnServicePropertyChanged;
             _options = service.TcpOptions ?? new TcpServiceOptions();
             ServiceType = service.Type;
             ServiceName = service.DisplayName;
@@ -256,10 +264,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             MessageTable.SetActiveService(ServiceType, ServiceName);
             OnPropertyChanged(nameof(IncomingData));
             OnPropertyChanged(nameof(OutgoingResults));
+            OnPropertyChanged(nameof(LastInputMessage));
+            OnPropertyChanged(nameof(LastOutputMessage));
             _ = InitializeRuntimeAsync();
             if (_service.IsActive)
             {
                 _ = StartNetworkAsync();
+            }
+        }
+
+        private void OnServicePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ServiceListModel.LastInputMessage) || string.IsNullOrEmpty(e.PropertyName))
+            {
+                OnPropertyChanged(nameof(LastInputMessage));
+            }
+
+            if (e.PropertyName == nameof(ServiceListModel.LastOutputMessage) || string.IsNullOrEmpty(e.PropertyName))
+            {
+                OnPropertyChanged(nameof(LastOutputMessage));
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -113,6 +113,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private readonly object _clientTasksLock = new();
         private bool _isApplicationExitHooked;
         private NetworkConfiguration _networkConfiguration = new();
+        private static readonly TimeSpan ClientReconnectDelay = TimeSpan.FromSeconds(2);
 
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
@@ -643,45 +644,93 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private async Task RunClientLoopAsync(TcpEndpoint endpoint, TcpClientOperation operation, CancellationToken cancellationToken)
         {
             var operationLabel = operation == TcpClientOperation.Receive ? "listening endpoint" : "destination";
+            var endpointDisplay = $"{endpoint.Host}:{endpoint.Port}";
 
-            try
+            while (!cancellationToken.IsCancellationRequested)
             {
-                using var client = new TcpClient();
-                await client.ConnectAsync(endpoint.Host, endpoint.Port, cancellationToken).ConfigureAwait(false);
-                Logger?.Log($"Connected to {operationLabel} {endpoint.Host}:{endpoint.Port}", LogLevel.Information);
-
-                using var stream = client.GetStream();
-                var message = _options.InputMessage ?? string.Empty;
-                var shouldSendMessage = operation == TcpClientOperation.Send && !string.IsNullOrWhiteSpace(message);
-                if (shouldSendMessage)
+                try
                 {
-                    var payload = Encoding.UTF8.GetBytes(message);
-                    await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
-                    Logger?.Log($"Sent message to {operationLabel} {endpoint.Host}:{endpoint.Port}: {message}", LogLevel.Information);
+                    using var client = new TcpClient();
+                    await client.ConnectAsync(endpoint.Host, endpoint.Port, cancellationToken).ConfigureAwait(false);
+                    Logger?.Log($"Connected to {operationLabel} {endpointDisplay}", LogLevel.Information);
+
+                    using var stream = client.GetStream();
+                    var message = _options.InputMessage ?? string.Empty;
+                    var shouldSendMessage = operation == TcpClientOperation.Send && !string.IsNullOrWhiteSpace(message);
+                    var pendingOutgoing = string.Empty;
+
+                    if (shouldSendMessage)
+                    {
+                        var payload = Encoding.UTF8.GetBytes(message);
+                        await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
+                        Logger?.Log($"Sent message to {operationLabel} {endpointDisplay}: {message}", LogLevel.Information);
+                        _routing.UpdateMessage(ServiceType, ServiceName, message, MessageRoutingDirection.Output);
+                        pendingOutgoing = message;
+                    }
+
+                    var buffer = new byte[4096];
+
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        int bytesRead;
+                        try
+                        {
+                            bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+
+                        if (bytesRead == 0)
+                        {
+                            Logger?.Log($"Connection closed by {endpointDisplay}", LogLevel.Information);
+                            break;
+                        }
+
+                        var payload = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+
+                        if (operation == TcpClientOperation.Receive)
+                        {
+                            Logger?.Log($"Received message from {endpointDisplay}: {payload}", LogLevel.Information);
+                            _routing.UpdateMessage(ServiceType, ServiceName, payload, MessageRoutingDirection.Input);
+                            await AppendMessageAsync(payload, string.Empty, endpointDisplay).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            Logger?.Log($"Received response from {endpointDisplay}: {payload}", LogLevel.Information);
+                            _routing.UpdateMessage(ServiceType, ServiceName, payload, MessageRoutingDirection.Input);
+                            await AppendMessageAsync(payload, pendingOutgoing, endpointDisplay).ConfigureAwait(false);
+                            pendingOutgoing = string.Empty;
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(pendingOutgoing))
+                    {
+                        await AppendMessageAsync(string.Empty, pendingOutgoing, endpointDisplay).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // graceful cancellation
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    LogConnectionIssues($"TCP client connection to {endpoint.Host}:{endpoint.Port}", ex);
                 }
 
-                var buffer = new byte[4096];
-                var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
-                var endpointDisplay = $"{endpoint.Host}:{endpoint.Port}";
-                if (bytesRead > 0)
+                if (!cancellationToken.IsCancellationRequested)
                 {
-                    var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
-                    Logger?.Log($"Received response from {endpointDisplay}: {response}", LogLevel.Information);
-                    await AppendMessageAsync(message, response, endpointDisplay).ConfigureAwait(false);
+                    try
+                    {
+                        await Task.Delay(ClientReconnectDelay, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
                 }
-                else
-                {
-                    await AppendMessageAsync(message, string.Empty, endpointDisplay).ConfigureAwait(false);
-                    Logger?.Log($"No response received from {endpointDisplay}", LogLevel.Warning);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // graceful cancellation
-            }
-            catch (Exception ex)
-            {
-                LogConnectionIssues($"TCP client connection to {endpoint.Host}:{endpoint.Port}", ex);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -693,20 +693,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                     Logger?.Log($"Connected to {operationLabel} {endpointDisplay}", LogLevel.Information);
 
                     using var stream = client.GetStream();
-                    var message = _options.InputMessage ?? string.Empty;
+                    var message = _options.OutputMessage ?? string.Empty;
                     var shouldSendMessage = operation == TcpClientOperation.Send && !string.IsNullOrWhiteSpace(message);
-                    var pendingOutgoing = string.Empty;
-
                     if (shouldSendMessage)
                     {
                         var payload = Encoding.UTF8.GetBytes(message);
                         await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
                         Logger?.Log($"Sent message to {operationLabel} {endpointDisplay}: {message}", LogLevel.Information);
                         _routing.UpdateMessage(ServiceType, ServiceName, message, MessageRoutingDirection.Output);
-                        pendingOutgoing = message;
                     }
 
                     var buffer = new byte[4096];
+                    var receivedAny = false;
 
                     while (!cancellationToken.IsCancellationRequested)
                     {
@@ -722,35 +720,34 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
                         if (bytesRead == 0)
                         {
-                            Logger?.Log($"Connection closed by {endpointDisplay}", LogLevel.Information);
                             break;
                         }
 
-                        var payload = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                        var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                        receivedAny = true;
 
                         if (operation == TcpClientOperation.Receive)
                         {
-                            Logger?.Log($"Received message from {endpointDisplay}: {payload}", LogLevel.Information);
-                            _routing.UpdateMessage(ServiceType, ServiceName, payload, MessageRoutingDirection.Input);
-                            await AppendMessageAsync(payload, string.Empty, endpointDisplay).ConfigureAwait(false);
+                            Logger?.Log($"Received message from {endpointDisplay}: {response}", LogLevel.Information);
+                            _routing.UpdateMessage(ServiceType, ServiceName, response, MessageRoutingDirection.Input);
+                            await AppendMessageAsync(response, string.Empty, endpointDisplay).ConfigureAwait(false);
                         }
                         else
                         {
-                            Logger?.Log($"Received response from {endpointDisplay}: {payload}", LogLevel.Information);
-                            _routing.UpdateMessage(ServiceType, ServiceName, payload, MessageRoutingDirection.Input);
-                            await AppendMessageAsync(payload, pendingOutgoing, endpointDisplay).ConfigureAwait(false);
-                            pendingOutgoing = string.Empty;
+                            Logger?.Log($"Received response from {endpointDisplay}: {response}", LogLevel.Information);
+                            _routing.UpdateMessage(ServiceType, ServiceName, response, MessageRoutingDirection.Input);
+                            await AppendMessageAsync(message, response, endpointDisplay).ConfigureAwait(false);
                         }
                     }
 
-                    if (!string.IsNullOrEmpty(pendingOutgoing))
+                    if (!receivedAny && shouldSendMessage)
                     {
-                        await AppendMessageAsync(string.Empty, pendingOutgoing, endpointDisplay).ConfigureAwait(false);
+                        await AppendMessageAsync(message, string.Empty, endpointDisplay).ConfigureAwait(false);
+                        Logger?.Log($"No response received from {endpointDisplay}", LogLevel.Warning);
                     }
                 }
                 catch (OperationCanceledException)
                 {
-                    // graceful cancellation
                     break;
                 }
                 catch (Exception ex)

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -768,6 +768,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
                 MessageTable.AddMessage(ServiceType, ServiceName, incomingMessage, outgoingMessage, destination);
 
+                if (_service is not null)
+                {
+                    if (!string.IsNullOrEmpty(incomingMessage))
+                    {
+                        _service.UpdateLastInputMessage(incomingMessage);
+                    }
+
+                    if (!string.IsNullOrEmpty(outgoingMessage))
+                    {
+                        _service.UpdateLastOutputMessage(outgoingMessage);
+                    }
+                }
+
                 OnPropertyChanged(nameof(IncomingData));
                 OnPropertyChanged(nameof(OutgoingResults));
             });

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -237,7 +237,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
             ApplyNetworkConfiguration(restartIfActive: false);
             Messages.Clear();
-            MessageTable.Messages.Clear();
+            MessageTable.SetActiveService(ServiceType, ServiceName);
             OnPropertyChanged(nameof(IncomingData));
             OnPropertyChanged(nameof(OutgoingResults));
             _ = InitializeRuntimeAsync();

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -237,7 +237,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             OutputMessage = _options.OutputMessage;
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
             ApplyNetworkConfiguration(restartIfActive: false);
+            var history = service.GetMessageHistorySnapshot();
+            MessageTable.LoadMessages(ServiceType, ServiceName, history);
             Messages.Clear();
+            foreach (var entry in history.AsEnumerable().Reverse())
+            {
+                var incomingDisplay = MessageDisplayFormatter.FormatForService(entry.IncomingMessage, true, ServiceType, ServiceName);
+                var outgoingDisplay = MessageDisplayFormatter.FormatForService(entry.OutgoingMessage, false, ServiceType, ServiceName);
+                Messages.Insert(0, new TcpMessageRow
+                {
+                    IncomingMessage = incomingDisplay,
+                    IncomingIp = string.Empty,
+                    OutgoingMessage = outgoingDisplay,
+                    ConnectedService = entry.Destination ?? string.Empty,
+                    Result = string.IsNullOrEmpty(outgoingDisplay) ? string.Empty : outgoingDisplay
+                });
+            }
             MessageTable.SetActiveService(ServiceType, ServiceName);
             OnPropertyChanged(nameof(IncomingData));
             OnPropertyChanged(nameof(OutgoingResults));
@@ -820,19 +835,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 }
 
                 MessageTable.AddMessage(ServiceType, ServiceName, incomingMessage, outgoingMessage, destination);
-
-                if (_service is not null)
-                {
-                    if (!string.IsNullOrEmpty(incomingMessage))
-                    {
-                        _service.UpdateLastInputMessage(incomingMessage);
-                    }
-
-                    if (!string.IsNullOrEmpty(outgoingMessage))
-                    {
-                        _service.UpdateLastOutputMessage(outgoingMessage);
-                    }
-                }
 
                 OnPropertyChanged(nameof(IncomingData));
                 OnPropertyChanged(nameof(OutgoingResults));

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -171,7 +171,8 @@
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                              SelectionChanged="ServiceList_SelectionChanged"
-                             MouseDoubleClick="ServiceList_MouseDoubleClick">
+                             MouseDoubleClick="ServiceList_MouseDoubleClick"
+                             PreviewMouseLeftButtonUp="ServiceList_PreviewMouseLeftButtonUp">
                         <ListBox.ItemContainerStyle>
                             <Style TargetType="ListBoxItem">
                                 <EventSetter Event="MouseDoubleClick" Handler="ServiceListItem_MouseDoubleClick" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -489,6 +489,36 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
+        private void ServiceList_PreviewMouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (e.Handled || e.ClickCount != 1)
+            {
+                return;
+            }
+
+            if (e.OriginalSource is not DependencyObject source)
+            {
+                return;
+            }
+
+            var item = Helpers.VisualTreeHelperExtensions.FindParent<ListBoxItem>(source);
+            if (item?.DataContext is not ServiceListModel svc)
+            {
+                return;
+            }
+
+            if (!ReferenceEquals(svc, _viewModel.SelectedService))
+            {
+                return;
+            }
+
+            var page = GetOrCreateServicePage(svc);
+            if (page != null)
+            {
+                ShowPage(page);
+            }
+        }
+
         private void ServiceList_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             if (e.Handled)

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -14,11 +14,12 @@
               IsReadOnly="True"
               HeadersVisibility="Column"
               RowHeaderWidth="0"
-              MaxHeight="200"
+              Height="200"
               ColumnWidth="Auto"
               MinColumnWidth="100"
               ScrollViewer.HorizontalScrollBarVisibility="Auto"
-              ScrollViewer.VerticalScrollBarVisibility="Auto">
+              ScrollViewer.VerticalScrollBarVisibility="Auto"
+              ScrollViewer.CanContentScroll="True">
         <DataGrid.ColumnHeaderStyle>
             <Style TargetType="DataGridColumnHeader">
                 <EventSetter Event="PreviewMouseDoubleClick"

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -15,7 +15,7 @@
               HeadersVisibility="Column"
               RowHeaderWidth="0"
               MaxHeight="200"
-              ColumnWidth="*"
+              ColumnWidth="Auto"
               MinColumnWidth="100"
               ScrollViewer.HorizontalScrollBarVisibility="Auto"
               ScrollViewer.VerticalScrollBarVisibility="Auto">
@@ -26,18 +26,26 @@
             </Style>
         </DataGrid.ColumnHeaderStyle>
         <DataGrid.Columns>
-            <DataGridTextColumn Header="Incoming"
+            <DataGridTextColumn Header="Date"
+                                 Binding="{Binding Timestamp, StringFormat={}{0:d}}"
+                                 Width="Auto"
+                                 MinWidth="110" />
+            <DataGridTextColumn Header="Time"
+                                 Binding="{Binding Timestamp, StringFormat={}{0:T}}"
+                                 Width="Auto"
+                                 MinWidth="110" />
+            <DataGridTextColumn Header="Incoming Message"
                                  Binding="{Binding IncomingMessage}"
-                                 Width="2*"
-                                 MinWidth="150" />
-            <DataGridTextColumn Header="Outgoing"
+                                 Width="Auto"
+                                 MinWidth="180" />
+            <DataGridTextColumn Header="Outgoing Message"
                                  Binding="{Binding OutgoingMessage}"
-                                 Width="2*"
-                                 MinWidth="150" />
+                                 Width="Auto"
+                                 MinWidth="180" />
             <DataGridTextColumn Header="Destination"
                                  Binding="{Binding Destination}"
-                                 Width="*"
-                                 MinWidth="120" />
+                                 Width="Auto"
+                                 MinWidth="140" />
         </DataGrid.Columns>
     </DataGrid>
 </UserControl>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -14,8 +14,8 @@
               IsReadOnly="True"
               HeadersVisibility="Column"
               RowHeaderWidth="0"
-              Height="200"
-              ColumnWidth="Auto"
+              MaxHeight="250"
+              ColumnWidth="*"
               MinColumnWidth="100"
               ScrollViewer.HorizontalScrollBarVisibility="Auto"
               ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -37,15 +37,15 @@
                                  MinWidth="110" />
             <DataGridTextColumn Header="Incoming Message"
                                  Binding="{Binding IncomingMessage}"
-                                 Width="Auto"
-                                 MinWidth="180" />
+                                 Width="2*"
+                                 MinWidth="200" />
             <DataGridTextColumn Header="Outgoing Message"
                                  Binding="{Binding OutgoingMessage}"
-                                 Width="Auto"
-                                 MinWidth="180" />
+                                 Width="2*"
+                                 MinWidth="200" />
             <DataGridTextColumn Header="Destination"
                                  Binding="{Binding Destination}"
-                                 Width="Auto"
+                                 Width="*"
                                  MinWidth="140" />
         </DataGrid.Columns>
     </DataGrid>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -29,6 +29,9 @@
                 <RowDefinition Height="Auto" /> <!-- Mode -->
                 <RowDefinition Height="Auto" /> <!-- Destination Host -->
                 <RowDefinition Height="Auto" /> <!-- Destination Port -->
+                <RowDefinition Height="Auto" /> <!-- Destination Subnet -->
+                <RowDefinition Height="Auto" /> <!-- Destination Primary DNS -->
+                <RowDefinition Height="Auto" /> <!-- Destination Alternate DNS -->
                 <RowDefinition Height="Auto" /> <!-- Destination Gateway -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
@@ -49,15 +52,13 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}"
                       Style="{StaticResource FormField}"
-                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                      IsEnabled="{Binding CanEditListeningConfiguration}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="2" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="2" Grid.Column="1" IsEnabled="{Binding CanEditListeningConfiguration}">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -72,9 +73,8 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="3" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="3" Grid.Column="1" IsEnabled="{Binding CanEditListeningConfiguration}">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -89,9 +89,8 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="4" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="4" Grid.Column="1">
                 <TextBox x:Name="SubnetBox" Text="{Binding SubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -106,9 +105,8 @@
                 <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=SubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="5" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="5" Grid.Column="1">
                 <TextBox x:Name="PrimaryDnsBox" Text="{Binding PrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -123,9 +121,8 @@
                 <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="6" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="6" Grid.Column="1">
                 <TextBox x:Name="AlternateDnsBox" Text="{Binding AlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -141,14 +138,15 @@
             </Grid>
 
             <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"
-                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                      IsEnabled="{Binding CanEditListeningConfiguration}"/>
 
             <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
             <TextBlock Grid.Row="9" Grid.Column="0" Text="Destination Host" Style="{StaticResource FormLabel}"
                        Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="9" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Grid.Row="9" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
                 <TextBox x:Name="DestinationHostBox" Text="{Binding DestinationHost, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -166,7 +164,8 @@
 
             <TextBlock Grid.Row="10" Grid.Column="0" Text="Destination Port" Style="{StaticResource FormLabel}"
                        Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="10" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Grid.Row="10" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
                 <TextBox x:Name="DestinationPortBox" Text="{Binding DestinationPort, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -182,9 +181,67 @@
                            Visibility="{Binding Text, ElementName=DestinationPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="11" Grid.Column="0" Text="Destination Gateway" Style="{StaticResource FormLabel}"
+            <TextBlock Grid.Row="11" Grid.Column="0" Text="Destination Subnet" Style="{StaticResource FormLabel}"
                        Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="11" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Grid.Row="11" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
+                <TextBox x:Name="DestinationSubnetBox" Text="{Binding DestinationSubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationSubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="12" Grid.Column="0" Text="Destination Primary DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="12" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
+                <TextBox x:Name="DestinationPrimaryDnsBox" Text="{Binding DestinationPrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationPrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="13" Grid.Column="0" Text="Destination Alternate DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="13" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
+                <TextBox x:Name="DestinationAlternateDnsBox" Text="{Binding DestinationAlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="1.1.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationAlternateDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="14" Grid.Column="0" Text="Destination Gateway" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="14" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
                 <TextBox x:Name="DestinationGatewayBox" Text="{Binding DestinationGateway, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -200,7 +257,7 @@
                            Visibility="{Binding Text, ElementName=DestinationGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <views:EditorButtonBar Grid.Row="12" Grid.ColumnSpan="2"
+            <views:EditorButtonBar Grid.Row="15" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -49,11 +49,15 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}"
+                      Style="{StaticResource FormField}"
+                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="2" Grid.Column="1">
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="2" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -68,8 +72,9 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="3" Grid.Column="1">
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="3" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -84,8 +89,9 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="4" Grid.Column="1">
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="4" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="SubnetBox" Text="{Binding SubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -100,8 +106,9 @@
                 <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=SubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="5" Grid.Column="1">
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="5" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="PrimaryDnsBox" Text="{Binding PrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -116,8 +123,9 @@
                 <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="6" Grid.Column="1">
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="6" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="AlternateDnsBox" Text="{Binding AlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -132,7 +140,8 @@
                 <TextBlock Text="1.1.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=AlternateDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"
+                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
             <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -49,11 +49,15 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"/>
-            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}" Style="{StaticResource FormField}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}"
+                      Style="{StaticResource FormField}"
+                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="2" Grid.Column="1">
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="2" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -68,8 +72,9 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="3" Grid.Column="1">
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="3" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -84,8 +89,9 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="4" Grid.Column="1">
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="4" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="SubnetBox" Text="{Binding SubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -100,8 +106,9 @@
                 <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=SubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="5" Grid.Column="1">
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="5" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="PrimaryDnsBox" Text="{Binding PrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -116,8 +123,9 @@
                 <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"/>
-            <Grid Grid.Row="6" Grid.Column="1">
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="6" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <TextBox x:Name="AlternateDnsBox" Text="{Binding AlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -132,7 +140,8 @@
                 <TextBlock Text="1.1.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=AlternateDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"/>
+            <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"
+                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
             <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -29,6 +29,9 @@
                 <RowDefinition Height="Auto" /> <!-- Mode -->
                 <RowDefinition Height="Auto" /> <!-- Destination Host -->
                 <RowDefinition Height="Auto" /> <!-- Destination Port -->
+                <RowDefinition Height="Auto" /> <!-- Destination Subnet -->
+                <RowDefinition Height="Auto" /> <!-- Destination Primary DNS -->
+                <RowDefinition Height="Auto" /> <!-- Destination Alternate DNS -->
                 <RowDefinition Height="Auto" /> <!-- Destination Gateway -->
                 <RowDefinition Height="Auto" /> <!-- Buttons -->
             </Grid.RowDefinitions>
@@ -49,15 +52,13 @@
                 <TextBlock Text="My TCP Service" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=ServiceNameBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <TextBlock Grid.Row="1" Grid.Column="0" Text="Connection Role" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="1" Grid.Column="1" ItemsSource="{Binding ConnectionRoles}" SelectedItem="{Binding ConnectionRole}"
                       Style="{StaticResource FormField}"
-                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                      IsEnabled="{Binding CanEditListeningConfiguration}"/>
 
-            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="2" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="2" Grid.Column="0" Text="Host" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="2" Grid.Column="1" IsEnabled="{Binding CanEditListeningConfiguration}">
                 <TextBox x:Name="HostBox" Text="{Binding Host, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -72,9 +73,8 @@
                 <TextBlock Text="192.168.1.10" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=HostBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="3" Grid.Column="1" Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="3" Grid.Column="0" Text="Port" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="3" Grid.Column="1" IsEnabled="{Binding CanEditListeningConfiguration}">
                 <TextBox x:Name="PortBox" Text="{Binding Port, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -89,9 +89,8 @@
                 <TextBlock Text="5020" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="4" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="4" Grid.Column="0" Text="Subnet" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="4" Grid.Column="1">
                 <TextBox x:Name="SubnetBox" Text="{Binding SubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -106,9 +105,8 @@
                 <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=SubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="5" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="5" Grid.Column="0" Text="Primary DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="5" Grid.Column="1">
                 <TextBox x:Name="PrimaryDnsBox" Text="{Binding PrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -123,9 +121,8 @@
                 <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center" Visibility="{Binding Text, ElementName=PrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"
-                       Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="6" Grid.Column="1" Visibility="{Binding ShowsNetworkProfileConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <TextBlock Grid.Row="6" Grid.Column="0" Text="Alternate DNS" Style="{StaticResource FormLabel}"/>
+            <Grid Grid.Row="6" Grid.Column="1">
                 <TextBox x:Name="AlternateDnsBox" Text="{Binding AlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -141,14 +138,15 @@
             </Grid>
 
             <CheckBox Grid.Row="7" Grid.ColumnSpan="2" Content="Use UDP" IsChecked="{Binding UseUdp}" Style="{StaticResource FormField}"
-                      Visibility="{Binding ShowsListeningConfiguration, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                      IsEnabled="{Binding CanEditListeningConfiguration}"/>
 
             <TextBlock Grid.Row="8" Grid.Column="0" Text="Mode" Style="{StaticResource FormLabel}"/>
             <ComboBox Grid.Row="8" Grid.Column="1" ItemsSource="{Binding Modes}" SelectedItem="{Binding Mode}" Style="{StaticResource FormField}"/>
 
             <TextBlock Grid.Row="9" Grid.Column="0" Text="Destination Host" Style="{StaticResource FormLabel}"
                        Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="9" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Grid.Row="9" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
                 <TextBox x:Name="DestinationHostBox" Text="{Binding DestinationHost, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -166,7 +164,8 @@
 
             <TextBlock Grid.Row="10" Grid.Column="0" Text="Destination Port" Style="{StaticResource FormLabel}"
                        Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="10" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Grid.Row="10" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
                 <TextBox x:Name="DestinationPortBox" Text="{Binding DestinationPort, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -182,9 +181,67 @@
                            Visibility="{Binding Text, ElementName=DestinationPortBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <TextBlock Grid.Row="11" Grid.Column="0" Text="Destination Gateway" Style="{StaticResource FormLabel}"
+            <TextBlock Grid.Row="11" Grid.Column="0" Text="Destination Subnet" Style="{StaticResource FormLabel}"
                        Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
-            <Grid Grid.Row="11" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Grid Grid.Row="11" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
+                <TextBox x:Name="DestinationSubnetBox" Text="{Binding DestinationSubnetMask, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="255.255.255.0" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationSubnetBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="12" Grid.Column="0" Text="Destination Primary DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="12" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
+                <TextBox x:Name="DestinationPrimaryDnsBox" Text="{Binding DestinationPrimaryDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="8.8.8.8" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationPrimaryDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="13" Grid.Column="0" Text="Destination Alternate DNS" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="13" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
+                <TextBox x:Name="DestinationAlternateDnsBox" Text="{Binding DestinationAlternateDns, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
+                            <Style.Triggers>
+                                <Trigger Property="Validation.HasError" Value="True">
+                                    <Setter Property="ToolTip" Value="{Binding (Validation.Errors)[0].ErrorContent, RelativeSource={RelativeSource Self}}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+                <TextBlock Text="1.1.1.1" IsHitTestVisible="False" Foreground="Gray" Margin="5,0,0,0" VerticalAlignment="Center"
+                           Visibility="{Binding Text, ElementName=DestinationAlternateDnsBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+            </Grid>
+
+            <TextBlock Grid.Row="14" Grid.Column="0" Text="Destination Gateway" Style="{StaticResource FormLabel}"
+                       Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+            <Grid Grid.Row="14" Grid.Column="1" Visibility="{Binding IsSendingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  IsEnabled="{Binding CanEditDestinationConfiguration}">
                 <TextBox x:Name="DestinationGatewayBox" Text="{Binding DestinationGateway, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.Style>
                         <Style TargetType="TextBox" BasedOn="{StaticResource FormField}">
@@ -200,7 +257,7 @@
                            Visibility="{Binding Text, ElementName=DestinationGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <views:EditorButtonBar Grid.Row="12" Grid.ColumnSpan="2"
+            <views:EditorButtonBar Grid.Row="15" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveAutomationName="Save TCP Service"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -20,32 +20,26 @@
 
                 <StackPanel Grid.Column="0">
                     <TextBlock Text="Incoming Data" FontWeight="Bold" Margin="0,0,0,5"/>
-                    <ListBox ItemsSource="{Binding IncomingData}"
-                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                             HorizontalContentAlignment="Stretch" Height="24">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding}"
-                                           TextWrapping="Wrap"
-                                           TextTrimming="CharacterEllipsis"/>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                    <TextBox Text="{Binding LastInputMessage, Mode=OneWay}"
+                             IsReadOnly="True"
+                             TextWrapping="Wrap"
+                             AcceptsReturn="True"
+                             VerticalScrollBarVisibility="Auto"
+                             HorizontalScrollBarVisibility="Auto"
+                             VerticalContentAlignment="Top"
+                             MinHeight="60"/>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1">
                     <TextBlock Text="Outgoing Results" FontWeight="Bold" Margin="0,0,0,5"/>
-                    <ListBox ItemsSource="{Binding OutgoingResults}"
-                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                             HorizontalContentAlignment="Stretch" Height="24">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding}"
-                                           TextWrapping="Wrap"
-                                           TextTrimming="CharacterEllipsis"/>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                    <TextBox Text="{Binding LastOutputMessage, Mode=OneWay}"
+                             IsReadOnly="True"
+                             TextWrapping="Wrap"
+                             AcceptsReturn="True"
+                             VerticalScrollBarVisibility="Auto"
+                             HorizontalScrollBarVisibility="Auto"
+                             VerticalContentAlignment="Top"
+                             MinHeight="60"/>
                 </StackPanel>
             </Grid>
 


### PR DESCRIPTION
## Summary
- remove service reference prefixes from TCP message displays and add date/time columns to the message table
- update service log formatting to drop timestamps while exposing last input/output messages for reuse
- ensure re-selecting a service after editing reopens its main view

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5674dd86c83268667db6c2517b2ce