### PR TITLE
Fix DocumentFormat.OpenXml version constraint for BuildDiagnostics

### DIFF
--- a/DesktopApplicationTemplate.BuildDiagnostics/DesktopApplicationTemplate.BuildDiagnostics.csproj
+++ b/DesktopApplicationTemplate.BuildDiagnostics/DesktopApplicationTemplate.BuildDiagnostics.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.102.2" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- pin DocumentFormat.OpenXml to v2.19.0 so it satisfies ClosedXML's < 3.0.0 dependency constraint

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7cde9be2483269ae5b406f5328c8a