### PR TITLE
Publish and persist service routing attributes

### DIFF
--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Windows service host sets explicit `ServiceName` and `DisplayName` values with the application name and installer uses the same constant.
 - Replaced verbose `ServiceName` strings with `ServiceType` enum properties for log view models.
 - Service persistence now stores `ServiceType` as short codes and reads legacy string names.
+- Service routing attributes (input/output text, message counters, runtime state, and protocol-specific metadata) persist with each service and are republished through `IMessageRoutingService` after load or rename operations.
 - Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
 - `ServiceManager` loads default services from configuration using `ServiceType` short codes and accepts legacy names.
 - `ServiceListModel` now exposes a `Type` enum property, removing string-based service comparisons.

--- a/Codex/docs/ServicePersistenceFormat.md
+++ b/Codex/docs/ServicePersistenceFormat.md
@@ -33,6 +33,7 @@ All properties use PascalCase to match the serialized `PersistedServiceRecord` m
 2. **`ServiceType`** – Canonical short code emitted by `ServiceTypeJsonConverter` (for example, `"HT"` for `Http`). The value is kept in sync with the descriptor metadata and persisted alongside the identifier for quick filtering.
 3. **Service-specific options** – Built-in services write their strongly-typed options (`HttpOptions`, `TcpOptions`, and so on). Plug-ins should continue to expose serializers that hydrate their view models from the stored JSON payload.
 4. **State metadata** – `DisplayName`, `IsActive`, `Created`, `Order`, `AssociatedServices`, `TotalExecutionTimeMs`, and `ExecutionCount` mirror the values surfaced by `ServiceListModel`.
+5. **`RoutingAttributes`** – Case-insensitive dictionary that captures the latest routed values published by each service (input/output text, message counters, runtime state, and any custom attributes emitted by protocol-specific view models). When a service is reloaded, these entries are republished so token references remain valid across restarts.
 
 ### Descriptor payload contract
 

--- a/DesktopApplicationTemplate.UI/DependencyInjection/CsvServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/CsvServiceCollectionExtensions.cs
@@ -49,7 +49,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<CsvServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/FileObserverServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/FileObserverServiceCollectionExtensions.cs
@@ -56,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<FileObserverServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/FtpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/FtpServiceCollectionExtensions.cs
@@ -57,7 +57,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                     var ctx = (ServiceFactoryOptions<CoreFtpServerOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
                     var ftpOptions = ctx.Options ?? new CoreFtpServerOptions();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/HeartbeatServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/HeartbeatServiceCollectionExtensions.cs
@@ -56,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<HeartbeatServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/HidServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/HidServiceCollectionExtensions.cs
@@ -56,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<HidServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/HttpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/HttpServiceCollectionExtensions.cs
@@ -56,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<HttpServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/MqttServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/MqttServiceCollectionExtensions.cs
@@ -52,7 +52,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<MqttServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var newService = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var newService = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/ScpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/ScpServiceCollectionExtensions.cs
@@ -56,7 +56,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<ScpServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/DependencyInjection/TcpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/TcpServiceCollectionExtensions.cs
@@ -54,7 +54,8 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 {
                     var ctx = (ServiceFactoryOptions<TcpServiceOptions>)optionsObj;
                     var mainView = provider.GetRequiredService<MainView>();
-                    var svc = new ServiceListModel
+                    var routing = provider.GetRequiredService<IMessageRoutingService>();
+                    var svc = new ServiceListModel(routing)
                     {
                         DescriptorId = descriptor.Id,
                         DisplayName = ctx.Name,

--- a/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
+++ b/DesktopApplicationTemplate.UI/Services/ServicePersistence.cs
@@ -76,6 +76,7 @@ namespace DesktopApplicationTemplate.Persistence
                         })
                         .ToList(),
                     MessageHistory = service.GetMessageHistorySnapshot().ToList(),
+                    RoutingAttributes = CloneRoutingAttributes(service.GetRoutingAttributesSnapshot()),
                 };
 
                 if (descriptor?.OptionsSerializer is { } serializer)
@@ -137,11 +138,16 @@ namespace DesktopApplicationTemplate.Persistence
             }
         }
 
-        public static List<ServiceListModel> Load(IServiceCatalog serviceCatalog, ILoggingService? logger = null)
+        public static List<ServiceListModel> Load(IServiceCatalog serviceCatalog, IMessageRoutingService routingService, ILoggingService? logger = null)
         {
             if (serviceCatalog is null)
             {
                 throw new ArgumentNullException(nameof(serviceCatalog));
+            }
+
+            if (routingService is null)
+            {
+                throw new ArgumentNullException(nameof(routingService));
             }
 
             if (!File.Exists(FilePath))
@@ -174,7 +180,9 @@ namespace DesktopApplicationTemplate.Persistence
                     info.SerializedOptions ??= new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
                     info.LegacySerializedOptions ??= new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
 
-                    var service = CreateServiceModel(info, serviceCatalog);
+                    info.RoutingAttributes ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                    var service = CreateServiceModel(info, serviceCatalog, routingService);
                     services.Add(service);
                 }
 
@@ -193,12 +201,12 @@ namespace DesktopApplicationTemplate.Persistence
             }
         }
 
-        private static ServiceListModel CreateServiceModel(ServiceInfo info, IServiceCatalog serviceCatalog)
+        private static ServiceListModel CreateServiceModel(ServiceInfo info, IServiceCatalog serviceCatalog, IMessageRoutingService routingService)
         {
             var descriptor = ResolveDescriptor(serviceCatalog, info.DescriptorId, info.ServiceType);
             var descriptorId = descriptor?.Id ?? info.DescriptorId;
 
-            var service = new ServiceListModel
+            var service = new ServiceListModel(routingService)
             {
                 DescriptorId = descriptorId,
                 DisplayName = info.DisplayName,
@@ -209,6 +217,8 @@ namespace DesktopApplicationTemplate.Persistence
             };
 
             service.SerializedOptions = CloneSerializedOptions(info.SerializedOptions);
+
+            service.RestoreRoutingAttributes(info.RoutingAttributes);
 
             foreach (var associated in info.AssociatedServices)
             {
@@ -221,6 +231,8 @@ namespace DesktopApplicationTemplate.Persistence
             service.InitializeActivationState(info.IsActive);
 
             ApplyOptions(info, service, descriptor);
+
+            service.RepublishRoutingAttributes();
 
             return service;
         }
@@ -332,6 +344,22 @@ namespace DesktopApplicationTemplate.Persistence
             {
                 service.SerializedOptions[key] = element;
             }
+        }
+
+        private static Dictionary<string, string> CloneRoutingAttributes(IReadOnlyDictionary<string, string>? source)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (source is null)
+            {
+                return result;
+            }
+
+            foreach (var pair in source)
+            {
+                result[pair.Key] = pair.Value ?? string.Empty;
+            }
+
+            return result;
         }
 
         private static Dictionary<string, JsonElement> CloneSerializedOptions(IReadOnlyDictionary<string, JsonElement>? source)
@@ -602,6 +630,8 @@ namespace DesktopApplicationTemplate.Persistence
         public int OutgoingMessageCount { get; set; }
         public List<LogEntry> Logs { get; set; } = new();
         public List<ServiceMessageHistoryEntry> MessageHistory { get; set; } = new();
+        [JsonInclude]
+        public Dictionary<string, string> RoutingAttributes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         [JsonExtensionData]
         public Dictionary<string, JsonElement> LegacySerializedOptions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -354,6 +354,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             _logger?.Log($"Removing service {target.DisplayName}", LogLevel.Debug);
             ClearRoutingCache(target.Type, target.DisplayName);
+            target.ClearRoutingAttributes();
             var index = Services.IndexOf(target);
             target.AddLog("Service removed", WpfBrushes.Red);
             if (target.Type != ServiceType.Csv)
@@ -401,6 +402,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
 
             _messageRoutingService.ClearService(serviceType, serviceName);
+            _messageRoutingService.ClearService(serviceName);
         }
 
         public async Task SaveServicesAsync()
@@ -422,7 +424,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void LoadServices()
         {
-            var existing = ServicePersistence.Load(_serviceCatalog, _logger);
+            var existing = ServicePersistence.Load(_serviceCatalog, _messageRoutingService, _logger);
             foreach (var service in existing.OrderBy(s => s.Order))
             {
                 if (string.IsNullOrWhiteSpace(service.DescriptorId))
@@ -430,6 +432,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     service.DescriptorId = ResolveDescriptorId(service.Type);
                 }
 
+                ClearRoutingCache(service.Type, service.DisplayName);
                 var normalizedName = NormalizeDisplayName(service.Type, service.DisplayName);
                 if (Services.Any(existingService => existingService.DisplayName.Equals(normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {
@@ -449,6 +452,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 }
 
                 Services.Add(service);
+
+                service.RepublishRoutingAttributes();
 
                 foreach (var log in service.Logs.Reverse())
                 {

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -39,6 +39,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         internal const int MaxLogEntries = 200;
 
+        public const string InputMessageAttributeName = "InputMessage";
+        public const string OutputMessageAttributeName = "OutputMessage";
+        public const string IncomingMessageCountAttributeName = "IncomingMessageCount";
+        public const string OutgoingMessageCountAttributeName = "OutgoingMessageCount";
+        public const string RuntimeStateAttributeName = "RuntimeState";
+
+        private readonly IMessageRoutingService _routingService;
+        private readonly Dictionary<string, RoutingAttributeValue> _routingAttributes = new(StringComparer.OrdinalIgnoreCase);
+
+        private readonly record struct RoutingAttributeValue(string Value, MessageRoutingDirection? Direction);
+
         private string _displayName = string.Empty;
         public string DisplayName
         {
@@ -50,9 +61,35 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     return;
                 }
 
+                var previousName = _displayName;
                 _displayName = value ?? string.Empty;
                 OnPropertyChanged();
                 RefreshLogMetadata();
+                OnDisplayNameChanged(previousName);
+            }
+        }
+
+        private void OnDisplayNameChanged(string previousName)
+        {
+            if (string.Equals(previousName, _displayName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (!string.IsNullOrWhiteSpace(_displayName))
+                {
+                    RepublishRoutingAttributes();
+                }
+
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(previousName))
+            {
+                _routingService.ClearService(Type, previousName);
+                _routingService.ClearService(previousName);
+            }
+
+            if (!string.IsNullOrWhiteSpace(_displayName))
+            {
+                RepublishRoutingAttributes();
             }
         }
 
@@ -67,10 +104,29 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     return;
                 }
 
+                var previousType = _type;
                 _type = value;
                 OnPropertyChanged();
                 RefreshLogMetadata();
+                OnServiceTypeChanged(previousType);
             }
+        }
+
+        private void OnServiceTypeChanged(ServiceType previousType)
+        {
+            if (previousType == _type)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(_displayName))
+            {
+                return;
+            }
+
+            _routingService.ClearService(previousType, _displayName);
+            _routingService.ClearService(_displayName);
+            RepublishRoutingAttributes();
         }
 
         private string? _descriptorId;
@@ -155,12 +211,19 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private static readonly object ServiceRegistryLock = new();
         private static readonly HashSet<ServiceListModel> ServiceRegistry = new();
 
-        public ServiceListModel()
+        public ServiceListModel(IMessageRoutingService routingService)
         {
+            _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
+
             lock (ServiceRegistryLock)
             {
                 ServiceRegistry.Add(this);
             }
+
+            ResetMessageCounts();
+            SetRoutingAttribute(InputMessageAttributeName, _inputMessage, MessageRoutingDirection.Input, publish: false);
+            SetRoutingAttribute(OutputMessageAttributeName, _outputMessage, MessageRoutingDirection.Output, publish: false);
+            SetRoutingAttribute(RuntimeStateAttributeName, _runtimeState.ToString(), publish: false);
         }
 
         private readonly LinkedList<ServiceMessageHistoryEntry> _messageHistory = new();
@@ -212,13 +275,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _incomingMessageCount;
             private set
             {
-                if (_incomingMessageCount == value)
+                var changed = _incomingMessageCount != value;
+                _incomingMessageCount = value;
+                if (changed)
                 {
-                    return;
+                    OnPropertyChanged();
                 }
 
-                _incomingMessageCount = value;
-                OnPropertyChanged();
+                SetRoutingAttribute(IncomingMessageCountAttributeName, value.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -227,13 +291,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _outgoingMessageCount;
             private set
             {
-                if (_outgoingMessageCount == value)
+                var changed = _outgoingMessageCount != value;
+                _outgoingMessageCount = value;
+                if (changed)
                 {
-                    return;
+                    OnPropertyChanged();
                 }
 
-                _outgoingMessageCount = value;
-                OnPropertyChanged();
+                SetRoutingAttribute(OutgoingMessageCountAttributeName, value.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -271,13 +336,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _inputMessage;
             private set
             {
-                if (_inputMessage == value)
+                var resolved = value ?? string.Empty;
+                var changed = _inputMessage != resolved;
+                _inputMessage = resolved;
+                if (changed)
                 {
-                    return;
+                    OnPropertyChanged();
                 }
 
-                _inputMessage = value;
-                OnPropertyChanged();
+                SetRoutingAttribute(InputMessageAttributeName, resolved, MessageRoutingDirection.Input);
             }
         }
 
@@ -289,13 +356,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _outputMessage;
             private set
             {
-                if (_outputMessage == value)
+                var resolved = value ?? string.Empty;
+                var changed = _outputMessage != resolved;
+                _outputMessage = resolved;
+                if (changed)
                 {
-                    return;
+                    OnPropertyChanged();
                 }
 
-                _outputMessage = value;
-                OnPropertyChanged();
+                SetRoutingAttribute(OutputMessageAttributeName, resolved, MessageRoutingDirection.Output);
             }
         }
 
@@ -840,11 +909,14 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get => _runtimeState;
             private set
             {
-                if (_runtimeState != value)
+                var changed = _runtimeState != value;
+                _runtimeState = value;
+                if (changed)
                 {
-                    _runtimeState = value;
                     OnPropertyChanged();
                 }
+
+                SetRoutingAttribute(RuntimeStateAttributeName, _runtimeState.ToString());
             }
         }
 
@@ -1381,6 +1453,146 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
 
             return fallback;
+        }
+
+        public void PublishRoutingAttribute(string attributeName, string? value, MessageRoutingDirection? direction = null)
+        {
+            SetRoutingAttribute(attributeName, value, direction, publish: true);
+        }
+
+        public void ClearRoutingAttribute(string attributeName)
+        {
+            SetRoutingAttribute(attributeName, null, direction: null, publish: true);
+        }
+
+        internal void RestoreRoutingAttributes(IDictionary<string, string>? attributes)
+        {
+            _routingAttributes.Clear();
+
+            if (attributes is null)
+            {
+                return;
+            }
+
+            foreach (var pair in attributes)
+            {
+                if (string.IsNullOrWhiteSpace(pair.Key))
+                {
+                    continue;
+                }
+
+                SetRoutingAttribute(pair.Key, pair.Value ?? string.Empty, direction: null, publish: false);
+            }
+        }
+
+        internal Dictionary<string, string> GetRoutingAttributesSnapshot()
+        {
+            return _routingAttributes.ToDictionary(
+                pair => pair.Key,
+                pair => pair.Value.Value,
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal void RepublishRoutingAttributes()
+        {
+            if (string.IsNullOrWhiteSpace(_displayName))
+            {
+                return;
+            }
+
+            foreach (var pair in _routingAttributes)
+            {
+                PublishNormalizedAttribute(pair.Key, pair.Value.Value, pair.Value.Direction);
+            }
+        }
+
+        internal void ClearRoutingAttributes()
+        {
+            if (!string.IsNullOrWhiteSpace(_displayName))
+            {
+                _routingService.ClearService(Type, _displayName);
+                _routingService.ClearService(_displayName);
+            }
+
+            _routingAttributes.Clear();
+        }
+
+        private void SetRoutingAttribute(string attributeName, string? value, MessageRoutingDirection? direction = null, bool publish = true)
+        {
+            if (string.IsNullOrWhiteSpace(attributeName))
+            {
+                throw new ArgumentException("Attribute name cannot be null or whitespace.", nameof(attributeName));
+            }
+
+            var normalized = attributeName.Trim();
+
+            if (value is null)
+            {
+                if (_routingAttributes.Remove(normalized, out var existing) && publish)
+                {
+                    ClearNormalizedAttribute(normalized, existing.Direction);
+                }
+
+                return;
+            }
+
+            var resolvedDirection = direction ?? InferDirection(normalized);
+            if (!resolvedDirection.HasValue &&
+                _routingAttributes.TryGetValue(normalized, out var current) &&
+                current.Direction.HasValue)
+            {
+                resolvedDirection = current.Direction;
+            }
+
+            var resolvedValue = value;
+            _routingAttributes[normalized] = new RoutingAttributeValue(resolvedValue, resolvedDirection);
+
+            if (publish)
+            {
+                PublishNormalizedAttribute(normalized, resolvedValue, resolvedDirection);
+            }
+        }
+
+        private void PublishNormalizedAttribute(string attributeName, string value, MessageRoutingDirection? direction)
+        {
+            if (string.IsNullOrWhiteSpace(_displayName))
+            {
+                return;
+            }
+
+            if (direction.HasValue)
+            {
+                _routingService.UpdateMessage(Type, _displayName, value, direction.Value);
+            }
+            else
+            {
+                _routingService.PublishAttribute(Type, _displayName, attributeName, value);
+            }
+        }
+
+        private void ClearNormalizedAttribute(string attributeName, MessageRoutingDirection? direction)
+        {
+            if (string.IsNullOrWhiteSpace(_displayName))
+            {
+                return;
+            }
+
+            _routingService.ClearAttribute(Type, _displayName, attributeName);
+        }
+
+        private static MessageRoutingDirection? InferDirection(string attributeName)
+        {
+            if (string.Equals(attributeName, InputMessageAttributeName, StringComparison.OrdinalIgnoreCase))
+            {
+                return MessageRoutingDirection.Input;
+            }
+
+            if (string.Equals(attributeName, OutputMessageAttributeName, StringComparison.OrdinalIgnoreCase))
+            {
+                return MessageRoutingDirection.Output;
+            }
+
+            return null;
         }
 
         public void ApplyPresentation(ServicePresentationMetadata metadata)

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -547,7 +547,8 @@ namespace DesktopApplicationTemplate.UI.Views
                 }
 
                 _viewModel.ClearRoutingCache(type, trimmed);
-                var svc = new ServiceListModel
+                var routing = _serviceProvider.GetRequiredService<IMessageRoutingService>();
+                var svc = new ServiceListModel(routing)
                 {
                     DisplayName = trimmed,
                     Type = type


### PR DESCRIPTION
## Summary
- Inject `IMessageRoutingService` into `ServiceListModel`, publish routed message/state attributes, and expose helpers for protocol-specific metadata.
- Persist routing attributes through `ServicePersistence`, rehydrate models on load, and clear caches during lifecycle transitions in `MainViewModel`.
- Document the new routing attribute persistence workflow in the changelog.

## Testing
- Not run (Windows-only solution; rely on CI)


------
https://chatgpt.com/codex/tasks/task_e_68e92acbcd74832683c740ca15628f79