### PR TITLE
Fix WPF namespace errors by including shared XAML views

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -35,11 +35,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Update="Views/**/*.xaml">
+    <Page Include="Views/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Update="Themes/**/*.xaml">
+    <Page Include="Themes/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>


### PR DESCRIPTION
## Summary
- ensure all Views and Themes XAML files are included in the UI project so shared controls compile

## Testing
- not run (dotnet CLI unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7e2893a748326b8b7f5a5f33e9e2c