### PR TITLE
Refine MQTT sessions per service

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -196,6 +196,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddCommonServices();
             services.AddSingleton<SaveConfirmationHelper>();
             services.AddSingleton<CloseConfirmationHelper>();
+            services.AddSingleton<IMqttClientSessionManager, MqttClientSessionManager>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<ServiceMessageTableViewModel>();
             services.AddSingleton<TcpServiceMessagesView>();

--- a/DesktopApplicationTemplate.UI/Services/MqttClientSessionManager.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttClientSessionManager.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
+using DesktopApplicationTemplate.UI.ViewModels;
+using Microsoft.Extensions.Logging;
+
+namespace DesktopApplicationTemplate.UI.Services;
+
+/// <summary>
+/// Provides MQTT client sessions scoped to individual services.
+/// </summary>
+public interface IMqttClientSessionManager
+{
+    /// <summary>
+    /// Gets or creates the MQTT client associated with the specified service.
+    /// </summary>
+    /// <param name="service">The owning service model.</param>
+    /// <returns>An MQTT client scoped to the service.</returns>
+    IMqttClientService GetClient(ServiceListModel service);
+
+    /// <summary>
+    /// Releases the MQTT client associated with the specified service.
+    /// </summary>
+    /// <param name="service">The owning service model.</param>
+    Task ReleaseAsync(ServiceListModel service);
+}
+
+/// <summary>
+/// Default implementation of <see cref="IMqttClientSessionManager"/> that caches sessions per service.
+/// </summary>
+public sealed class MqttClientSessionManager : IMqttClientSessionManager
+{
+    private readonly IMqttClientServiceFactory _clientFactory;
+    private readonly ILogger<MqttClientSessionManager> _logger;
+    private readonly Dictionary<ServiceListModel, IMqttClientService> _sessions = new();
+    private readonly object _syncRoot = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MqttClientSessionManager"/> class.
+    /// </summary>
+    public MqttClientSessionManager(IMqttClientServiceFactory clientFactory, ILogger<MqttClientSessionManager> logger)
+    {
+        _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public IMqttClientService GetClient(ServiceListModel service)
+    {
+        if (service is null)
+        {
+            throw new ArgumentNullException(nameof(service));
+        }
+
+        lock (_syncRoot)
+        {
+            if (!_sessions.TryGetValue(service, out var client))
+            {
+                var options = service.MqttOptions ??= new MqttServiceOptions();
+                client = _clientFactory.Create(options);
+                _sessions.Add(service, client);
+                _logger.LogDebug("Created MQTT client session for service {ServiceName}.", service.DisplayName);
+            }
+
+            return client;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ReleaseAsync(ServiceListModel service)
+    {
+        if (service is null)
+        {
+            return;
+        }
+
+        IMqttClientService? client = null;
+
+        lock (_syncRoot)
+        {
+            if (_sessions.TryGetValue(service, out client))
+            {
+                _sessions.Remove(service);
+            }
+        }
+
+        if (client is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await client.DisconnectAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to disconnect MQTT client for service {ServiceName}.", service.DisplayName);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
@@ -7,6 +7,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
 using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt.Edit;
@@ -43,13 +44,16 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
     /// Initializes a new instance of the <see cref="MqttEditConnectionViewModel"/> class.
     /// </summary>
     public MqttEditConnectionViewModel(
-        IMqttClientService clientService,
-        MqttServiceOptions options,
+        ServiceListModel service,
+        IMqttClientSessionManager sessionManager,
         IFileDialogService fileDialogService,
         ILoggingService? logger = null)
     {
-        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(sessionManager);
+
+        _clientService = sessionManager.GetClient(service);
+        _options = service.MqttOptions ??= new MqttServiceOptions();
         _fileDialogService = fileDialogService ?? throw new ArgumentNullException(nameof(fileDialogService));
         Logger = logger;
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
@@ -12,6 +12,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using MQTTnet.Protocol;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Mqtt;
@@ -40,10 +41,13 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
     /// <summary>
     /// Initializes a new instance of the <see cref="MqttTagSubscriptionsViewModel"/> class.
     /// </summary>
-    public MqttTagSubscriptionsViewModel(IMqttClientService clientService, MqttServiceOptions options)
+    public MqttTagSubscriptionsViewModel(ServiceListModel service, IMqttClientSessionManager sessionManager)
     {
-        _clientService = clientService ?? throw new ArgumentNullException(nameof(clientService));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(sessionManager);
+
+        _options = service.MqttOptions ??= new MqttServiceOptions();
+        _clientService = sessionManager.GetClient(service);
 
         Subscriptions = new ObservableCollection<TagSubscription>();
         Subscriptions.CollectionChanged += OnSubscriptionsChanged;
@@ -56,7 +60,6 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         _sendTestMessageCommand = new AsyncRelayCommand<TagSubscription>(SendTestMessageAsync, CanSendTestMessage);
 
         _clientService.ConnectionStateChanged += OnConnectionStateChanged;
-        IsConnected = _clientService.IsConnected;
     }
 
     /// <inheritdoc />

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -316,12 +316,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         public MqttServiceOptions? MqttOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the MQTT client instance associated with this service.
-        /// </summary>
-        [JsonIgnore]
-        public IMqttClientService? MqttClientService { get; set; }
-
         public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
 
         private bool _isActive;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -307,19 +307,11 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            var options = svc.MqttOptions ??= new MqttServiceOptions();
-            if (svc.MqttClientService is null)
-            {
-                var factory = _serviceProvider.GetRequiredService<IMqttClientServiceFactory>();
-                svc.MqttClientService = factory.Create(options);
-            }
-
             if (!_mqttSubscriptionViewModels.TryGetValue(svc, out var viewModel))
             {
                 viewModel = ActivatorUtilities.CreateInstance<MqttTagSubscriptionsViewModel>(
                     _serviceProvider,
-                    svc.MqttClientService!,
-                    options);
+                    svc);
                 _mqttSubscriptionViewModels[svc] = viewModel;
             }
 
@@ -332,7 +324,9 @@ namespace DesktopApplicationTemplate.UI.Views
             viewModel.EditConnectionRequested += handler;
             _mqttEditHandlers[svc] = handler;
 
-            page.Initialize(viewModel);
+            svc.MqttOptions ??= new MqttServiceOptions();
+
+            page.Initialize(svc, viewModel);
         }
 
         private void AttachTcpAdvancedHandler(ServiceListModel svc, TcpServiceMessagesViewModel vm)
@@ -389,11 +383,8 @@ namespace DesktopApplicationTemplate.UI.Views
             _mqttEditHandlers.Remove(svc);
             _mqttSubscriptionViewModels.Remove(svc);
 
-            if (svc.MqttClientService is not null)
-            {
-                _ = svc.MqttClientService.DisconnectAsync();
-                svc.MqttClientService = null;
-            }
+            var sessionManager = _serviceProvider.GetRequiredService<IMqttClientSessionManager>();
+            _ = sessionManager.ReleaseAsync(svc);
         }
 
         private void OpenTcpAdvancedSettings(ServiceListModel svc)
@@ -409,18 +400,12 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            var options = service.MqttOptions ??= new MqttServiceOptions();
-            if (service.MqttClientService is null)
-            {
-                var factory = _serviceProvider.GetRequiredService<IMqttClientServiceFactory>();
-                service.MqttClientService = factory.Create(options);
-            }
+            service.MqttOptions ??= new MqttServiceOptions();
 
             var logger = _serviceProvider.GetService<ILoggingService>();
             var viewModel = ActivatorUtilities.CreateInstance<MqttEditConnectionViewModel>(
                 _serviceProvider,
-                service.MqttClientService!,
-                options,
+                service,
                 logger);
 
             if (highlightMissingFields)

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/MqttTagSubscriptionsView.xaml.cs
@@ -26,16 +26,16 @@ public partial class MqttTagSubscriptionsView : Page, IServiceLogHost
     /// <summary>
     /// Applies the supplied view model to the page.
     /// </summary>
+    /// <param name="service">The service that owns the view model.</param>
     /// <param name="viewModel">The view model to use as the data context.</param>
-    public void Initialize(MqttTagSubscriptionsViewModel viewModel)
+    public void Initialize(ServiceListModel service, MqttTagSubscriptionsViewModel viewModel)
     {
-        if (viewModel is null)
-        {
-            throw new ArgumentNullException(nameof(viewModel));
-        }
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(viewModel);
 
         viewModel.Logger = _logger;
         DataContext = viewModel;
+        SetServiceContext(service);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
1. Add an IMqttClientSessionManager to cache MQTT client instances per service and register it with the UI host.
2. Update MQTT view models and MainWindow wiring to resolve clients via the session manager and default connection state to disconnected until a successful connect.
3. Adjust the MqttTagSubscriptions view initialization to include the owning ServiceListModel so logging and session resolution stay scoped to the correct service.

## Testing
- `dotnet build DesktopApplicationTemplate.sln -p:EnableWindowsTargeting=true` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e6876484048326855efc892ddb1aaa