### PR TITLE
Add save dialog workflow for service log exports

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -113,6 +113,7 @@ namespace DesktopApplicationTemplate.UI
         public static IHost AppHost { get; private set; } = null!;
         private static JoinableTaskContext UiThreadTaskContext { get; set; } = null!;
         public static JoinableTaskFactory UiThreadTaskFactory { get; private set; } = null!;
+        public static IFileDialogService FileDialogService => AppHost.Services.GetRequiredService<IFileDialogService>();
 
         public App()
         {

--- a/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/FileDialogService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Win32;
+using System;
 using System.IO;
 
 namespace DesktopApplicationTemplate.UI.Services
@@ -21,6 +22,22 @@ namespace DesktopApplicationTemplate.UI.Services
                 FileName = "Select Folder"
             };
             return dialog.ShowDialog() == true ? Path.GetDirectoryName(dialog.FileName) : null;
+        }
+
+        public string? SaveFile(string suggestedName, string filter)
+        {
+            ArgumentNullException.ThrowIfNull(suggestedName);
+            ArgumentNullException.ThrowIfNull(filter);
+
+            var dialog = new SaveFileDialog
+            {
+                FileName = suggestedName,
+                Filter = filter,
+                AddExtension = true,
+                OverwritePrompt = true
+            };
+
+            return dialog.ShowDialog() == true ? dialog.FileName : null;
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IFileDialogService.cs
@@ -11,5 +11,12 @@ namespace DesktopApplicationTemplate.UI.Services
         /// Opens a folder selection dialog and returns the chosen directory path or null if cancelled.
         /// </summary>
         string? SelectFolder();
+
+        /// <summary>
+        /// Opens a save file dialog with a suggested file name and filter, returning the chosen file path or null if cancelled.
+        /// </summary>
+        /// <param name="suggestedName">The default file name presented to the user.</param>
+        /// <param name="filter">The file filter string, e.g. "Text files (*.txt)|*.txt".</param>
+        string? SaveFile(string suggestedName, string filter);
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,9 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Windows;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -14,6 +18,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     /// </summary>
     public class ServiceLogViewModel : ViewModelBase
     {
+        private readonly ILogger<ServiceLogViewModel> _logger;
         private ObservableCollection<LogEntry> _logs;
         private NotifyCollectionChangedEventHandler? _logsChangedHandler;
 
@@ -22,7 +27,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// with default values.
         /// </summary>
         public ServiceLogViewModel()
-            : this(ServiceType.Mqtt, new ObservableCollection<LogEntry>())
+            : this(ServiceType.Mqtt, new ObservableCollection<LogEntry>(), null)
         {
         }
 
@@ -31,10 +36,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         /// <param name="type">The category of service associated with these logs.</param>
         /// <param name="logs">The collection of log entries to display.</param>
-        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs)
+        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs, ILogger<ServiceLogViewModel>? logger = null)
         {
             Type = type;
             _logs = logs;
+            _logger = logger ?? NullLogger<ServiceLogViewModel>.Instance;
             AttachLogCollection(_logs);
             RefreshLogCommand = new RelayCommand(RefreshLogs);
             ExportLogCommand = new RelayCommand(() => ExportLogs(Path.Combine(Path.GetTempPath(), "exported_logs.txt")));
@@ -109,8 +115,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <param name="filePath">The destination file path.</param>
         public void ExportLogs(string filePath)
         {
-            var lines = DisplayLogs.Select(l => l.Message).ToList();
-            File.WriteAllLines(filePath, lines);
+            try
+            {
+                var lines = DisplayLogs.Select(l => l.Message).ToList();
+                File.WriteAllLines(filePath, lines);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                _logger.LogError(ex, "Failed to export logs to {FilePath}.", filePath);
+                MessageBox.Show(
+                    $"Failed to export logs to '{filePath}': {ex.Message}",
+                    "Export Failed",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
         }
 
         /// <summary>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -29,7 +29,7 @@
                     <ComboBoxItem Content="Error" Tag="{x:Static services:LogLevel.Error}" />
                 </ComboBox>
                 <Button Content="Update Log" Width="100" Margin="10,0,0,0" Command="{Binding RefreshLogCommand}" Background="#FFFFCC"/>
-                <Button Content="Export Log" Width="100" Margin="10,0,0,0" Command="{Binding ExportLogCommand}" Background="#CCCCFF"/>
+                <Button Content="Export Log" Width="100" Margin="10,0,0,0" Background="#CCCCFF" Click="ExportLog_Click"/>
                 <Button Content="Clear Log" Width="100" Margin="10,0,0,0" Command="{Binding ClearLogCommand}" Background="#FFCCCC"/>
             </StackPanel>
             <ListBox x:Name="LogListBox"

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
@@ -1,9 +1,11 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.ViewModels;
 
 namespace DesktopApplicationTemplate.UI.Views.Shared
 {
@@ -12,6 +14,9 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
     /// </summary>
     public partial class ServiceLogView : UserControl
     {
+        private const string ExportDialogFilter = "Log files (*.log)|*.log|Text files (*.txt)|*.txt|All files (*.*)|*.*";
+        private const string ExportTimestampFormat = "yyyyMMdd_HHmmss";
+
         public ServiceLogView()
         {
             InitializeComponent();
@@ -48,6 +53,33 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
             {
                 // Clipboard.SetText can throw if the clipboard is unavailable; ignore and leave command silent.
             }
+        }
+
+        private void ExportLog_Click(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not ServiceLogViewModel viewModel)
+            {
+                return;
+            }
+
+            var timestamp = DateTime.Now.ToString(ExportTimestampFormat);
+            var sanitizedServiceName = SanitizeFileName(viewModel.Type.ToString());
+            var suggestedFileName = $"{sanitizedServiceName}_{timestamp}.log";
+
+            var selectedPath = App.FileDialogService.SaveFile(suggestedFileName, ExportDialogFilter);
+            if (string.IsNullOrWhiteSpace(selectedPath))
+            {
+                return;
+            }
+
+            viewModel.ExportLogs(selectedPath);
+        }
+
+        private static string SanitizeFileName(string name)
+        {
+            var invalidCharacters = Path.GetInvalidFileNameChars();
+            var sanitized = new string(name.Select(ch => invalidCharacters.Contains(ch) ? '_' : ch).ToArray());
+            return string.IsNullOrWhiteSpace(sanitized) ? "ServiceLog" : sanitized;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a save-file option to the file dialog service and expose it through the app host
- hook the service log export button to the save dialog with timestamped default filenames
- harden log export to handle and report IO failures with logging and message boxes

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e67365bbdc832690b597dcc122ab08