### PR TITLE
Persist service message counters and surface execution timing metrics

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -165,6 +165,8 @@ namespace DesktopApplicationTemplate.Persistence
                     ScpOptions = scp,
                     TotalExecutionTimeMs = s.TotalExecutionTimeMs,
                     ExecutionCount = s.ExecutionCount,
+                    IncomingMessageCount = s.IncomingMessageCount,
+                    OutgoingMessageCount = s.OutgoingMessageCount,
                     Logs = s.Logs
                         .Take(ServiceListModel.MaxLogEntries)
                         .Select(l => new LogEntry
@@ -270,6 +272,8 @@ namespace DesktopApplicationTemplate.Persistence
                             ScpOptions = info.ScpOptions,
                             TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                             ExecutionCount = info.ExecutionCount,
+                            IncomingMessageCount = info.IncomingMessageCount,
+                            OutgoingMessageCount = info.OutgoingMessageCount,
                             Logs = info.Logs ?? new List<LogEntry>()
                         });
                     }
@@ -414,6 +418,8 @@ namespace DesktopApplicationTemplate.Persistence
         public ScpServiceOptions? ScpOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
+        public int IncomingMessageCount { get; set; }
+        public int OutgoingMessageCount { get; set; }
         public List<LogEntry> Logs { get; set; } = new();
         public List<ServiceMessageHistoryEntry> MessageHistory { get; set; } = new();
     }
@@ -436,6 +442,8 @@ namespace DesktopApplicationTemplate.Persistence
         public ScpServiceOptions? ScpOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
+        public int IncomingMessageCount { get; set; }
+        public int OutgoingMessageCount { get; set; }
         public List<LogEntry> Logs { get; set; } = new();
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -26,6 +26,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public FilterViewModel Filters { get; } = new();
         public ObservableCollection<LogEntry> AllLogs { get; } = new();
         private ServiceListModel? _selectedService;
+        private ServiceListModel? _activeService;
+        private bool _suppressActiveServiceReset;
         public ServiceListModel? SelectedService
         {
             get => _selectedService;
@@ -33,7 +35,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 _selectedService = value;
                 OnPropertyChanged();
-                LogViewModel.SetLogs(_selectedService?.Logs ?? AllLogs);
+                if (!_suppressActiveServiceReset || value != null)
+                {
+                    ActiveService = value;
+                }
+            }
+        }
+        public ServiceListModel? ActiveService
+        {
+            get => _activeService;
+            private set
+            {
+                if (_activeService == value)
+                {
+                    return;
+                }
+
+                _activeService = value;
+                OnPropertyChanged();
+                LogViewModel.SetLogs(_activeService?.Logs ?? AllLogs);
                 (RemoveServiceCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
                 (EditServiceCommand as RelayCommand<ServiceListModel?>)?.RaiseCanExecuteChanged();
             }
@@ -43,6 +63,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public ICommand EditServiceCommand { get; }
         public ICommand ToggleServiceProcessCommand { get; }
         public ICommand ExportPluginsCommand { get; }
+        public ICommand ResetMessageCountsCommand { get; }
         public int ServicesCreated => Services.Count;
         public int CurrentActiveServices => Services.Count(s => s.IsActive);
 
@@ -127,16 +148,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 ServicePersistence.FilePath = servicesFilePath!;
                 _logger?.Log($"Using service persistence path {ServicePersistence.FilePath}", LogLevel.Debug);
             }
-            AddServiceCommand = new RelayCommand(AddService);
-            RemoveServiceCommand = new AsyncRelayCommand(RemoveSelectedServiceAsync, () => SelectedService != null);
-            EditServiceCommand = new RelayCommand<ServiceListModel?>(EditService, svc => svc != null);
-            ToggleServiceProcessCommand = new AsyncRelayCommand(ToggleServiceProcessAsync, () => !IsServiceProcessBusy);
-            ExportPluginsCommand = new RelayCommand(OnExportPlugins);
-            FilteredServices = CollectionViewSource.GetDefaultView(Services);
-            Filters.PropertyChanged += (_, __) => ApplyFilters();
-            LoadServices();
-            ServicesRunning = Services.Any(svc => svc.IsActive);
-            ApplyFilters();
+
             LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs);
             LogViewModel.PropertyChanged += (s, e) =>
             {
@@ -145,6 +157,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 if (e.PropertyName == nameof(ServiceLogViewModel.LogLevelFilter))
                     OnPropertyChanged(nameof(LogLevelFilter));
             };
+
+            AddServiceCommand = new RelayCommand(AddService);
+            RemoveServiceCommand = new AsyncRelayCommand(RemoveSelectedServiceAsync, () => ActiveService != null);
+            EditServiceCommand = new RelayCommand<ServiceListModel?>(EditService, svc => svc != null || ActiveService != null);
+            ToggleServiceProcessCommand = new AsyncRelayCommand(ToggleServiceProcessAsync, () => !IsServiceProcessBusy);
+            ExportPluginsCommand = new RelayCommand(OnExportPlugins);
+            ResetMessageCountsCommand = new AsyncRelayCommand(ResetMessageCountsAsync);
+            FilteredServices = CollectionViewSource.GetDefaultView(Services);
+            Filters.PropertyChanged += (_, __) => ApplyFilters();
+            LoadServices();
+            ServicesRunning = Services.Any(svc => svc.IsActive);
+            ApplyFilters();
             if (_logger is LoggingService concreteLogger)
             {
                 concreteLogger.Reload();
@@ -170,6 +194,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public event Action? AddServiceRequested;
         public event Action? ConfigurationChangeBlocked;
         public event EventHandler? ExportPluginsRequested;
+        public event EventHandler<string>? HomeRequested;
 
         public bool RequestConfigurationChange()
         {
@@ -184,7 +209,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void EditService(ServiceListModel? service)
         {
-            var target = service ?? SelectedService;
+            var target = service ?? ActiveService;
             if (target == null)
                 return;
 
@@ -215,6 +240,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _logger?.Log("AddService completed", LogLevel.Debug);
         }
 
+        private async Task ResetMessageCountsAsync()
+        {
+            foreach (var service in Services)
+            {
+                service.ResetMessageCounts();
+            }
+
+            await SaveServicesAsync().ConfigureAwait(false);
+            _logger?.Log("Message counters reset", LogLevel.Information);
+        }
+
         internal string GenerateServiceName(ServiceType serviceType)
         {
             var typeName = serviceType.ToBaseName();
@@ -233,7 +269,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task RemoveSelectedServiceAsync()
         {
-            if (SelectedService == null)
+            if (ActiveService == null)
             {
                 return;
             }
@@ -243,15 +279,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return;
             }
 
-            _logger?.Log($"Removing service {SelectedService.DisplayName}", LogLevel.Debug);
-            var index = Services.IndexOf(SelectedService);
-            SelectedService.AddLog("Service removed", WpfBrushes.Red);
-            if (SelectedService.Type != ServiceType.Csv)
-                _csvService.RemoveColumnsForService(SelectedService.DisplayName);
-            _activatingServices.Remove(SelectedService);
-            SelectedService.LogAdded -= OnServiceLogAdded;
-            SelectedService.ActiveChanged -= OnServiceActiveChanged;
-            Services.Remove(SelectedService);
+            _logger?.Log($"Removing service {ActiveService.DisplayName}", LogLevel.Debug);
+            var index = Services.IndexOf(ActiveService);
+            ActiveService.AddLog("Service removed", WpfBrushes.Red);
+            if (ActiveService.Type != ServiceType.Csv)
+                _csvService.RemoveColumnsForService(ActiveService.DisplayName);
+            _activatingServices.Remove(ActiveService);
+            ActiveService.LogAdded -= OnServiceLogAdded;
+            ActiveService.ActiveChanged -= OnServiceActiveChanged;
+            Services.Remove(ActiveService);
             if (Services.Count > 0)
             {
                 if (index >= Services.Count) index = Services.Count - 1;
@@ -307,6 +343,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                     ExecutionCount = info.ExecutionCount
                 };
+                svc.InitializeMessageCounts(info.IncomingMessageCount, info.OutgoingMessageCount);
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);
                 svc.LoadPersistedLogs(info.Logs ?? new List<LogEntry>());
@@ -452,6 +489,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
                     ServicesRunning = true;
                     _logger?.Log("Starting services", LogLevel.Information);
+                    HomeRequested?.Invoke(this, "Start Services");
                     await StartServicesAsync();
                 }
             }
@@ -597,6 +635,34 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         // OnPropertyChanged inherited from ViewModelBase
+
+        internal IDisposable PreserveActiveServiceSelection()
+        {
+            return new ActiveServiceSelectionScope(this);
+        }
+
+        private sealed class ActiveServiceSelectionScope : IDisposable
+        {
+            private readonly MainViewModel _owner;
+            private bool _disposed;
+
+            public ActiveServiceSelectionScope(MainViewModel owner)
+            {
+                _owner = owner;
+                _owner._suppressActiveServiceReset = true;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _owner._suppressActiveServiceReset = false;
+                _disposed = true;
+            }
+        }
     }
 
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -144,6 +144,26 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         /// <summary>
+        /// Applies persisted message counters to the current instance.
+        /// </summary>
+        /// <param name="incoming">The number of incoming messages previously recorded.</param>
+        /// <param name="outgoing">The number of outgoing messages previously recorded.</param>
+        public void InitializeMessageCounts(int incoming, int outgoing)
+        {
+            IncomingMessageCount = Math.Max(0, incoming);
+            OutgoingMessageCount = Math.Max(0, outgoing);
+        }
+
+        /// <summary>
+        /// Resets the incoming and outgoing message counters.
+        /// </summary>
+        public void ResetMessageCounts()
+        {
+            IncomingMessageCount = 0;
+            OutgoingMessageCount = 0;
+        }
+
+        /// <summary>
         /// Gets the most recent input message received by this service.
         /// </summary>
         public string InputMessage

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -704,8 +705,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                     using var stream = client.GetStream();
                     var message = _options.OutputMessage ?? string.Empty;
                     var shouldSendMessage = operation == TcpClientOperation.Send && !string.IsNullOrWhiteSpace(message);
+                    Stopwatch? sendStopwatch = null;
                     if (shouldSendMessage)
                     {
+                        sendStopwatch = Stopwatch.StartNew();
                         var payload = Encoding.UTF8.GetBytes(message);
                         await stream.WriteAsync(payload.AsMemory(0, payload.Length), cancellationToken).ConfigureAwait(false);
                         Logger?.Log($"Sent message to {operationLabel} {endpointDisplay}: {message}", LogLevel.Information);
@@ -735,6 +738,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                         var response = Encoding.UTF8.GetString(buffer, 0, bytesRead);
                         receivedAny = true;
 
+                        if (sendStopwatch is not null)
+                        {
+                            sendStopwatch.Stop();
+                            sendStopwatch = null;
+                        }
+
                         if (operation == TcpClientOperation.Receive)
                         {
                             Logger?.Log($"Received message from {endpointDisplay}: {response}", LogLevel.Information);
@@ -744,13 +753,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                             Logger?.Log($"Received response from {endpointDisplay}: {response}", LogLevel.Information);
                         }
 
+                        var responseStopwatch = Stopwatch.StartNew();
                         var processedOutput = await ExecuteIncomingMessageAsync(response, cancellationToken).ConfigureAwait(false);
                         await AppendMessageAsync(response, processedOutput, endpointDisplay, sentToEndpoint: false).ConfigureAwait(false);
+                        responseStopwatch.Stop();
+                        _service?.RecordExecutionTime(responseStopwatch.Elapsed);
                     }
 
                     if (!receivedAny && shouldSendMessage)
                     {
+                        sendStopwatch?.Stop();
                         await AppendMessageAsync(message, string.Empty, endpointDisplay, sentToEndpoint: true).ConfigureAwait(false);
+                        if (sendStopwatch is not null)
+                        {
+                            _service?.RecordExecutionTime(sendStopwatch.Elapsed);
+                        }
                         Logger?.Log($"No response received from {endpointDisplay}", LogLevel.Warning);
                     }
                 }
@@ -827,9 +844,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                         var formattedIncoming = MessageDisplayFormatter.FormatControlCharacters(incoming);
                         Logger?.Log($"Incoming message from {endpoint}: {formattedIncoming}", LogLevel.Information);
 
+                        var cycleStopwatch = Stopwatch.StartNew();
                         var outgoing = await ExecuteIncomingMessageAsync(incoming, cancellationToken).ConfigureAwait(false);
                         var hasResponse = !string.IsNullOrWhiteSpace(outgoing);
                         await AppendMessageAsync(incoming, outgoing, endpoint, hasResponse).ConfigureAwait(false);
+                        cycleStopwatch.Stop();
+                        _service?.RecordExecutionTime(cycleStopwatch.Elapsed);
 
                         if (hasResponse)
                         {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -102,6 +102,10 @@
                             Padding="12,6"
                             Click="HomeButton_Click"/>
                     <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Content="Reset Counts"
+                                Command="{Binding ResetMessageCountsCommand}"
+                                Margin="0,0,10,0"
+                                Padding="12,6"/>
                         <TextBlock VerticalAlignment="Center" Margin="0,0,5,0">
                             Active Services: <Run Text="{Binding CurrentActiveServices, Mode=OneWay}"/>/<Run Text="{Binding ServicesCreated, Mode=OneWay}"/>
                         </TextBlock>

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using System.Windows.Controls.Primitives;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using System.Windows.Threading;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.Views
 {
@@ -37,6 +38,8 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly Dictionary<ServiceListModel, Action<LogEntry>> _serviceLogHandlers = new();
         private readonly Dictionary<ServiceListModel, EventHandler> _tcpAdvancedHandlers = new();
         private readonly BrushConverter _brushConverter = new();
+        private JoinableTask? _shutdownTask;
+        private bool _shutdownCompleted;
 
         public MainView(
             MainViewModel viewModel,
@@ -68,10 +71,28 @@ namespace DesktopApplicationTemplate.UI.Views
             PreloadServicePages();
         }
 
-        private async void MainView_Closing(object? sender, CancelEventArgs e)
+        private void MainView_Closing(object? sender, CancelEventArgs e)
         {
             _logger?.LogInformation("MainView closing");
 
+            if (_shutdownCompleted)
+            {
+                return;
+            }
+
+            if (_shutdownTask is { IsCompleted: false })
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            e.Cancel = true;
+            _shutdownTask = App.UiThreadTaskFactory.RunAsync(PerformShutdownAsync);
+            ObserveAndLog(_shutdownTask);
+        }
+
+        private async Task PerformShutdownAsync()
+        {
             try
             {
                 await _viewModel.ShutdownServicesAsync().ConfigureAwait(true);
@@ -79,6 +100,13 @@ namespace DesktopApplicationTemplate.UI.Views
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Failed to stop services during shutdown");
+            }
+            finally
+            {
+                await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
+                _shutdownCompleted = true;
+                _shutdownTask = null;
+                Close();
             }
         }
 
@@ -152,10 +180,21 @@ namespace DesktopApplicationTemplate.UI.Views
             ShowHome();
         }
 
-        private async void OnHomeRequested(object? sender, string reason)
+        private void OnHomeRequested(object? sender, string reason)
         {
-            await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
-            NavigateHome(reason);
+            if (Dispatcher.CheckAccess())
+            {
+                NavigateHome(reason);
+                return;
+            }
+
+            var joinableTask = App.UiThreadTaskFactory.RunAsync(async () =>
+            {
+                await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
+                NavigateHome(reason);
+            });
+
+            ObserveAndLog(joinableTask);
         }
 
 
@@ -478,7 +517,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 _logger?.LogDebug("RemoveService command executed");
             }
         }
-        private async void ServiceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private void ServiceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _logger?.LogDebug("Service selection changed");
             if (_viewModel.SelectedService is ServiceListModel selected)
@@ -487,7 +526,6 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (page != null)
                 {
                     ShowPage(page);
-                    await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
                     using (_viewModel.PreserveActiveServiceSelection())
                     {
                         ServiceList.SelectedItem = null;
@@ -802,6 +840,13 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             _logger?.LogDebug("Refresh log button clicked");
             _viewModel.RefreshLogs();
+        }
+
+        private void ObserveAndLog(JoinableTask joinableTask)
+        {
+            joinableTask.Task.ContinueWith(
+                t => _logger?.LogError(t.Exception, "Unhandled exception in background operation"),
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
     }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -152,9 +152,10 @@ namespace DesktopApplicationTemplate.UI.Views
             ShowHome();
         }
 
-        private void OnHomeRequested(object? sender, string reason)
+        private async void OnHomeRequested(object? sender, string reason)
         {
-            Dispatcher.Invoke(() => NavigateHome(reason));
+            await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
+            NavigateHome(reason);
         }
 
 
@@ -477,7 +478,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 _logger?.LogDebug("RemoveService command executed");
             }
         }
-        private void ServiceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        private async void ServiceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _logger?.LogDebug("Service selection changed");
             if (_viewModel.SelectedService is ServiceListModel selected)
@@ -486,14 +487,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (page != null)
                 {
                     ShowPage(page);
-                    _ = App.UiThreadTaskFactory.RunAsync(async () =>
+                    await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
+                    using (_viewModel.PreserveActiveServiceSelection())
                     {
-                        await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
-                        using (_viewModel.PreserveActiveServiceSelection())
-                        {
-                            ServiceList.SelectedItem = null;
-                        }
-                    });
+                        ServiceList.SelectedItem = null;
+                    }
                 }
 
                 return;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -853,7 +853,7 @@ namespace DesktopApplicationTemplate.UI.Views
             {
                 try
                 {
-                    await joinableTask.Task.ConfigureAwait(false);
+                    await joinableTask.JoinAsync();
                 }
                 catch (Exception ex)
                 {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -57,6 +57,7 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.ConfigurationChangeBlocked += OnConfigurationChangeBlocked;
             _viewModel.AddServiceRequested += OnAddServiceRequested;
             _viewModel.ExportPluginsRequested += OnExportPluginsRequested;
+            _viewModel.HomeRequested += OnHomeRequested;
             _viewModel.Services.CollectionChanged += Services_CollectionChanged;
             MouseDown += MainView_MouseDown;
             CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, CloseCommand_Executed));
@@ -88,6 +89,7 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             _viewModel.ConfigurationChangeBlocked -= OnConfigurationChangeBlocked;
             _viewModel.ExportPluginsRequested -= OnExportPluginsRequested;
+            _viewModel.HomeRequested -= OnHomeRequested;
         }
 
         public void ShowHome()
@@ -149,7 +151,13 @@ namespace DesktopApplicationTemplate.UI.Views
         {
             _logger?.LogInformation("{Source} clicked", source);
             _viewModel.SelectedService = null;
+            ServiceList.SelectedItem = null;
             ShowHome();
+        }
+
+        private void OnHomeRequested(object? sender, string reason)
+        {
+            Dispatcher.Invoke(() => NavigateHome(reason));
         }
 
 
@@ -475,15 +483,25 @@ namespace DesktopApplicationTemplate.UI.Views
         private void ServiceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             _logger?.LogDebug("Service selection changed");
-            if (_viewModel.SelectedService != null)
+            if (_viewModel.SelectedService is ServiceListModel selected)
             {
-                var page = GetOrCreateServicePage(_viewModel.SelectedService);
+                var page = GetOrCreateServicePage(selected);
                 if (page != null)
                 {
                     ShowPage(page);
+                    Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        using (_viewModel.PreserveActiveServiceSelection())
+                        {
+                            ServiceList.SelectedItem = null;
+                        }
+                    }), DispatcherPriority.Background);
                 }
+
+                return;
             }
-            else
+
+            if (_viewModel.ActiveService is null)
             {
                 ShowHome();
             }
@@ -507,7 +525,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            if (!ReferenceEquals(svc, _viewModel.SelectedService))
+            if (!ReferenceEquals(svc, _viewModel.SelectedService) && !ReferenceEquals(svc, _viewModel.ActiveService))
             {
                 return;
             }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -842,11 +842,26 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.RefreshLogs();
         }
 
-        private void ObserveAndLog(JoinableTask joinableTask)
+        private void ObserveAndLog(JoinableTask? joinableTask)
         {
-            joinableTask.Task.ContinueWith(
-                t => _logger?.LogError(t.Exception, "Unhandled exception in background operation"),
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            if (joinableTask is null)
+            {
+                return;
+            }
+
+            async Task ObserveBackgroundTaskAsync()
+            {
+                try
+                {
+                    await joinableTask.Task.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "Unhandled exception in background operation");
+                }
+            }
+
+            _ = ObserveBackgroundTaskAsync();
         }
 
     }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -68,16 +68,13 @@ namespace DesktopApplicationTemplate.UI.Views
             PreloadServicePages();
         }
 
-        private void MainView_Closing(object? sender, CancelEventArgs e)
+        private async void MainView_Closing(object? sender, CancelEventArgs e)
         {
             _logger?.LogInformation("MainView closing");
 
             try
             {
-                App.UiThreadTaskFactory.Run(async () =>
-                {
-                    await _viewModel.ShutdownServicesAsync().ConfigureAwait(true);
-                });
+                await _viewModel.ShutdownServicesAsync().ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -489,13 +486,14 @@ namespace DesktopApplicationTemplate.UI.Views
                 if (page != null)
                 {
                     ShowPage(page);
-                    Dispatcher.BeginInvoke(new Action(() =>
+                    _ = App.UiThreadTaskFactory.RunAsync(async () =>
                     {
+                        await App.UiThreadTaskFactory.SwitchToMainThreadAsync();
                         using (_viewModel.PreserveActiveServiceSelection())
                         {
                             ServiceList.SelectedItem = null;
                         }
-                    }), DispatcherPriority.Background);
+                    });
                 }
 
                 return;

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -14,9 +14,10 @@
               IsReadOnly="True"
               HeadersVisibility="Column"
               RowHeaderWidth="0"
-              MaxHeight="250"
               ColumnWidth="*"
               MinColumnWidth="100"
+              VerticalAlignment="Stretch"
+              HorizontalAlignment="Stretch"
               ScrollViewer.HorizontalScrollBarVisibility="Auto"
               ScrollViewer.VerticalScrollBarVisibility="Auto"
               ScrollViewer.CanContentScroll="True">

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -5,8 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
       mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-        <Grid Margin="10">
+    <Grid Margin="10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
@@ -47,7 +46,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
@@ -59,8 +58,7 @@
                 </StackPanel>
                 <Button Grid.Row="1" Content="Advanced Settings" Command="{Binding OpenAdvancedSettingsCommand}" Width="150" HorizontalAlignment="Right" Margin="0,0,0,5"/>
                 <shared:ServiceMessageTableView Grid.Row="2" DataContext="{Binding MessageTable}" Margin="0,0,0,10" />
-                <shared:ServiceLogView Grid.Row="3" x:Name="LogView" Height="250" />
+                <shared:ServiceLogView Grid.Row="3" x:Name="LogView" />
             </Grid>
-        </Grid>
-    </ScrollViewer>
+    </Grid>
 </Page>


### PR DESCRIPTION
## Summary
- persist incoming/outgoing message counters through ServicePersistence and expose a Reset Counts command in the main window
- adjust main window navigation to clear the service list selection, return home when services start, and keep service logs focused on the active service
- capture and display execution timing data for TCP service cycles while resizing the service page layout so the message table and logs remain simultaneously visible

## Testing
- Not run (environment does not support Windows/WPF builds)

------
https://chatgpt.com/codex/tasks/task_e_68e6657763708326982b7a85f1ad7798