### PR TITLE
Fix built-in descriptors ServiceType references

### DIFF
--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/CsvServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/CsvServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class CsvServiceDescriptor : BuiltInServiceDescriptor<CsvServiceOp
             ServiceDescriptorIds.Csv,
             "CSV Creator",
             BuiltInServiceCategories.DataProcessing,
-            ServiceType.Csv,
+            ModelsServiceType.Csv,
             new ServicePresentationMetadata(
                 "📄",
                 "LightGray",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/FileObserverServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/FileObserverServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class FileObserverServiceDescriptor : BuiltInServiceDescriptor<Fil
             ServiceDescriptorIds.FileObserver,
             "File Observer",
             BuiltInServiceCategories.Monitoring,
-            ServiceType.FileObserver,
+            ModelsServiceType.FileObserver,
             new ServicePresentationMetadata(
                 "👀",
                 "LightSalmon",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/FtpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/FtpServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services.Protocols.Ftp;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class FtpServiceDescriptor : BuiltInServiceDescriptor<FtpServerOpt
             ServiceDescriptorIds.Ftp,
             "FTP Server",
             BuiltInServiceCategories.FileTransfer,
-            ServiceType.Ftp,
+            ModelsServiceType.Ftp,
             new ServicePresentationMetadata(
                 "🖥️",
                 "LightSteelBlue",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/HeartbeatServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/HeartbeatServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class HeartbeatServiceDescriptor : BuiltInServiceDescriptor<Heartb
             ServiceDescriptorIds.Heartbeat,
             "Heartbeat",
             BuiltInServiceCategories.Monitoring,
-            ServiceType.Heartbeat,
+            ModelsServiceType.Heartbeat,
             new ServicePresentationMetadata(
                 "❤️",
                 "LightPink",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/HidServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/HidServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Hid;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class HidServiceDescriptor : BuiltInServiceDescriptor<HidServiceOp
             ServiceDescriptorIds.Hid,
             "HID",
             BuiltInServiceCategories.Automation,
-            ServiceType.Hid,
+            ModelsServiceType.Hid,
             new ServicePresentationMetadata(
                 "🎛️",
                 "LightYellow",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/HttpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/HttpServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services.Protocols.Http;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class HttpServiceDescriptor : BuiltInServiceDescriptor<HttpService
             ServiceDescriptorIds.Http,
             "HTTP",
             BuiltInServiceCategories.Connectivity,
-            ServiceType.Http,
+            ModelsServiceType.Http,
             new ServicePresentationMetadata(
                 "🌐",
                 "LightGreen",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/MqttServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/MqttServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class MqttServiceDescriptor : BuiltInServiceDescriptor<MqttService
             ServiceDescriptorIds.Mqtt,
             "MQTT",
             BuiltInServiceCategories.Messaging,
-            ServiceType.Mqtt,
+            ModelsServiceType.Mqtt,
             new ServicePresentationMetadata(
                 "📡",
                 "LightGoldenrodYellow",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/ScpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/ScpServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class ScpServiceDescriptor : BuiltInServiceDescriptor<ScpServiceOp
             ServiceDescriptorIds.Scp,
             "SCP",
             BuiltInServiceCategories.FileTransfer,
-            ServiceType.Scp,
+            ModelsServiceType.Scp,
             new ServicePresentationMetadata(
                 "📦",
                 "LightCyan",

--- a/DesktopApplicationTemplate.Core/Modules/BuiltIn/TcpServiceDescriptor.cs
+++ b/DesktopApplicationTemplate.Core/Modules/BuiltIn/TcpServiceDescriptor.cs
@@ -1,6 +1,7 @@
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Models;
+using ModelsServiceType = DesktopApplicationTemplate.Models.ServiceType;
 
 namespace DesktopApplicationTemplate.Core.Modules.BuiltIn;
 
@@ -14,7 +15,7 @@ public sealed class TcpServiceDescriptor : BuiltInServiceDescriptor<TcpServiceOp
             ServiceDescriptorIds.Tcp,
             "TCP",
             BuiltInServiceCategories.Connectivity,
-            ServiceType.Tcp,
+            ModelsServiceType.Tcp,
             new ServicePresentationMetadata(
                 "🔗",
                 "LightBlue",


### PR DESCRIPTION
## Summary
- add explicit aliases so built-in service descriptors pass the DesktopApplicationTemplate.Models.ServiceType enum value to the base constructor

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6aef0520c832696788890b1be6640