### PR TITLE
Ensure shared controls use DesktopApplicationTemplate.UI.Views namespace

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/DataFlowDiagram.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/DataFlowDiagram.xaml.cs
@@ -1,18 +1,17 @@
 using System.Windows.Controls;
 
-namespace DesktopApplicationTemplate.UI.Views
+namespace DesktopApplicationTemplate.UI.Views;
+
+/// <summary>
+/// Visualizes data flow through incoming, processing, and outgoing stages.
+/// </summary>
+public partial class DataFlowDiagram : UserControl
 {
     /// <summary>
-    /// Visualizes data flow through incoming, processing, and outgoing stages.
+    /// Initializes a new instance of the <see cref="DataFlowDiagram"/> class.
     /// </summary>
-    public partial class DataFlowDiagram : UserControl
+    public DataFlowDiagram()
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataFlowDiagram"/> class.
-        /// </summary>
-        public DataFlowDiagram()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/FilterPanel.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/FilterPanel.xaml.cs
@@ -1,12 +1,11 @@
 using System.Windows.Controls;
 
-namespace DesktopApplicationTemplate.UI.Views
+namespace DesktopApplicationTemplate.UI.Views;
+
+public partial class FilterPanel : UserControl
 {
-    public partial class FilterPanel : UserControl
+    public FilterPanel()
     {
-        public FilterPanel()
-        {
-            InitializeComponent();
-        }
+        InitializeComponent();
     }
 }


### PR DESCRIPTION
## Summary
- normalize the DataFlowDiagram and FilterPanel code-behind to use the DesktopApplicationTemplate.UI.Views file-scoped namespace
- double-check that the shared button bar controls and filter panel XAML all declare DesktopApplicationTemplate.UI.Views in x:Class so consumers can load them
- verify consumers import DesktopApplicationTemplate.UI.Views via their views/local XML namespaces and that the project still includes these pages exactly once

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: `dotnet` is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7c6f07d1883269aa1b28d1340e7d6