### PR TITLE
Fix message count initialization for empty histories

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -239,8 +239,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// <param name="outgoing">The number of outgoing messages previously recorded.</param>
         public void InitializeMessageCounts(int incoming, int outgoing)
         {
-            if (_messageHistory.Count > 0)
+            if (_messageHistory.Count == 0)
             {
+                ResetMessageCounts();
                 return;
             }
 


### PR DESCRIPTION
## Summary
- reset message counters when no persisted history entries are available while still honoring stored totals when history exists

## Testing
- not run (not available on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68e81d5402ec8326b0172afd56fa2bd4