### PR TITLE
Remove redundant explicit WPF page includes

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -35,14 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Include="Views/Shared/AdvancedConfigButtonBar.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="Views/Shared/EditorButtonBar.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
     <Page Update="Views/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
## Summary
- remove the explicit Page entries for shared views so the wildcard includes them only once

## Testing
- not run (WPF build requires Windows)

------
https://chatgpt.com/codex/tasks/task_e_68e7c5bb258c8326bfdd8a17461b8d4c