### PR TITLE
Use save dialog for exporting home logs

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -628,6 +628,37 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _logger?.Log($"Exported {LogViewModel.DisplayLogs.Count()} logs to {filePath}", LogLevel.Debug);
         }
 
+        public bool TryExportAllLogs(string filePath, out string? errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                errorMessage = "A valid file path was not provided.";
+                _logger?.Log("Export aborted because the destination file path was empty.", LogLevel.Warning);
+                return false;
+            }
+
+            try
+            {
+                var lines = AllLogs.Select(entry => entry.Message).ToList();
+                File.WriteAllLines(filePath, lines);
+                _logger?.Log($"Exported {lines.Count} total logs to {filePath}", LogLevel.Information);
+                errorMessage = null;
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                errorMessage = ex.Message;
+                _logger?.Log($"Failed to export logs to {filePath}: {ex.Message}", LogLevel.Error);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                errorMessage = ex.Message;
+                _logger?.Log($"Failed to export logs to {filePath}: {ex.Message}", LogLevel.Error);
+                return false;
+            }
+        }
+
         public void RefreshLogs()
         {
             LogViewModel.RefreshLogs();

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -30,6 +30,10 @@ namespace DesktopApplicationTemplate.UI.Views
     [SupportedOSPlatform("windows")]
     public partial class MainView : Window
     {
+        private const string LogExportDialogFilter = "Log files (*.log)|*.log|Text files (*.txt)|*.txt|All files (*.*)|*.*";
+        private const string LogExportTimestampFormat = "yyyyMMdd_HHmmss";
+        private const string LogExportDefaultPrefix = "AllServices";
+
         private readonly MainViewModel _viewModel;
         private readonly ILogger<MainView>? _logger;
         private readonly IServiceUiRegistry<ServiceListModel, Page> _serviceRegistry;
@@ -830,10 +834,41 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void ExportLog_Click(object sender, RoutedEventArgs e)
         {
-            _logger?.LogInformation("Export log button clicked");
-            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "exported_logs.txt");
-            _viewModel.ExportDisplayedLogs(path);
-            _logger?.LogInformation("Logs exported to {Path}", path);
+            _logger?.LogInformation("Home view export logs button clicked");
+
+            var timestamp = DateTime.Now.ToString(LogExportTimestampFormat);
+            var suggestedName = $"{LogExportDefaultPrefix}_{timestamp}.log";
+            var selectedPath = App.FileDialogService.SaveFile(suggestedName, LogExportDialogFilter);
+
+            if (string.IsNullOrWhiteSpace(selectedPath))
+            {
+                _logger?.LogInformation("Log export canceled by the user.");
+                return;
+            }
+
+            if (_viewModel.TryExportAllLogs(selectedPath, out var errorMessage))
+            {
+                _logger?.LogInformation("All logs exported to {FilePath}", selectedPath);
+                MessageBox.Show(
+                    this,
+                    $"Logs exported to:\n{selectedPath}",
+                    "Export Complete",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            else
+            {
+                var failureMessage = string.IsNullOrWhiteSpace(errorMessage)
+                    ? "An unknown error occurred."
+                    : errorMessage;
+                _logger?.LogError("Failed to export logs to {FilePath}: {ErrorMessage}", selectedPath, failureMessage);
+                MessageBox.Show(
+                    this,
+                    $"Failed to export logs to '{selectedPath}': {failureMessage}",
+                    "Export Failed",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
         }
 
         private void RefreshLog_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- update MainView export handler to prompt for a destination file and show success or failure feedback
- add a MainViewModel helper to export the full log collection and log the outcome

## Testing
- not run (Windows-only build/test tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6750c5f248326bf8a1caf9b6e2447