### PR TITLE
Remove legacy service type mappings and persist descriptor identifiers

### DIFF
--- a/Codex/docs/ServicePersistenceFormat.md
+++ b/Codex/docs/ServicePersistenceFormat.md
@@ -11,13 +11,14 @@ The file stores an array of service records:
   {
     "DisplayName": "HTTP - My API",
     "DescriptorId": "custom.http",
-    "LegacyType": "http",
-    "LegacyTypeName": "Http",
+    "ServiceType": "HT",
     "IsActive": false,
     "Created": "2025-10-07T18:42:11.3246188Z",
     "Order": 0,
     "AssociatedServices": ["TCP - Listener"],
-    "SerializedPayload": "{\"BaseUrl\":\"https://example.com\"}",
+    "HttpOptions": {
+      "BaseUrl": "https://example.com"
+    },
     "TotalExecutionTimeMs": 0.0,
     "ExecutionCount": 0
   }
@@ -29,25 +30,25 @@ All properties use PascalCase to match the serialized `PersistedServiceRecord` m
 ### Core fields
 
 1. **`DescriptorId`** – Stable identifier exposed by the descriptor. Service persistence always prefers descriptor identifiers to locate factories and serializers.
-2. **`SerializedPayload`** – Descriptor-provided serialization of the options payload. `ServicePersistence` invokes `IServiceOptionsSerializer.Serialize` on save and `Deserialize` on load, so plug-ins can choose any JSON shape that fits their options model.
-3. **`LegacyType` / `LegacyTypeName`** – Compatibility values retained for migrations. `LegacyType` uses the short code written by `ServiceTypeJsonConverter` (for example, `"tcp"`); `LegacyTypeName` records the enum name (for example, `"Tcp"`). During load, the catalog uses `IServiceCatalog.LegacyMap` to translate legacy codes into the correct descriptor.
+2. **`ServiceType`** – Canonical short code emitted by `ServiceTypeJsonConverter` (for example, `"HT"` for `Http`). The value is kept in sync with the descriptor metadata and persisted alongside the identifier for quick filtering.
+3. **Service-specific options** – Built-in services write their strongly-typed options (`HttpOptions`, `TcpOptions`, and so on). Plug-ins should continue to expose serializers that hydrate their view models from the stored JSON payload.
 4. **State metadata** – `DisplayName`, `IsActive`, `Created`, `Order`, `AssociatedServices`, `TotalExecutionTimeMs`, and `ExecutionCount` mirror the values surfaced by `ServiceListModel`.
 
 ### Descriptor payload contract
 
 - Implement `IServiceOptionsSerializer` (or `IServiceOptionsSerializer<TOptions>`) on your descriptor to control persistence.
-- `SerializedPayload` **must** be valid JSON representing your options type. The serializer can emit compact or indented JSON; persistence stores the raw string.
-- When loading, `ServicePersistence` passes the stored string to `Deserialize`. If the serializer is unavailable, the loader falls back to `JsonSerializer.Deserialize<object>`.
+- Built-in descriptors persist their strongly typed option models directly. Plug-ins can emit whatever JSON shape their serializer understands, storing the document under descriptor-specific properties.
+- When loading, `ServicePersistence` passes the stored JSON to `Deserialize`. If the serializer is unavailable, the loader falls back to `JsonSerializer.Deserialize<object>`.
 
 ### Backward compatibility
 
-- Older files may contain a `Payload` object instead of `SerializedPayload`. The loader still supports this legacy shape by deserializing the JSON object via the descriptor serializer.
-- Very old releases used service-type names (`"ServiceType": "FTP"`). Those entries are mapped through `ServiceTypeExtensions.TryParse` and `IServiceCatalog.LegacyMap` so descriptors continue to resolve.
+- Older files may contain a `Payload` object instead of service-specific option properties. The loader still supports this legacy shape by deserializing the JSON object via the descriptor serializer.
+- Persisted records must now provide a `DescriptorId` and canonical `ServiceType` code. The loader no longer translates legacy enum names automatically, so update historical exports before migrating to the trimmed format.
 - Descriptors should preserve their identifiers and keep their serializers backward compatible. If options evolve, support migrating legacy JSON inside your `IServiceOptionsSerializer` implementation.
 
 ## Validation checklist for plug-in authors
 
-1. Provide a unique `DescriptorId` and `LegacyType` (if migrating an enum-based service).
+1. Provide a unique `DescriptorId` and canonical `ServiceType` code (if migrating an enum-based service).
 2. Supply an `IServiceOptionsSerializer` that round-trips your options and tolerates historical payload shapes.
 3. Confirm your descriptor registers factories so `MainViewModel` can request the appropriate UI/service factory during load.
 4. Add automated tests that serialize services using your descriptor and verify that deserialization restores the expected options and metadata.

--- a/DesktopApplicationTemplate.Core/Converters/ServiceTypeJsonConverter.cs
+++ b/DesktopApplicationTemplate.Core/Converters/ServiceTypeJsonConverter.cs
@@ -7,7 +7,7 @@ namespace DesktopApplicationTemplate.Core.Converters;
 
 /// <summary>
 /// Converts <see cref="ServiceType"/> values to short codes for persistence
-/// and parses legacy names.
+/// and parses canonical identifiers.
 /// </summary>
 public sealed class ServiceTypeJsonConverter : JsonConverter<ServiceType>
 {

--- a/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
+++ b/DesktopApplicationTemplate.Core/Models/ServiceTypeExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DesktopApplicationTemplate.Models;
 
@@ -22,29 +23,8 @@ public static class ServiceTypeExtensions
         { ServiceType.Heartbeat, "HB" }
     };
 
-    private static readonly Dictionary<string, ServiceType> LegacyMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        { "MQ", ServiceType.Mqtt },
-        { "MQTT", ServiceType.Mqtt },
-        { "HT", ServiceType.Http },
-        { "HTTP", ServiceType.Http },
-        { "FT", ServiceType.Ftp },
-        { "FTP", ServiceType.Ftp },
-        { "FTP Server", ServiceType.Ftp },
-        { "HD", ServiceType.Hid },
-        { "HID", ServiceType.Hid },
-        { "CV", ServiceType.Csv },
-        { "CSV", ServiceType.Csv },
-        { "CSV Creator", ServiceType.Csv },
-        { "FO", ServiceType.FileObserver },
-        { "File Observer", ServiceType.FileObserver },
-        { "SC", ServiceType.Scp },
-        { "SCP", ServiceType.Scp },
-        { "TC", ServiceType.Tcp },
-        { "TCP", ServiceType.Tcp },
-        { "HB", ServiceType.Heartbeat },
-        { "Heartbeat", ServiceType.Heartbeat }
-    };
+    private static readonly Dictionary<string, ServiceType> CodeLookup =
+        CodeMap.ToDictionary(kvp => kvp.Value, kvp => kvp.Key, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Converts a <see cref="ServiceType"/> to its short code representation.
@@ -57,32 +37,31 @@ public static class ServiceTypeExtensions
     /// </summary>
     public static bool TryParse(string? value, out ServiceType result)
     {
-        if (value != null && LegacyMap.TryGetValue(value, out result))
+        result = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmed = value.Trim();
+
+        if (CodeLookup.TryGetValue(trimmed, out result))
         {
             return true;
         }
 
-        return Enum.TryParse(value, true, out result);
-    }
+        var normalized = trimmed
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .Replace("-", string.Empty, StringComparison.Ordinal);
 
-    /// <summary>
-    /// Converts a <see cref="ServiceType"/> to one of its legacy display strings,
-    /// defaulting to the short code if no legacy name exists.
-    /// </summary>
-    public static string ToLegacyString(this ServiceType type) =>
-        type switch
+        if (!string.Equals(normalized, trimmed, StringComparison.Ordinal) &&
+            Enum.TryParse(normalized, true, out result))
         {
-            ServiceType.Ftp => "FTP",
-            ServiceType.Mqtt => "MQTT",
-            ServiceType.Http => "HTTP",
-            ServiceType.Tcp => "TCP",
-            ServiceType.Hid => "HID",
-            ServiceType.Csv => "CSV Creator",
-            ServiceType.FileObserver => "File Observer",
-            ServiceType.Scp => "SCP",
-            ServiceType.Heartbeat => "Heartbeat",
-            _ => type.ToCode()
-        };
+            return true;
+        }
+
+        return Enum.TryParse(trimmed, true, out result);
+    }
 
     /// <summary>
     /// Provides the default prefix used when generating service names.

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/BuiltInServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/BuiltInServiceDescriptor.cs
@@ -22,7 +22,7 @@ public abstract class BuiltInServiceDescriptor<TOptions> : IServiceDescriptor
         string id,
         string displayName,
         string category,
-        ServiceType legacyType,
+        ServiceType serviceType,
         ServicePresentationMetadata presentation,
         string? description = null,
         IServiceOptionsSerializer? serializer = null,
@@ -31,7 +31,7 @@ public abstract class BuiltInServiceDescriptor<TOptions> : IServiceDescriptor
         Id = id ?? throw new ArgumentNullException(nameof(id));
         DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
         Category = category ?? throw new ArgumentNullException(nameof(category));
-        LegacyType = legacyType;
+        ServiceType = serviceType;
         Description = description;
         _presentation = ServicePresentationMetadata.Normalize(presentation);
         _serializer = serializer ?? new JsonServiceOptionsSerializer<TOptions>();
@@ -57,7 +57,7 @@ public abstract class BuiltInServiceDescriptor<TOptions> : IServiceDescriptor
 
     public string? Description { get; }
 
-    public ServiceType? LegacyType { get; }
+    public ServiceType? ServiceType { get; }
 
     public IServiceOptionsSerializer OptionsSerializer => _serializer;
 

--- a/DesktopApplicationTemplate.Core/Services/IServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceCatalog.cs
@@ -20,19 +20,9 @@ public interface IServiceCatalog
     event EventHandler? DescriptorsChanged;
 
     /// <summary>
-    /// Gets a mapping of legacy <see cref="ServiceType"/> values to descriptor identifiers.
-    /// </summary>
-    IReadOnlyDictionary<ServiceType, string> LegacyMap { get; }
-
-    /// <summary>
     /// Attempts to retrieve a descriptor by its unique identifier.
     /// </summary>
     bool TryGetById(string id, out IServiceDescriptor descriptor);
-
-    /// <summary>
-    /// Attempts to retrieve a descriptor from a legacy <see cref="ServiceType"/>.
-    /// </summary>
-    bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor);
 
     /// <summary>
     /// Replaces the descriptor collection with the provided entries.

--- a/DesktopApplicationTemplate.Core/Services/IServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Services/IServiceDescriptor.cs
@@ -29,9 +29,9 @@ public interface IServiceDescriptor
     string? Description { get; }
 
     /// <summary>
-    /// Gets the legacy <see cref="ServiceType"/> associated with the service, if any.
+    /// Gets the canonical <see cref="ServiceType"/> associated with the service, if any.
     /// </summary>
-    ServiceType? LegacyType { get; }
+    ServiceType? ServiceType { get; }
 
     /// <summary>
     /// Gets the serializer used to persist service options, if available.

--- a/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
+++ b/DesktopApplicationTemplate.Core/Services/ServiceCatalog.cs
@@ -12,8 +12,6 @@ public sealed class ServiceCatalog : IServiceCatalog
 {
     private readonly object _sync = new();
     private IReadOnlyDictionary<string, IServiceDescriptor> _descriptorsById = new Dictionary<string, IServiceDescriptor>(StringComparer.Ordinal);
-    private IReadOnlyDictionary<ServiceType, IServiceDescriptor> _descriptorsByLegacy = new Dictionary<ServiceType, IServiceDescriptor>();
-    private IReadOnlyDictionary<ServiceType, string> _legacyMap = new Dictionary<ServiceType, string>();
     private IReadOnlyCollection<IServiceDescriptor> _descriptors = Array.Empty<IServiceDescriptor>();
 
     public ServiceCatalog(IEnumerable<IServiceDescriptor> descriptors)
@@ -23,15 +21,10 @@ public sealed class ServiceCatalog : IServiceCatalog
 
     public IReadOnlyCollection<IServiceDescriptor> Descriptors => _descriptors;
 
-    public IReadOnlyDictionary<ServiceType, string> LegacyMap => _legacyMap;
-
     public event EventHandler? DescriptorsChanged;
 
     public bool TryGetById(string id, out IServiceDescriptor descriptor) =>
         _descriptorsById.TryGetValue(id, out descriptor!);
-
-    public bool TryGetByLegacyType(ServiceType legacyType, out IServiceDescriptor descriptor) =>
-        _descriptorsByLegacy.TryGetValue(legacyType, out descriptor!);
 
     public void UpdateDescriptors(IEnumerable<IServiceDescriptor> descriptors)
     {
@@ -57,21 +50,8 @@ public sealed class ServiceCatalog : IServiceCatalog
             var snapshots = builders.Values.Select(b => b.Build()).ToList();
 
             var descriptorsById = snapshots.ToDictionary(d => d.Id, d => (IServiceDescriptor)d, StringComparer.Ordinal);
-            var legacyLookup = new Dictionary<ServiceType, IServiceDescriptor>();
-            foreach (var descriptor in snapshots)
-            {
-                if (descriptor.LegacyType is { } legacy)
-                {
-                    if (!legacyLookup.TryAdd(legacy, descriptor))
-                    {
-                        throw new InvalidOperationException($"Legacy service type '{legacy}' is already mapped to descriptor '{legacyLookup[legacy].Id}'.");
-                    }
-                }
-            }
 
             _descriptorsById = descriptorsById;
-            _descriptorsByLegacy = legacyLookup;
-            _legacyMap = legacyLookup.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Id);
             _descriptors = snapshots;
         }
 
@@ -84,7 +64,7 @@ public sealed class ServiceCatalog : IServiceCatalog
         private string? _displayName;
         private string? _category;
         private string? _description;
-        private ServiceType? _legacyType;
+        private ServiceType? _serviceType;
         private IServiceOptionsSerializer? _serializer;
         private readonly Dictionary<(ServiceFactoryKind Kind, Type ContractType, string? Key), ServiceFactoryBinding> _factories = new();
         private ServicePresentationMetadata? _presentation;
@@ -132,15 +112,15 @@ public sealed class ServiceCatalog : IServiceCatalog
                 }
             }
 
-            if (descriptor.LegacyType is { } legacy)
+            if (descriptor.ServiceType is { } serviceType)
             {
-                if (_legacyType is null)
+                if (_serviceType is null)
                 {
-                    _legacyType = legacy;
+                    _serviceType = serviceType;
                 }
-                else if (_legacyType.Value != legacy)
+                else if (_serviceType.Value != serviceType)
                 {
-                    throw new InvalidOperationException($"Conflicting legacy type assignments for descriptor '{_id}'.");
+                    throw new InvalidOperationException($"Conflicting service type assignments for descriptor '{_id}'.");
                 }
             }
 
@@ -182,7 +162,7 @@ public sealed class ServiceCatalog : IServiceCatalog
                 _displayName!,
                 _category!,
                 _description,
-                _legacyType,
+                _serviceType,
                 _serializer,
                 factories,
                 presentation,
@@ -218,7 +198,7 @@ public sealed class ServiceCatalog : IServiceCatalog
             string displayName,
             string category,
             string? description,
-            ServiceType? legacyType,
+            ServiceType? serviceType,
             IServiceOptionsSerializer? serializer,
             IReadOnlyCollection<ServiceFactoryBinding> factories,
             ServicePresentationMetadata presentation,
@@ -229,7 +209,7 @@ public sealed class ServiceCatalog : IServiceCatalog
             DisplayName = displayName;
             Category = category;
             Description = description;
-            LegacyType = legacyType;
+            ServiceType = serviceType;
             OptionsSerializer = serializer;
             Factories = factories;
             Presentation = presentation;
@@ -245,7 +225,7 @@ public sealed class ServiceCatalog : IServiceCatalog
 
         public string? Description { get; }
 
-        public ServiceType? LegacyType { get; }
+        public ServiceType? ServiceType { get; }
 
         public IServiceOptionsSerializer? OptionsSerializer { get; }
 

--- a/DesktopApplicationTemplate.Services/ServiceUiRegistration.cs
+++ b/DesktopApplicationTemplate.Services/ServiceUiRegistration.cs
@@ -17,7 +17,6 @@ public sealed record ServiceUiRegistration<TService, TPage>(
     Func<IServiceProvider, object, TService> CreateService,
     Func<IServiceProvider, TPage> CreateServicePage,
     Func<IServiceProvider, string, TPage> CreateNavigationPage,
-    ServiceType? LegacyServiceType = null,
     Action<TService, ServicePresentationMetadata>? ApplyPresentation = null);
 
 public interface IServiceUiRegistry<TService, TPage> : IDisposable
@@ -48,7 +47,7 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
 {
     private readonly IServiceCatalog _serviceCatalog;
     private readonly IReadOnlyDictionary<string, ServiceUiRegistration<TService, TPage>> _registrations;
-    private readonly Dictionary<ServiceType, string> _legacyMap = new();
+    private readonly Dictionary<ServiceType, string> _serviceTypeMap = new();
     private IReadOnlyCollection<ServiceType> _supportedServices = Array.Empty<ServiceType>();
     private readonly IReadOnlyCollection<string> _supportedDescriptorIds;
     private bool _disposed;
@@ -75,15 +74,11 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
             }
 
             map[registration.DescriptorId] = registration;
-            if (registration.LegacyServiceType is { } legacy)
-            {
-                _legacyMap[legacy] = registration.DescriptorId;
-            }
         }
 
         _registrations = new ReadOnlyDictionary<string, ServiceUiRegistration<TService, TPage>>(map);
         _supportedDescriptorIds = _registrations.Keys.ToArray();
-        UpdateLegacyMappings();
+        RefreshSupportedServices();
         _serviceCatalog.DescriptorsChanged += OnDescriptorsChanged;
     }
 
@@ -93,7 +88,7 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
 
     public bool TryCreateService(ServiceType serviceType, IServiceProvider provider, object options, out TService? service)
     {
-        if (!_legacyMap.TryGetValue(serviceType, out var descriptorId))
+        if (!_serviceTypeMap.TryGetValue(serviceType, out var descriptorId))
         {
             service = default;
             return false;
@@ -122,7 +117,7 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
 
     public bool TryCreateServicePage(ServiceType serviceType, IServiceProvider provider, out TPage? page)
     {
-        if (!_legacyMap.TryGetValue(serviceType, out var descriptorId))
+        if (!_serviceTypeMap.TryGetValue(serviceType, out var descriptorId))
         {
             page = default;
             return false;
@@ -150,7 +145,7 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
 
     public bool TryCreateNavigationPage(ServiceType serviceType, IServiceProvider provider, string defaultName, out TPage? page)
     {
-        if (!_legacyMap.TryGetValue(serviceType, out var descriptorId))
+        if (!_serviceTypeMap.TryGetValue(serviceType, out var descriptorId))
         {
             page = default;
             return false;
@@ -188,35 +183,22 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
         GC.SuppressFinalize(this);
     }
 
-    private void OnDescriptorsChanged(object? sender, EventArgs e) => UpdateLegacyMappings();
+    private void OnDescriptorsChanged(object? sender, EventArgs e) => RefreshSupportedServices();
 
-    private void UpdateLegacyMappings()
+    private void RefreshSupportedServices()
     {
-        var updated = new Dictionary<ServiceType, string>();
+        _serviceTypeMap.Clear();
 
-        foreach (var registration in _registrations.Values)
+        foreach (var descriptor in _serviceCatalog.Descriptors)
         {
-            if (registration.LegacyServiceType is { } legacy)
+            if (descriptor.ServiceType is { } serviceType &&
+                _registrations.ContainsKey(descriptor.Id))
             {
-                updated[legacy] = registration.DescriptorId;
+                _serviceTypeMap[serviceType] = descriptor.Id;
             }
         }
 
-        foreach (var kvp in _serviceCatalog.LegacyMap)
-        {
-            if (_registrations.ContainsKey(kvp.Value))
-            {
-                updated[kvp.Key] = kvp.Value;
-            }
-        }
-
-        _legacyMap.Clear();
-        foreach (var kvp in updated)
-        {
-            _legacyMap[kvp.Key] = kvp.Value;
-        }
-
-        _supportedServices = _legacyMap.Keys.ToArray();
+        _supportedServices = _serviceTypeMap.Keys.ToArray();
     }
 
     private void ApplyPresentationIfAvailable(TService? service, ServiceUiRegistration<TService, TPage> registration)

--- a/DesktopApplicationTemplate.UI.Tests/MainViewModelServiceCreationTests.cs
+++ b/DesktopApplicationTemplate.UI.Tests/MainViewModelServiceCreationTests.cs
@@ -250,29 +250,20 @@ namespace DesktopApplicationTemplate.UI.Tests
         private sealed class TestServiceCatalog : IServiceCatalog
         {
             private readonly List<IServiceDescriptor> descriptors = new();
-            private readonly Dictionary<ServiceType, string> legacyMap = new();
 
             public IReadOnlyCollection<IServiceDescriptor> Descriptors => descriptors;
 
             public event EventHandler? DescriptorsChanged;
-
-            public IReadOnlyDictionary<ServiceType, string> LegacyMap => legacyMap;
 
             public IEnumerable<IServiceDescriptor> GetAll() => Descriptors;
 
             public void UpdateDescriptors(IEnumerable<IServiceDescriptor> newDescriptors)
             {
                 descriptors.Clear();
-                legacyMap.Clear();
 
                 foreach (var descriptor in newDescriptors ?? Enumerable.Empty<IServiceDescriptor>())
                 {
                     descriptors.Add(descriptor);
-
-                    if (descriptor.LegacyType is ServiceType legacyType)
-                    {
-                        legacyMap[legacyType] = descriptor.Id;
-                    }
                 }
 
                 DescriptorsChanged?.Invoke(this, EventArgs.Empty);
@@ -287,17 +278,6 @@ namespace DesktopApplicationTemplate.UI.Tests
                 {
                     descriptor = match;
                     return true;
-                }
-
-                descriptor = null!;
-                return false;
-            }
-
-            public bool TryGetByLegacyType(ServiceType type, out IServiceDescriptor descriptor)
-            {
-                if (legacyMap.TryGetValue(type, out var descriptorId))
-                {
-                    return TryGetById(descriptorId, out descriptor);
                 }
 
                 descriptor = null!;

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -331,6 +331,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var newService = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Mqtt,
                         IsActive = false
@@ -355,7 +356,6 @@ namespace DesktopApplicationTemplate.UI
                     var view = ActivatorUtilities.CreateInstance<MqttCreateServiceView>(provider, vm);
                     return view;
                 },
-                LegacyServiceType: ServiceType.Mqtt,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -371,6 +371,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Ftp,
                         IsActive = false,
@@ -411,7 +412,6 @@ namespace DesktopApplicationTemplate.UI
                     };
                     return view;
                 },
-                LegacyServiceType: ServiceType.Ftp,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -427,6 +427,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Http,
                         IsActive = false,
@@ -459,7 +460,6 @@ namespace DesktopApplicationTemplate.UI
                     };
                     return view;
                 },
-                LegacyServiceType: ServiceType.Http,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -475,6 +475,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Tcp,
                         IsActive = false,
@@ -497,7 +498,6 @@ namespace DesktopApplicationTemplate.UI
                     vm.EditCancelled += mainView.ShowCreateServiceSelectionPage;
                     return ActivatorUtilities.CreateInstance<TcpCreateServiceView>(provider, vm);
                 },
-                LegacyServiceType: ServiceType.Tcp,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -513,6 +513,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Hid,
                         IsActive = false,
@@ -545,7 +546,6 @@ namespace DesktopApplicationTemplate.UI
                     };
                     return view;
                 },
-                LegacyServiceType: ServiceType.Hid,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -561,6 +561,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Scp,
                         IsActive = false,
@@ -593,7 +594,6 @@ namespace DesktopApplicationTemplate.UI
                     };
                     return view;
                 },
-                LegacyServiceType: ServiceType.Scp,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -609,6 +609,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.FileObserver,
                         IsActive = false,
@@ -641,7 +642,6 @@ namespace DesktopApplicationTemplate.UI
                     };
                     return view;
                 },
-                LegacyServiceType: ServiceType.FileObserver,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -657,6 +657,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Csv,
                         IsActive = false,
@@ -681,7 +682,6 @@ namespace DesktopApplicationTemplate.UI
                     view.Initialize(vm);
                     return view;
                 },
-                LegacyServiceType: ServiceType.Csv,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 
@@ -697,6 +697,7 @@ namespace DesktopApplicationTemplate.UI
                     var mainView = provider.GetRequiredService<MainView>();
                     var svc = new ServiceListModel
                     {
+                        DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Heartbeat,
                         IsActive = false,
@@ -729,7 +730,6 @@ namespace DesktopApplicationTemplate.UI
                     };
                     return view;
                 },
-                LegacyServiceType: ServiceType.Heartbeat,
                 ApplyPresentation: static (service, metadata) => service.ApplyPresentation(metadata));
         }
 

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -174,6 +174,7 @@ namespace DesktopApplicationTemplate.Persistence
                 data.Add(new ServiceInfo
                 {
                     DisplayName = s.DisplayName,
+                    DescriptorId = s.DescriptorId,
                     ServiceType = s.Type,
                     IsActive = s.IsActive,
                     Created = DateTime.Now,
@@ -249,6 +250,7 @@ namespace DesktopApplicationTemplate.Persistence
                 logger?.Log("Services file not found", LogLevel.Warning);
                 return new List<ServiceInfo>();
             }
+
             string json;
             try
             {
@@ -259,58 +261,19 @@ namespace DesktopApplicationTemplate.Persistence
                 logger?.Log("Services file not found", LogLevel.Warning);
                 return new List<ServiceInfo>();
             }
+
             try
             {
-                try
+                var services = JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+
+                foreach (var info in services)
                 {
-                    var current = JsonSerializer.Deserialize<List<ServiceInfo>>(json);
-                    if (current is { Count: > 0 })
-                    {
-                        logger?.Log($"Loaded {current.Count} services", LogLevel.Debug);
-                        return current;
-                    }
-                }
-                catch (JsonException)
-                {
-                    // fall back to legacy parsing below
+                    info.AssociatedServices ??= new List<string>();
+                    info.Logs ??= new List<LogEntry>();
+                    info.MessageHistory ??= new List<ServiceMessageHistoryEntry>();
                 }
 
-                var legacy = JsonSerializer.Deserialize<List<LegacyServiceInfo>>(json) ?? new List<LegacyServiceInfo>();
-                var result = new List<ServiceInfo>();
-                foreach (var info in legacy)
-                {
-                    if (ServiceTypeExtensions.TryParse(info.ServiceType, out var type))
-                    {
-                        result.Add(new ServiceInfo
-                        {
-                            DisplayName = info.DisplayName,
-                            ServiceType = type,
-                            IsActive = info.IsActive,
-                            Created = info.Created,
-                            Order = info.Order,
-                            AssociatedServices = info.AssociatedServices ?? new List<string>(),
-                            TcpOptions = info.TcpOptions,
-                            FtpOptions = info.FtpOptions,
-                            HttpOptions = info.HttpOptions,
-                            CsvOptions = info.CsvOptions,
-                            HeartbeatOptions = info.HeartbeatOptions,
-                            FileObserverOptions = info.FileObserverOptions,
-                            HidOptions = info.HidOptions,
-                            ScpOptions = info.ScpOptions,
-                            TotalExecutionTimeMs = info.TotalExecutionTimeMs,
-                            ExecutionCount = info.ExecutionCount,
-                            IncomingMessageCount = info.IncomingMessageCount,
-                            OutgoingMessageCount = info.OutgoingMessageCount,
-                            Logs = info.Logs ?? new List<LogEntry>()
-                        });
-                    }
-                    else
-                    {
-                        logger?.Log($"Unmapped service type '{info.ServiceType}' for '{info.DisplayName}'", LogLevel.Warning);
-                    }
-                }
-
-                foreach (var info in result)
+                foreach (var info in services)
                 {
                     if (info.ServiceType == ServiceType.Mqtt && info.MqttOptions is null)
                     {
@@ -365,6 +328,7 @@ namespace DesktopApplicationTemplate.Persistence
                             value.LastTestMessage = info.TcpOptions.LastTestMessage;
                         }
                     }
+
                     if (info.ServiceType == ServiceType.Ftp && info.FtpOptions != null)
                     {
                         try
@@ -385,6 +349,7 @@ namespace DesktopApplicationTemplate.Persistence
                             // ignore missing options during tests or early startup
                         }
                     }
+
                     if (info.ServiceType == ServiceType.Heartbeat && info.HeartbeatOptions != null)
                     {
                         var opt = App.AppHost?.Services.GetService<IOptions<HeartbeatServiceOptions>>();
@@ -443,8 +408,13 @@ namespace DesktopApplicationTemplate.Persistence
                     }
                 }
 
-                logger?.Log($"Loaded {result.Count} services", LogLevel.Debug);
-                return result;
+                logger?.Log($"Loaded {services.Count} services", LogLevel.Debug);
+                return services;
+            }
+            catch (JsonException)
+            {
+                logger?.Log("Failed to parse services file", LogLevel.Error);
+                return new List<ServiceInfo>();
             }
             catch
             {
@@ -457,6 +427,7 @@ namespace DesktopApplicationTemplate.Persistence
     public class ServiceInfo
     {
         public string DisplayName { get; set; } = string.Empty;
+        public string? DescriptorId { get; set; }
         public ServiceType ServiceType { get; set; }
         public bool IsActive { get; set; }
         public DateTime Created { get; set; }
@@ -479,26 +450,4 @@ namespace DesktopApplicationTemplate.Persistence
         public List<ServiceMessageHistoryEntry> MessageHistory { get; set; } = new();
     }
 
-    internal class LegacyServiceInfo
-    {
-        public string DisplayName { get; set; } = string.Empty;
-        public string ServiceType { get; set; } = string.Empty;
-        public bool IsActive { get; set; }
-        public DateTime Created { get; set; }
-        public int Order { get; set; }
-        public List<string> AssociatedServices { get; set; } = new();
-        public TcpServiceOptions? TcpOptions { get; set; }
-        public FtpServerOptions? FtpOptions { get; set; }
-        public HttpServiceOptions? HttpOptions { get; set; }
-        public CsvServiceOptions? CsvOptions { get; set; }
-        public HeartbeatServiceOptions? HeartbeatOptions { get; set; }
-        public FileObserverServiceOptions? FileObserverOptions { get; set; }
-        public HidServiceOptions? HidOptions { get; set; }
-        public ScpServiceOptions? ScpOptions { get; set; }
-        public double TotalExecutionTimeMs { get; set; }
-        public int ExecutionCount { get; set; }
-        public int IncomingMessageCount { get; set; }
-        public int OutgoingMessageCount { get; set; }
-        public List<LogEntry> Logs { get; set; } = new();
-    }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -373,8 +373,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var existing = ServicePersistence.Load(_logger);
             foreach (var info in existing.OrderBy(i => i.Order))
             {
+                var descriptorId = string.IsNullOrWhiteSpace(info.DescriptorId)
+                    ? ResolveDescriptorId(info.ServiceType)
+                    : info.DescriptorId;
+
                 var svc = new ServiceListModel
                 {
+                    DescriptorId = descriptorId,
                     DisplayName = info.DisplayName,
                     Type = info.ServiceType,
                     IsActive = info.IsActive,
@@ -402,6 +407,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     normalizedName = GenerateServiceName(svc.Type);
                 }
                 svc.DisplayName = normalizedName;
+                if (string.IsNullOrWhiteSpace(svc.DescriptorId))
+                {
+                    svc.DescriptorId = ResolveDescriptorId(svc.Type);
+                }
+
                 ApplyPresentationMetadata(svc);
                 svc.SetRuntimeState(svc.IsActive ? ServiceRuntimeState.Active : ServiceRuntimeState.Inactive);
                 svc.LogAdded += OnServiceLogAdded;
@@ -419,6 +429,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             OnPropertyChanged(nameof(CurrentActiveServices));
         }
 
+        private string? ResolveDescriptorId(ServiceType serviceType)
+        {
+            return _serviceCatalog.Descriptors.FirstOrDefault(d => d.ServiceType == serviceType)?.Id;
+        }
+
         private void ApplyPresentationMetadata(ServiceListModel service)
         {
             if (service is null)
@@ -426,7 +441,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return;
             }
 
-            if (_serviceCatalog.TryGetByLegacyType(service.Type, out var descriptor))
+            var descriptorId = service.DescriptorId;
+            if (string.IsNullOrWhiteSpace(descriptorId))
+            {
+                descriptorId = ResolveDescriptorId(service.Type);
+                service.DescriptorId = descriptorId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(descriptorId) &&
+                _serviceCatalog.TryGetById(descriptorId, out var descriptor))
             {
                 service.ApplyPresentation(descriptor.Presentation);
             }
@@ -450,13 +473,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 trimmed = trimmed[(separatorIndex + 3)..];
             }
 
-            var legacyPrefix = type.ToLegacyString();
             var baseName = type.ToBaseName();
-            if (!string.Equals(legacyPrefix, baseName, StringComparison.OrdinalIgnoreCase) &&
-                trimmed.StartsWith(legacyPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                trimmed = baseName + trimmed[legacyPrefix.Length..];
-            }
 
             var codePrefix = type.ToCode();
             if (!string.Equals(codePrefix, baseName, StringComparison.OrdinalIgnoreCase) &&
@@ -464,6 +481,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 !trimmed.StartsWith(baseName, StringComparison.OrdinalIgnoreCase))
             {
                 trimmed = baseName + trimmed[codePrefix.Length..];
+            }
+
+            var enumName = type.ToString();
+            if (!string.Equals(enumName, baseName, StringComparison.OrdinalIgnoreCase) &&
+                trimmed.StartsWith(enumName, StringComparison.OrdinalIgnoreCase) &&
+                !trimmed.StartsWith(baseName, StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = baseName + trimmed[enumName.Length..];
             }
 
             return trimmed;

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -71,6 +71,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 RefreshLogMetadata();
             }
         }
+
+        private string? _descriptorId;
+        public string? DescriptorId
+        {
+            get => _descriptorId;
+            set
+            {
+                if (string.Equals(_descriptorId, value, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _descriptorId = value;
+                OnPropertyChanged();
+            }
+        }
         [JsonIgnore] public Page? Page { get; set; }
         public int Order { get; set; }
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -542,7 +542,15 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            if (_serviceCatalog.TryGetByLegacyType(service.Type, out var descriptor))
+            var descriptorId = service.DescriptorId;
+            if (string.IsNullOrWhiteSpace(descriptorId))
+            {
+                descriptorId = _serviceCatalog.Descriptors.FirstOrDefault(d => d.ServiceType == service.Type)?.Id;
+                service.DescriptorId = descriptorId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(descriptorId) &&
+                _serviceCatalog.TryGetById(descriptorId, out var descriptor))
             {
                 service.ApplyPresentation(descriptor.Presentation);
             }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each service has an editor page where the parameters and test messages can be mo
 
 ## Extending the application
 
-`ServiceType` is an enum that identifies each supported service category. It is serialized using short codes and still recognizes legacy names so existing configurations continue to load.
+`ServiceType` is an enum that identifies each supported service category. It is serialized using short codes alongside descriptor identifiers so persisted services always resolve to the correct feature.
 
 Dictionary-based edit handlers are registered for each `ServiceType` and injected into the main view model as a lookup. When a user edits a service, the view model resolves the handler from that dictionary instead of relying on large switch statements, making it easy to plug in new handlers.
 


### PR DESCRIPTION
## Summary
- remove the legacy service type dictionaries and helpers so descriptors rely on canonical codes
- persist descriptor identifiers throughout the UI, including service creation, presentation lookups, and the JSON file format
- refresh the persistence documentation to describe the streamlined format without legacy codes

## Testing
- not run (Windows desktop build unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6a097700c83268fd75e093aac4845