### PR TITLE
Align shared service views with page expectations

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml
@@ -1,22 +1,22 @@
-<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceLogView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:services="clr-namespace:DesktopApplicationTemplate.Core.Services;assembly=DesktopApplicationTemplate.Core"
-             xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
-             d:DesignHeight="300"
-             d:DesignWidth="400"
-             d:DataContext="{d:DesignInstance Type=viewModels:ServiceLogViewModel}"
-             mc:Ignorable="d">
-    <UserControl.Resources>
+<Page x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceLogView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:services="clr-namespace:DesktopApplicationTemplate.Core.Services;assembly=DesktopApplicationTemplate.Core"
+      xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
+      d:DesignHeight="300"
+      d:DesignWidth="400"
+      d:DataContext="{d:DesignInstance Type=viewModels:ServiceLogViewModel}"
+      mc:Ignorable="d">
+    <Page.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-    </UserControl.Resources>
-    <UserControl.CommandBindings>
+    </Page.Resources>
+    <Page.CommandBindings>
         <CommandBinding Command="ApplicationCommands.Copy"
                         CanExecute="CopyCommand_CanExecute"
                         Executed="CopyCommand_Executed" />
-    </UserControl.CommandBindings>
+    </Page.CommandBindings>
     <Border Background="#E6E6E6" CornerRadius="5" Padding="10">
         <Grid>
             <Grid.RowDefinitions>
@@ -90,4 +90,4 @@
             </ListBox>
         </Grid>
     </Border>
-</UserControl>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
@@ -12,7 +12,7 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
     /// <summary>
     /// Interaction logic for ServiceLogView.xaml
     /// </summary>
-    public partial class ServiceLogView : UserControl
+    public partial class ServiceLogView : Page
     {
         private const string ExportDialogFilter = "Log files (*.log)|*.log|Text files (*.txt)|*.txt|All files (*.*)|*.*";
         private const string ExportTimestampFormat = "yyyyMMdd_HHmmss";

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml
@@ -1,11 +1,11 @@
-<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceMessageTableView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
-             d:DataContext="{d:DesignInstance Type=viewModels:ServiceMessageTableViewModel}"
-             mc:Ignorable="d">
+<Page x:Class="DesktopApplicationTemplate.UI.Views.Shared.ServiceMessageTableView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:viewModels="clr-namespace:DesktopApplicationTemplate.UI.ViewModels"
+      d:DataContext="{d:DesignInstance Type=viewModels:ServiceMessageTableViewModel}"
+      mc:Ignorable="d">
     <DataGrid ItemsSource="{Binding Messages}"
               AutoGenerateColumns="False"
               CanUserAddRows="False"
@@ -50,4 +50,4 @@
                                  MinWidth="140" />
         </DataGrid.Columns>
     </DataGrid>
-</UserControl>
+</Page>

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceMessageTableView.xaml.cs
@@ -7,7 +7,7 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
     /// <summary>
     /// Interaction logic for ServiceMessageTableView.xaml
     /// </summary>
-    public partial class ServiceMessageTableView : UserControl
+    public partial class ServiceMessageTableView : Page
     {
         public ServiceMessageTableView()
         {


### PR DESCRIPTION
## Summary
- update the ServiceLogView and ServiceMessageTableView XAML files to use Page roots so their x:Class declarations match the DesktopApplicationTemplate.UI.Views.Shared namespace expectations
- adjust both code-behind files to inherit from Page in support of the XAML changes

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: `dotnet` is not available in the Linux CI container; Windows-only build requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68e7cb3c95d08326a82a3c4220d47687