### PR TITLE
Add MSBuild dependencies for build diagnostics logger

### DIFF
--- a/DesktopApplicationTemplate.BuildDiagnostics/DesktopApplicationTemplate.BuildDiagnostics.csproj
+++ b/DesktopApplicationTemplate.BuildDiagnostics/DesktopApplicationTemplate.BuildDiagnostics.csproj
@@ -7,5 +7,7 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.102.2" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add explicit Microsoft.Build package references required by BuildErrorLogger

## Testing
- not run (Windows-specific build; rely on CI)

------
https://chatgpt.com/codex/tasks/task_e_68e7dc59f7c083268b7a9ecfad8985bd