### PR TITLE
Add service metadata to logs and introduce aggregated filtering

### DIFF
--- a/DesktopApplicationTemplate.Core/Models/LogEntry.cs
+++ b/DesktopApplicationTemplate.Core/Models/LogEntry.cs
@@ -23,5 +23,15 @@ namespace DesktopApplicationTemplate.Models
         /// Display color for the entry in a cross-platform format (e.g., "#FF0000").
         /// </summary>
         public string Color { get; set; } = "#000000";
+
+        /// <summary>
+        /// Identifies the originating service type when applicable.
+        /// </summary>
+        public ServiceType? ServiceType { get; set; }
+
+        /// <summary>
+        /// Friendly name of the originating service when available.
+        /// </summary>
+        public string ServiceName { get; set; } = string.Empty;
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -173,7 +173,9 @@ namespace DesktopApplicationTemplate.Persistence
                         {
                             Level = l.Level,
                             Message = l.Message,
-                            Color = l.Color
+                            Color = l.Color,
+                            ServiceType = l.ServiceType ?? s.Type,
+                            ServiceName = string.IsNullOrWhiteSpace(l.ServiceName) ? s.DisplayName : l.ServiceName
                         })
                         .ToList(),
                     MessageHistory = s.GetMessageHistorySnapshot().ToList()

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -1,6 +1,7 @@
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -53,7 +54,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
                 _activeService = value;
                 OnPropertyChanged();
-                LogViewModel.SetLogs(_activeService?.Logs ?? AllLogs);
+                LogViewModel.SetLogs(_activeService?.Logs ?? AllLogs, _activeService is null);
                 (RemoveServiceCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
                 (EditServiceCommand as RelayCommand<ServiceListModel?>)?.RaiseCanExecuteChanged();
             }
@@ -116,6 +117,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
         private readonly IStartupPreferencesService _startupPreferencesService;
         private readonly HashSet<ServiceListModel> _activatingServices = new();
+        private readonly HashSet<ServiceListModel> _trackedServices = new();
         private static readonly TimeSpan ActivationConfirmationDelay = TimeSpan.FromMilliseconds(500);
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
@@ -149,7 +151,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _logger?.Log($"Using service persistence path {ServicePersistence.FilePath}", LogLevel.Debug);
             }
 
-            LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs);
+            Services.CollectionChanged += OnServicesCollectionChanged;
+
+            LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs, null, isAggregated: true);
             LogViewModel.PropertyChanged += (s, e) =>
             {
                 if (e.PropertyName == nameof(ServiceLogViewModel.DisplayLogs))
@@ -167,6 +171,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
             Filters.PropertyChanged += (_, __) => ApplyFilters();
             LoadServices();
+            foreach (var service in Services)
+            {
+                TrackService(service);
+            }
+            LogViewModel.UpdateServiceFilters(Services.Select(s => s.DisplayName));
             ServicesRunning = Services.Any(svc => svc.IsActive);
             ApplyFilters();
             if (_logger is LoggingService concreteLogger)
@@ -573,6 +582,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public void OnServiceLogAdded(ServiceListModel svc, LogEntry entry)
         {
+            if (svc is null || entry is null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.ServiceName))
+            {
+                entry.ServiceName = svc.DisplayName;
+            }
+
+            entry.ServiceType ??= svc.Type;
+
             AllLogs.Insert(0, entry);
             if (svc.Type != ServiceType.Csv && Services.Any(s => s.Type == ServiceType.Csv))
             {
@@ -608,6 +629,83 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     }
                 }
             }
+        }
+
+        private void OnServicesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e is null)
+            {
+                return;
+            }
+
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var tracked in _trackedServices.ToList())
+                {
+                    UntrackService(tracked);
+                }
+
+                foreach (var service in Services)
+                {
+                    TrackService(service);
+                }
+            }
+            else
+            {
+                if (e.NewItems is not null)
+                {
+                    foreach (ServiceListModel service in e.NewItems)
+                    {
+                        TrackService(service);
+                    }
+                }
+
+                if (e.OldItems is not null && e.Action != NotifyCollectionChangedAction.Move)
+                {
+                    foreach (ServiceListModel service in e.OldItems)
+                    {
+                        UntrackService(service);
+                    }
+                }
+            }
+
+            LogViewModel.UpdateServiceFilters(Services.Select(s => s.DisplayName));
+        }
+
+        private void TrackService(ServiceListModel service)
+        {
+            if (service is null)
+            {
+                return;
+            }
+
+            if (_trackedServices.Add(service))
+            {
+                service.PropertyChanged += OnServicePropertyChanged;
+            }
+        }
+
+        private void UntrackService(ServiceListModel service)
+        {
+            if (service is null)
+            {
+                return;
+            }
+
+            if (_trackedServices.Remove(service))
+            {
+                service.PropertyChanged -= OnServicePropertyChanged;
+            }
+        }
+
+        private void OnServicePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (!string.Equals(e.PropertyName, nameof(ServiceListModel.DisplayName), StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            LogViewModel.UpdateServiceFilters(Services.Select(s => s.DisplayName));
         }
 
         internal void OnServiceActiveChanged(bool _)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -38,8 +38,39 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         internal const int MaxLogEntries = 200;
 
-        public string DisplayName { get; set; } = string.Empty;
-        public ServiceType Type { get; set; }
+        private string _displayName = string.Empty;
+        public string DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                if (string.Equals(_displayName, value, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _displayName = value ?? string.Empty;
+                OnPropertyChanged();
+                RefreshLogMetadata();
+            }
+        }
+
+        private ServiceType _type;
+        public ServiceType Type
+        {
+            get => _type;
+            set
+            {
+                if (_type == value)
+                {
+                    return;
+                }
+
+                _type = value;
+                OnPropertyChanged();
+                RefreshLogMetadata();
+            }
+        }
         [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 
@@ -329,6 +360,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         public ObservableCollection<LogEntry> Logs { get; set; } = new();
+
+        private void RefreshLogMetadata()
+        {
+            if (Logs is null)
+            {
+                return;
+            }
+
+            foreach (var entry in Logs)
+            {
+                entry.ServiceType = Type;
+                entry.ServiceName = DisplayName;
+            }
+        }
         public event Action<bool>? ActiveChanged;
 
         public event Action<ServiceListModel, LogEntry>? LogAdded;
@@ -344,7 +389,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 Message = entryMessage,
                 Color = brush.ToString(),
-                Level = level
+                Level = level,
+                ServiceType = Type,
+                ServiceName = DisplayName
             };
             Logs.Insert(0, entry);
             if (Logs.Count > MaxLogEntries)
@@ -367,9 +414,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var materialized = entries?.Where(e => !string.IsNullOrWhiteSpace(e.Message)).Take(MaxLogEntries).ToList() ?? new List<LogEntry>();
             Logs = new ObservableCollection<LogEntry>(materialized);
             OnPropertyChanged(nameof(Logs));
+            RefreshLogMetadata();
             if (Logs.FirstOrDefault() is { } latest)
             {
-            InputMessage = NormalizePersistedMessage(latest.Message);
+                InputMessage = NormalizePersistedMessage(latest.Message);
                 LastInputBrush = ParseBrush(latest.Color, WpfBrushes.Black);
             }
         }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Windows.Input;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Windows;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -23,11 +24,33 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private NotifyCollectionChangedEventHandler? _logsChangedHandler;
 
         /// <summary>
+        /// Gets the collection of service filters applied in aggregated mode.
+        /// </summary>
+        public ObservableCollection<ServiceLogFilterOption> ServiceFilters { get; } = new();
+
+        private bool _isAggregated;
+        public bool IsAggregated
+        {
+            get => _isAggregated;
+            private set
+            {
+                if (_isAggregated == value)
+                {
+                    return;
+                }
+
+                _isAggregated = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DisplayLogs));
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ServiceLogViewModel"/> class
         /// with default values.
         /// </summary>
         public ServiceLogViewModel()
-            : this(ServiceType.Mqtt, new ObservableCollection<LogEntry>(), null)
+            : this(ServiceType.Mqtt, new ObservableCollection<LogEntry>(), null, false)
         {
         }
 
@@ -36,11 +59,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         /// <param name="type">The category of service associated with these logs.</param>
         /// <param name="logs">The collection of log entries to display.</param>
-        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs, ILogger<ServiceLogViewModel>? logger = null)
+        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs, ILogger<ServiceLogViewModel>? logger = null, bool isAggregated = false)
         {
             Type = type;
             _logs = logs;
             _logger = logger ?? NullLogger<ServiceLogViewModel>.Instance;
+            IsAggregated = isAggregated;
             AttachLogCollection(_logs);
             RefreshLogCommand = new RelayCommand(RefreshLogs);
             ExportLogCommand = new RelayCommand(() => ExportLogs(Path.Combine(Path.GetTempPath(), "exported_logs.txt")));
@@ -65,7 +89,32 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <summary>
         /// Gets the log entries currently displayed.
         /// </summary>
-        public IEnumerable<LogEntry> DisplayLogs => _logs.Where(l => l.Level >= LogLevelFilter);
+        public IEnumerable<LogEntry> DisplayLogs
+        {
+            get
+            {
+                var filteredByLevel = _logs.Where(l => l.Level >= LogLevelFilter);
+
+                if (!IsAggregated)
+                {
+                    return filteredByLevel;
+                }
+
+                var selectedServices = ServiceFilters
+                    .Where(filter => filter.IsSelected)
+                    .Select(filter => filter.ServiceName)
+                    .ToList();
+
+                if (selectedServices.Count == 0)
+                {
+                    return Array.Empty<LogEntry>();
+                }
+
+                var selectedSet = new HashSet<string>(selectedServices, StringComparer.OrdinalIgnoreCase);
+                return filteredByLevel.Where(entry =>
+                    string.IsNullOrWhiteSpace(entry.ServiceName) || selectedSet.Contains(entry.ServiceName));
+            }
+        }
 
         /// <summary>
         /// Gets the command that refreshes the log display.
@@ -86,10 +135,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// Replaces the backing log collection.
         /// </summary>
         /// <param name="logs">The new log collection.</param>
-        public void SetLogs(ObservableCollection<LogEntry> logs)
+        /// <param name="isAggregated">Indicates whether the view is displaying aggregated logs.</param>
+        public void SetLogs(ObservableCollection<LogEntry> logs, bool isAggregated = false)
         {
+            if (logs is null)
+            {
+                return;
+            }
+
             if (_logs == logs)
             {
+                IsAggregated = isAggregated;
                 RefreshLogs();
                 return;
             }
@@ -97,6 +153,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             DetachLogCollection();
             _logs = logs;
             AttachLogCollection(_logs);
+            IsAggregated = isAggregated;
             OnPropertyChanged(nameof(DisplayLogs));
         }
 
@@ -106,6 +163,46 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public void ClearLogs()
         {
             _logs.Clear();
+            OnPropertyChanged(nameof(DisplayLogs));
+        }
+
+        /// <summary>
+        /// Updates the available service filters displayed in aggregated mode.
+        /// </summary>
+        /// <param name="serviceNames">The service display names to expose in the filter list.</param>
+        public void UpdateServiceFilters(IEnumerable<string> serviceNames)
+        {
+            var normalizedNames = (serviceNames ?? Enumerable.Empty<string>())
+                .Select(name => name?.Trim())
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            for (var i = ServiceFilters.Count - 1; i >= 0; i--)
+            {
+                var filter = ServiceFilters[i];
+                if (!normalizedNames.Contains(filter.ServiceName, StringComparer.OrdinalIgnoreCase))
+                {
+                    filter.PropertyChanged -= OnServiceFilterOptionPropertyChanged;
+                    ServiceFilters.RemoveAt(i);
+                }
+            }
+
+            foreach (var name in normalizedNames)
+            {
+                if (ServiceFilters.Any(f => f.ServiceName.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                var filter = new ServiceLogFilterOption(name)
+                {
+                    IsSelected = true
+                };
+                filter.PropertyChanged += OnServiceFilterOptionPropertyChanged;
+                ServiceFilters.Add(filter);
+            }
+
             OnPropertyChanged(nameof(DisplayLogs));
         }
 
@@ -136,6 +233,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public void RefreshLogs() => OnPropertyChanged(nameof(DisplayLogs));
 
+        private void OnServiceFilterOptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (!string.Equals(e.PropertyName, nameof(ServiceLogFilterOption.IsSelected), StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            OnPropertyChanged(nameof(DisplayLogs));
+        }
+
         private void AttachLogCollection(ObservableCollection<LogEntry> logs)
         {
             _logsChangedHandler ??= (_, __) => OnPropertyChanged(nameof(DisplayLogs));
@@ -150,6 +257,38 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
 
             _logs.CollectionChanged -= _logsChangedHandler;
+        }
+    }
+
+    /// <summary>
+    /// Represents a selectable service filter used by aggregated log views.
+    /// </summary>
+    public class ServiceLogFilterOption : ViewModelBase
+    {
+        public ServiceLogFilterOption(string serviceName)
+        {
+            ServiceName = serviceName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the display name for the service associated with this filter.
+        /// </summary>
+        public string ServiceName { get; }
+
+        private bool _isSelected = true;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set
+            {
+                if (_isSelected == value)
+                {
+                    return;
+                }
+
+                _isSelected = value;
+                OnPropertyChanged();
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -9,6 +9,9 @@
              d:DesignWidth="400"
              d:DataContext="{d:DesignInstance Type=viewModels:ServiceLogViewModel}"
              mc:Ignorable="d">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </UserControl.Resources>
     <UserControl.CommandBindings>
         <CommandBinding Command="ApplicationCommands.Copy"
                         CanExecute="CopyCommand_CanExecute"
@@ -31,6 +34,24 @@
                 <Button Content="Update Log" Width="100" Margin="10,0,0,0" Command="{Binding RefreshLogCommand}" Background="#FFFFCC"/>
                 <Button Content="Export Log" Width="100" Margin="10,0,0,0" Background="#CCCCFF" Click="ExportLog_Click"/>
                 <Button Content="Clear Log" Width="100" Margin="10,0,0,0" Command="{Binding ClearLogCommand}" Background="#FFCCCC"/>
+                <StackPanel Margin="20,0,0,0"
+                            Visibility="{Binding IsAggregated, Converter={StaticResource BooleanToVisibilityConverter}}"
+                            Width="220">
+                    <TextBlock Text="SERVICES" FontWeight="Bold" Margin="0,0,0,5"/>
+                    <ListBox ItemsSource="{Binding ServiceFilters}"
+                             SelectionMode="Multiple"
+                             BorderThickness="1"
+                             MaxHeight="140"
+                             HorizontalContentAlignment="Stretch">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox Content="{Binding ServiceName}"
+                                          IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                          Margin="0,0,0,5" />
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
             </StackPanel>
             <ListBox x:Name="LogListBox"
                      Grid.Row="1"


### PR DESCRIPTION
## Summary
- add service name/type metadata to `LogEntry` instances and persist the information so historical logs retain their source
- expose service-aware filtering in `ServiceLogViewModel` and surface a multi-select services control in `ServiceLogView`
- update `MainViewModel` to keep aggregated filters current when services change and hydrate persisted logs with their service metadata

## Testing
- not run (Windows-only WPF build is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e6762f7c9083269a5c7e6e8668d6ff