### PR TITLE
Run startup and shutdown tasks via joinable task factory

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -37,6 +37,7 @@ using System.Threading;
 using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Services;
+using System.Runtime.ExceptionServices;
 
 
 namespace DesktopApplicationTemplate.UI
@@ -238,10 +239,22 @@ namespace DesktopApplicationTemplate.UI
             Current?.Shutdown();
         }
 
-        protected override async void OnStartup(StartupEventArgs e)
+        protected override void OnStartup(StartupEventArgs e)
         {
-            await OnStartupAsync();
+            ExceptionDispatchInfo? capturedException = null;
+
+            try
+            {
+                UiThreadTaskFactory.Run(OnStartupAsync);
+            }
+            catch (Exception ex)
+            {
+                capturedException = ExceptionDispatchInfo.Capture(ex);
+            }
+
             base.OnStartup(e);
+
+            capturedException?.Throw();
         }
 
         private static async Task OnStartupAsync()
@@ -281,10 +294,22 @@ namespace DesktopApplicationTemplate.UI
             application.ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
 
-        protected override async void OnExit(ExitEventArgs e)
+        protected override void OnExit(ExitEventArgs e)
         {
-            await OnExitAsync();
+            ExceptionDispatchInfo? capturedException = null;
+
+            try
+            {
+                UiThreadTaskFactory.Run(OnExitAsync);
+            }
+            catch (Exception ex)
+            {
+                capturedException = ExceptionDispatchInfo.Capture(ex);
+            }
+
             base.OnExit(e);
+
+            capturedException?.Throw();
         }
 
         private static async Task OnExitAsync()


### PR DESCRIPTION
## Summary
- invoke the asynchronous startup and shutdown helpers via the existing joinable task factory from synchronous overrides
- capture exceptions from the startup and shutdown helpers so they can be rethrown after calling the base implementations
- add ExceptionDispatchInfo usage to preserve stack traces when rethrowing captured exceptions

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e750281f1883268305a640a2a3f026