### PR TITLE
Await async startup and shutdown in App

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -238,9 +238,9 @@ namespace DesktopApplicationTemplate.UI
             Current?.Shutdown();
         }
 
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
-            UiThreadTaskFactory.Run(() => OnStartupAsync());
+            await OnStartupAsync();
             base.OnStartup(e);
         }
 
@@ -281,9 +281,9 @@ namespace DesktopApplicationTemplate.UI
             application.ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
 
-        protected override void OnExit(ExitEventArgs e)
+        protected override async void OnExit(ExitEventArgs e)
         {
-            UiThreadTaskFactory.Run(OnExitAsync);
+            await OnExitAsync();
             base.OnExit(e);
         }
 


### PR DESCRIPTION
## Summary
- update the WPF application lifecycle overrides to await the existing async helpers instead of running them through the joinable task factory

## Testing
- not run (WPF application requires a Windows environment that is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e74d07d9b0832699f9befdb5520553