### PR TITLE
Fix initialization warning for TCP message table view model

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -35,12 +35,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
         private readonly Func<ServiceMessageTableViewModel> _messageTableFactory;
         private readonly Dictionary<ServiceListModel, ServiceMessageTableViewModel> _serviceMessageTables = new();
-        private ServiceMessageTableViewModel _messageTable;
+        private ServiceMessageTableViewModel? _messageTable;
 
         /// <summary>Table view model for displaying message history.</summary>
         public ServiceMessageTableViewModel MessageTable
         {
-            get => _messageTable;
+            get => _messageTable ?? throw new InvalidOperationException("Message table has not been initialized.");
             private set
             {
                 if (_messageTable == value)


### PR DESCRIPTION
## Summary
- allow the TCP message table backing field to remain nullable until the constructor assigns it
- guard against accessing the message table before initialization so the getter fails fast

## Testing
- not run (Windows-specific build)

------
https://chatgpt.com/codex/tasks/task_e_68e6cc3932308326bf903765c0785cb8