### PR TITLE
Handle null AppHost during unhandled exception logging

### DIFF
--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -173,7 +173,7 @@ namespace DesktopApplicationTemplate.UI
 
         private void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
-            var logger = AppHost.Services.GetService<ILogger<App>>();
+            var logger = AppHost?.Services?.GetService<ILogger<App>>();
             if (e.Exception is { } exception)
             {
                 logger?.LogError(exception, "Unhandled dispatcher exception");
@@ -208,7 +208,7 @@ namespace DesktopApplicationTemplate.UI
 
         internal static async Task OnAppDomainUnhandledExceptionAsync(object? sender, UnhandledExceptionEventArgs e)
         {
-            var logger = AppHost.Services.GetService<ILogger<App>>();
+            var logger = AppHost?.Services?.GetService<ILogger<App>>();
             if (e.ExceptionObject is Exception ex)
             {
                 logger?.LogError(ex, "Unhandled domain exception");

--- a/Error Log/Code Errors.csv
+++ b/Error Log/Code Errors.csv
@@ -1,3 +1,4 @@
 Error Code,Count,datetime
 MC3074,60,2025-10-09T18:06:21
 XDG0008,60,2025-10-09T18:06:21
+System.NullReferenceException,1,2025-10-09T18:15:23

--- a/Error Log/Detailed Errors.csv
+++ b/Error Log/Detailed Errors.csv
@@ -50,3 +50,4 @@ XDG0008,DesktopApplicationTemplate.UI/FileObserverCreateServiceView.xaml,'FormFi
 XDG0008,DesktopApplicationTemplate.UI/TcpServiceMessagesView.xaml,'FormField' resource not found.,1,2025-10-09T18:06:21
 XDG0008,DesktopApplicationTemplate.UI/FTPServiceView.xaml,"The resource ""StringNullOrEmptyToVisibilityConverter"" has an incompatible type.",1,2025-10-09T18:06:21
 XDG0008,DesktopApplicationTemplate.UI/FTPServiceView.xaml,'FormField' resource not found.,1,2025-10-09T18:06:21
+System.NullReferenceException,DesktopApplicationTemplate.UI/App.xaml.cs,Object reference not set to an instance of an object.,1,2025-10-09T18:15:23


### PR DESCRIPTION
## Summary
- guard the dispatcher and AppDomain exception handlers against a missing host service provider
- update the runtime error logs to capture the System.NullReferenceException entry

## Testing
- not run (Windows desktop build unsupported in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7fb7212ec832682aa70622c1bad60