### PR TITLE
Handle dispatcher exceptions gracefully

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -170,6 +170,36 @@ namespace DesktopApplicationTemplate.UI
             services.AddOptions<ScpServiceOptions>();
         }
 
+        private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            var logger = AppHost.Services.GetService<ILogger<App>>();
+            if (e.Exception is { } exception)
+            {
+                logger?.LogError(exception, "Unhandled dispatcher exception");
+            }
+            else
+            {
+                logger?.LogError("Unhandled dispatcher exception without an Exception instance");
+            }
+
+            e.Handled = true;
+
+            if (UiThreadTaskFactory is null)
+            {
+                logger?.LogWarning("Joinable task factory unavailable during dispatcher exception; shutting down synchronously.");
+                KeyboardSimulator.Reset();
+                Current?.Shutdown();
+                return;
+            }
+
+            UiThreadTaskFactory.Run(async () =>
+            {
+                KeyboardSimulator.Reset();
+                await Task.Yield();
+                Current?.Shutdown();
+            });
+        }
+
         private void HandleAppDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)
         {
             _ = OnAppDomainUnhandledExceptionAsync(sender, e);


### PR DESCRIPTION
## Summary
- add a DispatcherUnhandledException handler that logs failures and shuts down the UI gracefully
- coordinate shutdown work on the UI task factory when available and fall back to synchronous handling otherwise

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: `dotnet: command not found` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74aa259948326b0a94ce484dda151