### PR TITLE
Fix MQTT editor warning and align test doubles with interfaces

### DIFF
--- a/DesktopApplicationTemplate.UI.Tests/MainViewModelServiceCreationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewModelServiceCreationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.Core.Services;
@@ -181,9 +182,25 @@ namespace DesktopApplicationTemplate.UI.Tests
 
         private sealed class TestNetworkConfigurationService : INetworkConfigurationService
         {
-            public Task ApplyConfigurationAsync(NetworkConfiguration configuration) => Task.CompletedTask;
+            private NetworkConfiguration currentConfiguration = new();
 
-            public Task<NetworkConfiguration> GetConfigurationAsync() => Task.FromResult(new NetworkConfiguration());
+            public event EventHandler<NetworkConfiguration>? ConfigurationChanged;
+
+            public Task ApplyConfigurationAsync(
+                NetworkConfiguration configuration,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                currentConfiguration = configuration ?? new NetworkConfiguration();
+                ConfigurationChanged?.Invoke(this, currentConfiguration);
+                return Task.CompletedTask;
+            }
+
+            public Task<NetworkConfiguration> GetConfigurationAsync(CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(currentConfiguration);
+            }
         }
 
         private sealed class TestFileDialogService : IFileDialogService
@@ -231,16 +248,57 @@ namespace DesktopApplicationTemplate.UI.Tests
 
         private sealed class TestServiceCatalog : IServiceCatalog
         {
-            public IEnumerable<IServiceDescriptor> GetAll() => Enumerable.Empty<IServiceDescriptor>();
+            private readonly List<IServiceDescriptor> descriptors = new();
+            private readonly Dictionary<ServiceType, string> legacyMap = new();
+
+            public IReadOnlyCollection<IServiceDescriptor> Descriptors => descriptors;
+
+            public event EventHandler? DescriptorsChanged;
+
+            public IReadOnlyDictionary<ServiceType, string> LegacyMap => legacyMap;
+
+            public IEnumerable<IServiceDescriptor> GetAll() => Descriptors;
+
+            public void UpdateDescriptors(IEnumerable<IServiceDescriptor> newDescriptors)
+            {
+                descriptors.Clear();
+                legacyMap.Clear();
+
+                foreach (var descriptor in newDescriptors ?? Enumerable.Empty<IServiceDescriptor>())
+                {
+                    descriptors.Add(descriptor);
+
+                    if (descriptor.LegacyType is ServiceType legacyType)
+                    {
+                        legacyMap[legacyType] = descriptor.Id;
+                    }
+                }
+
+                DescriptorsChanged?.Invoke(this, EventArgs.Empty);
+            }
 
             public bool TryGetById(string descriptorId, out IServiceDescriptor descriptor)
             {
+                var match = descriptors.FirstOrDefault(
+                    d => string.Equals(d.Id, descriptorId, StringComparison.Ordinal));
+
+                if (match is not null)
+                {
+                    descriptor = match;
+                    return true;
+                }
+
                 descriptor = null!;
                 return false;
             }
 
             public bool TryGetByLegacyType(ServiceType type, out IServiceDescriptor descriptor)
             {
+                if (legacyMap.TryGetValue(type, out var descriptorId))
+                {
+                    return TryGetById(descriptorId, out descriptor);
+                }
+
                 descriptor = null!;
                 return false;
             }

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
@@ -11,6 +11,7 @@ using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using CoreLogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -79,8 +80,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <summary>
         /// Gets or sets the log level filter.
         /// </summary>
-        private LogLevel _logLevelFilter = LogLevel.Debug;
-        public LogLevel LogLevelFilter
+        private CoreLogLevel _logLevelFilter = CoreLogLevel.Debug;
+        public CoreLogLevel LogLevelFilter
         {
             get => _logLevelFilter;
             set { _logLevelFilter = value; OnPropertyChanged(); OnPropertyChanged(nameof(DisplayLogs)); }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -403,10 +403,14 @@ namespace DesktopApplicationTemplate.UI.Views
             service.MqttOptions ??= new MqttServiceOptions();
 
             var logger = _serviceProvider.GetService<ILoggingService>();
-            var viewModel = ActivatorUtilities.CreateInstance<MqttEditConnectionViewModel>(
-                _serviceProvider,
-                service,
-                logger);
+            var viewModel = logger is null
+                ? ActivatorUtilities.CreateInstance<MqttEditConnectionViewModel>(
+                    _serviceProvider,
+                    service)
+                : ActivatorUtilities.CreateInstance<MqttEditConnectionViewModel>(
+                    _serviceProvider,
+                    service,
+                    logger);
 
             if (highlightMissingFields)
             {


### PR DESCRIPTION
## Summary
- guard MQTT connection editor creation against a missing logging service
- disambiguate log level usage in the service log view model
- update UI test doubles to satisfy the latest service catalog and network configuration interfaces

## Testing
- Not run (solution targets Windows-only frameworks in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e69618c1e08326b227288769275abb