### PR TITLE
Clear message routing cache when services change names or are removed

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/IMessageRoutingService.cs
@@ -35,6 +35,19 @@ public interface IMessageRoutingService
     bool TryGetMessage(string serviceName, MessageRoutingDirection direction, out string? message);
 
     /// <summary>
+    /// Clears cached messages and dependency metadata for the specified service.
+    /// </summary>
+    /// <param name="serviceType">The category of the service.</param>
+    /// <param name="serviceName">The unique name of the service.</param>
+    void ClearService(ServiceType serviceType, string serviceName);
+
+    /// <summary>
+    /// Clears cached messages and dependency metadata for services matching the supplied name.
+    /// </summary>
+    /// <param name="serviceName">The unique name of the service.</param>
+    void ClearService(string serviceName);
+
+    /// <summary>
     /// Replaces <c>{ServiceName.InputMessage}</c> and <c>{ServiceName.OutputMessage}</c> tokens within the provided template.
     /// Legacy <c>LastInputMessage</c> and <c>LastOutputMessage</c> tokens are still recognized for compatibility.
     /// </summary>

--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
@@ -98,6 +98,36 @@ public class MessageRoutingService : IMessageRoutingService
     }
 
     /// <inheritdoc />
+    public void ClearService(ServiceType serviceType, string serviceName)
+    {
+        var normalized = NormalizeServiceName(serviceName);
+        if (normalized is null)
+        {
+            throw new ArgumentException("Service name cannot be null or whitespace.", nameof(serviceName));
+        }
+
+        _logger?.Log($"Clearing routing cache for {serviceType}.{normalized}", LogLevel.Debug);
+        ClearMessagesForService(normalized, serviceType);
+        ClearReferencesForService(normalized);
+        _logger?.Log($"Routing cache for {serviceType}.{normalized} cleared", LogLevel.Debug);
+    }
+
+    /// <inheritdoc />
+    public void ClearService(string serviceName)
+    {
+        var normalized = NormalizeServiceName(serviceName);
+        if (normalized is null)
+        {
+            throw new ArgumentException("Service name cannot be null or whitespace.", nameof(serviceName));
+        }
+
+        _logger?.Log($"Clearing routing cache for {normalized}", LogLevel.Debug);
+        ClearMessagesForService(normalized, serviceType: null);
+        ClearReferencesForService(normalized);
+        _logger?.Log($"Routing cache for {normalized} cleared", LogLevel.Debug);
+    }
+
+    /// <inheritdoc />
     public string ResolveTokens(string template, string? referencingServiceName = null)
     {
         if (template is null)
@@ -293,6 +323,71 @@ public class MessageRoutingService : IMessageRoutingService
         if (referencingMap.Count == 0)
         {
             _referencedByService.Remove(referencedService);
+        }
+    }
+
+    private void ClearMessagesForService(string normalizedServiceName, ServiceType? serviceType)
+    {
+        if (serviceType.HasValue)
+        {
+            _messages.TryRemove((serviceType.Value, normalizedServiceName), out _);
+        }
+        else
+        {
+            foreach (var key in _messages.Keys
+                .Where(k => string.Equals(k.Item2, normalizedServiceName, StringComparison.OrdinalIgnoreCase))
+                .ToList())
+            {
+                _messages.TryRemove(key, out _);
+            }
+        }
+
+        var replacement = _messages.FirstOrDefault(kvp =>
+            string.Equals(kvp.Key.Item2, normalizedServiceName, StringComparison.OrdinalIgnoreCase)).Value;
+
+        if (replacement is null)
+        {
+            _messagesByName.TryRemove(normalizedServiceName, out _);
+        }
+        else
+        {
+            _messagesByName[normalizedServiceName] = replacement;
+        }
+    }
+
+    private void ClearReferencesForService(string normalizedServiceName)
+    {
+        lock (_referencesLock)
+        {
+            if (_referencesByService.Remove(normalizedServiceName, out var references))
+            {
+                foreach (var referencedService in references.Keys.ToArray())
+                {
+                    RemoveReferencedByEntry(referencedService, normalizedServiceName);
+                }
+            }
+            else
+            {
+                foreach (var referencedService in _referencedByService.Keys.ToArray())
+                {
+                    RemoveReferencedByEntry(referencedService, normalizedServiceName);
+                }
+            }
+
+            if (_referencedByService.Remove(normalizedServiceName, out var referencingServices))
+            {
+                foreach (var referencingService in referencingServices.Keys.ToArray())
+                {
+                    if (_referencesByService.TryGetValue(referencingService, out var dependencies))
+                    {
+                        dependencies.Remove(normalizedServiceName);
+                        if (dependencies.Count == 0)
+                        {
+                            _referencesByService.Remove(referencingService);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
@@ -46,6 +46,13 @@ public class CsvEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.CsvOptions = opts;
             if (csvPage != null)

--- a/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
@@ -47,6 +47,13 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.FileObserverOptions = opts;
             if (foPage != null)

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -47,6 +47,13 @@ public class FtpEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.FtpOptions = opts;
             var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;

--- a/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
@@ -47,6 +47,13 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.HeartbeatOptions = opts;
             if (hbPage != null)

--- a/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
@@ -46,6 +46,13 @@ public class HidEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.HidOptions = opts;
             if (hidPage != null)

--- a/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
@@ -47,6 +47,13 @@ public class HttpEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.HttpOptions = opts;
             if (httpPage != null)

--- a/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
@@ -46,6 +46,13 @@ public class MqttEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             if (tagPage != null)
                 mainView.ShowPage(tagPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
@@ -47,6 +47,13 @@ public class ScpEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            if (!string.Equals(previousName, trimmed, StringComparison.Ordinal))
+            {
+                mainViewModel.ClearRoutingCache(service.Type, previousName);
+                mainViewModel.ClearRoutingCache(service.Type, trimmed);
+            }
+
             service.DisplayName = trimmed;
             service.ScpOptions = opts;
             if (scpPage != null)

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -47,8 +47,19 @@ public class TcpEditServiceHandler : IEditServiceHandler
                 trimmed = mainViewModel.GenerateServiceName(service.Type);
             }
 
+            var previousName = service.DisplayName;
+            var previousType = service.Type;
+            var newType = vm.ServiceType;
+            var nameChanged = !string.Equals(previousName, trimmed, StringComparison.Ordinal);
+            var typeChanged = previousType != newType;
+            if (nameChanged || typeChanged)
+            {
+                mainViewModel.ClearRoutingCache(previousType, previousName);
+                mainViewModel.ClearRoutingCache(newType, trimmed);
+            }
+
             service.DisplayName = trimmed;
-            service.Type = vm.ServiceType;
+            service.Type = newType;
             service.TcpOptions = opts;
             var page = mainView.GetOrCreateServicePage(service);
             if (page != null)

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -128,6 +128,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private readonly CsvServiceAdapter _csvService;
         private readonly ILoggingService? _logger;
+        private readonly IMessageRoutingService _messageRoutingService;
         private readonly INetworkConfigurationService _networkService;
         private readonly IServiceCatalog _serviceCatalog;
         private readonly IDictionary<ServiceType, IEditServiceHandler> _editHandlers;
@@ -152,12 +153,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             IServiceCatalog serviceCatalog,
             IDictionary<ServiceType, IEditServiceHandler> editHandlers,
             IStartupPreferencesService startupPreferencesService,
+            IMessageRoutingService messageRoutingService,
             ILoggingService? logger = null,
             string? servicesFilePath = null)
         {
             _csvService = csvService;
             _networkService = networkService;
             _serviceCatalog = serviceCatalog ?? throw new ArgumentNullException(nameof(serviceCatalog));
+            _messageRoutingService = messageRoutingService ?? throw new ArgumentNullException(nameof(messageRoutingService));
             _logger = logger;
             NetworkConfig = networkConfig;
             _editHandlers = editHandlers;
@@ -349,6 +352,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
 
             _logger?.Log($"Removing service {target.DisplayName}", LogLevel.Debug);
+            ClearRoutingCache(target.Type, target.DisplayName);
             var index = Services.IndexOf(target);
             target.AddLog("Service removed", WpfBrushes.Red);
             if (target.Type != ServiceType.Csv)
@@ -386,6 +390,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             LogViewModel.RefreshLogs();
             await SaveServicesAsync().ConfigureAwait(false);
             _logger?.Log("Service removed", LogLevel.Debug);
+        }
+
+        internal void ClearRoutingCache(ServiceType serviceType, string serviceName)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+            {
+                return;
+            }
+
+            _messageRoutingService.ClearService(serviceType, serviceName);
         }
 
         public async Task SaveServicesAsync()
@@ -443,6 +457,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 {
                     normalizedName = GenerateServiceName(svc.Type);
                 }
+                ClearRoutingCache(svc.Type, normalizedName);
                 svc.DisplayName = normalizedName;
                 if (string.IsNullOrWhiteSpace(svc.DescriptorId))
                 {

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -509,6 +509,7 @@ namespace DesktopApplicationTemplate.UI.Views
                     trimmed = _viewModel.GenerateServiceName(type);
                 }
 
+                _viewModel.ClearRoutingCache(type, trimmed);
                 var svc = new ServiceListModel
                 {
                     DisplayName = trimmed,
@@ -596,6 +597,8 @@ namespace DesktopApplicationTemplate.UI.Views
             }
 
             var normalizedContext = context with { Name = sanitizedName };
+
+            _viewModel.ClearRoutingCache(type, sanitizedName);
 
             if (!_serviceRegistry.TryCreateService(type, _serviceProvider, normalizedContext, out var svc) || svc is null)
             {
@@ -789,7 +792,12 @@ namespace DesktopApplicationTemplate.UI.Views
                     {
                         trimmed = _viewModel.GenerateServiceName(svc.Type);
                     }
-                    svc.DisplayName = trimmed;
+                    if (!string.Equals(svc.DisplayName, trimmed, StringComparison.Ordinal))
+                    {
+                        _viewModel.ClearRoutingCache(svc.Type, svc.DisplayName);
+                        _viewModel.ClearRoutingCache(svc.Type, trimmed);
+                        svc.DisplayName = trimmed;
+                    }
                     await _viewModel.SaveServicesAsync();
                     _createServicePage?.SetExistingNames(_viewModel.Services.Select(s => s.DisplayName));
                 }


### PR DESCRIPTION
## Summary
- extend the message routing service API to support clearing cached messages and reference metadata
- ensure the routing cache is purged when services are created, renamed, or removed via MainViewModel and MainWindow flows
- update service edit handlers so renames clear old and new service names before reapplying options

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6c82365d88326b67fa71ed5653400