### PR TITLE
Rename descriptor options variable to avoid shadowing

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -80,20 +80,20 @@ namespace DesktopApplicationTemplate.Persistence
 
                 if (descriptor?.OptionsSerializer is { } serializer)
                 {
-                    var options = GetOptionsForSerializer(service, serializer, descriptor.Id);
-                    if (options is null)
+                    var descriptorOptions = GetOptionsForSerializer(service, serializer, descriptor.Id);
+                    if (descriptorOptions is null)
                     {
                         try
                         {
-                            options = serializer.CreateDefaultOptions();
+                            descriptorOptions = serializer.CreateDefaultOptions();
                         }
                         catch (Exception)
                         {
-                            options = null;
+                            descriptorOptions = null;
                         }
                     }
 
-                    if (options is not null && TrySerializeOptions(serializer, options, out var element))
+                    if (descriptorOptions is not null && TrySerializeOptions(serializer, descriptorOptions, out var element))
                     {
                         info.SerializedOptions[descriptor.Id] = element;
                     }


### PR DESCRIPTION
## Summary
- rename the descriptor options variable when serializing service descriptors to avoid shadowing the later JsonSerializerOptions declaration

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e7499b44d48326adbf7f15376f2960