### PR TITLE
Use JsonDocument ReadOnlyMemory overload for service serialization

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -557,7 +557,7 @@ namespace DesktopApplicationTemplate.Persistence
                     serializer.Serialize(writer, options);
                 }
 
-                element = JsonDocument.Parse(buffer.WrittenSpan).RootElement.Clone();
+                element = JsonDocument.Parse(buffer.WrittenMemory).RootElement.Clone();
                 return true;
             }
             catch (JsonException)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -580,7 +580,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     serializer.Serialize(writer, options);
                 }
 
-                element = JsonDocument.Parse(buffer.WrittenSpan).RootElement.Clone();
+                element = JsonDocument.Parse(buffer.WrittenMemory).RootElement.Clone();
                 return true;
             }
             catch (JsonException)


### PR DESCRIPTION
## Summary
- switch the service persistence and list model serialization helpers to use the ReadOnlyMemory<byte> JsonDocument.Parse overload
- retain the existing RootElement.Clone logic so serialization semantics remain unchanged

## Testing
- dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj *(fails: `dotnet` CLI is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74a2f14a883269b2801769753d6ee