### PR TITLE
Ignore Visual Studio build diagnostics exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,7 @@ Resources/**/out/
 
 # Web project artifacts
 wwwroot/
+
+# Visual Studio diagnostics exports
+Build Errors/
+Build Errors/*.xlsx


### PR DESCRIPTION
## Summary
- add ignore rules for the Visual Studio Build Errors diagnostics exports

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e7d705b18c8326b0e633a0aae4afc6