### PR TITLE
Persist TCP editor state when saving services

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -398,7 +398,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 if (svc.ServicePage?.DataContext is TcpServiceMessagesViewModel tcpVm)
                 {
-                    await tcpVm.SaveAsync().ConfigureAwait(false);
+                    await tcpVm.PersistOptionsAsync().ConfigureAwait(false);
                 }
             }
             ServicePersistence.Save(Services);

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -1309,6 +1309,27 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);
 
+        /// <summary>
+        /// Copies the current editor state to the owning service without executing the runtime.
+        /// </summary>
+        public Task PersistOptionsAsync()
+        {
+            if (_service is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            var options = _service.TcpOptions ?? new TcpServiceOptions();
+            options.Script = Script ?? string.Empty;
+            options.LastTestMessage = TestMessage ?? string.Empty;
+            options.InputMessage = TestMessage ?? string.Empty;
+            options.OutputMessage = ScriptOutputMessage ?? string.Empty;
+            _service.TcpOptions = options;
+            _options = options;
+
+            return Task.CompletedTask;
+        }
+
         /// <summary>Saves the current test message to options and routing.</summary>
         public async Task SaveAsync()
         {


### PR DESCRIPTION
## Summary
- prevent MainViewModel.SaveServicesAsync from executing TCP runtime code during persistence
- add TcpServiceMessagesViewModel.PersistOptionsAsync to copy editor values to the service options

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e6baa57dd083268a8c4d7b69eafc66