### PR TITLE
Refactor service option storage to dictionary

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -337,7 +337,7 @@ namespace DesktopApplicationTemplate.UI
                         IsActive = false
                     };
 
-                    newService.MqttOptions = ctx.Options ?? new MqttServiceOptions();
+                    newService.SetOptions(ctx.Options ?? new MqttServiceOptions());
                     mainView.GetOrCreateServicePage(newService);
 
                     return newService;
@@ -376,8 +376,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Ftp,
                         IsActive = false,
-                        FtpOptions = ftpOptions
                     };
+
+                    svc.SetOptions(ftpOptions);
 
                     mainView.GetOrCreateServicePage(svc);
 
@@ -425,8 +426,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Http,
                         IsActive = false,
-                        HttpOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -473,8 +475,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Tcp,
                         IsActive = false,
-                        TcpOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -511,8 +514,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Hid,
                         IsActive = false,
-                        HidOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -559,8 +563,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Scp,
                         IsActive = false,
-                        ScpOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -607,8 +612,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.FileObserver,
                         IsActive = false,
-                        FileObserverOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -655,8 +661,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Csv,
                         IsActive = false,
-                        CsvOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -695,8 +702,9 @@ namespace DesktopApplicationTemplate.UI
                         DisplayName = ctx.Name,
                         Type = ServiceType.Heartbeat,
                         IsActive = false,
-                        HeartbeatOptions = ctx.Options
                     };
+
+                    svc.SetOptions(ctx.Options);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;

--- a/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
@@ -31,7 +31,7 @@ public class CsvEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var csvPage = mainView.GetOrCreateServicePage(service);
-        var options = service.CsvOptions ?? new CsvServiceOptions();
+        var options = service.GetOrCreateOptions(() => new CsvServiceOptions());
         var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
         vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<CsvServiceEditorView>();
@@ -54,7 +54,7 @@ public class CsvEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.CsvOptions = opts;
+            service.SetOptions((CsvServiceOptions)opts);
             if (csvPage != null)
                 mainView.ShowPage(csvPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
@@ -33,7 +33,7 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var foPage = mainView.GetOrCreateServicePage(service);
-        var options = service.FileObserverOptions ?? new FileObserverServiceOptions();
+        var options = service.GetOrCreateOptions(() => new FileObserverServiceOptions());
         var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<FileObserverEditServiceView>();
         editView.Initialize(vm);
@@ -55,7 +55,7 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.FileObserverOptions = opts;
+            service.SetOptions((FileObserverServiceOptions)opts);
             if (foPage != null)
                 mainView.ShowPage(foPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -33,7 +33,7 @@ public class FtpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var ftpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.FtpOptions ?? new FtpServerOptions();
+        var options = service.GetOrCreateOptions(() => new FtpServerOptions());
         var vm = ActivatorUtilities.CreateInstance<FtpServerEditViewModel>(_services, service.DisplayName, options);
         var editView = ActivatorUtilities.CreateInstance<FtpServerEditView>(_services, vm);
         vm.ServiceSaved += (name, opts) =>
@@ -54,7 +54,7 @@ public class FtpEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.FtpOptions = opts;
+            service.SetOptions((FtpServerOptions)opts);
             if (ftpPage != null)
                 mainView.ShowPage(ftpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
@@ -33,7 +33,7 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var hbPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HeartbeatOptions ?? new HeartbeatServiceOptions();
+        var options = service.GetOrCreateOptions(() => new HeartbeatServiceOptions());
         var vm = ActivatorUtilities.CreateInstance<HeartbeatEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HeartbeatEditServiceView>();
         editView.Initialize(vm);
@@ -55,7 +55,7 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.HeartbeatOptions = opts;
+            service.SetOptions((HeartbeatServiceOptions)opts);
             if (hbPage != null)
                 mainView.ShowPage(hbPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
@@ -32,7 +32,7 @@ public class HidEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var hidPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HidOptions ?? new HidServiceOptions();
+        var options = service.GetOrCreateOptions(() => new HidServiceOptions());
         var vm = ActivatorUtilities.CreateInstance<HidEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HidEditServiceView>();
         editView.Initialize(vm);
@@ -54,7 +54,7 @@ public class HidEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.HidOptions = opts;
+            service.SetOptions((HidServiceOptions)opts);
             if (hidPage != null)
                 mainView.ShowPage(hidPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
@@ -33,7 +33,7 @@ public class HttpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var httpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HttpOptions ?? new HttpServiceOptions();
+        var options = service.GetOrCreateOptions(() => new HttpServiceOptions());
         var vm = ActivatorUtilities.CreateInstance<HttpEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HttpEditServiceView>();
         editView.Initialize(vm);
@@ -55,7 +55,7 @@ public class HttpEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.HttpOptions = opts;
+            service.SetOptions((HttpServiceOptions)opts);
             if (httpPage != null)
                 mainView.ShowPage(httpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
@@ -31,8 +31,7 @@ public class MqttEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var tagPage = mainView.GetOrCreateServicePage(service);
-        var options = service.MqttOptions ?? new MqttServiceOptions();
-        service.MqttOptions = options;
+        var options = service.GetOrCreateOptions(() => new MqttServiceOptions());
         var vm = ActivatorUtilities.CreateInstance<MqttEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<MqttEditServiceView>();
         editView.Initialize(vm);
@@ -53,6 +52,7 @@ public class MqttEditServiceHandler : IEditServiceHandler
                 mainViewModel.ClearRoutingCache(service.Type, trimmed);
             }
 
+            service.SetOptions((MqttServiceOptions)opts);
             service.DisplayName = trimmed;
             if (tagPage != null)
                 mainView.ShowPage(tagPage);

--- a/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
@@ -32,7 +32,7 @@ public class ScpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var scpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.ScpOptions ?? new ScpServiceOptions();
+        var options = service.GetOrCreateOptions(() => new ScpServiceOptions());
         var vm = _services.GetRequiredService<ScpEditServiceViewModel>();
         vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<ScpEditServiceView>();
@@ -55,7 +55,7 @@ public class ScpEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.ScpOptions = opts;
+            service.SetOptions((ScpServiceOptions)opts);
             if (scpPage != null)
                 mainView.ShowPage(scpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -31,7 +31,7 @@ public class TcpEditServiceHandler : IEditServiceHandler
     {
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
-        var options = service.TcpOptions ?? new TcpServiceOptions();
+        var options = service.GetOrCreateOptions(() => new TcpServiceOptions());
         var vm = _services.GetRequiredService<TcpEditServiceViewModel>();
         vm.ServiceType = service.Type;
         vm.Load(service.DisplayName, options);
@@ -60,7 +60,7 @@ public class TcpEditServiceHandler : IEditServiceHandler
 
             service.DisplayName = trimmed;
             service.Type = newType;
-            service.TcpOptions = opts;
+            service.SetOptions((TcpServiceOptions)opts);
             var page = mainView.GetOrCreateServicePage(service);
             if (page != null)
             {

--- a/DesktopApplicationTemplate.UI/Services/MqttClientSessionManager.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttClientSessionManager.cs
@@ -57,7 +57,7 @@ public sealed class MqttClientSessionManager : IMqttClientSessionManager
         {
             if (!_sessions.TryGetValue(service, out var client))
             {
-                var options = service.MqttOptions ??= new MqttServiceOptions();
+                var options = service.GetOrCreateOptions(() => new MqttServiceOptions());
                 client = _clientFactory.Create(options);
                 _sessions.Add(service, client);
                 _logger.LogDebug("Created MQTT client session for service {ServiceName}.", service.DisplayName);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -34,6 +34,16 @@ namespace DesktopApplicationTemplate.Persistence
             var index = 0;
             foreach (var s in services)
             {
+                var tcpOptions = s.GetOptions<TcpServiceOptions>();
+                var ftpOptions = s.GetOptions<FtpServerOptions>();
+                var httpOptions = s.GetOptions<HttpServiceOptions>();
+                var csvOptions = s.GetOptions<CsvServiceOptions>();
+                var heartbeatOptions = s.GetOptions<HeartbeatServiceOptions>();
+                var fileObserverOptions = s.GetOptions<FileObserverServiceOptions>();
+                var hidOptions = s.GetOptions<HidServiceOptions>();
+                var scpOptions = s.GetOptions<ScpServiceOptions>();
+                var mqttOptions = s.GetOptions<MqttServiceOptions>();
+
                 TcpServiceOptions? tcp = null;
                 CsvServiceOptions? csv = null;
                 FtpServerOptions? ftp = null;
@@ -42,132 +52,132 @@ namespace DesktopApplicationTemplate.Persistence
                 FileObserverServiceOptions? fileObserver = null;
                 HidServiceOptions? hid = null;
                 ScpServiceOptions? scp = null;
-                if (s.Type == ServiceType.Tcp && s.TcpOptions != null)
+                if (s.Type == ServiceType.Tcp && tcpOptions != null)
                 {
                     tcp = new TcpServiceOptions
                     {
-                        Host = s.TcpOptions.Host,
-                        Port = s.TcpOptions.Port,
-                        UseUdp = s.TcpOptions.UseUdp,
-                        SubnetMask = s.TcpOptions.SubnetMask,
-                        PrimaryDns = s.TcpOptions.PrimaryDns,
-                        AlternateDns = s.TcpOptions.AlternateDns,
-                        Mode = s.TcpOptions.Mode,
-                        ConnectionRole = s.TcpOptions.ConnectionRole,
-                        DestinationHost = s.TcpOptions.DestinationHost,
-                        DestinationPort = s.TcpOptions.DestinationPort,
-                        DestinationGateway = s.TcpOptions.DestinationGateway,
-                        DestinationSubnetMask = s.TcpOptions.DestinationSubnetMask,
-                        DestinationPrimaryDns = s.TcpOptions.DestinationPrimaryDns,
-                        DestinationAlternateDns = s.TcpOptions.DestinationAlternateDns,
-                        InputMessage = s.TcpOptions.InputMessage,
-                        Script = s.TcpOptions.Script,
-                        OutputMessage = s.TcpOptions.OutputMessage,
-                        LastTestMessage = s.TcpOptions.LastTestMessage
+                        Host = tcpOptions.Host,
+                        Port = tcpOptions.Port,
+                        UseUdp = tcpOptions.UseUdp,
+                        SubnetMask = tcpOptions.SubnetMask,
+                        PrimaryDns = tcpOptions.PrimaryDns,
+                        AlternateDns = tcpOptions.AlternateDns,
+                        Mode = tcpOptions.Mode,
+                        ConnectionRole = tcpOptions.ConnectionRole,
+                        DestinationHost = tcpOptions.DestinationHost,
+                        DestinationPort = tcpOptions.DestinationPort,
+                        DestinationGateway = tcpOptions.DestinationGateway,
+                        DestinationSubnetMask = tcpOptions.DestinationSubnetMask,
+                        DestinationPrimaryDns = tcpOptions.DestinationPrimaryDns,
+                        DestinationAlternateDns = tcpOptions.DestinationAlternateDns,
+                        InputMessage = tcpOptions.InputMessage,
+                        Script = tcpOptions.Script,
+                        OutputMessage = tcpOptions.OutputMessage,
+                        LastTestMessage = tcpOptions.LastTestMessage
                     };
                 }
 
-                if (s.Type == ServiceType.Ftp && s.FtpOptions != null)
+                if (s.Type == ServiceType.Ftp && ftpOptions != null)
                 {
                     ftp = new FtpServerOptions
                     {
-                        Port = s.FtpOptions.Port,
-                        RootPath = s.FtpOptions.RootPath,
-                        AllowAnonymous = s.FtpOptions.AllowAnonymous,
-                        Username = s.FtpOptions.Username,
-                        Password = s.FtpOptions.Password
+                        Port = ftpOptions.Port,
+                        RootPath = ftpOptions.RootPath,
+                        AllowAnonymous = ftpOptions.AllowAnonymous,
+                        Username = ftpOptions.Username,
+                        Password = ftpOptions.Password
                     };
                 }
 
-                if (s.Type == ServiceType.Http && s.HttpOptions != null)
+                if (s.Type == ServiceType.Http && httpOptions != null)
                 {
                     http = new HttpServiceOptions
                     {
-                        BaseUrl = s.HttpOptions.BaseUrl,
-                        Username = s.HttpOptions.Username,
-                        Password = s.HttpOptions.Password,
-                        ClientCertificatePath = s.HttpOptions.ClientCertificatePath
+                        BaseUrl = httpOptions.BaseUrl,
+                        Username = httpOptions.Username,
+                        Password = httpOptions.Password,
+                        ClientCertificatePath = httpOptions.ClientCertificatePath
                     };
                 }
-                if (s.Type == ServiceType.Csv && s.CsvOptions != null)
+                if (s.Type == ServiceType.Csv && csvOptions != null)
                 {
                     csv = new CsvServiceOptions
                     {
-                        OutputPath = s.CsvOptions?.OutputPath ?? string.Empty,
-                        Delimiter = s.CsvOptions?.Delimiter ?? ",",
-                        IncludeHeaders = s.CsvOptions?.IncludeHeaders ?? true
+                        OutputPath = csvOptions.OutputPath ?? string.Empty,
+                        Delimiter = csvOptions.Delimiter ?? ",",
+                        IncludeHeaders = csvOptions.IncludeHeaders ?? true
                     };
                 }
 
-                if (s.Type == ServiceType.Heartbeat && s.HeartbeatOptions != null)
+                if (s.Type == ServiceType.Heartbeat && heartbeatOptions != null)
                 {
                     heartbeat = new HeartbeatServiceOptions
                     {
-                        BaseMessage = s.HeartbeatOptions.BaseMessage,
-                        IncludePing = s.HeartbeatOptions.IncludePing,
-                        IncludeStatus = s.HeartbeatOptions.IncludeStatus
+                        BaseMessage = heartbeatOptions.BaseMessage,
+                        IncludePing = heartbeatOptions.IncludePing,
+                        IncludeStatus = heartbeatOptions.IncludeStatus
                     };
                 }
 
-                if (s.Type == ServiceType.FileObserver && s.FileObserverOptions != null)
+                if (s.Type == ServiceType.FileObserver && fileObserverOptions != null)
                 {
                     fileObserver = new FileObserverServiceOptions
                     {
-                        FilePath = s.FileObserverOptions.FilePath,
-                        ImageNames = s.FileObserverOptions.ImageNames,
-                        SendAllImages = s.FileObserverOptions.SendAllImages,
-                        SendFirstX = s.FileObserverOptions.SendFirstX,
-                        XCount = s.FileObserverOptions.XCount,
-                        SendTcpCommand = s.FileObserverOptions.SendTcpCommand,
-                        TcpCommand = s.FileObserverOptions.TcpCommand
+                        FilePath = fileObserverOptions.FilePath,
+                        ImageNames = fileObserverOptions.ImageNames,
+                        SendAllImages = fileObserverOptions.SendAllImages,
+                        SendFirstX = fileObserverOptions.SendFirstX,
+                        XCount = fileObserverOptions.XCount,
+                        SendTcpCommand = fileObserverOptions.SendTcpCommand,
+                        TcpCommand = fileObserverOptions.TcpCommand
                     };
                 }
 
-                if (s.Type == ServiceType.Hid && s.HidOptions != null)
+                if (s.Type == ServiceType.Hid && hidOptions != null)
                 {
                     hid = new HidServiceOptions
                     {
-                        MessageTemplate = s.HidOptions.MessageTemplate,
-                        UsbProtocol = s.HidOptions.UsbProtocol,
-                        AttachedService = s.HidOptions.AttachedService,
-                        DebounceTimeMs = s.HidOptions.DebounceTimeMs,
-                        KeyDownTimeMs = s.HidOptions.KeyDownTimeMs
+                        MessageTemplate = hidOptions.MessageTemplate,
+                        UsbProtocol = hidOptions.UsbProtocol,
+                        AttachedService = hidOptions.AttachedService,
+                        DebounceTimeMs = hidOptions.DebounceTimeMs,
+                        KeyDownTimeMs = hidOptions.KeyDownTimeMs
                     };
                 }
 
-                if (s.Type == ServiceType.Scp && s.ScpOptions != null)
+                if (s.Type == ServiceType.Scp && scpOptions != null)
                 {
                     scp = new ScpServiceOptions
                     {
-                        Host = s.ScpOptions.Host,
-                        Port = s.ScpOptions.Port,
-                        Username = s.ScpOptions.Username,
-                        Password = s.ScpOptions.Password,
-                        LocalPath = s.ScpOptions.LocalPath,
-                        RemotePath = s.ScpOptions.RemotePath
+                        Host = scpOptions.Host,
+                        Port = scpOptions.Port,
+                        Username = scpOptions.Username,
+                        Password = scpOptions.Password,
+                        LocalPath = scpOptions.LocalPath,
+                        RemotePath = scpOptions.RemotePath
                     };
                 }
 
                 MqttServiceOptions? mqtt = null;
-                if (s.Type == ServiceType.Mqtt && s.MqttOptions != null)
+                if (s.Type == ServiceType.Mqtt && mqttOptions != null)
                 {
                     mqtt = new MqttServiceOptions
                     {
-                        Host = s.MqttOptions.Host,
-                        Port = s.MqttOptions.Port,
-                        ClientId = s.MqttOptions.ClientId,
-                        Username = s.MqttOptions.Username,
-                        Password = s.MqttOptions.Password,
-                        ConnectionType = s.MqttOptions.ConnectionType,
-                        WebSocketPath = s.MqttOptions.WebSocketPath,
-                        ClientCertificate = s.MqttOptions.ClientCertificate?.ToArray(),
-                        WillTopic = s.MqttOptions.WillTopic,
-                        WillPayload = s.MqttOptions.WillPayload,
-                        WillQualityOfService = s.MqttOptions.WillQualityOfService,
-                        WillRetain = s.MqttOptions.WillRetain,
-                        KeepAliveSeconds = s.MqttOptions.KeepAliveSeconds,
-                        CleanSession = s.MqttOptions.CleanSession,
-                        ReconnectDelay = s.MqttOptions.ReconnectDelay
+                        Host = mqttOptions.Host,
+                        Port = mqttOptions.Port,
+                        ClientId = mqttOptions.ClientId,
+                        Username = mqttOptions.Username,
+                        Password = mqttOptions.Password,
+                        ConnectionType = mqttOptions.ConnectionType,
+                        WebSocketPath = mqttOptions.WebSocketPath,
+                        ClientCertificate = mqttOptions.ClientCertificate?.ToArray(),
+                        WillTopic = mqttOptions.WillTopic,
+                        WillPayload = mqttOptions.WillPayload,
+                        WillQualityOfService = mqttOptions.WillQualityOfService,
+                        WillRetain = mqttOptions.WillRetain,
+                        KeepAliveSeconds = mqttOptions.KeepAliveSeconds,
+                        CleanSession = mqttOptions.CleanSession,
+                        ReconnectDelay = mqttOptions.ReconnectDelay
                     };
                 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
@@ -47,7 +47,7 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(sessionManager);
 
-        _options = service.MqttOptions ??= new MqttServiceOptions();
+        _options = service.GetOrCreateOptions(() => new MqttServiceOptions());
         _clientService = sessionManager.GetClient(service);
 
         Subscriptions = new ObservableCollection<TagSubscription>();

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -268,7 +268,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             MessageTable = messageTable;
             _service.ActiveChanged += OnServiceActiveChanged;
             _service.PropertyChanged += OnServicePropertyChanged;
-            _options = service.TcpOptions ?? new TcpServiceOptions();
+            _options = service.GetOrCreateOptions(() => new TcpServiceOptions());
             ServiceType = service.Type;
             _suppressRuntimeInitialization = true;
             try
@@ -1380,12 +1380,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 return Task.CompletedTask;
             }
 
-            var options = _service.TcpOptions ?? new TcpServiceOptions();
+            var options = _service.GetOrCreateOptions(() => new TcpServiceOptions());
             options.Script = Script ?? string.Empty;
             options.LastTestMessage = TestMessage ?? string.Empty;
             options.InputMessage = TestMessage ?? string.Empty;
             options.OutputMessage = ScriptOutputMessage ?? string.Empty;
-            _service.TcpOptions = options;
+            _service.SetOptions(options);
             _options = options;
 
             return Task.CompletedTask;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -351,7 +351,7 @@ namespace DesktopApplicationTemplate.UI.Views
             viewModel.EditConnectionRequested += handler;
             _mqttEditHandlers[svc] = handler;
 
-            svc.MqttOptions ??= new MqttServiceOptions();
+            _ = svc.GetOrCreateOptions(() => new MqttServiceOptions());
 
             page.Initialize(svc, viewModel);
         }
@@ -437,7 +437,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            service.MqttOptions ??= new MqttServiceOptions();
+            _ = service.GetOrCreateOptions(() => new MqttServiceOptions());
 
             var logger = _serviceProvider.GetService<ILoggingService>();
             var viewModel = logger is null


### PR DESCRIPTION
## Summary
- replace per-protocol option properties in `ServiceListModel` with a dictionary-backed store and typed helpers
- update service registrations, persistence, and editing workflows to set and retrieve options through the new helpers
- add migration hooks so legacy serialized models hydrate the new option store

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e72c9beb888326bf26f1cafe313c8e