### PR TITLE
Enable Delete key removal for service list

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -57,8 +57,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _activeService = value;
                 OnPropertyChanged();
                 LogViewModel.SetLogs(_activeService?.Logs ?? AllLogs, _activeService is null);
-                (RemoveServiceCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
-                (EditServiceCommand as RelayCommand<ServiceListModel?>)?.RaiseCanExecuteChanged();
+                RefreshServiceCommandStates();
             }
         }
         public ICommand AddServiceCommand { get; }
@@ -81,6 +80,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     _servicesRunning = value;
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(ServiceProcessButtonText));
+                    RefreshServiceCommandStates();
                 }
             }
         }
@@ -96,6 +96,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     _isServiceProcessBusy = value;
                     OnPropertyChanged();
                     (ToggleServiceProcessCommand as AsyncRelayCommand)?.RaiseCanExecuteChanged();
+                    RefreshServiceCommandStates();
                 }
             }
         }
@@ -111,6 +112,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         public IEnumerable<LogEntry> DisplayLogs => LogViewModel.DisplayLogs;
+
+        private void RefreshServiceCommandStates()
+        {
+            if (RemoveServiceCommand is AsyncRelayCommand<ServiceListModel?> removeCommand)
+            {
+                removeCommand.RaiseCanExecuteChanged();
+            }
+
+            if (EditServiceCommand is RelayCommand<ServiceListModel?> editCommand)
+            {
+                editCommand.RaiseCanExecuteChanged();
+            }
+        }
 
         private readonly CsvServiceAdapter _csvService;
         private readonly ILoggingService? _logger;
@@ -128,6 +142,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         internal int ActivatingServicesCount => _activatingServices.Count;
 
         public NetworkConfigurationViewModel NetworkConfig { get; }
+
+        private bool CanModifyConfiguration => !IsServiceProcessBusy && !ServicesRunning;
 
         public MainViewModel(
             CsvServiceAdapter csvService,
@@ -170,7 +186,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             };
 
             AddServiceCommand = new RelayCommand(AddService);
-            RemoveServiceCommand = new AsyncRelayCommand(RemoveSelectedServiceAsync, () => ActiveService != null);
+            RemoveServiceCommand = new AsyncRelayCommand<ServiceListModel?>(RemoveServiceAsync, CanRemoveService);
             EditServiceCommand = new RelayCommand<ServiceListModel?>(EditService, svc => svc != null || ActiveService != null);
             ToggleServiceProcessCommand = new AsyncRelayCommand(ToggleServiceProcessAsync, () => !IsServiceProcessBusy);
             ExportPluginsCommand = new RelayCommand(OnExportPlugins);
@@ -245,13 +261,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public bool RequestConfigurationChange()
         {
-            if (IsServiceProcessBusy || ServicesRunning)
+            if (!CanModifyConfiguration)
             {
                 ConfigurationChangeBlocked?.Invoke();
                 return false;
             }
 
             return true;
+        }
+
+        private bool CanRemoveService(ServiceListModel? service)
+        {
+            return (service ?? ActiveService) != null && CanModifyConfiguration;
         }
 
         private void EditService(ServiceListModel? service)
@@ -314,9 +335,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             return $"{typeName}{index}";
         }
 
-        private async Task RemoveSelectedServiceAsync()
+        private async Task RemoveServiceAsync(ServiceListModel? service)
         {
-            if (ActiveService == null)
+            var target = service ?? ActiveService;
+            if (target == null)
             {
                 return;
             }
@@ -326,24 +348,38 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return;
             }
 
-            _logger?.Log($"Removing service {ActiveService.DisplayName}", LogLevel.Debug);
-            var index = Services.IndexOf(ActiveService);
-            ActiveService.AddLog("Service removed", WpfBrushes.Red);
-            if (ActiveService.Type != ServiceType.Csv)
-                _csvService.RemoveColumnsForService(ActiveService.DisplayName);
-            _activatingServices.Remove(ActiveService);
-            ActiveService.LogAdded -= OnServiceLogAdded;
-            ActiveService.ActiveChanged -= OnServiceActiveChanged;
-            Services.Remove(ActiveService);
+            _logger?.Log($"Removing service {target.DisplayName}", LogLevel.Debug);
+            var index = Services.IndexOf(target);
+            target.AddLog("Service removed", WpfBrushes.Red);
+            if (target.Type != ServiceType.Csv)
+            {
+                _csvService.RemoveColumnsForService(target.DisplayName);
+            }
+
+            _activatingServices.Remove(target);
+            target.LogAdded -= OnServiceLogAdded;
+            target.ActiveChanged -= OnServiceActiveChanged;
+            Services.Remove(target);
+
+            if (ReferenceEquals(ActiveService, target))
+            {
+                ActiveService = null;
+            }
+
             if (Services.Count > 0)
             {
-                if (index >= Services.Count) index = Services.Count - 1;
+                if (index >= Services.Count)
+                {
+                    index = Services.Count - 1;
+                }
+
                 SelectedService = Services[index];
             }
             else
             {
                 SelectedService = null;
             }
+
             OnPropertyChanged(nameof(ServicesCreated));
             OnPropertyChanged(nameof(CurrentActiveServices));
             LogViewModel.RefreshLogs();

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml
@@ -127,6 +127,11 @@
                              SelectionChanged="ServiceList_SelectionChanged"
                              MouseDoubleClick="ServiceList_MouseDoubleClick"
                              PreviewMouseLeftButtonUp="ServiceList_PreviewMouseLeftButtonUp">
+                        <ListBox.InputBindings>
+                            <KeyBinding Key="Delete"
+                                        Command="{Binding RemoveServiceCommand}"
+                                        CommandParameter="{Binding SelectedItem, ElementName=ServiceList}" />
+                        </ListBox.InputBindings>
                         <ListBox.ItemContainerStyle>
                             <Style TargetType="ListBoxItem">
                                 <EventSetter Event="MouseDoubleClick" Handler="ServiceListItem_MouseDoubleClick" />

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -628,11 +628,14 @@ namespace DesktopApplicationTemplate.UI.Views
         private void RemoveService_Click(object sender, RoutedEventArgs e)
         {
             _logger?.LogDebug("RemoveService button clicked");
-            if (DataContext is ViewModels.MainViewModel vm &&
-                vm.RemoveServiceCommand.CanExecute(null))
+            if (DataContext is ViewModels.MainViewModel vm)
             {
-                vm.RemoveServiceCommand.Execute(null);
-                _logger?.LogDebug("RemoveService command executed");
+                var target = vm.SelectedService ?? vm.ActiveService;
+                if (vm.RemoveServiceCommand.CanExecute(target))
+                {
+                    vm.RemoveServiceCommand.Execute(target);
+                    _logger?.LogDebug("RemoveService command executed");
+                }
             }
         }
         private void ServiceList_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -894,6 +897,23 @@ namespace DesktopApplicationTemplate.UI.Views
         internal void ServiceItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             _dragStart = e.GetPosition(null);
+        }
+
+        internal void ServiceItem_PreviewMouseRightButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (sender is not DependencyObject source)
+            {
+                return;
+            }
+
+            var item = Helpers.VisualTreeHelperExtensions.FindParent<ListBoxItem>(source);
+            if (item != null)
+            {
+                item.Focus();
+                item.IsSelected = true;
+            }
+
+            ServiceList.Focus();
         }
 
         internal void ServiceItem_PreviewMouseMove(object sender, System.Windows.Input.MouseEventArgs e)

--- a/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml
@@ -62,6 +62,7 @@
             Padding="5"
             Margin="2"
             PreviewMouseLeftButtonDown="ServiceItem_PreviewMouseLeftButtonDown"
+            PreviewMouseRightButtonDown="ServiceItem_PreviewMouseRightButtonDown"
             PreviewMouseMove="ServiceItem_PreviewMouseMove"
             AllowDrop="True"
             Drop="ServiceItem_Drop">

--- a/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ListServiceBox.xaml.cs
@@ -20,6 +20,14 @@ public partial class ListServiceBox : UserControl
         }
     }
 
+    private void ServiceItem_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (Window.GetWindow(this) is MainView mainView)
+        {
+            mainView.ServiceItem_PreviewMouseRightButtonDown(sender, e);
+        }
+    }
+
     private void ServiceItem_PreviewMouseMove(object sender, MouseEventArgs e)
     {
         if (Window.GetWindow(this) is MainView mainView)


### PR DESCRIPTION
## Summary
- bind the ServiceList Delete key to RemoveServiceCommand and focus the list when right-clicking items
- update RemoveServiceCommand to accept a selected service parameter and allow execution whenever configuration edits are permitted
- refresh command state when service process activity changes so removal availability stays accurate

## Testing
- not run (Windows-only WPF solution)


------
https://chatgpt.com/codex/tasks/task_e_68e6b64057248326bf98f4468656df7a