### PR TITLE
Guard service activation while adding new services

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/DesktopApplicationTemplate.UI.Tests.csproj
+++ b/DesktopApplicationTemplate.UI.Tests/DesktopApplicationTemplate.UI.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DesktopApplicationTemplate.UI\DesktopApplicationTemplate.UI.csproj" />
+  </ItemGroup>
+</Project>

--- a/DesktopApplicationTemplate.UI.Tests/MainViewModelServiceCreationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewModelServiceCreationTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DesktopApplicationTemplate.Core.Models;
+using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
+using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
+using DesktopApplicationTemplate.UI.ViewModels;
+using FluentAssertions;
+using Xunit;
+
+namespace DesktopApplicationTemplate.UI.Tests
+{
+    public class MainViewModelServiceCreationTests : IDisposable
+    {
+        private readonly TestLoggingService logger = new();
+        private readonly MainViewModelTestEnvironment environment;
+
+        public MainViewModelServiceCreationTests()
+        {
+            environment = new MainViewModelTestEnvironment(logger);
+        }
+
+        public void Dispose()
+        {
+            environment.Dispose();
+        }
+
+        [Fact]
+        public async Task StartServicesAsync_DoesNotActivateServicesDuringCreation()
+        {
+            var viewModel = environment.ViewModel;
+            var service = CreateService("CreationGuard");
+            viewModel.Services.Add(service);
+
+            using (viewModel.BeginServiceCreationScope())
+            {
+                await viewModel.StartServicesForTestingAsync();
+            }
+
+            service.IsActive.Should().BeFalse();
+            service.Logs.Should().BeEmpty();
+            viewModel.ActivatingServicesCount.Should().Be(0);
+            logger.Messages.Should().Contain(message => message.Contains("Skipping service activation while creation is in progress."));
+        }
+
+        [Fact]
+        public async Task StopServicesAsync_DoesNotDeactivateServicesDuringCreation()
+        {
+            var viewModel = environment.ViewModel;
+            var service = CreateService("ActiveService");
+            service.InitializeActivationState(true);
+            viewModel.Services.Add(service);
+
+            using (viewModel.BeginServiceCreationScope())
+            {
+                await viewModel.StopServicesForTestingAsync();
+            }
+
+            service.IsActive.Should().BeTrue();
+            viewModel.ActivatingServicesCount.Should().Be(0);
+            logger.Messages.Should().Contain(message => message.Contains("Skipping service deactivation while creation is in progress."));
+        }
+
+        [Fact]
+        public async Task StartServicesAsync_ActivatesAfterCreationScopeDisposes()
+        {
+            var viewModel = environment.ViewModel;
+            var service = CreateService("DeferredStart");
+            viewModel.Services.Add(service);
+
+            using (viewModel.BeginServiceCreationScope())
+            {
+                // Intentionally empty to exit scope immediately.
+            }
+
+            await viewModel.StartServicesForTestingAsync();
+
+            service.IsActive.Should().BeTrue();
+            viewModel.ActivatingServicesCount.Should().BeGreaterThan(0);
+            logger.Messages.Should().NotContain(message => message.Contains("Skipping service activation while creation is in progress."));
+        }
+
+        [Fact]
+        public void InitializeActivationState_DoesNotLogWhenSuppressed()
+        {
+            var service = CreateService("Initializer");
+            service.Logs.Should().BeEmpty();
+
+            service.InitializeActivationState(true);
+            service.IsActive.Should().BeTrue();
+            service.Logs.Should().BeEmpty();
+
+            service.InitializeActivationState(false);
+            service.IsActive.Should().BeFalse();
+            service.Logs.Should().BeEmpty();
+        }
+
+        private static ServiceListModel CreateService(string name)
+        {
+            return new ServiceListModel
+            {
+                DisplayName = name,
+                Type = ServiceType.Http
+            };
+        }
+
+        private sealed class MainViewModelTestEnvironment : IDisposable
+        {
+            private readonly string servicesFilePath;
+            public MainViewModel ViewModel { get; }
+
+            public MainViewModelTestEnvironment(TestLoggingService logger)
+            {
+                var basePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(basePath);
+                servicesFilePath = Path.Combine(basePath, "services.json");
+
+                var fileDialog = new TestFileDialogService();
+                var csvViewModel = new CsvViewerViewModel(fileDialog, Path.Combine(basePath, "csv_config.json"));
+                var csvService = new TestCsvService();
+                var csvOutput = new TestCsvOutput();
+                var csvAdapter = new CsvServiceAdapter(csvViewModel, csvService, csvOutput, logger);
+                var networkService = new TestNetworkConfigurationService();
+                var networkConfig = new NetworkConfigurationViewModel(networkService, logger);
+                var serviceCatalog = new TestServiceCatalog();
+                var startupPreferences = new TestStartupPreferencesService();
+
+                ViewModel = new MainViewModel(
+                    csvAdapter,
+                    networkConfig,
+                    networkService,
+                    serviceCatalog,
+                    new Dictionary<ServiceType, IEditServiceHandler>(),
+                    startupPreferences,
+                    logger,
+                    servicesFilePath);
+            }
+
+            public void Dispose()
+            {
+                if (File.Exists(servicesFilePath))
+                {
+                    File.Delete(servicesFilePath);
+                }
+
+                var directory = Path.GetDirectoryName(servicesFilePath);
+                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+        }
+
+        private sealed class TestLoggingService : ILoggingService
+        {
+            public List<string> Messages { get; } = new();
+
+            public LogLevel MinimumLevel { get; set; } = LogLevel.Debug;
+
+            public event Action<LogEntry>? LogAdded;
+
+            public void Log(string message, LogLevel level)
+            {
+                Messages.Add(message);
+                LogAdded?.Invoke(new LogEntry
+                {
+                    Message = message,
+                    Level = level
+                });
+            }
+
+            public void Reload()
+            {
+            }
+        }
+
+        private sealed class TestNetworkConfigurationService : INetworkConfigurationService
+        {
+            public Task ApplyConfigurationAsync(NetworkConfiguration configuration) => Task.CompletedTask;
+
+            public Task<NetworkConfiguration> GetConfigurationAsync() => Task.FromResult(new NetworkConfiguration());
+        }
+
+        private sealed class TestFileDialogService : IFileDialogService
+        {
+            public string? OpenFile() => null;
+
+            public string? SelectFolder() => null;
+
+            public string? SaveFile(string suggestedName, string filter) => null;
+        }
+
+        private sealed class TestCsvService : DesktopApplicationTemplate.Core.Services.Protocols.Csv.ICsvService
+        {
+            public bool EnsureColumnsForService(CsvConfiguration configuration, string serviceName) => false;
+
+            public bool RemoveColumnsForService(CsvConfiguration configuration, CsvServiceState state, string serviceName) => false;
+
+            public void RecordLog(CsvConfiguration configuration, CsvServiceState state, ICsvOutput output, string serviceName, string message)
+            {
+            }
+
+            public void AppendRow(CsvConfiguration configuration, CsvServiceState state, ICsvOutput output, IEnumerable<string?> values)
+            {
+            }
+        }
+
+        private sealed class TestCsvOutput : ICsvOutput
+        {
+            public bool FileExists(string filePath) => false;
+
+            public long GetFileLength(string filePath) => 0;
+
+            public void AppendLine(string filePath, string content)
+            {
+            }
+
+            public void EnsureDirectoryForFile(string filePath)
+            {
+            }
+
+            public void DeleteFile(string filePath)
+            {
+            }
+        }
+
+        private sealed class TestServiceCatalog : IServiceCatalog
+        {
+            public IEnumerable<IServiceDescriptor> GetAll() => Enumerable.Empty<IServiceDescriptor>();
+
+            public bool TryGetById(string descriptorId, out IServiceDescriptor descriptor)
+            {
+                descriptor = null!;
+                return false;
+            }
+
+            public bool TryGetByLegacyType(ServiceType type, out IServiceDescriptor descriptor)
+            {
+                descriptor = null!;
+                return false;
+            }
+        }
+
+        private sealed class TestStartupPreferencesService : IStartupPreferencesService
+        {
+            public StartupPreferencesResult ShowDialog(bool runServicesOnStartup, bool runUiOnStartup)
+                => new(true, runServicesOnStartup, runUiOnStartup);
+        }
+    }
+}

--- a/DesktopApplicationTemplate.UI/AssemblyInfo.cs
+++ b/DesktopApplicationTemplate.UI/AssemblyInfo.cs
@@ -1,4 +1,7 @@
+using System.Runtime.CompilerServices;
 using System.Windows;
+
+[assembly: InternalsVisibleTo("DesktopApplicationTemplate.UI.Tests")]
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.TestHooks.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.TestHooks.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace DesktopApplicationTemplate.UI.ViewModels
+{
+    public partial class MainViewModel
+    {
+        internal Task StartServicesForTestingAsync() => StartServicesAsync();
+
+        internal Task StopServicesForTestingAsync() => StopServicesAsync();
+    }
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -21,7 +22,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public class MainViewModel : ViewModelBase
+    public partial class MainViewModel : ViewModelBase
     {
         public ObservableCollection<ServiceListModel> Services { get; set; } = new();
         public ICollectionView FilteredServices { get; }
@@ -120,6 +121,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly HashSet<ServiceListModel> _activatingServices = new();
         private readonly HashSet<ServiceListModel> _trackedServices = new();
         private static readonly TimeSpan ActivationConfirmationDelay = TimeSpan.FromMilliseconds(500);
+        private int _serviceCreationScopeDepth;
+
+        internal bool IsServiceCreationInProgress => Volatile.Read(ref _serviceCreationScopeDepth) > 0;
+
+        internal int ActivatingServicesCount => _activatingServices.Count;
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
 
@@ -182,6 +188,37 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (_logger is LoggingService concreteLogger)
             {
                 concreteLogger.Reload();
+            }
+        }
+
+        internal IDisposable BeginServiceCreationScope()
+        {
+            Interlocked.Increment(ref _serviceCreationScopeDepth);
+            return new ServiceCreationScope(this);
+        }
+
+        private void EndServiceCreationScope()
+        {
+            var newDepth = Interlocked.Decrement(ref _serviceCreationScopeDepth);
+            if (newDepth < 0)
+            {
+                Interlocked.Exchange(ref _serviceCreationScopeDepth, 0);
+            }
+        }
+
+        private sealed class ServiceCreationScope : IDisposable
+        {
+            private MainViewModel? owner;
+
+            public ServiceCreationScope(MainViewModel owner)
+            {
+                this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
+            }
+
+            public void Dispose()
+            {
+                owner?.EndServiceCreationScope();
+                owner = null;
             }
         }
 
@@ -460,6 +497,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task ToggleServiceProcessAsync()
         {
+            if (IsServiceCreationInProgress)
+            {
+                _logger?.Log("Service process toggle ignored because a service is being created.", LogLevel.Debug);
+                return;
+            }
+
             if (IsServiceProcessBusy)
             {
                 return;
@@ -512,6 +555,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public async Task ShutdownServicesAsync()
         {
+            if (IsServiceCreationInProgress)
+            {
+                _logger?.Log("Shutdown skipped because a service is being created.", LogLevel.Debug);
+                return;
+            }
+
             if (!Services.Any(s => s.IsActive) && _activatingServices.Count == 0)
             {
                 return;
@@ -536,6 +585,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task StartServicesAsync()
         {
+            if (IsServiceCreationInProgress)
+            {
+                _logger?.Log("Skipping service activation while creation is in progress.", LogLevel.Debug);
+                return;
+            }
+
             foreach (var svc in Services)
             {
                 if (svc.IsActive)
@@ -558,6 +613,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private async Task StopServicesAsync()
         {
+            if (IsServiceCreationInProgress)
+            {
+                _logger?.Log("Skipping service deactivation while creation is in progress.", LogLevel.Debug);
+                return;
+            }
+
             foreach (var svc in Services)
             {
                 _activatingServices.Remove(svc);

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -345,6 +345,27 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
+        internal void InitializeActivationState(bool isActive, bool notify = false)
+        {
+            var stateChanged = _isActive != isActive;
+            _isActive = isActive;
+
+            if (isActive)
+            {
+                SetRuntimeState(ServiceRuntimeState.Active);
+            }
+            else if (RuntimeState != ServiceRuntimeState.Error)
+            {
+                SetRuntimeState(ServiceRuntimeState.Inactive);
+            }
+
+            if (stateChanged && notify)
+            {
+                OnPropertyChanged(nameof(IsActive));
+                ActiveChanged?.Invoke(_isActive);
+            }
+        }
+
         public void SetRuntimeState(ServiceRuntimeState state)
         {
             RuntimeState = state;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -496,6 +496,7 @@ namespace DesktopApplicationTemplate.UI.Views
             page.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
             page.ServiceCreated += (name, type) =>
             {
+                using var creationScope = _viewModel.BeginServiceCreationScope();
                 var trimmed = string.IsNullOrWhiteSpace(name)
                     ? _viewModel.GenerateServiceName(type)
                     : name.Trim();
@@ -507,9 +508,9 @@ namespace DesktopApplicationTemplate.UI.Views
                 var svc = new ServiceListModel
                 {
                     DisplayName = trimmed,
-                    Type = type,
-                    IsActive = false
+                    Type = type
                 };
+                svc.InitializeActivationState(isActive: false);
                 ApplyPresentation(svc);
                 svc.LogAdded += _viewModel.OnServiceLogAdded;
                 svc.ActiveChanged += _viewModel.OnServiceActiveChanged;
@@ -567,6 +568,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
         internal async Task<bool> TryAddServiceAsync<TOptions>(ServiceType type, ServiceFactoryOptions<TOptions> context)
         {
+            using var creationScope = _viewModel.BeginServiceCreationScope();
             var sanitizedName = string.IsNullOrWhiteSpace(context.Name)
                 ? _viewModel.GenerateServiceName(type)
                 : context.Name.Trim();
@@ -588,6 +590,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 return false;
             }
 
+            svc.InitializeActivationState(isActive: false);
             ApplyPresentation(svc);
             svc.LogAdded += _viewModel.OnServiceLogAdded;
             svc.ActiveChanged += _viewModel.OnServiceActiveChanged;

--- a/DesktopApplicationTemplate.sln
+++ b/DesktopApplicationTemplate.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.UI", "DesktopApplicationTemplate.UI\DesktopApplicationTemplate.UI.csproj", "{ECFDCBB9-CEBD-4236-B96D-8519760318B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.UI.Tests", "DesktopApplicationTemplate.UI.Tests\DesktopApplicationTemplate.UI.Tests.csproj", "{7F2F167B-1F74-4D69-9DC2-DC23A0C2530F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
                 {ECFDCBB9-CEBD-4236-B96D-8519760318B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {ECFDCBB9-CEBD-4236-B96D-8519760318B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {ECFDCBB9-CEBD-4236-B96D-8519760318B9}.Release|Any CPU.Build.0 = Release|Any CPU
+                {7F2F167B-1F74-4D69-9DC2-DC23A0C2530F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7F2F167B-1F74-4D69-9DC2-DC23A0C2530F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7F2F167B-1F74-4D69-9DC2-DC23A0C2530F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7F2F167B-1F74-4D69-9DC2-DC23A0C2530F}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a service-creation scope in `MainViewModel` so start/stop helpers bail out and log when a service is being added
- ensure UI service-add flows initialize new services as inactive without touching activation flags
- introduce `DesktopApplicationTemplate.UI.Tests` with regression coverage for the creation guard and activation initialization

## Testing
- not run (environment lacks the .NET SDK / WindowsDesktop runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e68b84f04c83268bbe9d56b1a08292