### PR TITLE
Add build diagnostics error tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ StyleCopReport.xml
 *.pgc
 *.pgd
 *.rsp
+!Directory.Build.rsp
 *.sbr
 *.tlb
 *.tli

--- a/DesktopApplicationTemplate.BuildDiagnostics/BuildErrorLogger.cs
+++ b/DesktopApplicationTemplate.BuildDiagnostics/BuildErrorLogger.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace DesktopApplicationTemplate.BuildDiagnostics;
+
+public sealed class BuildErrorLogger : Logger
+{
+    private IEventSource? _eventSource;
+    private IErrorTrackingService? _errorTrackingService;
+
+    public override void Initialize(IEventSource eventSource)
+    {
+        if (eventSource is null)
+        {
+            throw new ArgumentNullException(nameof(eventSource));
+        }
+
+        _eventSource = eventSource;
+        _errorTrackingService = CreateErrorTrackingService(Parameters);
+        _eventSource.ErrorRaised += OnErrorRaised;
+    }
+
+    public override void Shutdown()
+    {
+        if (_eventSource is not null)
+        {
+            _eventSource.ErrorRaised -= OnErrorRaised;
+            _eventSource = null;
+        }
+
+        _errorTrackingService = null;
+    }
+
+    private void OnErrorRaised(object sender, BuildErrorEventArgs e)
+    {
+        if (_errorTrackingService is null)
+        {
+            return;
+        }
+
+        var description = string.IsNullOrWhiteSpace(e.Message) ? "Unspecified" : e.Message.Trim();
+        var filePath = string.IsNullOrWhiteSpace(e.File) ? "Unknown" : e.File;
+        var errorCode = string.IsNullOrWhiteSpace(e.Code) ? "UNKNOWN" : e.Code.Trim();
+
+        _errorTrackingService.RecordBuildError(errorCode, filePath, description);
+    }
+
+    private static IErrorTrackingService CreateErrorTrackingService(string? parameters)
+    {
+        var rootDirectory = string.IsNullOrWhiteSpace(parameters) ? null : parameters.Trim();
+        return new ExcelErrorTrackingService(rootDirectory);
+    }
+}

--- a/DesktopApplicationTemplate.BuildDiagnostics/DesktopApplicationTemplate.BuildDiagnostics.csproj
+++ b/DesktopApplicationTemplate.BuildDiagnostics/DesktopApplicationTemplate.BuildDiagnostics.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.102.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+  </ItemGroup>
+</Project>

--- a/DesktopApplicationTemplate.BuildDiagnostics/ExcelErrorTrackingService.cs
+++ b/DesktopApplicationTemplate.BuildDiagnostics/ExcelErrorTrackingService.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using ClosedXML.Excel;
+
+namespace DesktopApplicationTemplate.BuildDiagnostics;
+
+public sealed class ExcelErrorTrackingService : IErrorTrackingService
+{
+    private const string ErrorsByFileSheetName = "ErrorsByFile";
+    private const string ErrorsByCodeSheetName = "ErrorsByCode";
+    private const string DetailedErrorsSheetName = "DetailedErrors";
+
+    private readonly string _errorsDirectory;
+    private readonly string _buildErrorsWorkbookPath;
+    private readonly string _detailedErrorsWorkbookPath;
+    private readonly object _syncRoot = new();
+
+    public ExcelErrorTrackingService(string? rootDirectory = null)
+    {
+        var baseDirectory = string.IsNullOrWhiteSpace(rootDirectory)
+            ? AppContext.BaseDirectory
+            : rootDirectory!;
+
+        _errorsDirectory = Path.Combine(baseDirectory, "Build Errors");
+        _buildErrorsWorkbookPath = Path.Combine(_errorsDirectory, "BuildErrors.xlsx");
+        _detailedErrorsWorkbookPath = Path.Combine(_errorsDirectory, "Detailed Errors.xlsx");
+    }
+
+    public void RecordBuildError(string errorCode, string filePath, string description)
+    {
+        var normalizedErrorCode = NormalizeErrorCode(errorCode);
+        var normalizedFileName = NormalizeFileName(filePath);
+        var normalizedDescription = NormalizeDescription(description);
+
+        lock (_syncRoot)
+        {
+            EnsureDirectoryExists();
+            UpdateBuildErrorsWorkbook(normalizedErrorCode, normalizedFileName);
+            UpdateDetailedErrorsWorkbook(normalizedErrorCode, normalizedFileName, normalizedDescription);
+        }
+    }
+
+    public void RecordRuntimeException(Exception exception, string? filePath)
+    {
+        if (exception is null)
+        {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        var errorCode = NormalizeErrorCode(exception.GetType().FullName ?? exception.GetType().Name);
+        var fileName = NormalizeFileName(filePath);
+        var description = NormalizeDescription(exception.ToString());
+
+        lock (_syncRoot)
+        {
+            EnsureDirectoryExists();
+            UpdateBuildErrorsWorkbook(errorCode, fileName);
+            UpdateDetailedErrorsWorkbook(errorCode, fileName, description);
+        }
+    }
+
+    private void EnsureDirectoryExists()
+    {
+        if (!Directory.Exists(_errorsDirectory))
+        {
+            Directory.CreateDirectory(_errorsDirectory);
+        }
+    }
+
+    private void UpdateBuildErrorsWorkbook(string errorCode, string fileName)
+    {
+        using var workbook = LoadOrCreateWorkbook(_buildErrorsWorkbookPath);
+        var errorsByFile = GetOrCreateWorksheet(workbook, ErrorsByFileSheetName, "Error Code", "File Name", "Count");
+        var errorsByCode = GetOrCreateWorksheet(workbook, ErrorsByCodeSheetName, "Error Code", "Count");
+
+        IncrementCount(errorsByFile, new[] { errorCode, fileName });
+        IncrementCount(errorsByCode, new[] { errorCode });
+
+        workbook.SaveAs(_buildErrorsWorkbookPath);
+    }
+
+    private void UpdateDetailedErrorsWorkbook(string errorCode, string fileName, string description)
+    {
+        using var workbook = LoadOrCreateWorkbook(_detailedErrorsWorkbookPath);
+        var worksheet = GetOrCreateWorksheet(workbook, DetailedErrorsSheetName, "Error Code", "File Name", "Description", "Count");
+
+        IncrementCount(worksheet, new[] { errorCode, fileName, description });
+
+        workbook.SaveAs(_detailedErrorsWorkbookPath);
+    }
+
+    private static XLWorkbook LoadOrCreateWorkbook(string path)
+    {
+        return File.Exists(path) ? new XLWorkbook(path) : new XLWorkbook();
+    }
+
+    private static IXLWorksheet GetOrCreateWorksheet(XLWorkbook workbook, string worksheetName, params string[] headers)
+    {
+        if (!workbook.TryGetWorksheet(worksheetName, out var worksheet))
+        {
+            worksheet = workbook.Worksheets.Add(worksheetName);
+            for (var index = 0; index < headers.Length; index++)
+            {
+                worksheet.Cell(1, index + 1).Value = headers[index];
+            }
+        }
+
+        return worksheet;
+    }
+
+    private static void IncrementCount(IXLWorksheet worksheet, IReadOnlyList<string> keyValues)
+    {
+        var lastRow = worksheet.LastRowUsed()?.RowNumber() ?? 1;
+        for (var row = 2; row <= lastRow; row++)
+        {
+            if (!RowMatches(worksheet, row, keyValues))
+            {
+                continue;
+            }
+
+            var countCell = worksheet.Cell(row, keyValues.Count + 1);
+            var currentValue = countCell.GetValue<int>();
+            countCell.Value = currentValue + 1;
+            return;
+        }
+
+        var newRow = lastRow + 1;
+        for (var column = 0; column < keyValues.Count; column++)
+        {
+            worksheet.Cell(newRow, column + 1).Value = keyValues[column];
+        }
+
+        worksheet.Cell(newRow, keyValues.Count + 1).Value = 1;
+    }
+
+    private static bool RowMatches(IXLWorksheet worksheet, int rowNumber, IReadOnlyList<string> keyValues)
+    {
+        for (var column = 0; column < keyValues.Count; column++)
+        {
+            var cellValue = worksheet.Cell(rowNumber, column + 1).GetString();
+            if (!string.Equals(cellValue, keyValues[column], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string NormalizeErrorCode(string errorCode)
+    {
+        return string.IsNullOrWhiteSpace(errorCode)
+            ? "UNKNOWN"
+            : errorCode.Trim();
+    }
+
+    private static string NormalizeFileName(string? filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return "Unknown";
+        }
+
+        var fileName = Path.GetFileName(filePath);
+        return string.IsNullOrWhiteSpace(fileName) ? filePath.Trim() : fileName;
+    }
+
+    private static string NormalizeDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return "Unspecified";
+        }
+
+        return description.Trim();
+    }
+}

--- a/DesktopApplicationTemplate.BuildDiagnostics/IErrorTrackingService.cs
+++ b/DesktopApplicationTemplate.BuildDiagnostics/IErrorTrackingService.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace DesktopApplicationTemplate.BuildDiagnostics;
+
+public interface IErrorTrackingService
+{
+    void RecordBuildError(string errorCode, string filePath, string description);
+
+    void RecordRuntimeException(Exception exception, string? filePath);
+}

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -38,6 +38,7 @@ using DesktopApplicationTemplate.Models;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Services;
 using System.Runtime.ExceptionServices;
+using DesktopApplicationTemplate.BuildDiagnostics;
 
 
 namespace DesktopApplicationTemplate.UI
@@ -125,6 +126,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<NetworkConfigurationViewModel>();
             services.AddSingleton<IRichTextLogger, NullRichTextLogger>();
             services.AddSingleton<ILoggingService, LoggingService>();
+            services.AddSingleton<IErrorTrackingService, ExcelErrorTrackingService>();
             services.AddSingleton<IMessageRoutingService, MessageRoutingService>();
             services.AddSingleton<IFileDialogService, FileDialogService>();
             services.AddSingleton<IStartupPreferencesService, StartupPreferencesDialogService>();
@@ -174,8 +176,10 @@ namespace DesktopApplicationTemplate.UI
         private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             var logger = AppHost.Services.GetService<ILogger<App>>();
+            var errorTracking = AppHost.Services.GetService<IErrorTrackingService>();
             if (e.Exception is { } exception)
             {
+                errorTracking?.RecordRuntimeException(exception, null);
                 logger?.LogError(exception, "Unhandled dispatcher exception");
             }
             else
@@ -209,8 +213,10 @@ namespace DesktopApplicationTemplate.UI
         internal static async Task OnAppDomainUnhandledExceptionAsync(object? sender, UnhandledExceptionEventArgs e)
         {
             var logger = AppHost.Services.GetService<ILogger<App>>();
+            var errorTracking = AppHost.Services.GetService<IErrorTrackingService>();
             if (e.ExceptionObject is Exception ex)
             {
+                errorTracking?.RecordRuntimeException(ex, null);
                 logger?.LogError(ex, "Unhandled domain exception");
             }
             else

--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DesktopApplicationTemplate.Core\DesktopApplicationTemplate.Core.csproj" />
     <ProjectReference Include="..\DesktopApplicationTemplate.Services\DesktopApplicationTemplate.Services.csproj" />
+    <ProjectReference Include="..\DesktopApplicationTemplate.BuildDiagnostics\DesktopApplicationTemplate.BuildDiagnostics.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DesktopApplicationTemplate.sln
+++ b/DesktopApplicationTemplate.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.UI", "DesktopApplicationTemplate.UI\DesktopApplicationTemplate.UI.csproj", "{ECFDCBB9-CEBD-4236-B96D-8519760318B9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesktopApplicationTemplate.BuildDiagnostics", "DesktopApplicationTemplate.BuildDiagnostics\DesktopApplicationTemplate.BuildDiagnostics.csproj", "{F64E71F0-C894-47BB-88FC-B4612E5F9664}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
                 {ECFDCBB9-CEBD-4236-B96D-8519760318B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {ECFDCBB9-CEBD-4236-B96D-8519760318B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {ECFDCBB9-CEBD-4236-B96D-8519760318B9}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F64E71F0-C894-47BB-88FC-B4612E5F9664}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F64E71F0-C894-47BB-88FC-B4612E5F9664}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F64E71F0-C894-47BB-88FC-B4612E5F9664}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F64E71F0-C894-47BB-88FC-B4612E5F9664}.Release|Any CPU.Build.0 = Release|Any CPU
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,1 @@
+/logger:DesktopApplicationTemplate.BuildDiagnostics.BuildErrorLogger,DesktopApplicationTemplate.BuildDiagnostics


### PR DESCRIPTION
## Summary
- add the DesktopApplicationTemplate.BuildDiagnostics project with an Excel-based error tracking service and MSBuild logger
- persist build and runtime errors into Build Errors workbooks and automatically load the logger via Directory.Build.rsp
- register the error tracking service in the UI project and record runtime exceptions before logging

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e7cf3c9fbc83269ac2d14ac0b7b77c