### PR TITLE
Standardize routed message naming to InputMessage/OutputMessage

### DIFF
--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
 - `ServiceManager` loads default services from configuration using `ServiceType` short codes and accepts legacy names.
 - `ServiceListModel` now exposes a `Type` enum property, removing string-based service comparisons.
+- Standardized routed message naming to `{Service}.InputMessage` and `{Service}.OutputMessage` in the editor and UI, while keeping legacy `Last*` tokens working for compatibility.
 
 #### Fixed
 - Event raising helpers in `ServiceEditorViewModelBase` invoked themselves recursively; now invoke events directly.
@@ -100,7 +101,7 @@
 - Script editor raises an `OutputGenerated` event and TCP service messages view updates its output message when scripts run.
 - TcpServiceMessagesViewModel executes scripts asynchronously and awaits results when saving.
 - TcpServiceMessagesViewModel logs script execution results and exceptions.
-- Restricted `TcpServiceMessagesViewModel.OutputMessage` setter to internal to prevent external modification.
+- Restricted `TcpServiceMessagesViewModel.ScriptOutputMessage` setter to internal to prevent external modification.
 - TcpServiceMessagesViewModel runs the initial script asynchronously to avoid blocking.
 - App domain unhandled exception handler is asynchronous and awaits dispatcher shutdown.
 - Main window resolves edit workflows through a DI-injected handler dictionary instead of a large if/else chain.
@@ -330,4 +331,5 @@
 - Guarded WPF test thread apartment configuration with an OS check to avoid CA1416 build errors on non-Windows hosts.
 - Added `StubFileDialogService` to test project to support file dialog operations.
 - Console test logger writes plain text messages to avoid Visual Studio RPC errors when expanding test results.
+- TCP runtime initialization now prefers routed input messages over saved test messages so connected services respond with the incoming payload instead of the last test value.
 

--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Removed unsupported `DisplayName` assignment from Windows service options to restore service build.
 - Service factories populate the `Type` property when creating service models.
 - Removed duplicate `ServiceType` enum to resolve namespace conflicts.
+- TCP runtime now feeds live input through the script pipeline so routed output reflects processed messages, and stopping a service restores the configured test message.
 
 ### Navigation & UI
 #### Added

--- a/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
@@ -35,7 +35,8 @@ public interface IMessageRoutingService
     bool TryGetMessage(string serviceName, MessageRoutingDirection direction, out string? message);
 
     /// <summary>
-    /// Replaces <c>{ServiceName.LastInputMessage}</c> and <c>{ServiceName.LastOutputMessage}</c> tokens within the provided template.
+    /// Replaces <c>{ServiceName.InputMessage}</c> and <c>{ServiceName.OutputMessage}</c> tokens within the provided template.
+    /// Legacy <c>LastInputMessage</c> and <c>LastOutputMessage</c> tokens are still recognized for compatibility.
     /// </summary>
     /// <param name="template">The template containing message tokens.</param>
     /// <param name="referencingServiceName">

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingScriptTransformer.cs
@@ -14,8 +14,9 @@ public static class MessageRoutingScriptTransformer
     private static readonly CSharpParseOptions ScriptParseOptions = new(kind: SourceCodeKind.Script);
 
     /// <summary>
-    /// Rewrites <c>{ServiceName}.LastInputMessage</c> and <c>{ServiceName}.LastOutputMessage</c> member access
-    /// expressions into string literals backed by the routing service.
+    /// Rewrites <c>{ServiceName}.InputMessage</c> and <c>{ServiceName}.OutputMessage</c> member access expressions
+    /// into string literals backed by the routing service. Legacy tokens using <c>LastInputMessage</c> and
+    /// <c>LastOutputMessage</c> remain supported for backward compatibility.
     /// </summary>
     /// <param name="script">The user provided script.</param>
     /// <param name="routingService">Routing service supplying the latest message snapshots.</param>
@@ -85,13 +86,15 @@ public static class MessageRoutingScriptTransformer
 
         private static bool TryGetDirection(string identifier, out MessageRoutingDirection direction)
         {
-            if (string.Equals(identifier, "LastInputMessage", StringComparison.Ordinal))
+            if (string.Equals(identifier, "InputMessage", StringComparison.Ordinal) ||
+                string.Equals(identifier, "LastInputMessage", StringComparison.Ordinal))
             {
                 direction = MessageRoutingDirection.Input;
                 return true;
             }
 
-            if (string.Equals(identifier, "LastOutputMessage", StringComparison.Ordinal))
+            if (string.Equals(identifier, "OutputMessage", StringComparison.Ordinal) ||
+                string.Equals(identifier, "LastOutputMessage", StringComparison.Ordinal))
             {
                 direction = MessageRoutingDirection.Output;
                 return true;

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
@@ -18,7 +18,7 @@ public class MessageRoutingService : IMessageRoutingService
     private readonly Dictionary<string, Dictionary<string, HashSet<MessageRoutingDirection>>> _referencedByService = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _referencesLock = new();
     private readonly ILoggingService? _logger;
-    private static readonly Regex NewTokenRegex = new(@"\{([A-Za-z0-9_]+)\.(LastInputMessage|LastOutputMessage)\}", RegexOptions.Compiled);
+    private static readonly Regex NewTokenRegex = new(@"\{([A-Za-z0-9_]+)\.(InputMessage|OutputMessage|LastInputMessage|LastOutputMessage)\}", RegexOptions.Compiled);
     private static readonly Regex LegacyTokenRegex = new(@"\{([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\.Message\}", RegexOptions.Compiled);
 
     /// <summary>
@@ -109,9 +109,7 @@ public class MessageRoutingService : IMessageRoutingService
         var result = NewTokenRegex.Replace(template, m =>
         {
             var name = m.Groups[1].Value;
-            var direction = string.Equals(m.Groups[2].Value, nameof(RoutingMessageEntry.LastInputMessage), StringComparison.Ordinal)
-                ? MessageRoutingDirection.Input
-                : MessageRoutingDirection.Output;
+            var direction = ParseDirection(m.Groups[2].Value);
 
             if (references is not null)
             {
@@ -130,7 +128,7 @@ public class MessageRoutingService : IMessageRoutingService
             if (Enum.TryParse<ServiceType>(typeStr, out var type) &&
                 _messages.TryGetValue((type, name), out var entry))
             {
-                return entry.LastInputMessage;
+                return entry.InputMessage;
             }
 
             return string.Empty;
@@ -305,11 +303,22 @@ public class MessageRoutingService : IMessageRoutingService
             : serviceName.Trim();
     }
 
+    private static MessageRoutingDirection ParseDirection(string propertyName)
+    {
+        if (string.Equals(propertyName, nameof(RoutingMessageEntry.InputMessage), StringComparison.Ordinal) ||
+            string.Equals(propertyName, "LastInputMessage", StringComparison.Ordinal))
+        {
+            return MessageRoutingDirection.Input;
+        }
+
+        return MessageRoutingDirection.Output;
+    }
+
     private static string ToPropertyName(MessageRoutingDirection direction)
     {
         return direction == MessageRoutingDirection.Input
-            ? nameof(RoutingMessageEntry.LastInputMessage)
-            : nameof(RoutingMessageEntry.LastOutputMessage);
+            ? nameof(RoutingMessageEntry.InputMessage)
+            : nameof(RoutingMessageEntry.OutputMessage);
     }
 
     private static RoutingMessageEntry CreateEntry(MessageRoutingDirection direction, string payload)
@@ -335,27 +344,27 @@ public class MessageRoutingService : IMessageRoutingService
 
     private sealed class RoutingMessageEntry
     {
-        private string _lastInputMessage = string.Empty;
-        private string _lastOutputMessage = string.Empty;
+        private string _inputMessage = string.Empty;
+        private string _outputMessage = string.Empty;
 
-        public string LastInputMessage => _lastInputMessage;
-        public string LastOutputMessage => _lastOutputMessage;
+        public string InputMessage => _inputMessage;
+        public string OutputMessage => _outputMessage;
 
         public void Update(MessageRoutingDirection direction, string payload)
         {
             if (direction == MessageRoutingDirection.Input)
             {
-                _lastInputMessage = payload ?? string.Empty;
+                _inputMessage = payload ?? string.Empty;
             }
             else
             {
-                _lastOutputMessage = payload ?? string.Empty;
+                _outputMessage = payload ?? string.Empty;
             }
         }
 
         public string Get(MessageRoutingDirection direction)
         {
-            return direction == MessageRoutingDirection.Input ? _lastInputMessage : _lastOutputMessage;
+            return direction == MessageRoutingDirection.Input ? _inputMessage : _outputMessage;
         }
     }
 }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
@@ -68,11 +68,8 @@ public sealed class TcpRuntime : ITcpRuntime
         var output = await ExecuteScriptInternalAsync(script, testMessage, cancellationToken).ConfigureAwait(false);
 
         options.Script = script;
-        if (isInputMessage)
-        {
-            options.InputMessage = testMessage;
-        }
-        else
+        options.InputMessage = testMessage;
+        if (!isInputMessage)
         {
             options.LastTestMessage = testMessage;
         }
@@ -97,16 +94,22 @@ public sealed class TcpRuntime : ITcpRuntime
         _name = $"{context.ServiceType}.{context.ServiceName}";
 
         _logger?.LogInformation(this, "Executing TCP script");
-        var output = await ExecuteScriptInternalAsync(request.Script, request.TestMessage, cancellationToken).ConfigureAwait(false);
+        var script = request.Script ?? string.Empty;
+        var message = request.TestMessage ?? string.Empty;
+        var output = await ExecuteScriptInternalAsync(script, message, cancellationToken).ConfigureAwait(false);
 
-        context.Options.Script = request.Script;
-        context.Options.LastTestMessage = request.TestMessage;
+        context.Options.Script = script;
+        context.Options.InputMessage = message;
+        if (!request.IsLiveInput)
+        {
+            context.Options.LastTestMessage = message;
+        }
         context.Options.OutputMessage = output;
 
-        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, request.TestMessage, MessageRoutingDirection.Input);
+        _routingService.UpdateMessage(context.ServiceType, context.ServiceName, message, MessageRoutingDirection.Input);
         _routingService.UpdateMessage(context.ServiceType, context.ServiceName, output, MessageRoutingDirection.Output);
 
-        return new TcpRuntimeState(request.Script, request.TestMessage, output);
+        return new TcpRuntimeState(script, message, output);
     }
 
     private string ResolveInitialMessage(TcpRuntimeContext context, out bool isInputMessage)

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntime.cs
@@ -61,14 +61,21 @@ public sealed class TcpRuntime : ITcpRuntime
 
         var options = context.Options ?? throw new ArgumentNullException(nameof(context.Options));
         var script = string.IsNullOrWhiteSpace(options.Script) ? context.DefaultScript : options.Script;
-        var testMessage = ResolveInitialMessage(context);
+        var testMessage = ResolveInitialMessage(context, out var isInputMessage);
 
         _logger?.LogInformation(this, "Initializing TCP script runtime");
 
         var output = await ExecuteScriptInternalAsync(script, testMessage, cancellationToken).ConfigureAwait(false);
 
         options.Script = script;
-        options.LastTestMessage = testMessage;
+        if (isInputMessage)
+        {
+            options.InputMessage = testMessage;
+        }
+        else
+        {
+            options.LastTestMessage = testMessage;
+        }
         options.OutputMessage = output;
 
         _routingService.UpdateMessage(context.ServiceType, context.ServiceName, testMessage, MessageRoutingDirection.Input);
@@ -102,20 +109,27 @@ public sealed class TcpRuntime : ITcpRuntime
         return new TcpRuntimeState(request.Script, request.TestMessage, output);
     }
 
-    private string ResolveInitialMessage(TcpRuntimeContext context)
+    private string ResolveInitialMessage(TcpRuntimeContext context, out bool isInputMessage)
     {
         var options = context.Options;
         var serviceName = context.ServiceName;
 
-        if (string.IsNullOrWhiteSpace(options.LastTestMessage) &&
-            _routingService.TryGetMessage(context.ServiceType, serviceName, MessageRoutingDirection.Input, out var routed))
+        if (_routingService.TryGetMessage(context.ServiceType, serviceName, MessageRoutingDirection.Input, out var routed))
         {
-            return routed ?? string.Empty;
+            isInputMessage = true;
+            var resolved = routed ?? string.Empty;
+            options.InputMessage = resolved;
+            return resolved;
         }
 
-        return string.IsNullOrWhiteSpace(options.LastTestMessage)
-            ? $"{serviceName}-PEAK-123456789"
-            : options.LastTestMessage;
+        if (!string.IsNullOrWhiteSpace(options.LastTestMessage))
+        {
+            isInputMessage = false;
+            return options.LastTestMessage;
+        }
+
+        isInputMessage = false;
+        return $"{serviceName}-PEAK-123456789";
     }
 
     private async Task<string> ExecuteScriptInternalAsync(string script, string message, CancellationToken cancellationToken)

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeExecutionRequest.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpRuntimeExecutionRequest.cs
@@ -1,18 +1,21 @@
+using System;
+
 namespace DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 
 /// <summary>
-/// Describes a request to execute a TCP script against a test message.
+/// Describes a request to execute a TCP script against a message payload.
 /// </summary>
 public sealed class TcpRuntimeExecutionRequest
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="TcpRuntimeExecutionRequest"/> class.
     /// </summary>
-    public TcpRuntimeExecutionRequest(TcpRuntimeContext context, string script, string testMessage)
+    public TcpRuntimeExecutionRequest(TcpRuntimeContext context, string script, string testMessage, bool isLiveInput = false)
     {
-        Context = context;
-        Script = script;
-        TestMessage = testMessage;
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Script = script ?? string.Empty;
+        TestMessage = testMessage ?? string.Empty;
+        IsLiveInput = isLiveInput;
     }
 
     /// <summary>
@@ -26,7 +29,12 @@ public sealed class TcpRuntimeExecutionRequest
     public string Script { get; }
 
     /// <summary>
-    /// Gets the test message provided by the user.
+    /// Gets the message supplied for script execution.
     /// </summary>
     public string TestMessage { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the message originated from a live connection.
+    /// </summary>
+    public bool IsLiveInput { get; }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -78,8 +78,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private double _totalExecutionTimeMs;
         private int _executionCount;
         private TimeSpan _lastExecutionDuration;
-        private string _lastInputMessage = string.Empty;
-        private string _lastOutputMessage = string.Empty;
+        private string _inputMessage = string.Empty;
+        private string _outputMessage = string.Empty;
         private WpfBrush _lastInputBrush = WpfBrushes.Black;
         private int _incomingMessageCount;
         private int _outgoingMessageCount;
@@ -144,37 +144,37 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         /// <summary>
-        /// Gets the last input message received by this service.
+        /// Gets the most recent input message received by this service.
         /// </summary>
-        public string LastInputMessage
+        public string InputMessage
         {
-            get => _lastInputMessage;
+            get => _inputMessage;
             private set
             {
-                if (_lastInputMessage == value)
+                if (_inputMessage == value)
                 {
                     return;
                 }
 
-                _lastInputMessage = value;
+                _inputMessage = value;
                 OnPropertyChanged();
             }
         }
 
         /// <summary>
-        /// Gets the last outgoing message produced by this service.
+        /// Gets the most recent outgoing message produced by this service.
         /// </summary>
-        public string LastOutputMessage
+        public string OutputMessage
         {
-            get => _lastOutputMessage;
+            get => _outputMessage;
             private set
             {
-                if (_lastOutputMessage == value)
+                if (_outputMessage == value)
                 {
                     return;
                 }
 
-                _lastOutputMessage = value;
+                _outputMessage = value;
                 OnPropertyChanged();
             }
         }
@@ -349,7 +349,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             OnPropertyChanged(nameof(Logs));
             if (Logs.FirstOrDefault() is { } latest)
             {
-                LastInputMessage = NormalizePersistedMessage(latest.Message);
+            InputMessage = NormalizePersistedMessage(latest.Message);
                 LastInputBrush = ParseBrush(latest.Color, WpfBrushes.Black);
             }
         }
@@ -361,8 +361,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void LoadMessageHistory(IEnumerable<ServiceMessageHistoryEntry> entries)
         {
             _messageHistory.Clear();
-            LastInputMessage = string.Empty;
-            LastOutputMessage = string.Empty;
+            InputMessage = string.Empty;
+            OutputMessage = string.Empty;
             LastInputBrush = WpfBrushes.Black;
             if (entries is null)
             {
@@ -387,7 +387,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 if (!string.IsNullOrEmpty(historyEntry.IncomingMessage))
                 {
-                    UpdateLastInputMessage(historyEntry.IncomingMessage);
+                    UpdateInputMessage(historyEntry.IncomingMessage);
                     break;
                 }
             }
@@ -396,7 +396,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 if (!string.IsNullOrEmpty(historyEntry.OutgoingMessage))
                 {
-                    UpdateLastOutputMessage(historyEntry.OutgoingMessage);
+                    UpdateOutputMessage(historyEntry.OutgoingMessage);
                     break;
                 }
             }
@@ -408,10 +408,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <param name="message">The raw message text.</param>
         /// <param name="brush">The brush used to display the message in the UI.</param>
         /// <returns>The normalized message stored on the model.</returns>
-        public string UpdateLastInputMessage(string? message, WpfBrush? brush = null)
+        public string UpdateInputMessage(string? message, WpfBrush? brush = null)
         {
             var normalizedMessage = NormalizeLatestMessage(message);
-            LastInputMessage = normalizedMessage;
+            InputMessage = normalizedMessage;
             LastInputBrush = brush ?? WpfBrushes.Black;
             return normalizedMessage;
         }
@@ -421,10 +421,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         /// <param name="message">The raw message text.</param>
         /// <returns>The normalized message stored on the model.</returns>
-        public string UpdateLastOutputMessage(string? message)
+        public string UpdateOutputMessage(string? message)
         {
             var normalizedMessage = NormalizeLatestMessage(message);
-            LastOutputMessage = normalizedMessage;
+            OutputMessage = normalizedMessage;
             return normalizedMessage;
         }
 
@@ -449,12 +449,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             if (!string.IsNullOrEmpty(incomingMessage))
             {
-                UpdateLastInputMessage(incomingMessage);
+                UpdateInputMessage(incomingMessage);
             }
 
             if (!string.IsNullOrEmpty(outgoingMessage))
             {
-                UpdateLastOutputMessage(outgoingMessage);
+                UpdateOutputMessage(outgoingMessage);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -52,10 +52,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         public ObservableCollection<LogEntry> Logs { get; } = new();
 
         /// <summary>Latest incoming message text for the associated service.</summary>
-        public string LastInputMessage => _service?.LastInputMessage ?? string.Empty;
+        public string InputMessage => _service?.InputMessage ?? string.Empty;
 
         /// <summary>Latest outgoing message text for the associated service.</summary>
-        public string LastOutputMessage => _service?.LastOutputMessage ?? string.Empty;
+        public string OutputMessage => _service?.OutputMessage ?? string.Empty;
 
         /// <inheritdoc />
         private ILoggingService? _logger;
@@ -143,7 +143,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private string _script = string.Empty;
 
-        private string _outputMessage = string.Empty;
+        private string _scriptOutputMessage = string.Empty;
 
         /// <summary>Message used for testing communication.</summary>
         public string TestMessage
@@ -170,12 +170,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         }
 
         /// <summary>Result of executing the test message with the current script.</summary>
-        public string OutputMessage
+        public string ScriptOutputMessage
         {
-            get => _outputMessage;
+            get => _scriptOutputMessage;
             internal set
             {
-                _outputMessage = value ?? string.Empty;
+                _scriptOutputMessage = value ?? string.Empty;
                 OnPropertyChanged();
             }
         }
@@ -242,7 +242,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             Script = string.IsNullOrWhiteSpace(_options.Script)
                 ? ScriptEditorViewModel.DefaultScript
                 : _options.Script;
-            OutputMessage = _options.OutputMessage;
+            ScriptOutputMessage = _options.OutputMessage;
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
             ApplyNetworkConfiguration(restartIfActive: false);
             var history = service.GetMessageHistorySnapshot();
@@ -264,8 +264,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             MessageTable.SetActiveService(ServiceType, ServiceName);
             OnPropertyChanged(nameof(IncomingData));
             OnPropertyChanged(nameof(OutgoingResults));
-            OnPropertyChanged(nameof(LastInputMessage));
-            OnPropertyChanged(nameof(LastOutputMessage));
+            OnPropertyChanged(nameof(InputMessage));
+            OnPropertyChanged(nameof(OutputMessage));
             _ = InitializeRuntimeAsync();
             if (_service.IsActive)
             {
@@ -275,14 +275,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private void OnServicePropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(ServiceListModel.LastInputMessage) || string.IsNullOrEmpty(e.PropertyName))
+            if (e.PropertyName == nameof(ServiceListModel.InputMessage) || string.IsNullOrEmpty(e.PropertyName))
             {
-                OnPropertyChanged(nameof(LastInputMessage));
+                OnPropertyChanged(nameof(InputMessage));
             }
 
-            if (e.PropertyName == nameof(ServiceListModel.LastOutputMessage) || string.IsNullOrEmpty(e.PropertyName))
+            if (e.PropertyName == nameof(ServiceListModel.OutputMessage) || string.IsNullOrEmpty(e.PropertyName))
             {
-                OnPropertyChanged(nameof(LastOutputMessage));
+                OnPropertyChanged(nameof(OutputMessage));
             }
         }
 
@@ -347,15 +347,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 var state = await _tcpRuntime.InitializeAsync(_runtimeContext).ConfigureAwait(false);
                 Script = state.Script;
                 TestMessage = state.TestMessage;
-                OutputMessage = state.OutputMessage;
+                ScriptOutputMessage = state.OutputMessage;
                 _options.OutputMessage = state.OutputMessage;
                 _routing.UpdateMessage(ServiceType, ServiceName, state.TestMessage, MessageRoutingDirection.Input);
                 _routing.UpdateMessage(ServiceType, ServiceName, state.OutputMessage, MessageRoutingDirection.Output);
-                Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
+                Logger?.Log($"Script executed successfully: {ScriptOutputMessage}", LogLevel.Information);
             }
             catch (Exception ex)
             {
-                OutputMessage = ex.ToString();
+                ScriptOutputMessage = ex.ToString();
                 Logger?.Log($"Script execution failed: {ex}", LogLevel.Error);
             }
         }
@@ -1211,15 +1211,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 var result = await _tcpRuntime.ExecuteAsync(new TcpRuntimeExecutionRequest(_runtimeContext, Script, TestMessage)).ConfigureAwait(false);
                 Script = result.Script;
                 TestMessage = result.TestMessage;
-                OutputMessage = result.OutputMessage;
+                ScriptOutputMessage = result.OutputMessage;
                 _options.OutputMessage = result.OutputMessage;
                 _routing.UpdateMessage(ServiceType, ServiceName, result.TestMessage, MessageRoutingDirection.Input);
                 _routing.UpdateMessage(ServiceType, ServiceName, result.OutputMessage, MessageRoutingDirection.Output);
-                Logger?.Log($"Script executed successfully: {OutputMessage}", LogLevel.Information);
+                Logger?.Log($"Script executed successfully: {ScriptOutputMessage}", LogLevel.Information);
             }
             catch (Exception ex)
             {
-                OutputMessage = ex.ToString();
+                ScriptOutputMessage = ex.ToString();
                 Logger?.Log($"Script execution failed: {ex}", LogLevel.Error);
             }
         }
@@ -1249,7 +1249,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
             void OnOutputGenerated(string output)
             {
-                OutputMessage = _options.OutputMessage = output;
+                ScriptOutputMessage = _options.OutputMessage = output;
                 TestMessage = svm.TestMessage;
                 _options.LastTestMessage = svm.TestMessage;
                 _routing.UpdateMessage(ServiceType, ServiceName, svm.TestMessage, MessageRoutingDirection.Input);

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -500,6 +500,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
 
             Logger?.Log("TCP network loop stopped", LogLevel.Debug);
+            _ = RestoreTestMessageAsync();
         }
 
         private bool ShouldStartServerListener()
@@ -729,20 +730,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                         if (operation == TcpClientOperation.Receive)
                         {
                             Logger?.Log($"Received message from {endpointDisplay}: {response}", LogLevel.Information);
-                            _routing.UpdateMessage(ServiceType, ServiceName, response, MessageRoutingDirection.Input);
-                            await AppendMessageAsync(response, string.Empty, endpointDisplay).ConfigureAwait(false);
                         }
                         else
                         {
                             Logger?.Log($"Received response from {endpointDisplay}: {response}", LogLevel.Information);
-                            _routing.UpdateMessage(ServiceType, ServiceName, response, MessageRoutingDirection.Input);
-                            await AppendMessageAsync(message, response, endpointDisplay).ConfigureAwait(false);
                         }
+
+                        var processedOutput = await ExecuteIncomingMessageAsync(response, cancellationToken).ConfigureAwait(false);
+                        await AppendMessageAsync(response, processedOutput, endpointDisplay, sentToEndpoint: false).ConfigureAwait(false);
                     }
 
                     if (!receivedAny && shouldSendMessage)
                     {
-                        await AppendMessageAsync(message, string.Empty, endpointDisplay).ConfigureAwait(false);
+                        await AppendMessageAsync(message, string.Empty, endpointDisplay, sentToEndpoint: true).ConfigureAwait(false);
                         Logger?.Log($"No response received from {endpointDisplay}", LogLevel.Warning);
                     }
                 }
@@ -769,6 +769,32 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
+        private async Task<string> ExecuteIncomingMessageAsync(string incomingMessage, CancellationToken cancellationToken)
+        {
+            if (_runtimeContext is null)
+            {
+                _routing.UpdateMessage(ServiceType, ServiceName, incomingMessage, MessageRoutingDirection.Input);
+                return _options.OutputMessage ?? string.Empty;
+            }
+
+            try
+            {
+                var state = await _tcpRuntime.ExecuteAsync(
+                    new TcpRuntimeExecutionRequest(_runtimeContext, Script, incomingMessage, isLiveInput: true),
+                    cancellationToken).ConfigureAwait(false);
+
+                _options.OutputMessage = state.OutputMessage;
+                return state.OutputMessage;
+            }
+            catch (Exception ex)
+            {
+                Logger?.Log($"TCP script execution failed: {ex.Message}", LogLevel.Error);
+                Logger?.Log(ex.ToString(), LogLevel.Debug);
+                _routing.UpdateMessage(ServiceType, ServiceName, incomingMessage, MessageRoutingDirection.Input);
+                return _options.OutputMessage ?? string.Empty;
+            }
+        }
+
         private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
         {
             using (client)
@@ -792,16 +818,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                         var incoming = Encoding.UTF8.GetString(buffer, 0, bytesRead);
                         var formattedIncoming = MessageDisplayFormatter.FormatControlCharacters(incoming);
                         Logger?.Log($"Incoming message from {endpoint}: {formattedIncoming}", LogLevel.Information);
-                        _routing.UpdateMessage(ServiceType, ServiceName, incoming, MessageRoutingDirection.Input);
-                        await AppendMessageAsync(incoming, _options.OutputMessage, endpoint).ConfigureAwait(false);
 
-                        if (!string.IsNullOrWhiteSpace(_options.OutputMessage))
+                        var outgoing = await ExecuteIncomingMessageAsync(incoming, cancellationToken).ConfigureAwait(false);
+                        var hasResponse = !string.IsNullOrWhiteSpace(outgoing);
+                        await AppendMessageAsync(incoming, outgoing, endpoint, hasResponse).ConfigureAwait(false);
+
+                        if (hasResponse)
                         {
-                            var response = Encoding.UTF8.GetBytes(_options.OutputMessage);
+                            var response = Encoding.UTF8.GetBytes(outgoing);
                             await stream.WriteAsync(response.AsMemory(0, response.Length), cancellationToken).ConfigureAwait(false);
-                            var formattedOutgoing = MessageDisplayFormatter.FormatControlCharacters(_options.OutputMessage);
+                            var formattedOutgoing = MessageDisplayFormatter.FormatControlCharacters(outgoing);
                             Logger?.Log($"Outgoing message to {endpoint}: {formattedOutgoing}", LogLevel.Debug);
-                            _routing.UpdateMessage(ServiceType, ServiceName, _options.OutputMessage, MessageRoutingDirection.Output);
                         }
                     }
                 }
@@ -820,16 +847,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
-        private Task AppendMessageAsync(string? incoming, string? outgoing, string? endpoint)
+        private Task AppendMessageAsync(string? incoming, string? outgoing, string? endpoint, bool sentToEndpoint)
         {
             var incomingMessage = incoming ?? string.Empty;
             var outgoingMessage = outgoing ?? string.Empty;
             var incomingEndpoint = endpoint ?? string.Empty;
             var referencingServices = _routing.GetReferencingServices(ServiceName);
             var destination = string.Empty;
-            if (!string.IsNullOrWhiteSpace(outgoingMessage))
+            if (sentToEndpoint && !string.IsNullOrWhiteSpace(incomingEndpoint))
             {
                 destination = incomingEndpoint;
+            }
+            else if (!string.IsNullOrWhiteSpace(outgoingMessage) && referencingServices.Count > 0)
+            {
+                destination = string.Join(", ", referencingServices);
             }
             else if (referencingServices.Count > 0)
             {
@@ -1046,6 +1077,40 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                     }
                 }
             }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        private async Task RestoreTestMessageAsync()
+        {
+            if (_runtimeContext is null)
+            {
+                return;
+            }
+
+            var fallback = string.IsNullOrWhiteSpace(TestMessage)
+                ? (_options.LastTestMessage ?? string.Empty)
+                : TestMessage;
+
+            try
+            {
+                var state = await _tcpRuntime.ExecuteAsync(
+                    new TcpRuntimeExecutionRequest(_runtimeContext, Script, fallback, isLiveInput: false)).ConfigureAwait(false);
+
+                _options.OutputMessage = state.OutputMessage;
+
+                await RunOnUiThreadAsync(() =>
+                {
+                    TestMessage = state.TestMessage;
+                    ScriptOutputMessage = state.OutputMessage;
+                    _service?.UpdateInputMessage(state.TestMessage);
+                    _service?.UpdateOutputMessage(state.OutputMessage);
+                }).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger?.Log($"Failed to restore test message after stopping TCP service: {ex.Message}", LogLevel.Error);
+                Logger?.Log(ex.ToString(), LogLevel.Debug);
+                _routing.UpdateMessage(ServiceType, ServiceName, fallback, MessageRoutingDirection.Input);
+            }
         }
 
         private void EnsureApplicationExitHooked()

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -205,7 +205,7 @@
                                             <StackPanel Grid.Column="1">
                                                 <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
                                                 <TextBlock Text="{Binding ExecutionTimeText}" />
-                                                <TextBlock Text="{Binding LastInputMessage}" TextTrimming="CharacterEllipsis" Foreground="{Binding LastInputBrush}" />
+                                                <TextBlock Text="{Binding InputMessage}" TextTrimming="CharacterEllipsis" Foreground="{Binding LastInputBrush}" />
                                                 <TextBlock>
                                                     <Run Text="{Binding IncomingMessageCount, Mode=OneWay}"/>
                                                     <Run Text=" - incoming"/>

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -20,7 +20,7 @@
 
                 <StackPanel Grid.Column="0">
                     <TextBlock Text="Incoming Data" FontWeight="Bold" Margin="0,0,0,5"/>
-                    <TextBox Text="{Binding LastInputMessage, Mode=OneWay}"
+                    <TextBox Text="{Binding InputMessage, Mode=OneWay}"
                              IsReadOnly="True"
                              TextWrapping="Wrap"
                              AcceptsReturn="True"
@@ -32,7 +32,7 @@
 
                 <StackPanel Grid.Column="1">
                     <TextBlock Text="Outgoing Results" FontWeight="Bold" Margin="0,0,0,5"/>
-                    <TextBox Text="{Binding LastOutputMessage, Mode=OneWay}"
+                    <TextBox Text="{Binding OutputMessage, Mode=OneWay}"
                              IsReadOnly="True"
                              TextWrapping="Wrap"
                              AcceptsReturn="True"
@@ -54,7 +54,7 @@
                     <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
                     <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
                     <Button Content="Edit Script" Margin="10,0,0,0" Command="{Binding OpenScriptEditorCommand}" Height="24"/>
-                    <TextBox Text="{Binding OutputMessage, Mode=OneWay}" Width="300"
+                    <TextBox Text="{Binding ScriptOutputMessage, Mode=OneWay}" Width="300"
                              IsReadOnly="True" Margin="10,0,0,0" Background="#EDEDED"/>
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>


### PR DESCRIPTION
## Summary
- rename service message properties and UI bindings to use InputMessage/OutputMessage for routed data
- update routing infrastructure to accept the new token names while keeping legacy aliases working
- retitle the TCP script preview property to ScriptOutputMessage and document the naming change

## Testing
- not run (requires Windows for WPF projects)


------
https://chatgpt.com/codex/tasks/task_e_68e59354ac1483268a0f955a0971f0e2