### PR TITLE
Scope TCP message tables per view

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -198,8 +198,8 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<IMqttClientSessionManager, MqttClientSessionManager>();
             services.AddSingleton<MainViewModel>();
-            services.AddSingleton<ServiceMessageTableViewModel>();
-            services.AddSingleton<TcpServiceMessagesView>();
+            services.AddTransient<ServiceMessageTableViewModel>();
+            services.AddTransient<TcpServiceMessagesView>();
             services.AddTransient<TcpServiceMessagesViewModel>();
             services.AddSingleton<HttpServiceView>();
             services.AddSingleton<HttpServiceViewModel>();

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -33,8 +33,25 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
     {
         private LogLevel _logLevelFilter = LogLevel.Debug;
 
+        private readonly Func<ServiceMessageTableViewModel> _messageTableFactory;
+        private readonly Dictionary<ServiceListModel, ServiceMessageTableViewModel> _serviceMessageTables = new();
+        private ServiceMessageTableViewModel _messageTable;
+
         /// <summary>Table view model for displaying message history.</summary>
-        public ServiceMessageTableViewModel MessageTable { get; }
+        public ServiceMessageTableViewModel MessageTable
+        {
+            get => _messageTable;
+            private set
+            {
+                if (_messageTable == value)
+                {
+                    return;
+                }
+
+                _messageTable = value ?? throw new ArgumentNullException(nameof(MessageTable));
+                OnPropertyChanged();
+            }
+        }
 
         /// <summary>Collection of TCP message rows.</summary>
         public ObservableCollection<TcpMessageRow> Messages { get; } = new();
@@ -207,11 +224,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private readonly ITcpRuntime _tcpRuntime;
 
-        public TcpServiceMessagesViewModel(ServiceMessageTableViewModel messageTable, IMessageRoutingService routing, ITcpRuntime tcpRuntime)
+        public TcpServiceMessagesViewModel(Func<ServiceMessageTableViewModel> messageTableFactory, IMessageRoutingService routing, ITcpRuntime tcpRuntime)
         {
-            MessageTable = messageTable ?? throw new ArgumentNullException(nameof(messageTable));
+            _messageTableFactory = messageTableFactory ?? throw new ArgumentNullException(nameof(messageTableFactory));
             _routing = routing ?? throw new ArgumentNullException(nameof(routing));
             _tcpRuntime = tcpRuntime ?? throw new ArgumentNullException(nameof(tcpRuntime));
+            MessageTable = _messageTableFactory();
             Messages.CollectionChanged += (_, _) =>
             {
                 OnPropertyChanged(nameof(IncomingData));
@@ -241,6 +259,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
 
             _service = service;
+            if (!_serviceMessageTables.TryGetValue(service, out var messageTable))
+            {
+                messageTable = _messageTableFactory();
+                _serviceMessageTables[service] = messageTable;
+            }
+
+            MessageTable = messageTable;
             _service.ActiveChanged += OnServiceActiveChanged;
             _service.PropertyChanged += OnServicePropertyChanged;
             _options = service.TcpOptions ?? new TcpServiceOptions();


### PR DESCRIPTION
## Summary
- register `ServiceMessageTableViewModel` and the TCP messages page as transient services so each TCP page gets an isolated message table instance
- update `TcpServiceMessagesViewModel` to use a factory for `ServiceMessageTableViewModel`, caching a dedicated table for every service context and swapping it when the active service changes

## Testing
- DOTNET_EnableWindowsTargeting=1 dotnet build *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c27f8a88832694377ca43aecefd2