### PR TITLE
Stop mutating protocol option singletons during service load

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -87,7 +87,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.Threading;
 using MQTTnet;
 using FubarDev.FtpServer;
@@ -370,23 +369,17 @@ namespace DesktopApplicationTemplate.UI
                 {
                     var ctx = (ServiceFactoryOptions<CoreFtpServerOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
+                    var ftpOptions = ctx.Options ?? new CoreFtpServerOptions();
                     var svc = new ServiceListModel
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Ftp,
                         IsActive = false,
-                        FtpOptions = ctx.Options
+                        FtpOptions = ftpOptions
                     };
 
                     mainView.GetOrCreateServicePage(svc);
-
-                    var resolved = provider.GetRequiredService<IOptions<CoreFtpServerOptions>>().Value;
-                    resolved.Port = ctx.Options.Port;
-                    resolved.RootPath = ctx.Options.RootPath;
-                    resolved.AllowAnonymous = ctx.Options.AllowAnonymous;
-                    resolved.Username = ctx.Options.Username;
-                    resolved.Password = ctx.Options.Password;
 
                     return svc;
                 },

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -10,7 +10,6 @@ using DesktopApplicationTemplate.UI.Views.Ftp.Advanced;
 using DesktopApplicationTemplate.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.EditHandlers;
 
@@ -56,12 +55,6 @@ public class FtpEditServiceHandler : IEditServiceHandler
 
             service.DisplayName = trimmed;
             service.FtpOptions = opts;
-            var opt = _services.GetRequiredService<IOptions<FtpServerOptions>>().Value;
-            opt.Port = opts.Port;
-            opt.RootPath = opts.RootPath;
-            opt.AllowAnonymous = opts.AllowAnonymous;
-            opt.Username = opts.Username;
-            opt.Password = opts.Password;
             if (ftpPage != null)
                 mainView.ShowPage(ftpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -300,111 +300,45 @@ namespace DesktopApplicationTemplate.Persistence
                                 ReconnectDelay = value.ReconnectDelay
                             };
                         }
-                    }
-
-                    if (info.ServiceType == ServiceType.Tcp && info.TcpOptions != null)
-                    {
-                        var opt = App.AppHost?.Services.GetService<IOptions<TcpServiceOptions>>();
-                        if (opt != null)
+                        else
                         {
-                            var value = opt.Value;
-                            value.Host = info.TcpOptions.Host;
-                            value.Port = info.TcpOptions.Port;
-                            value.UseUdp = info.TcpOptions.UseUdp;
-                            value.SubnetMask = info.TcpOptions.SubnetMask;
-                            value.PrimaryDns = info.TcpOptions.PrimaryDns;
-                            value.AlternateDns = info.TcpOptions.AlternateDns;
-                            value.Mode = info.TcpOptions.Mode;
-                            value.ConnectionRole = info.TcpOptions.ConnectionRole;
-                            value.DestinationHost = info.TcpOptions.DestinationHost;
-                            value.DestinationPort = info.TcpOptions.DestinationPort;
-                            value.DestinationGateway = info.TcpOptions.DestinationGateway;
-                            value.DestinationSubnetMask = info.TcpOptions.DestinationSubnetMask;
-                            value.DestinationPrimaryDns = info.TcpOptions.DestinationPrimaryDns;
-                            value.DestinationAlternateDns = info.TcpOptions.DestinationAlternateDns;
-                            value.InputMessage = info.TcpOptions.InputMessage;
-                            value.Script = info.TcpOptions.Script;
-                            value.OutputMessage = info.TcpOptions.OutputMessage;
-                            value.LastTestMessage = info.TcpOptions.LastTestMessage;
+                            info.MqttOptions = new MqttServiceOptions();
                         }
                     }
 
-                    if (info.ServiceType == ServiceType.Ftp && info.FtpOptions != null)
+                    if (info.ServiceType == ServiceType.Tcp && info.TcpOptions is null)
                     {
-                        try
-                        {
-                            var opt = App.AppHost?.Services.GetService<IOptions<FtpServerOptions>>();
-                            if (opt != null)
-                            {
-                                var value = opt.Value;
-                                value.Port = info.FtpOptions.Port;
-                                value.RootPath = info.FtpOptions.RootPath;
-                                value.AllowAnonymous = info.FtpOptions.AllowAnonymous;
-                                value.Username = info.FtpOptions.Username;
-                                value.Password = info.FtpOptions.Password;
-                            }
-                        }
-                        catch
-                        {
-                            // ignore missing options during tests or early startup
-                        }
+                        info.TcpOptions = new TcpServiceOptions();
                     }
 
-                    if (info.ServiceType == ServiceType.Heartbeat && info.HeartbeatOptions != null)
+                    if (info.ServiceType == ServiceType.Ftp && info.FtpOptions is null)
                     {
-                        var opt = App.AppHost?.Services.GetService<IOptions<HeartbeatServiceOptions>>();
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            value.BaseMessage = info.HeartbeatOptions.BaseMessage;
-                            value.IncludePing = info.HeartbeatOptions.IncludePing;
-                            value.IncludeStatus = info.HeartbeatOptions.IncludeStatus;
-                        }
+                        info.FtpOptions = new FtpServerOptions();
                     }
 
-                    if (info.ServiceType == ServiceType.FileObserver && info.FileObserverOptions != null)
+                    if (info.ServiceType == ServiceType.Http && info.HttpOptions is null)
                     {
-                        var opt = App.AppHost?.Services.GetService<IOptions<FileObserverServiceOptions>>();
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            value.FilePath = info.FileObserverOptions.FilePath;
-                            value.ImageNames = info.FileObserverOptions.ImageNames;
-                            value.SendAllImages = info.FileObserverOptions.SendAllImages;
-                            value.SendFirstX = info.FileObserverOptions.SendFirstX;
-                            value.XCount = info.FileObserverOptions.XCount;
-                            value.SendTcpCommand = info.FileObserverOptions.SendTcpCommand;
-                            value.TcpCommand = info.FileObserverOptions.TcpCommand;
-                        }
+                        info.HttpOptions = new HttpServiceOptions();
                     }
 
-                    if (info.ServiceType == ServiceType.Hid && info.HidOptions != null)
+                    if (info.ServiceType == ServiceType.Heartbeat && info.HeartbeatOptions is null)
                     {
-                        var opt = App.AppHost?.Services.GetService<IOptions<HidServiceOptions>>();
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            value.MessageTemplate = info.HidOptions.MessageTemplate;
-                            value.UsbProtocol = info.HidOptions.UsbProtocol;
-                            value.AttachedService = info.HidOptions.AttachedService;
-                            value.DebounceTimeMs = info.HidOptions.DebounceTimeMs;
-                            value.KeyDownTimeMs = info.HidOptions.KeyDownTimeMs;
-                        }
+                        info.HeartbeatOptions = new HeartbeatServiceOptions();
                     }
 
-                    if (info.ServiceType == ServiceType.Scp && info.ScpOptions != null)
+                    if (info.ServiceType == ServiceType.FileObserver && info.FileObserverOptions is null)
                     {
-                        var opt = App.AppHost?.Services.GetService<IOptions<ScpServiceOptions>>();
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            value.Host = info.ScpOptions.Host;
-                            value.Port = info.ScpOptions.Port;
-                            value.Username = info.ScpOptions.Username;
-                            value.Password = info.ScpOptions.Password;
-                            value.LocalPath = info.ScpOptions.LocalPath;
-                            value.RemotePath = info.ScpOptions.RemotePath;
-                        }
+                        info.FileObserverOptions = new FileObserverServiceOptions();
+                    }
+
+                    if (info.ServiceType == ServiceType.Hid && info.HidOptions is null)
+                    {
+                        info.HidOptions = new HidServiceOptions();
+                    }
+
+                    if (info.ServiceType == ServiceType.Scp && info.ScpOptions is null)
+                    {
+                        info.ScpOptions = new ScpServiceOptions();
                     }
                 }
 


### PR DESCRIPTION
## Summary
- ensure the FTP UI registration keeps its per-service options and no longer mutates global option singletons
- update the FTP edit handler to persist edits on the owning service model instead of `IOptions`
- stop copying deserialized protocol settings into global `IOptions` values and instantiate per-service option objects when missing

## Testing
- not run (WPF projects require a Windows build environment)


------
https://chatgpt.com/codex/tasks/task_e_68e727dd10e08326b14796f1fe9f8a7f