### PR TITLE
Refactor service option storage

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -337,7 +337,7 @@ namespace DesktopApplicationTemplate.UI
                         IsActive = false
                     };
 
-                    newService.MqttOptions = ctx.Options ?? new MqttServiceOptions();
+                    newService.SetOptions(ctx.Options ?? new MqttServiceOptions(), descriptor.Id);
                     mainView.GetOrCreateServicePage(newService);
 
                     return newService;
@@ -375,9 +375,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Ftp,
-                        IsActive = false,
-                        FtpOptions = ftpOptions
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ftpOptions, descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
 
@@ -424,9 +425,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Http,
-                        IsActive = false,
-                        HttpOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new HttpServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -472,9 +474,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Tcp,
-                        IsActive = false,
-                        TcpOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new TcpServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -510,9 +513,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Hid,
-                        IsActive = false,
-                        HidOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new HidServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -558,9 +562,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Scp,
-                        IsActive = false,
-                        ScpOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new ScpServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -606,9 +611,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.FileObserver,
-                        IsActive = false,
-                        FileObserverOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new FileObserverServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -654,9 +660,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Csv,
-                        IsActive = false,
-                        CsvOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new CsvServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
@@ -694,9 +701,10 @@ namespace DesktopApplicationTemplate.UI
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,
                         Type = ServiceType.Heartbeat,
-                        IsActive = false,
-                        HeartbeatOptions = ctx.Options
+                        IsActive = false
                     };
+
+                    svc.SetOptions(ctx.Options ?? new HeartbeatServiceOptions(), descriptor.Id);
 
                     mainView.GetOrCreateServicePage(svc);
                     return svc;

--- a/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/CsvEditServiceHandler.cs
@@ -31,7 +31,8 @@ public class CsvEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var csvPage = mainView.GetOrCreateServicePage(service);
-        var options = service.CsvOptions ?? new CsvServiceOptions();
+        var options = service.GetOptions<CsvServiceOptions>() ?? new CsvServiceOptions();
+        service.SetOptions(options);
         var vm = _services.GetRequiredService<CsvServiceEditorViewModel>();
         vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<CsvServiceEditorView>();
@@ -54,7 +55,7 @@ public class CsvEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.CsvOptions = opts;
+            service.SetOptions(opts);
             if (csvPage != null)
                 mainView.ShowPage(csvPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FileObserverEditServiceHandler.cs
@@ -33,7 +33,8 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var foPage = mainView.GetOrCreateServicePage(service);
-        var options = service.FileObserverOptions ?? new FileObserverServiceOptions();
+        var options = service.GetOptions<FileObserverServiceOptions>() ?? new FileObserverServiceOptions();
+        service.SetOptions(options);
         var vm = ActivatorUtilities.CreateInstance<FileObserverEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<FileObserverEditServiceView>();
         editView.Initialize(vm);
@@ -55,7 +56,7 @@ public class FileObserverEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.FileObserverOptions = opts;
+            service.SetOptions(opts);
             if (foPage != null)
                 mainView.ShowPage(foPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/FtpEditServiceHandler.cs
@@ -33,7 +33,8 @@ public class FtpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var ftpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.FtpOptions ?? new FtpServerOptions();
+        var options = service.GetOptions<FtpServerOptions>() ?? new FtpServerOptions();
+        service.SetOptions(options);
         var vm = ActivatorUtilities.CreateInstance<FtpServerEditViewModel>(_services, service.DisplayName, options);
         var editView = ActivatorUtilities.CreateInstance<FtpServerEditView>(_services, vm);
         vm.ServiceSaved += (name, opts) =>
@@ -54,7 +55,7 @@ public class FtpEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.FtpOptions = opts;
+            service.SetOptions(opts);
             if (ftpPage != null)
                 mainView.ShowPage(ftpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HeartbeatEditServiceHandler.cs
@@ -33,7 +33,8 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var hbPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HeartbeatOptions ?? new HeartbeatServiceOptions();
+        var options = service.GetOptions<HeartbeatServiceOptions>() ?? new HeartbeatServiceOptions();
+        service.SetOptions(options);
         var vm = ActivatorUtilities.CreateInstance<HeartbeatEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HeartbeatEditServiceView>();
         editView.Initialize(vm);
@@ -55,7 +56,7 @@ public class HeartbeatEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.HeartbeatOptions = opts;
+            service.SetOptions(opts);
             if (hbPage != null)
                 mainView.ShowPage(hbPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HidEditServiceHandler.cs
@@ -32,7 +32,8 @@ public class HidEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var hidPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HidOptions ?? new HidServiceOptions();
+        var options = service.GetOptions<HidServiceOptions>() ?? new HidServiceOptions();
+        service.SetOptions(options);
         var vm = ActivatorUtilities.CreateInstance<HidEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HidEditServiceView>();
         editView.Initialize(vm);
@@ -54,7 +55,7 @@ public class HidEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.HidOptions = opts;
+            service.SetOptions(opts);
             if (hidPage != null)
                 mainView.ShowPage(hidPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/HttpEditServiceHandler.cs
@@ -33,7 +33,8 @@ public class HttpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var httpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.HttpOptions ?? new HttpServiceOptions();
+        var options = service.GetOptions<HttpServiceOptions>() ?? new HttpServiceOptions();
+        service.SetOptions(options);
         var vm = ActivatorUtilities.CreateInstance<HttpEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<HttpEditServiceView>();
         editView.Initialize(vm);
@@ -55,7 +56,7 @@ public class HttpEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.HttpOptions = opts;
+            service.SetOptions(opts);
             if (httpPage != null)
                 mainView.ShowPage(httpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/MqttEditServiceHandler.cs
@@ -31,8 +31,8 @@ public class MqttEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var tagPage = mainView.GetOrCreateServicePage(service);
-        var options = service.MqttOptions ?? new MqttServiceOptions();
-        service.MqttOptions = options;
+        var options = service.GetOptions<MqttServiceOptions>() ?? new MqttServiceOptions();
+        service.SetOptions(options);
         var vm = ActivatorUtilities.CreateInstance<MqttEditServiceViewModel>(_services, service.DisplayName, options);
         var editView = _services.GetRequiredService<MqttEditServiceView>();
         editView.Initialize(vm);

--- a/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/ScpEditServiceHandler.cs
@@ -32,7 +32,8 @@ public class ScpEditServiceHandler : IEditServiceHandler
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
         var scpPage = mainView.GetOrCreateServicePage(service);
-        var options = service.ScpOptions ?? new ScpServiceOptions();
+        var options = service.GetOptions<ScpServiceOptions>() ?? new ScpServiceOptions();
+        service.SetOptions(options);
         var vm = _services.GetRequiredService<ScpEditServiceViewModel>();
         vm.Load(service.DisplayName, options);
         var editView = _services.GetRequiredService<ScpEditServiceView>();
@@ -55,7 +56,7 @@ public class ScpEditServiceHandler : IEditServiceHandler
             }
 
             service.DisplayName = trimmed;
-            service.ScpOptions = opts;
+            service.SetOptions(opts);
             if (scpPage != null)
                 mainView.ShowPage(scpPage);
             _ = mainViewModel.SaveServicesAsync();

--- a/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
+++ b/DesktopApplicationTemplate.UI/EditHandlers/TcpEditServiceHandler.cs
@@ -31,7 +31,8 @@ public class TcpEditServiceHandler : IEditServiceHandler
     {
         var mainView = _getMainView();
         var mainViewModel = _getMainViewModel();
-        var options = service.TcpOptions ?? new TcpServiceOptions();
+        var options = service.GetOptions<TcpServiceOptions>() ?? new TcpServiceOptions();
+        service.SetOptions(options);
         var vm = _services.GetRequiredService<TcpEditServiceViewModel>();
         vm.ServiceType = service.Type;
         vm.Load(service.DisplayName, options);
@@ -60,7 +61,7 @@ public class TcpEditServiceHandler : IEditServiceHandler
 
             service.DisplayName = trimmed;
             service.Type = newType;
-            service.TcpOptions = opts;
+            service.SetOptions(opts);
             var page = mainView.GetOrCreateServicePage(service);
             if (page != null)
             {

--- a/DesktopApplicationTemplate.UI/Services/MqttClientSessionManager.cs
+++ b/DesktopApplicationTemplate.UI/Services/MqttClientSessionManager.cs
@@ -57,7 +57,7 @@ public sealed class MqttClientSessionManager : IMqttClientSessionManager
         {
             if (!_sessions.TryGetValue(service, out var client))
             {
-                var options = service.MqttOptions ??= new MqttServiceOptions();
+                var options = service.GetOrCreateOptions(() => new MqttServiceOptions());
                 client = _clientFactory.Create(options);
                 _sessions.Add(service, client);
                 _logger.LogDebug("Created MQTT client session for service {ServiceName}.", service.DisplayName);

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -42,132 +42,141 @@ namespace DesktopApplicationTemplate.Persistence
                 FileObserverServiceOptions? fileObserver = null;
                 HidServiceOptions? hid = null;
                 ScpServiceOptions? scp = null;
-                if (s.Type == ServiceType.Tcp && s.TcpOptions != null)
+                var tcpSource = s.GetOptions<TcpServiceOptions>();
+                if (s.Type == ServiceType.Tcp && tcpSource != null)
                 {
                     tcp = new TcpServiceOptions
                     {
-                        Host = s.TcpOptions.Host,
-                        Port = s.TcpOptions.Port,
-                        UseUdp = s.TcpOptions.UseUdp,
-                        SubnetMask = s.TcpOptions.SubnetMask,
-                        PrimaryDns = s.TcpOptions.PrimaryDns,
-                        AlternateDns = s.TcpOptions.AlternateDns,
-                        Mode = s.TcpOptions.Mode,
-                        ConnectionRole = s.TcpOptions.ConnectionRole,
-                        DestinationHost = s.TcpOptions.DestinationHost,
-                        DestinationPort = s.TcpOptions.DestinationPort,
-                        DestinationGateway = s.TcpOptions.DestinationGateway,
-                        DestinationSubnetMask = s.TcpOptions.DestinationSubnetMask,
-                        DestinationPrimaryDns = s.TcpOptions.DestinationPrimaryDns,
-                        DestinationAlternateDns = s.TcpOptions.DestinationAlternateDns,
-                        InputMessage = s.TcpOptions.InputMessage,
-                        Script = s.TcpOptions.Script,
-                        OutputMessage = s.TcpOptions.OutputMessage,
-                        LastTestMessage = s.TcpOptions.LastTestMessage
+                        Host = tcpSource.Host,
+                        Port = tcpSource.Port,
+                        UseUdp = tcpSource.UseUdp,
+                        SubnetMask = tcpSource.SubnetMask,
+                        PrimaryDns = tcpSource.PrimaryDns,
+                        AlternateDns = tcpSource.AlternateDns,
+                        Mode = tcpSource.Mode,
+                        ConnectionRole = tcpSource.ConnectionRole,
+                        DestinationHost = tcpSource.DestinationHost,
+                        DestinationPort = tcpSource.DestinationPort,
+                        DestinationGateway = tcpSource.DestinationGateway,
+                        DestinationSubnetMask = tcpSource.DestinationSubnetMask,
+                        DestinationPrimaryDns = tcpSource.DestinationPrimaryDns,
+                        DestinationAlternateDns = tcpSource.DestinationAlternateDns,
+                        InputMessage = tcpSource.InputMessage,
+                        Script = tcpSource.Script,
+                        OutputMessage = tcpSource.OutputMessage,
+                        LastTestMessage = tcpSource.LastTestMessage
                     };
                 }
 
-                if (s.Type == ServiceType.Ftp && s.FtpOptions != null)
+                var ftpSource = s.GetOptions<FtpServerOptions>();
+                if (s.Type == ServiceType.Ftp && ftpSource != null)
                 {
                     ftp = new FtpServerOptions
                     {
-                        Port = s.FtpOptions.Port,
-                        RootPath = s.FtpOptions.RootPath,
-                        AllowAnonymous = s.FtpOptions.AllowAnonymous,
-                        Username = s.FtpOptions.Username,
-                        Password = s.FtpOptions.Password
+                        Port = ftpSource.Port,
+                        RootPath = ftpSource.RootPath,
+                        AllowAnonymous = ftpSource.AllowAnonymous,
+                        Username = ftpSource.Username,
+                        Password = ftpSource.Password
                     };
                 }
 
-                if (s.Type == ServiceType.Http && s.HttpOptions != null)
+                var httpSource = s.GetOptions<HttpServiceOptions>();
+                if (s.Type == ServiceType.Http && httpSource != null)
                 {
                     http = new HttpServiceOptions
                     {
-                        BaseUrl = s.HttpOptions.BaseUrl,
-                        Username = s.HttpOptions.Username,
-                        Password = s.HttpOptions.Password,
-                        ClientCertificatePath = s.HttpOptions.ClientCertificatePath
+                        BaseUrl = httpSource.BaseUrl,
+                        Username = httpSource.Username,
+                        Password = httpSource.Password,
+                        ClientCertificatePath = httpSource.ClientCertificatePath
                     };
                 }
-                if (s.Type == ServiceType.Csv && s.CsvOptions != null)
+                var csvSource = s.GetOptions<CsvServiceOptions>();
+                if (s.Type == ServiceType.Csv && csvSource != null)
                 {
                     csv = new CsvServiceOptions
                     {
-                        OutputPath = s.CsvOptions?.OutputPath ?? string.Empty,
-                        Delimiter = s.CsvOptions?.Delimiter ?? ",",
-                        IncludeHeaders = s.CsvOptions?.IncludeHeaders ?? true
+                        OutputPath = csvSource.OutputPath ?? string.Empty,
+                        Delimiter = csvSource.Delimiter ?? ",",
+                        IncludeHeaders = csvSource.IncludeHeaders ?? true
                     };
                 }
 
-                if (s.Type == ServiceType.Heartbeat && s.HeartbeatOptions != null)
+                var heartbeatSource = s.GetOptions<HeartbeatServiceOptions>();
+                if (s.Type == ServiceType.Heartbeat && heartbeatSource != null)
                 {
                     heartbeat = new HeartbeatServiceOptions
                     {
-                        BaseMessage = s.HeartbeatOptions.BaseMessage,
-                        IncludePing = s.HeartbeatOptions.IncludePing,
-                        IncludeStatus = s.HeartbeatOptions.IncludeStatus
+                        BaseMessage = heartbeatSource.BaseMessage,
+                        IncludePing = heartbeatSource.IncludePing,
+                        IncludeStatus = heartbeatSource.IncludeStatus
                     };
                 }
 
-                if (s.Type == ServiceType.FileObserver && s.FileObserverOptions != null)
+                var fileObserverSource = s.GetOptions<FileObserverServiceOptions>();
+                if (s.Type == ServiceType.FileObserver && fileObserverSource != null)
                 {
                     fileObserver = new FileObserverServiceOptions
                     {
-                        FilePath = s.FileObserverOptions.FilePath,
-                        ImageNames = s.FileObserverOptions.ImageNames,
-                        SendAllImages = s.FileObserverOptions.SendAllImages,
-                        SendFirstX = s.FileObserverOptions.SendFirstX,
-                        XCount = s.FileObserverOptions.XCount,
-                        SendTcpCommand = s.FileObserverOptions.SendTcpCommand,
-                        TcpCommand = s.FileObserverOptions.TcpCommand
+                        FilePath = fileObserverSource.FilePath,
+                        ImageNames = fileObserverSource.ImageNames,
+                        SendAllImages = fileObserverSource.SendAllImages,
+                        SendFirstX = fileObserverSource.SendFirstX,
+                        XCount = fileObserverSource.XCount,
+                        SendTcpCommand = fileObserverSource.SendTcpCommand,
+                        TcpCommand = fileObserverSource.TcpCommand
                     };
                 }
 
-                if (s.Type == ServiceType.Hid && s.HidOptions != null)
+                var hidSource = s.GetOptions<HidServiceOptions>();
+                if (s.Type == ServiceType.Hid && hidSource != null)
                 {
                     hid = new HidServiceOptions
                     {
-                        MessageTemplate = s.HidOptions.MessageTemplate,
-                        UsbProtocol = s.HidOptions.UsbProtocol,
-                        AttachedService = s.HidOptions.AttachedService,
-                        DebounceTimeMs = s.HidOptions.DebounceTimeMs,
-                        KeyDownTimeMs = s.HidOptions.KeyDownTimeMs
+                        MessageTemplate = hidSource.MessageTemplate,
+                        UsbProtocol = hidSource.UsbProtocol,
+                        AttachedService = hidSource.AttachedService,
+                        DebounceTimeMs = hidSource.DebounceTimeMs,
+                        KeyDownTimeMs = hidSource.KeyDownTimeMs
                     };
                 }
 
-                if (s.Type == ServiceType.Scp && s.ScpOptions != null)
+                var scpSource = s.GetOptions<ScpServiceOptions>();
+                if (s.Type == ServiceType.Scp && scpSource != null)
                 {
                     scp = new ScpServiceOptions
                     {
-                        Host = s.ScpOptions.Host,
-                        Port = s.ScpOptions.Port,
-                        Username = s.ScpOptions.Username,
-                        Password = s.ScpOptions.Password,
-                        LocalPath = s.ScpOptions.LocalPath,
-                        RemotePath = s.ScpOptions.RemotePath
+                        Host = scpSource.Host,
+                        Port = scpSource.Port,
+                        Username = scpSource.Username,
+                        Password = scpSource.Password,
+                        LocalPath = scpSource.LocalPath,
+                        RemotePath = scpSource.RemotePath
                     };
                 }
 
                 MqttServiceOptions? mqtt = null;
-                if (s.Type == ServiceType.Mqtt && s.MqttOptions != null)
+                var mqttSource = s.GetOptions<MqttServiceOptions>();
+                if (s.Type == ServiceType.Mqtt && mqttSource != null)
                 {
                     mqtt = new MqttServiceOptions
                     {
-                        Host = s.MqttOptions.Host,
-                        Port = s.MqttOptions.Port,
-                        ClientId = s.MqttOptions.ClientId,
-                        Username = s.MqttOptions.Username,
-                        Password = s.MqttOptions.Password,
-                        ConnectionType = s.MqttOptions.ConnectionType,
-                        WebSocketPath = s.MqttOptions.WebSocketPath,
-                        ClientCertificate = s.MqttOptions.ClientCertificate?.ToArray(),
-                        WillTopic = s.MqttOptions.WillTopic,
-                        WillPayload = s.MqttOptions.WillPayload,
-                        WillQualityOfService = s.MqttOptions.WillQualityOfService,
-                        WillRetain = s.MqttOptions.WillRetain,
-                        KeepAliveSeconds = s.MqttOptions.KeepAliveSeconds,
-                        CleanSession = s.MqttOptions.CleanSession,
-                        ReconnectDelay = s.MqttOptions.ReconnectDelay
+                        Host = mqttSource.Host,
+                        Port = mqttSource.Port,
+                        ClientId = mqttSource.ClientId,
+                        Username = mqttSource.Username,
+                        Password = mqttSource.Password,
+                        ConnectionType = mqttSource.ConnectionType,
+                        WebSocketPath = mqttSource.WebSocketPath,
+                        ClientCertificate = mqttSource.ClientCertificate?.ToArray(),
+                        WillTopic = mqttSource.WillTopic,
+                        WillPayload = mqttSource.WillPayload,
+                        WillQualityOfService = mqttSource.WillQualityOfService,
+                        WillRetain = mqttSource.WillRetain,
+                        KeepAliveSeconds = mqttSource.KeepAliveSeconds,
+                        CleanSession = mqttSource.CleanSession,
+                        ReconnectDelay = mqttSource.ReconnectDelay
                     };
                 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -435,18 +435,39 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     Type = info.ServiceType,
                     IsActive = info.IsActive,
                     Order = info.Order,
-                    TcpOptions = info.TcpOptions,
-                    FtpOptions = info.FtpOptions,
-                    HttpOptions = info.HttpOptions,
-                    CsvOptions = info.CsvOptions,
-                    HeartbeatOptions = info.HeartbeatOptions,
-                    FileObserverOptions = info.FileObserverOptions,
-                    HidOptions = info.HidOptions,
-                    ScpOptions = info.ScpOptions,
-                    MqttOptions = info.MqttOptions ?? new MqttServiceOptions(),
                     TotalExecutionTimeMs = info.TotalExecutionTimeMs,
                     ExecutionCount = info.ExecutionCount
                 };
+                switch (info.ServiceType)
+                {
+                    case ServiceType.Tcp when info.TcpOptions is not null:
+                        svc.SetOptions(info.TcpOptions, descriptorId);
+                        break;
+                    case ServiceType.Ftp when info.FtpOptions is not null:
+                        svc.SetOptions(info.FtpOptions, descriptorId);
+                        break;
+                    case ServiceType.Http when info.HttpOptions is not null:
+                        svc.SetOptions(info.HttpOptions, descriptorId);
+                        break;
+                    case ServiceType.Csv when info.CsvOptions is not null:
+                        svc.SetOptions(info.CsvOptions, descriptorId);
+                        break;
+                    case ServiceType.Heartbeat when info.HeartbeatOptions is not null:
+                        svc.SetOptions(info.HeartbeatOptions, descriptorId);
+                        break;
+                    case ServiceType.FileObserver when info.FileObserverOptions is not null:
+                        svc.SetOptions(info.FileObserverOptions, descriptorId);
+                        break;
+                    case ServiceType.Hid when info.HidOptions is not null:
+                        svc.SetOptions(info.HidOptions, descriptorId);
+                        break;
+                    case ServiceType.Scp when info.ScpOptions is not null:
+                        svc.SetOptions(info.ScpOptions, descriptorId);
+                        break;
+                    case ServiceType.Mqtt:
+                        svc.SetOptions(info.MqttOptions ?? new MqttServiceOptions(), descriptorId);
+                        break;
+                }
                 svc.InitializeMessageCounts(info.IncomingMessageCount, info.OutgoingMessageCount);
                 foreach (var a in info.AssociatedServices ?? new List<string>())
                     svc.AssociatedServices.Add(a);

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
@@ -53,7 +53,8 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         ArgumentNullException.ThrowIfNull(sessionManager);
 
         _clientService = sessionManager.GetClient(service);
-        _options = service.MqttOptions ??= new MqttServiceOptions();
+        _options = service.GetOptions<MqttServiceOptions>() ?? new MqttServiceOptions();
+        service.SetOptions(_options);
         _fileDialogService = fileDialogService ?? throw new ArgumentNullException(nameof(fileDialogService));
         Logger = logger;
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/MqttTagSubscriptionsViewModel.cs
@@ -47,7 +47,8 @@ public class MqttTagSubscriptionsViewModel : ValidatableViewModelBase, ILoggingV
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(sessionManager);
 
-        _options = service.MqttOptions ??= new MqttServiceOptions();
+        _options = service.GetOptions<MqttServiceOptions>() ?? new MqttServiceOptions();
+        service.SetOptions(_options);
         _clientService = sessionManager.GetClient(service);
 
         Subscriptions = new ObservableCollection<TagSubscription>();

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows.Controls;
-using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
 using DesktopApplicationTemplate.Core.Services.Protocols.Ftp;
@@ -15,6 +15,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Hid;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Models;
@@ -119,6 +120,21 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         [JsonIgnore] public Page? ServicePage { get; set; }
 
         public ObservableCollection<string> AssociatedServices { get; } = new();
+
+        private Dictionary<string, JsonElement> _serializedOptions = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Gets or sets the serialized representation of protocol options for persistence.
+        /// </summary>
+        [JsonInclude]
+        public Dictionary<string, JsonElement> SerializedOptions
+        {
+            get => _serializedOptions;
+            set => _serializedOptions = value ?? new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        [JsonIgnore]
+        private readonly Dictionary<string, object?> _options = new(StringComparer.OrdinalIgnoreCase);
 
         private static readonly object ServiceRegistryLock = new();
         private static readonly HashSet<ServiceListModel> ServiceRegistry = new();
@@ -298,49 +314,247 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         /// <summary>
-        /// TCP-specific configuration for this service, if applicable.
+        /// Stores strongly typed options for the service keyed by descriptor or service type.
         /// </summary>
-        public TcpServiceOptions? TcpOptions { get; set; }
+        /// <param name="options">The options instance to persist.</param>
+        /// <param name="key">Optional override for the storage key.</param>
+        /// <typeparam name="TOptions">The options type.</typeparam>
+        public void SetOptions<TOptions>(TOptions? options, string? key = null)
+            where TOptions : class
+        {
+            var keyCandidates = EnumerateOptionKeys(key).ToArray();
+            var resolvedKey = keyCandidates.FirstOrDefault();
+            if (resolvedKey is null)
+            {
+                return;
+            }
+
+            if (options is null)
+            {
+                _options.Remove(resolvedKey);
+                _serializedOptions.Remove(resolvedKey);
+                return;
+            }
+
+            _options[resolvedKey] = options;
+
+            try
+            {
+                _serializedOptions[resolvedKey] = JsonSerializer.SerializeToElement(options);
+            }
+            catch (NotSupportedException)
+            {
+                _serializedOptions.Remove(resolvedKey);
+            }
+            catch (JsonException)
+            {
+                _serializedOptions.Remove(resolvedKey);
+            }
+
+            foreach (var candidate in keyCandidates.Skip(1))
+            {
+                _options.Remove(candidate);
+                _serializedOptions.Remove(candidate);
+            }
+        }
 
         /// <summary>
-        /// FTP server-specific configuration for this service, if applicable.
+        /// Retrieves strongly typed options previously registered for the service.
         /// </summary>
-        public FtpServerOptions? FtpOptions { get; set; }
+        /// <typeparam name="TOptions">The expected options type.</typeparam>
+        /// <param name="key">Optional override for the storage key.</param>
+        /// <returns>The stored options instance, or <c>null</c> when unavailable.</returns>
+        public TOptions? GetOptions<TOptions>(string? key = null)
+            where TOptions : class
+        {
+            var keyCandidates = EnumerateOptionKeys(key).ToArray();
+            var resolvedKey = keyCandidates.FirstOrDefault();
+            if (resolvedKey is null)
+            {
+                return null;
+            }
+
+            foreach (var candidate in keyCandidates)
+            {
+                if (_options.TryGetValue(candidate, out var raw) && raw is TOptions typed)
+                {
+                    PromoteOptionKey(candidate, resolvedKey, typed);
+                    return typed;
+                }
+
+                if (_serializedOptions.TryGetValue(candidate, out var element))
+                {
+                    try
+                    {
+                        var deserialized = element.Deserialize<TOptions>();
+                        if (deserialized is not null)
+                        {
+                            PromoteOptionKey(candidate, resolvedKey, deserialized);
+                            return deserialized;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Ignore and try next candidate.
+                    }
+                }
+            }
+
+            return null;
+        }
 
         /// <summary>
-        /// HTTP-specific configuration for this service, if applicable.
+        /// Retrieves existing options or creates a new instance via the provided factory.
         /// </summary>
-        public HttpServiceOptions? HttpOptions { get; set; }
+        /// <typeparam name="TOptions">The expected options type.</typeparam>
+        /// <param name="factory">Factory used when no stored options exist.</param>
+        /// <param name="key">Optional override for the storage key.</param>
+        /// <returns>The resolved options instance.</returns>
+        public TOptions GetOrCreateOptions<TOptions>(Func<TOptions> factory, string? key = null)
+            where TOptions : class
+        {
+            if (factory is null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
 
-        /// <summary>
-        /// HID-specific configuration for this service, if applicable.
-        /// </summary>
-        public HidServiceOptions? HidOptions { get; set; }
+            var existing = GetOptions<TOptions>(key);
+            if (existing is not null)
+            {
+                return existing;
+            }
 
-        /// <summary>
-        /// Heartbeat-specific configuration for this service, if applicable.
-        /// </summary>
-        public HeartbeatServiceOptions? HeartbeatOptions { get; set; }
+            var created = factory();
+            SetOptions(created, key);
+            return created;
+        }
 
-        /// <summary>
-        /// File Observer-specific configuration for this service, if applicable.
-        /// </summary>
-        public FileObserverServiceOptions? FileObserverOptions { get; set; }
+        private IEnumerable<string> EnumerateOptionKeys(string? overrideKey)
+        {
+            if (!string.IsNullOrWhiteSpace(overrideKey))
+            {
+                yield return overrideKey;
+            }
 
-        /// <summary>
-        /// SCP-specific configuration for this service, if applicable.
-        /// </summary>
-        public ScpServiceOptions? ScpOptions { get; set; }
+            if (!string.IsNullOrWhiteSpace(DescriptorId))
+            {
+                yield return DescriptorId;
+            }
 
-        /// <summary>
-        /// CSV creator-specific configuration for this service, if applicable.
-        /// </summary>
-        public CsvServiceOptions? CsvOptions { get; set; }
+            if (Type != default)
+            {
+                yield return Type.ToString();
+            }
+        }
 
-        /// <summary>
-        /// MQTT-specific configuration for this service, if applicable.
-        /// </summary>
-        public MqttServiceOptions? MqttOptions { get; set; }
+        private void PromoteOptionKey<TOptions>(string sourceKey, string targetKey, TOptions value)
+            where TOptions : class
+        {
+            if (string.Equals(sourceKey, targetKey, StringComparison.Ordinal))
+            {
+                _options[targetKey] = value;
+                return;
+            }
+
+            _options[targetKey] = value;
+            _options.Remove(sourceKey);
+
+            if (_serializedOptions.TryGetValue(sourceKey, out var element))
+            {
+                _serializedOptions[targetKey] = element;
+                _serializedOptions.Remove(sourceKey);
+                return;
+            }
+
+            try
+            {
+                _serializedOptions[targetKey] = JsonSerializer.SerializeToElement(value);
+            }
+            catch (NotSupportedException)
+            {
+                _serializedOptions.Remove(targetKey);
+            }
+            catch (JsonException)
+            {
+                _serializedOptions.Remove(targetKey);
+            }
+        }
+
+        #region Legacy option bindings
+
+        [JsonPropertyName("TcpOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public TcpServiceOptions? LegacyTcpOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("FtpOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public FtpServerOptions? LegacyFtpOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("HttpOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public HttpServiceOptions? LegacyHttpOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("HidOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public HidServiceOptions? LegacyHidOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("HeartbeatOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public HeartbeatServiceOptions? LegacyHeartbeatOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("FileObserverOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public FileObserverServiceOptions? LegacyFileObserverOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("ScpOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public ScpServiceOptions? LegacyScpOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("CsvOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public CsvServiceOptions? LegacyCsvOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        [JsonPropertyName("MqttOptions")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public MqttServiceOptions? LegacyMqttOptions
+        {
+            get => null;
+            set => SetOptions(value);
+        }
+
+        #endregion
 
         public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -268,7 +268,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             MessageTable = messageTable;
             _service.ActiveChanged += OnServiceActiveChanged;
             _service.PropertyChanged += OnServicePropertyChanged;
-            _options = service.TcpOptions ?? new TcpServiceOptions();
+            _options = service.GetOptions<TcpServiceOptions>() ?? new TcpServiceOptions();
+            service.SetOptions(_options);
             ServiceType = service.Type;
             _suppressRuntimeInitialization = true;
             try
@@ -1380,12 +1381,12 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 return Task.CompletedTask;
             }
 
-            var options = _service.TcpOptions ?? new TcpServiceOptions();
+            var options = _service.GetOrCreateOptions(() => new TcpServiceOptions());
             options.Script = Script ?? string.Empty;
             options.LastTestMessage = TestMessage ?? string.Empty;
             options.InputMessage = TestMessage ?? string.Empty;
             options.OutputMessage = ScriptOutputMessage ?? string.Empty;
-            _service.TcpOptions = options;
+            _service.SetOptions(options);
             _options = options;
 
             return Task.CompletedTask;

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -351,7 +351,7 @@ namespace DesktopApplicationTemplate.UI.Views
             viewModel.EditConnectionRequested += handler;
             _mqttEditHandlers[svc] = handler;
 
-            svc.MqttOptions ??= new MqttServiceOptions();
+            _ = svc.GetOrCreateOptions(() => new MqttServiceOptions());
 
             page.Initialize(svc, viewModel);
         }
@@ -437,7 +437,7 @@ namespace DesktopApplicationTemplate.UI.Views
                 return;
             }
 
-            service.MqttOptions ??= new MqttServiceOptions();
+            _ = service.GetOrCreateOptions(() => new MqttServiceOptions());
 
             var logger = _serviceProvider.GetService<ILoggingService>();
             var viewModel = logger is null


### PR DESCRIPTION
## Summary
- replace the protocol-specific option properties on `ServiceListModel` with a descriptor-keyed option store and helper APIs
- update service creation, edit handlers, and runtime consumers to set or fetch options through the new helpers
- persist options through the new store while maintaining backward compatibility for previously saved models

## Testing
- Not run (WPF build unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e72c9beb888326bf26f1cafe313c8e