### PR TITLE
Extract MainView service list item into shared control

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -4,7 +4,6 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views"
-        xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
         xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
         xmlns:sys="clr-namespace:System.Windows;assembly=PresentationFramework"
         xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
@@ -25,55 +24,6 @@
                 <ResourceDictionary Source="../Themes/BubblyWindow.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
-            <Style x:Key="ServiceStatusIndicatorStyle" TargetType="Ellipse">
-                <Setter Property="Width" Value="12" />
-                <Setter Property="Height" Value="12" />
-                <Setter Property="Margin" Value="0,0,8,0" />
-                <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Stroke" Value="#FF4A4A4A" />
-                <Setter Property="StrokeThickness" Value="1" />
-                <Setter Property="Fill">
-                    <Setter.Value>
-                        <SolidColorBrush Color="#FFD32F2F" />
-                    </Setter.Value>
-                </Setter>
-                <Style.Triggers>
-                    <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Active}">
-                        <Setter Property="Fill">
-                            <Setter.Value>
-                                <SolidColorBrush Color="#FF2E7D32" />
-                            </Setter.Value>
-                        </Setter>
-                    </DataTrigger>
-                    <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Activating}">
-                        <Setter Property="Fill">
-                            <Setter.Value>
-                                <SolidColorBrush Color="#FFF9A825" />
-                            </Setter.Value>
-                        </Setter>
-                    </DataTrigger>
-                    <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Error}">
-                        <Setter Property="Fill">
-                            <Setter.Value>
-                                <SolidColorBrush Color="#FFD32F2F" />
-                            </Setter.Value>
-                        </Setter>
-                        <DataTrigger.EnterActions>
-                            <BeginStoryboard x:Name="ErrorFlashStoryboard">
-                                <Storyboard RepeatBehavior="Forever" FillBehavior="Stop">
-                                    <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)" Duration="0:0:0.8">
-                                        <DiscreteColorKeyFrame KeyTime="0:0:0" Value="#FFD32F2F" />
-                                        <DiscreteColorKeyFrame KeyTime="0:0:0.4" Value="#FF808080" />
-                                    </ColorAnimationUsingKeyFrames>
-                                </Storyboard>
-                            </BeginStoryboard>
-                        </DataTrigger.EnterActions>
-                        <DataTrigger.ExitActions>
-                            <StopStoryboard BeginStoryboardName="ErrorFlashStoryboard" />
-                        </DataTrigger.ExitActions>
-                    </DataTrigger>
-                </Style.Triggers>
-            </Style>
         </ResourceDictionary>
     </Window.Resources>
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -180,44 +180,7 @@
                         </ListBox.ItemContainerStyle>
                         <ListBox.ItemTemplate>
                             <DataTemplate>
-                                <Border CornerRadius="8" BorderBrush="{Binding BorderColor}" Background="{Binding BackgroundColor}" BorderThickness="2" Padding="5" Margin="2"
-                                        PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown" PreviewMouseMove="ServiceItem_PreviewMouseMove"
-                                        AllowDrop="True" Drop="ServiceItem_Drop">
-                                        <Border CornerRadius="8" BorderBrush="Gray" BorderThickness="1" Padding="5" Margin="2"
-                                                Tag="{Binding DataContext.EditServiceCommand, RelativeSource={RelativeSource AncestorType=ListBox}}">
-                                        <Border.ContextMenu>
-                                            <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
-                                                <MenuItem Header="Edit Service"
-                                                          Command="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                                          CommandParameter="{Binding}" />
-                                                <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
-                                                <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
-                                                <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
-                                            </ContextMenu>
-                                        </Border.ContextMenu>
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="Auto"/>
-                                                <ColumnDefinition Width="*"/>
-                                            </Grid.ColumnDefinitions>
-                                            <Ellipse Style="{StaticResource ServiceStatusIndicatorStyle}"
-                                                     ToolTip="{Binding RuntimeState}"/>
-                                            <StackPanel Grid.Column="1">
-                                                <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
-                                                <TextBlock Text="{Binding ExecutionTimeText}" />
-                                                <TextBlock Text="{Binding InputMessage}" TextTrimming="CharacterEllipsis" Foreground="{Binding LastInputBrush}" />
-                                                <TextBlock>
-                                                    <Run Text="{Binding IncomingMessageCount, Mode=OneWay}"/>
-                                                    <Run Text=" - incoming"/>
-                                                </TextBlock>
-                                                <TextBlock>
-                                                    <Run Text="{Binding OutgoingMessageCount, Mode=OneWay}"/>
-                                                    <Run Text=" - outgoing"/>
-                                                </TextBlock>
-                                            </StackPanel>
-                                        </Grid>
-                                    </Border>
-                                </Border>
+                                <shared:ListServiceBox />
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -568,7 +568,7 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
-        private void DeleteServiceMenu_Click(object sender, RoutedEventArgs e) => _ = DeleteServiceMenuAsync(sender, e);
+        internal void DeleteServiceMenu_Click(object sender, RoutedEventArgs e) => _ = DeleteServiceMenuAsync(sender, e);
 
         private async Task DeleteServiceMenuAsync(object sender, RoutedEventArgs e)
         {
@@ -596,7 +596,7 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
-        private void RenameServiceMenu_Click(object sender, RoutedEventArgs e) => _ = RenameServiceMenuAsync(sender, e);
+        internal void RenameServiceMenu_Click(object sender, RoutedEventArgs e) => _ = RenameServiceMenuAsync(sender, e);
 
         private async Task RenameServiceMenuAsync(object sender, RoutedEventArgs e)
         {
@@ -622,7 +622,7 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
-        private void ChangeColorMenu_Click(object sender, RoutedEventArgs e) => _ = ChangeColorMenuAsync(sender, e);
+        internal void ChangeColorMenu_Click(object sender, RoutedEventArgs e) => _ = ChangeColorMenuAsync(sender, e);
 
         private async Task ChangeColorMenuAsync(object sender, RoutedEventArgs e)
         {
@@ -721,12 +721,12 @@ namespace DesktopApplicationTemplate.UI.Views
         }
 
         private System.Windows.Point _dragStart;
-        private void ServiceItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        internal void ServiceItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             _dragStart = e.GetPosition(null);
         }
 
-        private void ServiceItem_PreviewMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        internal void ServiceItem_PreviewMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
         {
             if (e.LeftButton != System.Windows.Input.MouseButtonState.Pressed)
                 return;
@@ -742,7 +742,7 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
-        private void ServiceItem_Drop(object sender, System.Windows.DragEventArgs e) => _ = ServiceItemDropAsync(sender, e);
+        internal void ServiceItem_Drop(object sender, System.Windows.DragEventArgs e) => _ = ServiceItemDropAsync(sender, e);
 
         private async Task ServiceItemDropAsync(object sender, System.Windows.DragEventArgs e)
         {

--- a/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml
@@ -1,0 +1,58 @@
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ListServiceBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Focusable="False"
+             Background="Transparent">
+    <Border CornerRadius="8"
+            BorderBrush="{Binding BorderColor}"
+            Background="{Binding BackgroundColor}"
+            BorderThickness="2"
+            Padding="5"
+            Margin="2"
+            PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown"
+            PreviewMouseMove="ServiceItem_PreviewMouseMove"
+            AllowDrop="True"
+            Drop="ServiceItem_Drop">
+        <Border CornerRadius="8"
+                BorderBrush="Gray"
+                BorderThickness="1"
+                Padding="5"
+                Margin="2"
+                Tag="{Binding DataContext.EditServiceCommand, RelativeSource={RelativeSource AncestorType=ListBox}}">
+            <Border.ContextMenu>
+                <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}">
+                    <MenuItem Header="Edit Service"
+                              Command="{Binding PlacementTarget.Tag, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                              CommandParameter="{Binding}" />
+                    <MenuItem Header="Rename Service" Click="RenameServiceMenu_Click" />
+                    <MenuItem Header="Delete Service" Click="DeleteServiceMenu_Click" />
+                    <MenuItem Header="Change Color" Click="ChangeColorMenu_Click" />
+                </ContextMenu>
+            </Border.ContextMenu>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Ellipse Grid.Column="0"
+                         Style="{StaticResource ServiceStatusIndicatorStyle}"
+                         ToolTip="{Binding RuntimeState}" />
+                <StackPanel Grid.Column="1">
+                    <TextBlock FontWeight="Bold" Text="{Binding DisplayName}" />
+                    <TextBlock Text="{Binding ExecutionTimeText}" />
+                    <TextBlock Text="{Binding InputMessage}"
+                               TextTrimming="CharacterEllipsis"
+                               Foreground="{Binding LastInputBrush}" />
+                    <TextBlock>
+                        <Run Text="{Binding IncomingMessageCount, Mode=OneWay}" />
+                        <Run Text=" - incoming" />
+                    </TextBlock>
+                    <TextBlock>
+                        <Run Text="{Binding OutgoingMessageCount, Mode=OneWay}" />
+                        <Run Text=" - outgoing" />
+                    </TextBlock>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Border>
+</UserControl>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml
@@ -1,8 +1,60 @@
 <UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ListServiceBox"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
              Focusable="False"
              Background="Transparent">
+    <UserControl.Resources>
+        <Style x:Key="ServiceStatusIndicatorStyle" TargetType="Ellipse">
+            <Setter Property="Width" Value="12" />
+            <Setter Property="Height" Value="12" />
+            <Setter Property="Margin" Value="0,0,8,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Stroke" Value="#FF4A4A4A" />
+            <Setter Property="StrokeThickness" Value="1" />
+            <Setter Property="Fill">
+                <Setter.Value>
+                    <SolidColorBrush Color="#FFD32F2F" />
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Active}">
+                    <Setter Property="Fill">
+                        <Setter.Value>
+                            <SolidColorBrush Color="#FF2E7D32" />
+                        </Setter.Value>
+                    </Setter>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Activating}">
+                    <Setter Property="Fill">
+                        <Setter.Value>
+                            <SolidColorBrush Color="#FFF9A825" />
+                        </Setter.Value>
+                    </Setter>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding RuntimeState}" Value="{x:Static viewModels:ServiceRuntimeState.Error}">
+                    <Setter Property="Fill">
+                        <Setter.Value>
+                            <SolidColorBrush Color="#FFD32F2F" />
+                        </Setter.Value>
+                    </Setter>
+                    <DataTrigger.EnterActions>
+                        <BeginStoryboard x:Name="ErrorFlashStoryboard">
+                            <Storyboard RepeatBehavior="Forever" FillBehavior="Stop">
+                                <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)" Duration="0:0:0.8">
+                                    <DiscreteColorKeyFrame KeyTime="0:0:0" Value="#FFD32F2F" />
+                                    <DiscreteColorKeyFrame KeyTime="0:0:0.4" Value="#FF808080" />
+                                </ColorAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <StopStoryboard BeginStoryboardName="ErrorFlashStoryboard" />
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
     <Border CornerRadius="8"
             BorderBrush="{Binding BorderColor}"
             Background="{Binding BackgroundColor}"

--- a/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml.cs
@@ -1,0 +1,62 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using DesktopApplicationTemplate.UI.Views;
+
+namespace DesktopApplicationTemplate.UI.Views.Shared;
+
+public partial class ListServiceBox : UserControl
+{
+    public ListServiceBox()
+    {
+        InitializeComponent();
+    }
+
+    private void ServiceItem_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.ServiceItem_PreviewMouseLeftButtonDown(sender, e);
+        }
+    }
+
+    private void ServiceItem_PreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.ServiceItem_PreviewMouseMove(sender, e);
+        }
+    }
+
+    private void ServiceItem_Drop(object sender, DragEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.ServiceItem_Drop(sender, e);
+        }
+    }
+
+    private void RenameServiceMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.RenameServiceMenu_Click(sender, e);
+        }
+    }
+
+    private void DeleteServiceMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.DeleteServiceMenu_Click(sender, e);
+        }
+    }
+
+    private void ChangeColorMenu_Click(object sender, RoutedEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.ChangeColorMenu_Click(sender, e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable ListServiceBox user control that mirrors the existing service ListBox item layout and context actions
- update MainView to use the shared control for each service entry and expose existing handlers so the control can forward interactions

## Testing
- not run (dotnet tooling is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68e65d9fa33083269ab56cd74d9adda4