### PR TITLE
Fix XAML control inclusion and annotate Windows-specific UI

### DIFF
--- a/DesktopApplicationTemplate.UI/AssemblyInfo.cs
+++ b/DesktopApplicationTemplate.UI/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using System.Windows;
 
 [assembly: ThemeInfo(
@@ -8,3 +9,5 @@ using System.Windows;
                                                 //(used if a resource is not found in the page,
                                                 // app, or any theme specific resource dictionaries)
 )]
+
+[assembly: SupportedOSPlatform("windows")]

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -35,6 +35,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Page Include="Views/Shared/AdvancedConfigButtonBar.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views/Shared/EditorButtonBar.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Update="Views/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
## Summary
- explicitly include the shared EditorButtonBar and AdvancedConfigButtonBar XAML files so their controls are available during build
- mark the UI assembly as Windows-only to silence platform analyzer warnings

## Testing
- not run (Windows-only application; CI will build on Windows)


------
https://chatgpt.com/codex/tasks/task_e_68e7540c260883268e72ea8ebdbf558a