### PR TITLE
Fix duplicate XAML includes in UI project

### DIFF
--- a/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
+++ b/DesktopApplicationTemplate.UI/DesktopApplicationTemplate.UI.csproj
@@ -35,11 +35,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Include="Views/**/*.xaml">
+    <Page Update="Views/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="Themes/**/*.xaml">
+    <Page Update="Themes/**/*.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>


### PR DESCRIPTION
## Summary
- switch the UI project to update existing XAML items instead of re-including them
- resolve duplicate Page/Compile entries that broke the EditorButtonBar lookup during builds

## Testing
- not run (environment lacks Windows desktop tooling)

------
https://chatgpt.com/codex/tasks/task_e_68e7e99d22d483269411faef1ffee61a