### PR TITLE
Refactor service persistence to use descriptor option serializers

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Reflection;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.Core.Services.Protocols.Ftp;
@@ -17,8 +19,8 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Models;
 using DesktopApplicationTemplate.UI.ViewModels;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -28,193 +30,84 @@ namespace DesktopApplicationTemplate.Persistence
     {
         public static string FilePath { get; set; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "services.json");
 
-        public static void Save(IEnumerable<ServiceListModel> services, ILoggingService? logger = null)
+        public static void Save(IEnumerable<ServiceListModel> services, IServiceCatalog serviceCatalog, ILoggingService? logger = null)
         {
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (serviceCatalog is null)
+            {
+                throw new ArgumentNullException(nameof(serviceCatalog));
+            }
+
             var data = new List<ServiceInfo>();
             var index = 0;
-            foreach (var s in services)
+
+            foreach (var service in services)
             {
-                TcpServiceOptions? tcp = null;
-                CsvServiceOptions? csv = null;
-                FtpServerOptions? ftp = null;
-                HttpServiceOptions? http = null;
-                HeartbeatServiceOptions? heartbeat = null;
-                FileObserverServiceOptions? fileObserver = null;
-                HidServiceOptions? hid = null;
-                ScpServiceOptions? scp = null;
-                var tcpSource = s.GetOptions<TcpServiceOptions>();
-                if (s.Type == ServiceType.Tcp && tcpSource != null)
+                var info = new ServiceInfo
                 {
-                    tcp = new TcpServiceOptions
-                    {
-                        Host = tcpSource.Host,
-                        Port = tcpSource.Port,
-                        UseUdp = tcpSource.UseUdp,
-                        SubnetMask = tcpSource.SubnetMask,
-                        PrimaryDns = tcpSource.PrimaryDns,
-                        AlternateDns = tcpSource.AlternateDns,
-                        Mode = tcpSource.Mode,
-                        ConnectionRole = tcpSource.ConnectionRole,
-                        DestinationHost = tcpSource.DestinationHost,
-                        DestinationPort = tcpSource.DestinationPort,
-                        DestinationGateway = tcpSource.DestinationGateway,
-                        DestinationSubnetMask = tcpSource.DestinationSubnetMask,
-                        DestinationPrimaryDns = tcpSource.DestinationPrimaryDns,
-                        DestinationAlternateDns = tcpSource.DestinationAlternateDns,
-                        InputMessage = tcpSource.InputMessage,
-                        Script = tcpSource.Script,
-                        OutputMessage = tcpSource.OutputMessage,
-                        LastTestMessage = tcpSource.LastTestMessage
-                    };
-                }
-
-                var ftpSource = s.GetOptions<FtpServerOptions>();
-                if (s.Type == ServiceType.Ftp && ftpSource != null)
-                {
-                    ftp = new FtpServerOptions
-                    {
-                        Port = ftpSource.Port,
-                        RootPath = ftpSource.RootPath,
-                        AllowAnonymous = ftpSource.AllowAnonymous,
-                        Username = ftpSource.Username,
-                        Password = ftpSource.Password
-                    };
-                }
-
-                var httpSource = s.GetOptions<HttpServiceOptions>();
-                if (s.Type == ServiceType.Http && httpSource != null)
-                {
-                    http = new HttpServiceOptions
-                    {
-                        BaseUrl = httpSource.BaseUrl,
-                        Username = httpSource.Username,
-                        Password = httpSource.Password,
-                        ClientCertificatePath = httpSource.ClientCertificatePath
-                    };
-                }
-                var csvSource = s.GetOptions<CsvServiceOptions>();
-                if (s.Type == ServiceType.Csv && csvSource != null)
-                {
-                    csv = new CsvServiceOptions
-                    {
-                        OutputPath = csvSource.OutputPath ?? string.Empty,
-                        Delimiter = csvSource.Delimiter ?? ",",
-                        IncludeHeaders = csvSource.IncludeHeaders ?? true
-                    };
-                }
-
-                var heartbeatSource = s.GetOptions<HeartbeatServiceOptions>();
-                if (s.Type == ServiceType.Heartbeat && heartbeatSource != null)
-                {
-                    heartbeat = new HeartbeatServiceOptions
-                    {
-                        BaseMessage = heartbeatSource.BaseMessage,
-                        IncludePing = heartbeatSource.IncludePing,
-                        IncludeStatus = heartbeatSource.IncludeStatus
-                    };
-                }
-
-                var fileObserverSource = s.GetOptions<FileObserverServiceOptions>();
-                if (s.Type == ServiceType.FileObserver && fileObserverSource != null)
-                {
-                    fileObserver = new FileObserverServiceOptions
-                    {
-                        FilePath = fileObserverSource.FilePath,
-                        ImageNames = fileObserverSource.ImageNames,
-                        SendAllImages = fileObserverSource.SendAllImages,
-                        SendFirstX = fileObserverSource.SendFirstX,
-                        XCount = fileObserverSource.XCount,
-                        SendTcpCommand = fileObserverSource.SendTcpCommand,
-                        TcpCommand = fileObserverSource.TcpCommand
-                    };
-                }
-
-                var hidSource = s.GetOptions<HidServiceOptions>();
-                if (s.Type == ServiceType.Hid && hidSource != null)
-                {
-                    hid = new HidServiceOptions
-                    {
-                        MessageTemplate = hidSource.MessageTemplate,
-                        UsbProtocol = hidSource.UsbProtocol,
-                        AttachedService = hidSource.AttachedService,
-                        DebounceTimeMs = hidSource.DebounceTimeMs,
-                        KeyDownTimeMs = hidSource.KeyDownTimeMs
-                    };
-                }
-
-                var scpSource = s.GetOptions<ScpServiceOptions>();
-                if (s.Type == ServiceType.Scp && scpSource != null)
-                {
-                    scp = new ScpServiceOptions
-                    {
-                        Host = scpSource.Host,
-                        Port = scpSource.Port,
-                        Username = scpSource.Username,
-                        Password = scpSource.Password,
-                        LocalPath = scpSource.LocalPath,
-                        RemotePath = scpSource.RemotePath
-                    };
-                }
-
-                MqttServiceOptions? mqtt = null;
-                var mqttSource = s.GetOptions<MqttServiceOptions>();
-                if (s.Type == ServiceType.Mqtt && mqttSource != null)
-                {
-                    mqtt = new MqttServiceOptions
-                    {
-                        Host = mqttSource.Host,
-                        Port = mqttSource.Port,
-                        ClientId = mqttSource.ClientId,
-                        Username = mqttSource.Username,
-                        Password = mqttSource.Password,
-                        ConnectionType = mqttSource.ConnectionType,
-                        WebSocketPath = mqttSource.WebSocketPath,
-                        ClientCertificate = mqttSource.ClientCertificate?.ToArray(),
-                        WillTopic = mqttSource.WillTopic,
-                        WillPayload = mqttSource.WillPayload,
-                        WillQualityOfService = mqttSource.WillQualityOfService,
-                        WillRetain = mqttSource.WillRetain,
-                        KeepAliveSeconds = mqttSource.KeepAliveSeconds,
-                        CleanSession = mqttSource.CleanSession,
-                        ReconnectDelay = mqttSource.ReconnectDelay
-                    };
-                }
-
-                data.Add(new ServiceInfo
-                {
-                    DisplayName = s.DisplayName,
-                    DescriptorId = s.DescriptorId,
-                    ServiceType = s.Type,
-                    IsActive = s.IsActive,
+                    DisplayName = service.DisplayName,
+                    DescriptorId = service.DescriptorId,
+                    ServiceType = service.Type,
+                    IsActive = service.IsActive,
                     Created = DateTime.Now,
                     Order = index++,
-                    AssociatedServices = new List<string>(s.AssociatedServices),
-                    TcpOptions = tcp,
-                    FtpOptions = ftp,
-                    HttpOptions = http,
-                    CsvOptions = csv,
-                    HeartbeatOptions = heartbeat,
-                    FileObserverOptions = fileObserver,
-                    HidOptions = hid,
-                    ScpOptions = scp,
-                    MqttOptions = mqtt,
-                    TotalExecutionTimeMs = s.TotalExecutionTimeMs,
-                    ExecutionCount = s.ExecutionCount,
-                    IncomingMessageCount = s.IncomingMessageCount,
-                    OutgoingMessageCount = s.OutgoingMessageCount,
-                    Logs = s.Logs
+                    AssociatedServices = new List<string>(service.AssociatedServices),
+                    SerializedOptions = CloneSerializedOptions(service.SerializedOptions),
+                    TotalExecutionTimeMs = service.TotalExecutionTimeMs,
+                    ExecutionCount = service.ExecutionCount,
+                    IncomingMessageCount = service.IncomingMessageCount,
+                    OutgoingMessageCount = service.OutgoingMessageCount,
+                    Logs = service.Logs
                         .Take(ServiceListModel.MaxLogEntries)
                         .Select(l => new LogEntry
                         {
                             Level = l.Level,
                             Message = l.Message,
                             Color = l.Color,
-                            ServiceType = l.ServiceType ?? s.Type,
-                            ServiceName = string.IsNullOrWhiteSpace(l.ServiceName) ? s.DisplayName : l.ServiceName
+                            ServiceType = l.ServiceType ?? service.Type,
+                            ServiceName = string.IsNullOrWhiteSpace(l.ServiceName) ? service.DisplayName : l.ServiceName
                         })
                         .ToList(),
-                    MessageHistory = s.GetMessageHistorySnapshot().ToList()
-                });
+                    MessageHistory = service.GetMessageHistorySnapshot().ToList(),
+                    TcpOptions = null,
+                    FtpOptions = null,
+                    HttpOptions = null,
+                    CsvOptions = null,
+                    HeartbeatOptions = null,
+                    FileObserverOptions = null,
+                    HidOptions = null,
+                    ScpOptions = null,
+                    MqttOptions = null
+                };
+
+                if (!string.IsNullOrWhiteSpace(service.DescriptorId) &&
+                    serviceCatalog.TryGetById(service.DescriptorId, out var descriptor) &&
+                    descriptor.OptionsSerializer is { } serializer)
+                {
+                    var options = GetOptionsForSerializer(service, serializer, descriptor.Id);
+                    if (options is null)
+                    {
+                        try
+                        {
+                            options = serializer.CreateDefaultOptions();
+                        }
+                        catch (Exception)
+                        {
+                            options = null;
+                        }
+                    }
+
+                    if (options is not null && TrySerializeOptions(serializer, options, out var element))
+                    {
+                        info.SerializedOptions[descriptor.Id] = element;
+                    }
+                }
+
+                data.Add(info);
             }
 
             var options = new JsonSerializerOptions
@@ -252,12 +145,17 @@ namespace DesktopApplicationTemplate.Persistence
             }
         }
 
-        public static List<ServiceInfo> Load(ILoggingService? logger = null)
+        public static List<ServiceListModel> Load(IServiceCatalog serviceCatalog, ILoggingService? logger = null)
         {
+            if (serviceCatalog is null)
+            {
+                throw new ArgumentNullException(nameof(serviceCatalog));
+            }
+
             if (!File.Exists(FilePath))
             {
                 logger?.Log("Services file not found", LogLevel.Warning);
-                return new List<ServiceInfo>();
+                return new List<ServiceListModel>();
             }
 
             string json;
@@ -268,87 +166,23 @@ namespace DesktopApplicationTemplate.Persistence
             catch (FileNotFoundException)
             {
                 logger?.Log("Services file not found", LogLevel.Warning);
-                return new List<ServiceInfo>();
+                return new List<ServiceListModel>();
             }
 
             try
             {
-                var services = JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+                var infos = JsonSerializer.Deserialize<List<ServiceInfo>>(json) ?? new List<ServiceInfo>();
+                var services = new List<ServiceListModel>(infos.Count);
 
-                foreach (var info in services)
+                foreach (var info in infos)
                 {
                     info.AssociatedServices ??= new List<string>();
                     info.Logs ??= new List<LogEntry>();
                     info.MessageHistory ??= new List<ServiceMessageHistoryEntry>();
-                }
+                    info.SerializedOptions ??= new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
 
-                foreach (var info in services)
-                {
-                    if (info.ServiceType == ServiceType.Mqtt && info.MqttOptions is null)
-                    {
-                        var opt = App.AppHost?.Services.GetService<IOptions<MqttServiceOptions>>();
-                        if (opt != null)
-                        {
-                            var value = opt.Value;
-                            info.MqttOptions = new MqttServiceOptions
-                            {
-                                Host = value.Host,
-                                Port = value.Port,
-                                ClientId = value.ClientId,
-                                Username = value.Username,
-                                Password = value.Password,
-                                ConnectionType = value.ConnectionType,
-                                WebSocketPath = value.WebSocketPath,
-                                ClientCertificate = value.ClientCertificate?.ToArray(),
-                                WillTopic = value.WillTopic,
-                                WillPayload = value.WillPayload,
-                                WillQualityOfService = value.WillQualityOfService,
-                                WillRetain = value.WillRetain,
-                                KeepAliveSeconds = value.KeepAliveSeconds,
-                                CleanSession = value.CleanSession,
-                                ReconnectDelay = value.ReconnectDelay
-                            };
-                        }
-                        else
-                        {
-                            info.MqttOptions = new MqttServiceOptions();
-                        }
-                    }
-
-                    if (info.ServiceType == ServiceType.Tcp && info.TcpOptions is null)
-                    {
-                        info.TcpOptions = new TcpServiceOptions();
-                    }
-
-                    if (info.ServiceType == ServiceType.Ftp && info.FtpOptions is null)
-                    {
-                        info.FtpOptions = new FtpServerOptions();
-                    }
-
-                    if (info.ServiceType == ServiceType.Http && info.HttpOptions is null)
-                    {
-                        info.HttpOptions = new HttpServiceOptions();
-                    }
-
-                    if (info.ServiceType == ServiceType.Heartbeat && info.HeartbeatOptions is null)
-                    {
-                        info.HeartbeatOptions = new HeartbeatServiceOptions();
-                    }
-
-                    if (info.ServiceType == ServiceType.FileObserver && info.FileObserverOptions is null)
-                    {
-                        info.FileObserverOptions = new FileObserverServiceOptions();
-                    }
-
-                    if (info.ServiceType == ServiceType.Hid && info.HidOptions is null)
-                    {
-                        info.HidOptions = new HidServiceOptions();
-                    }
-
-                    if (info.ServiceType == ServiceType.Scp && info.ScpOptions is null)
-                    {
-                        info.ScpOptions = new ScpServiceOptions();
-                    }
+                    var service = CreateServiceModel(info, serviceCatalog);
+                    services.Add(service);
                 }
 
                 logger?.Log($"Loaded {services.Count} services", LogLevel.Debug);
@@ -357,12 +191,288 @@ namespace DesktopApplicationTemplate.Persistence
             catch (JsonException)
             {
                 logger?.Log("Failed to parse services file", LogLevel.Error);
-                return new List<ServiceInfo>();
+                return new List<ServiceListModel>();
             }
             catch
             {
                 logger?.Log("Failed to parse services file", LogLevel.Error);
-                return new List<ServiceInfo>();
+                return new List<ServiceListModel>();
+            }
+        }
+
+        private static ServiceListModel CreateServiceModel(ServiceInfo info, IServiceCatalog serviceCatalog)
+        {
+            var descriptor = ResolveDescriptor(serviceCatalog, info.DescriptorId, info.ServiceType);
+            var descriptorId = descriptor?.Id ?? info.DescriptorId;
+
+            var service = new ServiceListModel
+            {
+                DescriptorId = descriptorId,
+                DisplayName = info.DisplayName,
+                Type = info.ServiceType,
+                Order = info.Order,
+                TotalExecutionTimeMs = info.TotalExecutionTimeMs,
+                ExecutionCount = info.ExecutionCount
+            };
+
+            service.SerializedOptions = CloneSerializedOptions(info.SerializedOptions);
+
+            foreach (var associated in info.AssociatedServices)
+            {
+                service.AssociatedServices.Add(associated);
+            }
+
+            service.LoadPersistedLogs(info.Logs);
+            service.LoadMessageHistory(info.MessageHistory);
+            service.InitializeMessageCounts(info.IncomingMessageCount, info.OutgoingMessageCount);
+            service.InitializeActivationState(info.IsActive);
+
+            ApplyOptions(info, service, descriptor);
+
+            return service;
+        }
+
+        private static void ApplyOptions(ServiceInfo info, ServiceListModel service, IServiceDescriptor? descriptor)
+        {
+            var serializer = descriptor?.OptionsSerializer;
+            var applied = false;
+
+            if (serializer is not null)
+            {
+                if (!string.IsNullOrWhiteSpace(descriptor?.Id) &&
+                    info.SerializedOptions.TryGetValue(descriptor.Id, out var descriptorPayload) &&
+                    service.TryApplySerializedOptions(serializer, descriptorPayload, descriptor.Id))
+                {
+                    applied = true;
+                }
+
+                if (!applied &&
+                    info.SerializedOptions.TryGetValue(info.ServiceType.ToString(), out var typePayload) &&
+                    service.TryApplySerializedOptions(serializer, typePayload, descriptor?.Id ?? service.DescriptorId))
+                {
+                    applied = true;
+                }
+
+                if (!applied)
+                {
+                    foreach (var payload in info.SerializedOptions)
+                    {
+                        if (service.TryApplySerializedOptions(serializer, payload.Value, descriptor?.Id ?? payload.Key))
+                        {
+                            applied = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!applied)
+            {
+                applied = TryApplyLegacyOptions(info, service);
+            }
+
+            if (!applied && serializer is not null)
+            {
+                try
+                {
+                    var defaults = serializer.CreateDefaultOptions();
+                    if (defaults is not null && TrySerializeOptions(serializer, defaults, out var element))
+                    {
+                        service.TryApplySerializedOptions(serializer, element, descriptor?.Id ?? service.DescriptorId);
+                        applied = true;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Ignore failures and fall through to type-based defaults.
+                }
+            }
+
+            if (!applied)
+            {
+                ApplyDefaultOptions(info.ServiceType, service);
+            }
+        }
+
+        private static IServiceDescriptor? ResolveDescriptor(IServiceCatalog catalog, string? descriptorId, ServiceType serviceType)
+        {
+            if (!string.IsNullOrWhiteSpace(descriptorId) && catalog.TryGetById(descriptorId, out var descriptor))
+            {
+                return descriptor;
+            }
+
+            return catalog.Descriptors.FirstOrDefault(d => d.ServiceType == serviceType);
+        }
+
+        private static Dictionary<string, JsonElement> CloneSerializedOptions(IReadOnlyDictionary<string, JsonElement>? source)
+        {
+            var result = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+            if (source is null)
+            {
+                return result;
+            }
+
+            foreach (var pair in source)
+            {
+                result[pair.Key] = pair.Value.Clone();
+            }
+
+            return result;
+        }
+
+        private static bool TryApplyLegacyOptions(ServiceInfo info, ServiceListModel service)
+        {
+            switch (info.ServiceType)
+            {
+                case ServiceType.Tcp when info.TcpOptions is not null:
+                    service.SetOptions(info.TcpOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Ftp when info.FtpOptions is not null:
+                    service.SetOptions(info.FtpOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Http when info.HttpOptions is not null:
+                    service.SetOptions(info.HttpOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Csv when info.CsvOptions is not null:
+                    service.SetOptions(info.CsvOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Heartbeat when info.HeartbeatOptions is not null:
+                    service.SetOptions(info.HeartbeatOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.FileObserver when info.FileObserverOptions is not null:
+                    service.SetOptions(info.FileObserverOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Hid when info.HidOptions is not null:
+                    service.SetOptions(info.HidOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Scp when info.ScpOptions is not null:
+                    service.SetOptions(info.ScpOptions, service.DescriptorId);
+                    return true;
+                case ServiceType.Mqtt:
+                    var mqtt = info.MqttOptions ?? ResolveDefaultMqttOptions() ?? new MqttServiceOptions();
+                    service.SetOptions(mqtt, service.DescriptorId);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static void ApplyDefaultOptions(ServiceType serviceType, ServiceListModel service)
+        {
+            switch (serviceType)
+            {
+                case ServiceType.Tcp:
+                    service.SetOptions(new TcpServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Ftp:
+                    service.SetOptions(new FtpServerOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Http:
+                    service.SetOptions(new HttpServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Csv:
+                    service.SetOptions(new CsvServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Heartbeat:
+                    service.SetOptions(new HeartbeatServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.FileObserver:
+                    service.SetOptions(new FileObserverServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Hid:
+                    service.SetOptions(new HidServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Scp:
+                    service.SetOptions(new ScpServiceOptions(), service.DescriptorId);
+                    break;
+                case ServiceType.Mqtt:
+                    var mqttDefaults = ResolveDefaultMqttOptions() ?? new MqttServiceOptions();
+                    service.SetOptions(mqttDefaults, service.DescriptorId);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private static MqttServiceOptions? ResolveDefaultMqttOptions()
+        {
+            var provider = App.AppHost?.Services;
+            var options = provider?.GetService<IOptions<MqttServiceOptions>>();
+            if (options is null)
+            {
+                return null;
+            }
+
+            var value = options.Value;
+            return new MqttServiceOptions
+            {
+                Host = value.Host,
+                Port = value.Port,
+                ClientId = value.ClientId,
+                Username = value.Username,
+                Password = value.Password,
+                ConnectionType = value.ConnectionType,
+                WebSocketPath = value.WebSocketPath,
+                ClientCertificate = value.ClientCertificate?.ToArray(),
+                WillTopic = value.WillTopic,
+                WillPayload = value.WillPayload,
+                WillQualityOfService = value.WillQualityOfService,
+                WillRetain = value.WillRetain,
+                KeepAliveSeconds = value.KeepAliveSeconds,
+                CleanSession = value.CleanSession,
+                ReconnectDelay = value.ReconnectDelay
+            };
+        }
+
+        private static object? GetOptionsForSerializer(ServiceListModel service, IServiceOptionsSerializer serializer, string? key)
+        {
+            var method = typeof(ServiceListModel).GetMethod(nameof(ServiceListModel.GetOptions), BindingFlags.Public | BindingFlags.Instance);
+            if (method is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var generic = method.MakeGenericMethod(serializer.OptionsType);
+                return generic.Invoke(service, new object?[] { key });
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+            catch (TargetInvocationException)
+            {
+                return null;
+            }
+        }
+
+        private static bool TrySerializeOptions(IServiceOptionsSerializer serializer, object options, out JsonElement element)
+        {
+            element = default;
+            try
+            {
+                if (!serializer.OptionsType.IsInstanceOfType(options))
+                {
+                    return false;
+                }
+
+                var buffer = new ArrayBufferWriter<byte>();
+                using (var writer = new Utf8JsonWriter(buffer))
+                {
+                    serializer.Serialize(writer, options);
+                }
+
+                element = JsonDocument.Parse(buffer.WrittenSpan).RootElement.Clone();
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
             }
         }
     }
@@ -376,6 +486,8 @@ namespace DesktopApplicationTemplate.Persistence
         public DateTime Created { get; set; }
         public int Order { get; set; }
         public List<string> AssociatedServices { get; set; } = new();
+        [JsonInclude]
+        public Dictionary<string, JsonElement> SerializedOptions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public TcpServiceOptions? TcpOptions { get; set; }
         public FtpServerOptions? FtpOptions { get; set; }
         public HttpServiceOptions? HttpOptions { get; set; }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -165,6 +165,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             NetworkConfig = networkConfig;
             _editHandlers = editHandlers;
             _startupPreferencesService = startupPreferencesService ?? throw new ArgumentNullException(nameof(startupPreferencesService));
+            ServiceListModel.OptionsSerializerResolver = ResolveOptionsSerializer;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             ServiceListModel.ResolveService = (type, name) =>
@@ -416,90 +417,60 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     await tcpVm.PersistOptionsAsync().ConfigureAwait(false);
                 }
             }
-            ServicePersistence.Save(Services);
+            ServicePersistence.Save(Services, _serviceCatalog, _logger);
         }
 
         private void LoadServices()
         {
-            var existing = ServicePersistence.Load(_logger);
-            foreach (var info in existing.OrderBy(i => i.Order))
+            var existing = ServicePersistence.Load(_serviceCatalog, _logger);
+            foreach (var service in existing.OrderBy(s => s.Order))
             {
-                var descriptorId = string.IsNullOrWhiteSpace(info.DescriptorId)
-                    ? ResolveDescriptorId(info.ServiceType)
-                    : info.DescriptorId;
-
-                var svc = new ServiceListModel
+                if (string.IsNullOrWhiteSpace(service.DescriptorId))
                 {
-                    DescriptorId = descriptorId,
-                    DisplayName = info.DisplayName,
-                    Type = info.ServiceType,
-                    IsActive = info.IsActive,
-                    Order = info.Order,
-                    TotalExecutionTimeMs = info.TotalExecutionTimeMs,
-                    ExecutionCount = info.ExecutionCount
-                };
-                switch (info.ServiceType)
-                {
-                    case ServiceType.Tcp when info.TcpOptions is not null:
-                        svc.SetOptions(info.TcpOptions, descriptorId);
-                        break;
-                    case ServiceType.Ftp when info.FtpOptions is not null:
-                        svc.SetOptions(info.FtpOptions, descriptorId);
-                        break;
-                    case ServiceType.Http when info.HttpOptions is not null:
-                        svc.SetOptions(info.HttpOptions, descriptorId);
-                        break;
-                    case ServiceType.Csv when info.CsvOptions is not null:
-                        svc.SetOptions(info.CsvOptions, descriptorId);
-                        break;
-                    case ServiceType.Heartbeat when info.HeartbeatOptions is not null:
-                        svc.SetOptions(info.HeartbeatOptions, descriptorId);
-                        break;
-                    case ServiceType.FileObserver when info.FileObserverOptions is not null:
-                        svc.SetOptions(info.FileObserverOptions, descriptorId);
-                        break;
-                    case ServiceType.Hid when info.HidOptions is not null:
-                        svc.SetOptions(info.HidOptions, descriptorId);
-                        break;
-                    case ServiceType.Scp when info.ScpOptions is not null:
-                        svc.SetOptions(info.ScpOptions, descriptorId);
-                        break;
-                    case ServiceType.Mqtt:
-                        svc.SetOptions(info.MqttOptions ?? new MqttServiceOptions(), descriptorId);
-                        break;
-                }
-                svc.InitializeMessageCounts(info.IncomingMessageCount, info.OutgoingMessageCount);
-                foreach (var a in info.AssociatedServices ?? new List<string>())
-                    svc.AssociatedServices.Add(a);
-                svc.LoadPersistedLogs(info.Logs ?? new List<LogEntry>());
-                svc.LoadMessageHistory(info.MessageHistory ?? new List<ServiceMessageHistoryEntry>());
-                var normalizedName = NormalizeDisplayName(svc.Type, svc.DisplayName);
-                if (Services.Any(existing => existing.DisplayName.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)))
-                {
-                    normalizedName = GenerateServiceName(svc.Type);
-                }
-                ClearRoutingCache(svc.Type, normalizedName);
-                svc.DisplayName = normalizedName;
-                if (string.IsNullOrWhiteSpace(svc.DescriptorId))
-                {
-                    svc.DescriptorId = ResolveDescriptorId(svc.Type);
+                    service.DescriptorId = ResolveDescriptorId(service.Type);
                 }
 
-                ApplyPresentationMetadata(svc);
-                svc.SetRuntimeState(svc.IsActive ? ServiceRuntimeState.Active : ServiceRuntimeState.Inactive);
-                svc.LogAdded += OnServiceLogAdded;
-                svc.ActiveChanged += OnServiceActiveChanged;
-                if (svc.Type != ServiceType.Csv)
-                    _csvService.EnsureColumnsForService(svc.DisplayName);
-                Services.Add(svc);
-                foreach (var log in svc.Logs.Reverse())
+                var normalizedName = NormalizeDisplayName(service.Type, service.DisplayName);
+                if (Services.Any(existingService => existingService.DisplayName.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    normalizedName = GenerateServiceName(service.Type);
+                }
+
+                ClearRoutingCache(service.Type, normalizedName);
+                service.DisplayName = normalizedName;
+
+                ApplyPresentationMetadata(service);
+                service.LogAdded += OnServiceLogAdded;
+                service.ActiveChanged += OnServiceActiveChanged;
+
+                if (service.Type != ServiceType.Csv)
+                {
+                    _csvService.EnsureColumnsForService(service.DisplayName);
+                }
+
+                Services.Add(service);
+
+                foreach (var log in service.Logs.Reverse())
                 {
                     AllLogs.Insert(0, log);
                 }
-                _logger?.Log($"Loaded service {svc.DisplayName}", LogLevel.Debug);
+
+                _logger?.Log($"Loaded service {service.DisplayName}", LogLevel.Debug);
             }
             OnPropertyChanged(nameof(ServicesCreated));
             OnPropertyChanged(nameof(CurrentActiveServices));
+        }
+
+        private IServiceOptionsSerializer? ResolveOptionsSerializer(string? descriptorId)
+        {
+            if (string.IsNullOrWhiteSpace(descriptorId))
+            {
+                return null;
+            }
+
+            return _serviceCatalog.TryGetById(descriptorId, out var descriptor)
+                ? descriptor.OptionsSerializer
+                : null;
         }
 
         private string? ResolveDescriptorId(ServiceType serviceType)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Buffers;
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
@@ -123,6 +124,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private Dictionary<string, JsonElement> _serializedOptions = new(StringComparer.OrdinalIgnoreCase);
 
+        internal static Func<string?, IServiceOptionsSerializer?>? OptionsSerializerResolver { get; set; }
+
         /// <summary>
         /// Gets or sets the serialized representation of protocol options for persistence.
         /// </summary>
@@ -130,7 +133,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         public Dictionary<string, JsonElement> SerializedOptions
         {
             get => _serializedOptions;
-            set => _serializedOptions = value ?? new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+            set
+            {
+                if (value is null)
+                {
+                    _serializedOptions = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+                    return;
+                }
+
+                _serializedOptions = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+                foreach (var pair in value)
+                {
+                    _serializedOptions[pair.Key] = pair.Value.Clone();
+                }
+            }
         }
 
         [JsonIgnore]
@@ -331,31 +347,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             if (options is null)
             {
-                _options.Remove(resolvedKey);
-                _serializedOptions.Remove(resolvedKey);
+                RemoveOptionKeys(keyCandidates);
                 return;
             }
 
-            _options[resolvedKey] = options;
-
-            try
+            var serializer = ResolveSerializer(keyCandidates);
+            if (serializer is not null && serializer.OptionsType.IsAssignableFrom(typeof(TOptions)))
             {
-                _serializedOptions[resolvedKey] = JsonSerializer.SerializeToElement(options);
-            }
-            catch (NotSupportedException)
-            {
-                _serializedOptions.Remove(resolvedKey);
-            }
-            catch (JsonException)
-            {
-                _serializedOptions.Remove(resolvedKey);
+                SetOptionsWithSerializer(serializer, options, resolvedKey, keyCandidates);
+                return;
             }
 
-            foreach (var candidate in keyCandidates.Skip(1))
-            {
-                _options.Remove(candidate);
-                _serializedOptions.Remove(candidate);
-            }
+            SetOptionsWithDefault(options, resolvedKey, keyCandidates);
         }
 
         /// <summary>
@@ -374,33 +377,220 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return null;
             }
 
+            var serializer = ResolveSerializer(keyCandidates);
+
             foreach (var candidate in keyCandidates)
             {
                 if (_options.TryGetValue(candidate, out var raw) && raw is TOptions typed)
                 {
-                    PromoteOptionKey(candidate, resolvedKey, typed);
+                    if (!string.Equals(candidate, resolvedKey, StringComparison.Ordinal))
+                    {
+                        SetOptions(typed, resolvedKey);
+                    }
+
                     return typed;
                 }
 
-                if (_serializedOptions.TryGetValue(candidate, out var element))
+                if (!_serializedOptions.TryGetValue(candidate, out var element))
+                {
+                    continue;
+                }
+
+                TOptions? deserialized = null;
+                if (serializer is not null && serializer.OptionsType.IsAssignableFrom(typeof(TOptions)))
                 {
                     try
                     {
-                        var deserialized = element.Deserialize<TOptions>();
-                        if (deserialized is not null)
-                        {
-                            PromoteOptionKey(candidate, resolvedKey, deserialized);
-                            return deserialized;
-                        }
+                        deserialized = serializer.Deserialize(element) as TOptions;
                     }
                     catch (JsonException)
                     {
-                        // Ignore and try next candidate.
+                        deserialized = null;
                     }
+                    catch (InvalidCastException)
+                    {
+                        deserialized = null;
+                    }
+                }
+
+                if (deserialized is null)
+                {
+                    try
+                    {
+                        deserialized = element.Deserialize<TOptions>();
+                    }
+                    catch (JsonException)
+                    {
+                        deserialized = null;
+                    }
+                }
+
+                if (deserialized is not null)
+                {
+                    SetOptions(deserialized, resolvedKey);
+                    return deserialized;
                 }
             }
 
             return null;
+        }
+
+        internal bool TryApplySerializedOptions(IServiceOptionsSerializer serializer, JsonElement payload, string? key = null)
+        {
+            var keyCandidates = EnumerateOptionKeys(key).ToArray();
+            var resolvedKey = keyCandidates.FirstOrDefault();
+            if (resolvedKey is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var options = serializer.Deserialize(payload);
+                if (!serializer.OptionsType.IsInstanceOfType(options))
+                {
+                    return false;
+                }
+
+                SetOptionsWithSerializer(serializer, options, resolvedKey, keyCandidates, payload);
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+        }
+
+        private IServiceOptionsSerializer? ResolveSerializer(string[] keyCandidates)
+        {
+            var resolver = OptionsSerializerResolver;
+            if (resolver is null)
+            {
+                return null;
+            }
+
+            foreach (var candidate in keyCandidates)
+            {
+                if (string.IsNullOrWhiteSpace(candidate))
+                {
+                    continue;
+                }
+
+                var serializer = resolver(candidate);
+                if (serializer is not null)
+                {
+                    return serializer;
+                }
+            }
+
+            return null;
+        }
+
+        private void SetOptionsWithSerializer(IServiceOptionsSerializer serializer, object options, string resolvedKey, string[] keyCandidates, JsonElement? payloadOverride = null)
+        {
+            if (!serializer.OptionsType.IsInstanceOfType(options))
+            {
+                throw new ArgumentException($"Options must be assignable to {serializer.OptionsType}.", nameof(options));
+            }
+
+            _options[resolvedKey] = options;
+
+            if (payloadOverride is JsonElement payload)
+            {
+                _serializedOptions[resolvedKey] = payload.Clone();
+            }
+            else if (TrySerializeOptions(serializer, options, out var element))
+            {
+                _serializedOptions[resolvedKey] = element;
+            }
+            else
+            {
+                _serializedOptions.Remove(resolvedKey);
+            }
+
+            RemoveCandidateKeys(keyCandidates, resolvedKey);
+        }
+
+        private void SetOptionsWithDefault<TOptions>(TOptions options, string resolvedKey, string[] keyCandidates)
+            where TOptions : class
+        {
+            _options[resolvedKey] = options;
+
+            try
+            {
+                _serializedOptions[resolvedKey] = JsonSerializer.SerializeToElement(options);
+            }
+            catch (NotSupportedException)
+            {
+                _serializedOptions.Remove(resolvedKey);
+            }
+            catch (JsonException)
+            {
+                _serializedOptions.Remove(resolvedKey);
+            }
+
+            RemoveCandidateKeys(keyCandidates, resolvedKey);
+        }
+
+        private void RemoveOptionKeys(string[] keyCandidates)
+        {
+            foreach (var candidate in keyCandidates)
+            {
+                if (string.IsNullOrWhiteSpace(candidate))
+                {
+                    continue;
+                }
+
+                _options.Remove(candidate);
+                _serializedOptions.Remove(candidate);
+            }
+        }
+
+        private void RemoveCandidateKeys(string[] keyCandidates, string keepKey)
+        {
+            foreach (var candidate in keyCandidates)
+            {
+                if (string.IsNullOrWhiteSpace(candidate) || string.Equals(candidate, keepKey, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                _options.Remove(candidate);
+                _serializedOptions.Remove(candidate);
+            }
+        }
+
+        private static bool TrySerializeOptions(IServiceOptionsSerializer serializer, object options, out JsonElement element)
+        {
+            element = default;
+            try
+            {
+                if (!serializer.OptionsType.IsInstanceOfType(options))
+                {
+                    return false;
+                }
+
+                var buffer = new ArrayBufferWriter<byte>();
+                using (var writer = new Utf8JsonWriter(buffer))
+                {
+                    serializer.Serialize(writer, options);
+                }
+
+                element = JsonDocument.Parse(buffer.WrittenSpan).RootElement.Clone();
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -444,39 +634,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (Type != default)
             {
                 yield return Type.ToString();
-            }
-        }
-
-        private void PromoteOptionKey<TOptions>(string sourceKey, string targetKey, TOptions value)
-            where TOptions : class
-        {
-            if (string.Equals(sourceKey, targetKey, StringComparison.Ordinal))
-            {
-                _options[targetKey] = value;
-                return;
-            }
-
-            _options[targetKey] = value;
-            _options.Remove(sourceKey);
-
-            if (_serializedOptions.TryGetValue(sourceKey, out var element))
-            {
-                _serializedOptions[targetKey] = element;
-                _serializedOptions.Remove(sourceKey);
-                return;
-            }
-
-            try
-            {
-                _serializedOptions[targetKey] = JsonSerializer.SerializeToElement(value);
-            }
-            catch (NotSupportedException)
-            {
-                _serializedOptions.Remove(targetKey);
-            }
-            catch (JsonException)
-            {
-                _serializedOptions.Remove(targetKey);
             }
         }
 


### PR DESCRIPTION
## Summary
- persist service options using each descriptor's options serializer and store the JSON payload in ServiceInfo
- rehydrate services from the new payload via ServiceListModel helpers while maintaining legacy option fallback
- centralize serializer resolution in ServiceListModel and MainViewModel so editors and runtime features share the same persistence path

## Testing
- ⚠️ `dotnet build DesktopApplicationTemplate.sln` *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e73522e31c8326b4ead1d2d217418b