### PR TITLE
Guard cross-service associations behind opt-in

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -356,6 +356,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _csvService.RemoveColumnsForService(target.DisplayName);
             }
 
+            ServiceListModel.RemoveServiceAssociations(target);
             _activatingServices.Remove(target);
             target.LogAdded -= OnServiceLogAdded;
             target.ActiveChanged -= OnServiceActiveChanged;

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -120,6 +120,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public ObservableCollection<string> AssociatedServices { get; } = new();
 
+        private static readonly object ServiceRegistryLock = new();
+        private static readonly HashSet<ServiceListModel> ServiceRegistry = new();
+
+        public ServiceListModel()
+        {
+            lock (ServiceRegistryLock)
+            {
+                ServiceRegistry.Add(this);
+            }
+        }
+
         private readonly LinkedList<ServiceMessageHistoryEntry> _messageHistory = new();
         private double _totalExecutionTimeMs;
         private int _executionCount;
@@ -337,7 +348,24 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// Enables forwarding of log entries between services when cross-service references are detected.
         /// Defaults to <c>false</c> so services remain independent unless explicitly linked.
         /// </summary>
-        public static bool EnableCrossServiceLogForwarding { get; set; }
+        private static bool _enableCrossServiceLogForwarding;
+        public static bool EnableCrossServiceLogForwarding
+        {
+            get => _enableCrossServiceLogForwarding;
+            set
+            {
+                if (_enableCrossServiceLogForwarding == value)
+                {
+                    return;
+                }
+
+                _enableCrossServiceLogForwarding = value;
+                if (!value)
+                {
+                    ClearAllCrossServiceAssociations();
+                }
+            }
+        }
 
         private bool _isActive;
         public bool IsActive
@@ -628,6 +656,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return;
             }
 
+            if (!EnableCrossServiceLogForwarding)
+            {
+                RemoveAssociation(target);
+                return;
+            }
+
+            EnsureAssociation(target);
+            target.AddLog(forwardedMessage, color, level, false);
+        }
+
+        private void EnsureAssociation(ServiceListModel target)
+        {
             if (!AssociatedServices.Contains(target.DisplayName))
             {
                 AssociatedServices.Add(target.DisplayName);
@@ -637,10 +677,70 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             {
                 target.AssociatedServices.Add(DisplayName);
             }
+        }
 
-            if (EnableCrossServiceLogForwarding)
+        private void RemoveAssociation(ServiceListModel target)
+        {
+            RemoveStaleAssociation(this, target);
+        }
+
+        private static void RemoveStaleAssociation(ServiceListModel first, ServiceListModel second)
+        {
+            if (first is null || second is null)
             {
-                target.AddLog(forwardedMessage, color, level, false);
+                return;
+            }
+
+            first.AssociatedServices.Remove(second.DisplayName);
+            second.AssociatedServices.Remove(first.DisplayName);
+        }
+
+        private static void ClearAllCrossServiceAssociations()
+        {
+            var snapshot = GetRegisteredServicesSnapshot();
+            for (var i = 0; i < snapshot.Count; i++)
+            {
+                var current = snapshot[i];
+                for (var j = i + 1; j < snapshot.Count; j++)
+                {
+                    RemoveStaleAssociation(current, snapshot[j]);
+                }
+
+                current.AssociatedServices.Clear();
+            }
+        }
+
+        private static IReadOnlyList<ServiceListModel> GetRegisteredServicesSnapshot()
+        {
+            lock (ServiceRegistryLock)
+            {
+                return ServiceRegistry.ToList();
+            }
+        }
+
+        internal static void RemoveServiceAssociations(ServiceListModel service)
+        {
+            if (service is null)
+            {
+                return;
+            }
+
+            var snapshot = GetRegisteredServicesSnapshot();
+            foreach (var other in snapshot)
+            {
+                if (ReferenceEquals(other, service))
+                {
+                    continue;
+                }
+
+                RemoveStaleAssociation(service, other);
+            }
+
+            service.AssociatedServices.Clear();
+
+            lock (ServiceRegistryLock)
+            {
+                ServiceRegistry.Remove(service);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -754,6 +754,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
                 var index = _viewModel.Services.IndexOf(svc);
                 svc.LogAdded -= _viewModel.OnServiceLogAdded;
+                ServiceListModel.RemoveServiceAssociations(svc);
                 _viewModel.Services.Remove(svc);
                 if (_viewModel.Services.Count > 0)
                 {


### PR DESCRIPTION
## Summary
- gate cross-service association creation behind the cross-service log forwarding flag
- centralize helper logic to clear mutual associations when forwarding is disabled or a service is removed
- ensure service deletions invoke the cleanup helper so persisted service lists stay in sync

## Testing
- not run (environment lacks the .NET SDK in this container)


------
https://chatgpt.com/codex/tasks/task_e_68e6c40627188326ba6d3cb18c8ae12c