### PR TITLE
Use per-service MQTT clients and add connection test

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttClientServiceFactory.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttClientServiceFactory.cs
@@ -1,0 +1,49 @@
+using System;
+using DesktopApplicationTemplate.Core.Services;
+using Microsoft.Extensions.Options;
+using MQTTnet;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
+
+/// <summary>
+/// Factory for creating isolated <see cref="IMqttClientService"/> instances.
+/// </summary>
+public interface IMqttClientServiceFactory
+{
+    /// <summary>
+    /// Creates a new MQTT client service bound to the specified options instance.
+    /// </summary>
+    /// <param name="options">The options to associate with the client.</param>
+    /// <returns>A configured MQTT client service.</returns>
+    IMqttClientService Create(MqttServiceOptions options);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IMqttClientServiceFactory"/>.
+/// </summary>
+public sealed class MqttClientServiceFactory : IMqttClientServiceFactory
+{
+    private readonly IMessageRoutingService _routingService;
+    private readonly ILoggingService _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MqttClientServiceFactory"/> class.
+    /// </summary>
+    public MqttClientServiceFactory(IMessageRoutingService routingService, ILoggingService logger)
+    {
+        _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public IMqttClientService Create(MqttServiceOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var client = new MqttFactory().CreateMqttClient();
+        return new MqttService(client, Options.Create(options), _routingService, _logger);
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Mqtt/MqttServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class MqttServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddMqttClientService(this IServiceCollection services)
     {
-        services.AddSingleton<IMqttClientService, MqttService>();
+        services.AddSingleton<IMqttClientServiceFactory, MqttClientServiceFactory>();
         return services;
     }
 }

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -270,9 +270,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<HttpAdvancedConfigView>();
             services.AddTransient<HttpAdvancedConfigViewModel>();
             services.AddTransient<MqttEditConnectionView>();
-            services.AddTransient<MqttEditConnectionViewModel>();
             services.AddTransient<MqttTagSubscriptionsView>();
-            services.AddTransient<MqttTagSubscriptionsViewModel>();
             services.AddTransient<HidCreateServiceView>();
             services.AddTransient<HidCreateServiceViewModel>();
             services.AddTransient<ServiceCreateViewModelBase<HidServiceOptions>, HidCreateServiceViewModel>();
@@ -334,7 +332,6 @@ namespace DesktopApplicationTemplate.UI
                 {
                     var ctx = (ServiceFactoryOptions<MqttServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var mainViewModel = provider.GetRequiredService<MainViewModel>();
                     var newService = new ServiceListModel
                     {
                         DisplayName = ctx.Name,
@@ -342,57 +339,8 @@ namespace DesktopApplicationTemplate.UI
                         IsActive = false
                     };
 
+                    newService.MqttOptions = ctx.Options ?? new MqttServiceOptions();
                     mainView.GetOrCreateServicePage(newService);
-
-                    var options = ctx.Options;
-                    var resolved = provider.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
-                    resolved.Host = options.Host;
-                    resolved.Port = options.Port;
-                    resolved.ClientId = options.ClientId;
-                    resolved.Username = options.Username;
-                    resolved.Password = options.Password;
-                    resolved.ConnectionType = options.ConnectionType;
-                    resolved.WillTopic = options.WillTopic;
-                    resolved.WillPayload = options.WillPayload;
-                    resolved.WillQualityOfService = options.WillQualityOfService;
-                    resolved.WillRetain = options.WillRetain;
-                    resolved.KeepAliveSeconds = options.KeepAliveSeconds;
-                    resolved.CleanSession = options.CleanSession;
-                    resolved.ReconnectDelay = options.ReconnectDelay;
-
-                    if (newService.ServicePage is MqttTagSubscriptionsView mqttView &&
-                        mqttView.DataContext is MqttTagSubscriptionsViewModel mqttVm)
-                    {
-                        newService.ActiveChanged += active =>
-                        {
-                            if (active)
-                            {
-                                _ = mqttVm.ConnectAsync();
-                            }
-                        };
-
-                        mqttVm.EditConnectionRequested += (_, _) =>
-                        {
-                            var editView = provider.GetRequiredService<MqttEditConnectionView>();
-                            if (editView.DataContext is MqttEditConnectionViewModel vm)
-                            {
-                                var opt = provider.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
-                                vm.Load(opt);
-                                vm.HighlightMissingFields();
-                                vm.RequestClose += (_, _) =>
-                                {
-                                    if (newService.ServicePage != null)
-                                    {
-                                        mainView.ShowPage(newService.ServicePage);
-                                    }
-
-                                    _ = mainViewModel.SaveServicesAsync();
-                                };
-                            }
-
-                            mainView.ShowPage(editView);
-                        };
-                    }
 
                     return newService;
                 },

--- a/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
@@ -10,7 +10,6 @@ using DesktopApplicationTemplate.UI.Views.Mqtt.Advanced;
 using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.EditHandlers;
 
@@ -34,7 +33,8 @@ public class MqttEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var tagPage = mainView.GetOrCreateServicePage(service);
-        var options = _services.GetRequiredService<IOptions<MqttServiceOptions>>().Value;
+        var options = service.MqttOptions ?? new MqttServiceOptions();
+        service.MqttOptions = options;
         var vm = ActivatorUtilities.CreateInstance<MqttEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<MqttEditServiceView>();
         editView.Initialize(vm);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -12,6 +12,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
 using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.Core.Services.Protocols.Hid;
+using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Models;
@@ -147,6 +148,29 @@ namespace DesktopApplicationTemplate.Persistence
                     };
                 }
 
+                MqttServiceOptions? mqtt = null;
+                if (s.Type == ServiceType.Mqtt && s.MqttOptions != null)
+                {
+                    mqtt = new MqttServiceOptions
+                    {
+                        Host = s.MqttOptions.Host,
+                        Port = s.MqttOptions.Port,
+                        ClientId = s.MqttOptions.ClientId,
+                        Username = s.MqttOptions.Username,
+                        Password = s.MqttOptions.Password,
+                        ConnectionType = s.MqttOptions.ConnectionType,
+                        WebSocketPath = s.MqttOptions.WebSocketPath,
+                        ClientCertificate = s.MqttOptions.ClientCertificate?.ToArray(),
+                        WillTopic = s.MqttOptions.WillTopic,
+                        WillPayload = s.MqttOptions.WillPayload,
+                        WillQualityOfService = s.MqttOptions.WillQualityOfService,
+                        WillRetain = s.MqttOptions.WillRetain,
+                        KeepAliveSeconds = s.MqttOptions.KeepAliveSeconds,
+                        CleanSession = s.MqttOptions.CleanSession,
+                        ReconnectDelay = s.MqttOptions.ReconnectDelay
+                    };
+                }
+
                 data.Add(new ServiceInfo
                 {
                     DisplayName = s.DisplayName,
@@ -163,6 +187,7 @@ namespace DesktopApplicationTemplate.Persistence
                     FileObserverOptions = fileObserver,
                     HidOptions = hid,
                     ScpOptions = scp,
+                    MqttOptions = mqtt,
                     TotalExecutionTimeMs = s.TotalExecutionTimeMs,
                     ExecutionCount = s.ExecutionCount,
                     IncomingMessageCount = s.IncomingMessageCount,
@@ -287,6 +312,33 @@ namespace DesktopApplicationTemplate.Persistence
 
                 foreach (var info in result)
                 {
+                    if (info.ServiceType == ServiceType.Mqtt && info.MqttOptions is null)
+                    {
+                        var opt = App.AppHost?.Services.GetService<IOptions<MqttServiceOptions>>();
+                        if (opt != null)
+                        {
+                            var value = opt.Value;
+                            info.MqttOptions = new MqttServiceOptions
+                            {
+                                Host = value.Host,
+                                Port = value.Port,
+                                ClientId = value.ClientId,
+                                Username = value.Username,
+                                Password = value.Password,
+                                ConnectionType = value.ConnectionType,
+                                WebSocketPath = value.WebSocketPath,
+                                ClientCertificate = value.ClientCertificate?.ToArray(),
+                                WillTopic = value.WillTopic,
+                                WillPayload = value.WillPayload,
+                                WillQualityOfService = value.WillQualityOfService,
+                                WillRetain = value.WillRetain,
+                                KeepAliveSeconds = value.KeepAliveSeconds,
+                                CleanSession = value.CleanSession,
+                                ReconnectDelay = value.ReconnectDelay
+                            };
+                        }
+                    }
+
                     if (info.ServiceType == ServiceType.Tcp && info.TcpOptions != null)
                     {
                         var opt = App.AppHost?.Services.GetService<IOptions<TcpServiceOptions>>();
@@ -418,6 +470,7 @@ namespace DesktopApplicationTemplate.Persistence
         public FileObserverServiceOptions? FileObserverOptions { get; set; }
         public HidServiceOptions? HidOptions { get; set; }
         public ScpServiceOptions? ScpOptions { get; set; }
+        public MqttServiceOptions? MqttOptions { get; set; }
         public double TotalExecutionTimeMs { get; set; }
         public int ExecutionCount { get; set; }
         public int IncomingMessageCount { get; set; }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -17,6 +17,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -349,6 +350,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     FileObserverOptions = info.FileObserverOptions,
                     HidOptions = info.HidOptions,
                     ScpOptions = info.ScpOptions,
+                    MqttOptions = info.MqttOptions ?? new MqttServiceOptions(),
                     TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                     ExecutionCount = info.ExecutionCount
                 };

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
@@ -4,7 +4,6 @@ using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.UI.Helpers;
-using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
 
@@ -30,11 +29,11 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
     /// </summary>
     public MqttEditConnectionViewModel(
         IMqttClientService clientService,
-        IOptions<MqttServiceOptions> options,
+        MqttServiceOptions options,
         ILoggingService? logger = null)
     {
         _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
-        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
         Logger = logger;
 
         Load(_options);

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -11,7 +12,6 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
-using Microsoft.Extensions.Options;
 using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt;
@@ -27,6 +27,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     private readonly AsyncRelayCommand _addTopicCommand;
     private readonly AsyncRelayCommand _removeTopicCommand;
     private readonly AsyncRelayCommand _connectCommand;
+    private readonly AsyncRelayCommand _testConnectionCommand;
     private readonly AsyncRelayCommand<TagSubscription> _sendTestMessageCommand;
 
     private TagSubscription? _selectedSubscription;
@@ -39,10 +40,10 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttTagSubscriptionsViewModel"/> class.
     /// </summary>
-    public MqttTagSubscriptionsViewModel(IMqttClientService clientService, IOptions<MqttServiceOptions> options)
+    public MqttTagSubscriptionsViewModel(IMqttClientService clientService, MqttServiceOptions options)
     {
         _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
-        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
 
         Subscriptions = new ObservableCollection<TagSubscription>();
         Subscriptions.CollectionChanged += OnSubscriptionsChanged;
@@ -51,6 +52,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         _addTopicCommand = new AsyncRelayCommand(AddTopicAsync, () => CanAddTopic);
         _removeTopicCommand = new AsyncRelayCommand(RemoveTopicAsync, () => SelectedSubscription != null);
         _connectCommand = new AsyncRelayCommand(ConnectAsync, () => !_isBusy);
+        _testConnectionCommand = new AsyncRelayCommand(TestConnectionAsync, () => !_isBusy);
         _sendTestMessageCommand = new AsyncRelayCommand<TagSubscription>(SendTestMessageAsync, CanSendTestMessage);
 
         _clientService.ConnectionStateChanged += OnConnectionStateChanged;
@@ -101,6 +103,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
             OnPropertyChanged();
             OnPropertyChanged(nameof(ConnectionActionLabel));
             _connectCommand.RaiseCanExecuteChanged();
+            _testConnectionCommand.RaiseCanExecuteChanged();
             _sendTestMessageCommand.RaiseCanExecuteChanged();
 
             if (!value)
@@ -180,6 +183,11 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     public ICommand ConnectCommand => _connectCommand;
 
     /// <summary>
+    /// Command to test the MQTT connection using the current settings.
+    /// </summary>
+    public ICommand TestConnectionCommand => _testConnectionCommand;
+
+    /// <summary>
     /// Command to publish a test message for a subscription.
     /// </summary>
     public ICommand SendTestMessageCommand => _sendTestMessageCommand;
@@ -193,6 +201,38 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// Gets a value indicating whether a topic can be added.
     /// </summary>
     public bool CanAddTopic => !string.IsNullOrWhiteSpace(NewTopic);
+
+    private bool TryValidateConnectionOptions(out List<string> errors)
+    {
+        errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(_options.Host))
+        {
+            errors.Add("Host is required.");
+        }
+
+        if (_options.Port < 1 || _options.Port > 65535)
+        {
+            errors.Add("Port must be between 1 and 65535.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.ClientId))
+        {
+            errors.Add("Client Id is required.");
+        }
+
+        return errors.Count == 0;
+    }
+
+    private void NotifyValidationErrors(IEnumerable<string> errors)
+    {
+        foreach (var error in errors)
+        {
+            Logger?.Log($"MQTT configuration error: {error}", LogLevel.Warning);
+        }
+
+        EditConnectionRequested?.Invoke(this, EventArgs.Empty);
+    }
 
     private async Task AddTopicAsync()
     {
@@ -263,6 +303,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
 
         _isBusy = true;
         _connectCommand.RaiseCanExecuteChanged();
+        _testConnectionCommand.RaiseCanExecuteChanged();
 
         try
         {
@@ -272,30 +313,84 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
                 return;
             }
 
-            Logger?.Log("MQTT connect start", LogLevel.Debug);
-            try
+            if (!TryValidateConnectionOptions(out var errors))
             {
-                await _clientService.ConnectAsync(_options);
-                IsConnected = true;
-                await SubscribeAllAsync();
-                Logger?.Log("MQTT connect finished", LogLevel.Debug);
+                NotifyValidationErrors(errors);
+                return;
             }
-            catch (ArgumentException ex)
+
+            await ConnectCoreAsync();
+        }
+        finally
+        {
+            _isBusy = false;
+            _connectCommand.RaiseCanExecuteChanged();
+            _testConnectionCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private async Task<bool> ConnectCoreAsync()
+    {
+        Logger?.Log("MQTT connect start", LogLevel.Debug);
+        try
+        {
+            await _clientService.ConnectAsync(_options);
+            IsConnected = true;
+            await SubscribeAllAsync();
+            Logger?.Log("MQTT connect finished", LogLevel.Debug);
+            return true;
+        }
+        catch (ArgumentException ex)
+        {
+            IsConnected = false;
+            Logger?.Log(ex.Message, LogLevel.Warning);
+            EditConnectionRequested?.Invoke(this, EventArgs.Empty);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            IsConnected = false;
+            Logger?.Log($"MQTT connect failed: {ex.Message}", LogLevel.Error);
+            return false;
+        }
+    }
+
+    private async Task TestConnectionAsync()
+    {
+        if (_isBusy)
+        {
+            return;
+        }
+
+        if (!TryValidateConnectionOptions(out var errors))
+        {
+            NotifyValidationErrors(errors);
+            return;
+        }
+
+        _isBusy = true;
+        _connectCommand.RaiseCanExecuteChanged();
+        _testConnectionCommand.RaiseCanExecuteChanged();
+
+        try
+        {
+            if (IsConnected)
             {
-                IsConnected = false;
-                Logger?.Log(ex.Message, LogLevel.Warning);
-                EditConnectionRequested?.Invoke(this, EventArgs.Empty);
+                Logger?.Log("MQTT client is already connected.", LogLevel.Information);
+                return;
             }
-            catch (Exception ex)
+
+            var connected = await ConnectCoreAsync();
+            if (connected)
             {
-                IsConnected = false;
-                Logger?.Log($"MQTT connect failed: {ex.Message}", LogLevel.Error);
+                Logger?.Log("MQTT test connection succeeded.", LogLevel.Information);
             }
         }
         finally
         {
             _isBusy = false;
             _connectCommand.RaiseCanExecuteChanged();
+            _testConnectionCommand.RaiseCanExecuteChanged();
         }
     }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -311,6 +311,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public CsvServiceOptions? CsvOptions { get; set; }
 
+        /// <summary>
+        /// MQTT-specific configuration for this service, if applicable.
+        /// </summary>
+        public MqttServiceOptions? MqttOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MQTT client instance associated with this service.
+        /// </summary>
+        [JsonIgnore]
+        public IMqttClientService? MqttClientService { get; set; }
+
         public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
 
         private bool _isActive;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -11,6 +11,11 @@ using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
+using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
+using DesktopApplicationTemplate.UI.Views.Mqtt;
+using DesktopApplicationTemplate.UI.Views.Mqtt.Edit;
+using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using LogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -41,6 +46,8 @@ namespace DesktopApplicationTemplate.UI.Views
         private readonly IServiceProvider _serviceProvider;
         private readonly Dictionary<ServiceListModel, Action<LogEntry>> _serviceLogHandlers = new();
         private readonly Dictionary<ServiceListModel, EventHandler> _tcpAdvancedHandlers = new();
+        private readonly Dictionary<ServiceListModel, EventHandler> _mqttEditHandlers = new();
+        private readonly Dictionary<ServiceListModel, MqttTagSubscriptionsViewModel> _mqttSubscriptionViewModels = new();
         private readonly BrushConverter _brushConverter = new();
         private JoinableTask? _shutdownTask;
         private bool _shutdownCompleted;
@@ -211,6 +218,11 @@ namespace DesktopApplicationTemplate.UI.Views
 
             if (svc.ServicePage != null)
             {
+                if (svc.Type == ServiceType.Mqtt && svc.ServicePage is MqttTagSubscriptionsView mqttPage)
+                {
+                    InitializeMqttSubscriptionsPage(svc, mqttPage);
+                }
+
                 if (svc.ServicePage.DataContext is ILoggingViewModel vm)
                 {
                     AttachServiceLogger(svc, vm);
@@ -288,6 +300,41 @@ namespace DesktopApplicationTemplate.UI.Views
             }
         }
 
+        private void InitializeMqttSubscriptionsPage(ServiceListModel svc, MqttTagSubscriptionsView page)
+        {
+            if (svc is null || page is null)
+            {
+                return;
+            }
+
+            var options = svc.MqttOptions ??= new MqttServiceOptions();
+            if (svc.MqttClientService is null)
+            {
+                var factory = _serviceProvider.GetRequiredService<IMqttClientServiceFactory>();
+                svc.MqttClientService = factory.Create(options);
+            }
+
+            if (!_mqttSubscriptionViewModels.TryGetValue(svc, out var viewModel))
+            {
+                viewModel = ActivatorUtilities.CreateInstance<MqttTagSubscriptionsViewModel>(
+                    _serviceProvider,
+                    svc.MqttClientService!,
+                    options);
+                _mqttSubscriptionViewModels[svc] = viewModel;
+            }
+
+            if (_mqttEditHandlers.TryGetValue(svc, out var existingHandler))
+            {
+                viewModel.EditConnectionRequested -= existingHandler;
+            }
+
+            EventHandler handler = (_, _) => ShowMqttEditConnectionView(svc, highlightMissingFields: true);
+            viewModel.EditConnectionRequested += handler;
+            _mqttEditHandlers[svc] = handler;
+
+            page.Initialize(viewModel);
+        }
+
         private void AttachTcpAdvancedHandler(ServiceListModel svc, TcpServiceMessagesViewModel vm)
         {
             if (_tcpAdvancedHandlers.TryGetValue(svc, out var existing))
@@ -302,18 +349,18 @@ namespace DesktopApplicationTemplate.UI.Views
 
         private void DetachServiceLogger(ServiceListModel svc)
         {
-            if (!_serviceLogHandlers.TryGetValue(svc, out var handler))
+            if (_serviceLogHandlers.TryGetValue(svc, out var handler))
             {
-                return;
+                if (svc.ServicePage?.DataContext is ILoggingViewModel vm && vm.Logger is not null)
+                {
+                    vm.Logger.LogAdded -= handler;
+                }
+
+                _serviceLogHandlers.Remove(svc);
             }
 
-            if (svc.ServicePage?.DataContext is ILoggingViewModel vm && vm.Logger is not null)
-            {
-                vm.Logger.LogAdded -= handler;
-            }
-
-            _serviceLogHandlers.Remove(svc);
             DetachTcpAdvancedHandler(svc);
+            DetachMqttHandlers(svc);
         }
 
         private void DetachTcpAdvancedHandler(ServiceListModel svc)
@@ -331,10 +378,73 @@ namespace DesktopApplicationTemplate.UI.Views
             _tcpAdvancedHandlers.Remove(svc);
         }
 
+        private void DetachMqttHandlers(ServiceListModel svc)
+        {
+            if (_mqttEditHandlers.TryGetValue(svc, out var handler) &&
+                _mqttSubscriptionViewModels.TryGetValue(svc, out var viewModel))
+            {
+                viewModel.EditConnectionRequested -= handler;
+            }
+
+            _mqttEditHandlers.Remove(svc);
+            _mqttSubscriptionViewModels.Remove(svc);
+
+            if (svc.MqttClientService is not null)
+            {
+                _ = svc.MqttClientService.DisconnectAsync();
+                svc.MqttClientService = null;
+            }
+        }
+
         private void OpenTcpAdvancedSettings(ServiceListModel svc)
         {
             var handler = _serviceProvider.GetKeyedService<IEditServiceHandler>(ServiceType.Tcp);
             handler?.Edit(svc);
+        }
+
+        private void ShowMqttEditConnectionView(ServiceListModel service, bool highlightMissingFields = false)
+        {
+            if (service is null)
+            {
+                return;
+            }
+
+            var options = service.MqttOptions ??= new MqttServiceOptions();
+            if (service.MqttClientService is null)
+            {
+                var factory = _serviceProvider.GetRequiredService<IMqttClientServiceFactory>();
+                service.MqttClientService = factory.Create(options);
+            }
+
+            var logger = _serviceProvider.GetService<ILoggingService>();
+            var viewModel = ActivatorUtilities.CreateInstance<MqttEditConnectionViewModel>(
+                _serviceProvider,
+                service.MqttClientService!,
+                options,
+                logger);
+
+            if (highlightMissingFields)
+            {
+                viewModel.HighlightMissingFields();
+            }
+
+            var editView = _serviceProvider.GetRequiredService<MqttEditConnectionView>();
+            editView.Initialize(viewModel);
+
+            EventHandler? closeHandler = null;
+            closeHandler = (_, _) =>
+            {
+                viewModel.RequestClose -= closeHandler;
+                if (service.ServicePage != null)
+                {
+                    ShowPage(service.ServicePage);
+                }
+
+                _ = _viewModel.SaveServicesAsync();
+            };
+            viewModel.RequestClose += closeHandler;
+
+            ShowPage(editView);
         }
 
         private void Services_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -364,6 +474,10 @@ namespace DesktopApplicationTemplate.UI.Views
                 foreach (var svc in _tcpAdvancedHandlers.Keys.ToList())
                 {
                     DetachTcpAdvancedHandler(svc);
+                }
+                foreach (var svc in _mqttEditHandlers.Keys.ToList())
+                {
+                    DetachMqttHandlers(svc);
                 }
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/Edit/MqttEditConnectionView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/Edit/MqttEditConnectionView.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Controls;
 using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
 
@@ -5,9 +6,13 @@ namespace DesktopApplicationTemplate.UI.Views.Mqtt.Edit;
 
 public partial class MqttEditConnectionView : Page
 {
-    public MqttEditConnectionView(MqttEditConnectionViewModel vm)
+    public MqttEditConnectionView()
     {
         InitializeComponent();
-        DataContext = vm;
+    }
+
+    public void Initialize(MqttEditConnectionViewModel viewModel)
+    {
+        DataContext = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml
@@ -30,6 +30,11 @@
                     Command="{Binding ConnectCommand}"
                     Width="80"
                     AutomationProperties.Name="{Binding ConnectionActionLabel, StringFormat={}{0} MQTT}"/>
+            <Button Content="Test Connection"
+                    Command="{Binding TestConnectionCommand}"
+                    Width="120"
+                    Margin="5,0,0,0"
+                    AutomationProperties.Name="Test MQTT Connection"/>
             <Ellipse Width="10" Height="10" Margin="5,0,0,0" Fill="{Binding IsConnected, Converter={StaticResource BoolToBrush}}"/>
             <TextBox Text="{Binding NewTopic, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="10,0,0,0" x:Name="NewTopicBox" ToolTip="Topic to subscribe"
                      behaviors:TextBoxHintBehavior.AutoToolTip="True"/>

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml.cs
@@ -12,14 +12,30 @@ namespace DesktopApplicationTemplate.UI.Views.Mqtt;
 /// </summary>
 public partial class MqttTagSubscriptionsView : Page, IServiceLogHost
 {
+    private readonly ILoggingService _logger;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttTagSubscriptionsView"/> class.
     /// </summary>
-    public MqttTagSubscriptionsView(MqttTagSubscriptionsViewModel vm, ILoggingService logger)
+    public MqttTagSubscriptionsView(ILoggingService logger)
     {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         InitializeComponent();
-        vm.Logger = logger;
-        DataContext = vm;
+    }
+
+    /// <summary>
+    /// Applies the supplied view model to the page.
+    /// </summary>
+    /// <param name="viewModel">The view model to use as the data context.</param>
+    public void Initialize(MqttTagSubscriptionsViewModel viewModel)
+    {
+        if (viewModel is null)
+        {
+            throw new ArgumentNullException(nameof(viewModel));
+        }
+
+        viewModel.Logger = _logger;
+        DataContext = viewModel;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- persist `MqttServiceOptions` per service and register a factory for scoped `IMqttClientService` instances
- initialize MQTT pages with service-specific clients/options and expose a Test Connection workflow instead of auto-connecting
- refactor persistence, view models, and views to hydrate and edit MQTT configurations per service instance

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e67c76fd0083268497e532ecd6ece1