### PR TITLE
Use transient lifetime for protocol views

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -202,22 +202,22 @@ namespace DesktopApplicationTemplate.UI
             services.AddTransient<Func<ServiceMessageTableViewModel>>(sp => () => sp.GetRequiredService<ServiceMessageTableViewModel>());
             services.AddTransient<TcpServiceMessagesView>();
             services.AddTransient<TcpServiceMessagesViewModel>();
-            services.AddSingleton<HttpServiceView>();
-            services.AddSingleton<HttpServiceViewModel>();
-            services.AddSingleton<FileObserverView>();
-            services.AddSingleton<FileObserverViewModel>();
-            services.AddSingleton<HeartbeatView>();
-            services.AddSingleton<HeartbeatViewModel>();
-            services.AddSingleton<SCPServiceView>();
-            services.AddSingleton<ScpServiceViewModel>();
-            services.AddSingleton<HidViewModel>();
-            services.AddSingleton<HidViews>();
-            services.AddSingleton<FTPServiceView>();
-            services.AddSingleton<FtpServiceViewModel>();
-            services.AddSingleton<CsvViewerViewModel>();
+            services.AddTransient<HttpServiceView>();
+            services.AddTransient<HttpServiceViewModel>();
+            services.AddTransient<FileObserverView>();
+            services.AddTransient<FileObserverViewModel>();
+            services.AddTransient<HeartbeatView>();
+            services.AddTransient<HeartbeatViewModel>();
+            services.AddTransient<SCPServiceView>();
+            services.AddTransient<ScpServiceViewModel>();
+            services.AddTransient<HidViewModel>();
+            services.AddTransient<HidViews>();
+            services.AddTransient<FTPServiceView>();
+            services.AddTransient<FtpServiceViewModel>();
+            services.AddTransient<CsvViewerViewModel>();
             services.AddSingleton<ICsvOutput, FileCsvOutput>();
-            services.AddSingleton<CsvServiceAdapter>();
-            services.AddSingleton<CsvServiceView>();
+            services.AddTransient<CsvServiceAdapter>();
+            services.AddTransient<CsvServiceView>();
             services.AddSingleton<SettingsViewModel>();
             services.AddSingleton<IServiceUiRegistry<ServiceListModel, Page>>(sp =>
             {


### PR DESCRIPTION
## Summary
- switch the protocol views and view models for HTTP, FTP, HID, CSV, SCP, file observer, and heartbeat to transient registrations
- ensure the CSV service adapter follows the transient lifetime so each protocol view resolves its own instance

## Testing
- not run (environment does not support WPF execution)

------
https://chatgpt.com/codex/tasks/task_e_68e72763a5e88326841028aa216a0a85