### PR TITLE
Add UI service factory namespace to DI extensions

### DIFF
--- a/DesktopApplicationTemplate.UI/DependencyInjection/FileObserverServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/FileObserverServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.FileObserver;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.FileObserver;
 using DesktopApplicationTemplate.UI.ViewModels.FileObserver.Advanced;

--- a/DesktopApplicationTemplate.UI/DependencyInjection/HeartbeatServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/HeartbeatServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Heartbeat;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Heartbeat;
 using DesktopApplicationTemplate.UI.ViewModels.Heartbeat.Advanced;

--- a/DesktopApplicationTemplate.UI/DependencyInjection/HidServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/HidServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Hid;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Hid;
 using DesktopApplicationTemplate.UI.ViewModels.Hid.Advanced;

--- a/DesktopApplicationTemplate.UI/DependencyInjection/HttpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/HttpServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Http;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Http;
 using DesktopApplicationTemplate.UI.ViewModels.Http.Advanced;

--- a/DesktopApplicationTemplate.UI/DependencyInjection/MqttServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/MqttServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Mqtt;
 using DesktopApplicationTemplate.UI.ViewModels.Mqtt.Create;

--- a/DesktopApplicationTemplate.UI/DependencyInjection/ScpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/ScpServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Scp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Scp;
 using DesktopApplicationTemplate.UI.ViewModels.Scp.Advanced;

--- a/DesktopApplicationTemplate.UI/DependencyInjection/TcpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/TcpServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using DesktopApplicationTemplate.Core.Services.Protocols.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Services;
 using DesktopApplicationTemplate.UI.Models;
+using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp.Create;


### PR DESCRIPTION
## Summary
- import DesktopApplicationTemplate.UI.Services in the UI DI extensions that use ServiceFactoryOptions
- ensure factory delegates can reference ServiceFactoryOptions without fully qualified names

## Testing
- `dotnet build DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj` *(fails: `dotnet` not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74ba8e304832699972d36b8c9114b