### PR TITLE
Fix shared button bar namespace references

### DIFF
--- a/DesktopApplicationTemplate.UI/Views/Csv/Edit/CsvServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Csv/Edit/CsvServiceEditorView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -66,7 +66,7 @@
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Include Headers" Style="{StaticResource FormLabel}"/>
             <CheckBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding IncludeHeaders}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="3"
+            <shared:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="3"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/FileObserver/Advanced/FileObserverAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserver/Advanced/FileObserverAdvancedConfigView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -35,7 +35,7 @@
             <TextBox Text="{Binding TcpCommand}" Width="150" Margin="10,0,0,0" Style="{StaticResource FormField}"/>
         </StackPanel>
 
-        <views:AdvancedConfigButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+        <shared:AdvancedConfigButtonBar Grid.Row="5" Grid.ColumnSpan="2"
                                        SaveCommand="{Binding SaveCommand}"
                                        BackCommand="{Binding BackCommand}"
                                        SaveAutomationName="Save File Observer Advanced Configuration"

--- a/DesktopApplicationTemplate.UI/Views/FileObserver/Create/FileObserverCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserver/Create/FileObserverCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -44,7 +44,7 @@
         </TextBox>
         <Button Grid.Row="1" Grid.Column="2" Content="Browse" Width="75" Margin="5,0,0,0" Command="{Binding BrowseCommand}"/>
 
-        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="3"
+        <shared:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="3"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding CreateCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/FileObserver/Edit/FileObserverEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/FileObserver/Edit/FileObserverEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -42,7 +42,7 @@
             </TextBox.Style>
         </TextBox>
 
-        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+        <shared:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding SaveCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Ftp/Advanced/FtpServerAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Ftp/Advanced/FtpServerAdvancedConfigView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -25,7 +25,7 @@
         <TextBlock Grid.Row="2" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-        <views:AdvancedConfigButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+        <shared:AdvancedConfigButtonBar Grid.Row="3" Grid.ColumnSpan="2"
                                        SaveCommand="{Binding SaveCommand}"
                                        BackCommand="{Binding BackCommand}"
                                        SaveButtonText="Save Configuration"

--- a/DesktopApplicationTemplate.UI/Views/Ftp/Create/FtpServerCreateView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Ftp/Create/FtpServerCreateView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -27,7 +27,7 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Root Path" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Ftp/Edit/FtpServerEditView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Ftp/Edit/FtpServerEditView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -27,7 +27,7 @@
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Root Path" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RootPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="3" Grid.ColumnSpan="2"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Heartbeat/Advanced/HeartbeatAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Heartbeat/Advanced/HeartbeatAdvancedConfigView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -22,7 +22,7 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Include Status" Style="{StaticResource FormLabel}"/>
         <CheckBox Grid.Row="1" Grid.Column="1" IsChecked="{Binding IncludeStatus}" Style="{StaticResource FormField}"/>
 
-        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+        <shared:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                        SaveCommand="{Binding SaveCommand}"
                                        BackCommand="{Binding BackCommand}"
                                        SaveAutomationName="Save Heartbeat Advanced Configuration"

--- a/DesktopApplicationTemplate.UI/Views/Heartbeat/Create/HeartbeatCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Heartbeat/Create/HeartbeatCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -23,7 +23,7 @@
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Base Message" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseMessage}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Heartbeat/Edit/HeartbeatEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Heartbeat/Edit/HeartbeatEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -23,7 +23,7 @@
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Base Message" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseMessage}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Hid/Advanced/HidAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Hid/Advanced/HidAdvancedConfigView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -22,7 +22,7 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Key Down (ms)" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding KeyDownTimeMs}" Style="{StaticResource FormField}"/>
 
-        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+        <shared:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                        SaveCommand="{Binding SaveCommand}"
                                        BackCommand="{Binding BackCommand}"
                                        SaveAutomationName="Save HID Advanced Configuration"

--- a/DesktopApplicationTemplate.UI/Views/Hid/Create/HidCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Hid/Create/HidCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -31,7 +31,7 @@
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Attached Service" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AttachedService}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="2"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Hid/Edit/HidEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Hid/Edit/HidEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -31,7 +31,7 @@
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Attached Service" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding AttachedService}" Style="{StaticResource FormField}"/>
 
-            <views:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="4" Grid.ColumnSpan="2"
                                    AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Http/Advanced/HttpAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Http/Advanced/HttpAdvancedConfigView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -26,7 +26,7 @@
         <TextBlock Grid.Row="2" Grid.Column="0" Text="Certificate Path" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding ClientCertificatePath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-        <views:AdvancedConfigButtonBar Grid.Row="3" Grid.ColumnSpan="2"
+        <shared:AdvancedConfigButtonBar Grid.Row="3" Grid.ColumnSpan="2"
                                        SaveCommand="{Binding SaveCommand}"
                                        BackCommand="{Binding BackCommand}"
                                        SaveButtonText="Save Configuration"

--- a/DesktopApplicationTemplate.UI/Views/Http/Create/HttpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Http/Create/HttpCreateServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -22,7 +22,7 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Base URL" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseUrl}" Style="{StaticResource FormField}"/>
 
-        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+        <shared:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding CreateCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Http/Edit/HttpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Http/Edit/HttpEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -22,7 +22,7 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Base URL" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BaseUrl}" Style="{StaticResource FormField}"/>
 
-        <views:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+        <shared:EditorButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding SaveCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/Create/MqttCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/Create/MqttCreateServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:svc="clr-namespace:DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;assembly=DesktopApplicationTemplate.Core"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -185,7 +185,7 @@
                 </TextBox.Style>
             </TextBox>
 
-            <views:EditorButtonBar Grid.Row="16" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="16" Grid.ColumnSpan="2"
                                    IsAdvancedVisible="False"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Mqtt/Edit/MqttEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Mqtt/Edit/MqttEditServiceView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid Margin="20">
@@ -79,7 +79,7 @@
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
             <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Password}" Style="{StaticResource FormField}" ToolTip="Password"/>
 
-            <views:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="6" Grid.ColumnSpan="2"
                                    IsAdvancedVisible="False"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Scp/Advanced/ScpAdvancedConfigView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Scp/Advanced/ScpAdvancedConfigView.xaml
@@ -3,7 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -22,7 +22,7 @@
         <TextBlock Grid.Row="1" Grid.Column="0" Text="Remote Path" Style="{StaticResource FormLabel}"/>
         <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding RemotePath}" Style="{StaticResource FormField}"/>
 
-        <views:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
+        <shared:AdvancedConfigButtonBar Grid.Row="2" Grid.ColumnSpan="2"
                                        SaveCommand="{Binding SaveCommand}"
                                        BackCommand="{Binding BackCommand}"
                                        SaveAutomationName="Save SCP Advanced Configuration"

--- a/DesktopApplicationTemplate.UI/Views/Scp/Create/ScpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Scp/Create/ScpCreateServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -35,7 +35,7 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
         <PasswordBox Grid.Row="4" Grid.Column="1" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource FormField}"/>
 
-        <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+        <shared:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding CreateCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Scp/Edit/ScpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Scp/Edit/ScpEditServiceView.xaml
@@ -4,7 +4,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Grid Margin="20">
         <Grid.ColumnDefinitions>
@@ -35,7 +35,7 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Password" Style="{StaticResource FormLabel}"/>
         <PasswordBox Grid.Row="4" Grid.Column="1" helpers:PasswordBoxAssistant.BindPassword="True" helpers:PasswordBoxAssistant.BoundPassword="{Binding Password}" Style="{StaticResource FormField}"/>
 
-        <views:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
+        <shared:EditorButtonBar Grid.Row="5" Grid.ColumnSpan="2"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding SaveCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="DesktopApplicationTemplate.UI.Views.AdvancedConfigButtonBar"
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.AdvancedConfigButtonBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">

--- a/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/AdvancedConfigButtonBar.xaml.cs
@@ -2,7 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
-namespace DesktopApplicationTemplate.UI.Views;
+namespace DesktopApplicationTemplate.UI.Views.Shared;
 
 public partial class AdvancedConfigButtonBar : UserControl
 {

--- a/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="DesktopApplicationTemplate.UI.Views.EditorButtonBar"
+<UserControl x:Class="DesktopApplicationTemplate.UI.Views.Shared.EditorButtonBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Name="Root">

--- a/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/EditorButtonBar.xaml.cs
@@ -2,7 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
-namespace DesktopApplicationTemplate.UI.Views;
+namespace DesktopApplicationTemplate.UI.Views.Shared;
 
 public partial class EditorButtonBar : UserControl
 {

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceEditorView.xaml
@@ -1,7 +1,7 @@
 <Page x:Class="DesktopApplicationTemplate.UI.Views.ServiceEditorView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       x:Name="Root">
     <Grid Margin="20">
         <Grid.RowDefinitions>
@@ -9,7 +9,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <ContentPresenter Grid.Row="0" />
-        <views:EditorButtonBar Grid.Row="1"
+        <shared:EditorButtonBar Grid.Row="1"
                                AdvancedConfigCommand="{Binding AdvancedConfigCommand}"
                                SaveCommand="{Binding SaveCommand}"
                                CancelCommand="{Binding CancelCommand}"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Create/TcpCreateServiceView.xaml
@@ -5,7 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
@@ -257,7 +257,7 @@
                            Visibility="{Binding Text, ElementName=DestinationGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <views:EditorButtonBar Grid.Row="15" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="15" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding CreateCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveButtonText="Create"

--- a/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/Edit/TcpEditServiceView.xaml
@@ -5,7 +5,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:behaviors="clr-namespace:DesktopApplicationTemplate.UI.Behaviors"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
-      xmlns:views="clr-namespace:DesktopApplicationTemplate.UI.Views;assembly=DesktopApplicationTemplate.UI"
+      xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared;assembly=DesktopApplicationTemplate.UI"
       mc:Ignorable="d">
     <Page.Resources>
         <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
@@ -257,7 +257,7 @@
                            Visibility="{Binding Text, ElementName=DestinationGatewayBox, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
             </Grid>
 
-            <views:EditorButtonBar Grid.Row="15" Grid.ColumnSpan="2"
+            <shared:EditorButtonBar Grid.Row="15" Grid.ColumnSpan="2"
                                    SaveCommand="{Binding SaveCommand}"
                                    CancelCommand="{Binding CancelCommand}"
                                    SaveAutomationName="Save TCP Service"


### PR DESCRIPTION
## Summary
- move EditorButtonBar and AdvancedConfigButtonBar into the Views.Shared namespace
- update service and advanced configuration XAML to reference the shared button bars through the shared namespace alias

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68e7dd8386a483268e061af3ad0fb27f