### PR TITLE
Add routing expression binder and wire into TCP messages

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Tcp/TcpServiceOptions.cs
@@ -32,6 +32,11 @@ public class TcpServiceOptions
     public string Host { get; set; } = string.Empty;
 
     /// <summary>
+    /// Expression used to calculate <see cref="Host"/> when routing attributes are referenced.
+    /// </summary>
+    public string HostExpression { get; set; } = string.Empty;
+
+    /// <summary>
     /// Port number used for the connection.
     /// </summary>
     public int Port { get; set; }
@@ -40,6 +45,11 @@ public class TcpServiceOptions
     /// Remote host name or address used when the service is configured to send messages.
     /// </summary>
     public string DestinationHost { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Expression used to calculate <see cref="DestinationHost"/> when routing attributes are referenced.
+    /// </summary>
+    public string DestinationHostExpression { get; set; } = string.Empty;
 
     /// <summary>
     /// Remote port used when the service is configured to send messages.
@@ -102,9 +112,19 @@ public class TcpServiceOptions
     public string InputMessage { get; set; } = string.Empty;
 
     /// <summary>
+    /// Expression that generates <see cref="InputMessage"/>.
+    /// </summary>
+    public string InputMessageExpression { get; set; } = string.Empty;
+
+    /// <summary>
     /// Script applied to <see cref="InputMessage"/> to produce an output.
     /// </summary>
     public string Script { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Expression that generates <see cref="Script"/>.
+    /// </summary>
+    public string ScriptExpression { get; set; } = string.Empty;
 
     /// <summary>
     /// Resulting message after executing <see cref="Script"/>.

--- a/DesktopApplicationTemplate.UI/Helpers/ServiceAttributeExpressionBinder.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/ServiceAttributeExpressionBinder.cs
@@ -1,0 +1,261 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.UI.Helpers;
+
+/// <summary>
+/// Resolves routed service attribute expressions and tracks referenced attributes for change notifications.
+/// </summary>
+public sealed class ServiceAttributeExpressionBinder
+{
+    private static readonly Regex TokenRegex = new("\\{([A-Za-z0-9_]+)\\.([A-Za-z0-9_]+)\\}", RegexOptions.Compiled);
+
+    private readonly IMessageRoutingService _routingService;
+    private readonly Action<string> _onResolved;
+    private readonly Action<string?>? _onError;
+    private string? _referencingServiceName;
+    private readonly SynchronizationContext? _context;
+
+    private readonly object _sync = new();
+    private List<AttributeReference> _references = new();
+
+    private string _expression = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceAttributeExpressionBinder"/> class.
+    /// </summary>
+    /// <param name="routingService">Routing service used to resolve expressions.</param>
+    /// <param name="onResolved">Callback invoked with the resolved value.</param>
+    /// <param name="onError">Optional callback invoked with an error message when referenced attributes are missing.</param>
+    /// <param name="referencingServiceName">Optional service name that owns the expression.</param>
+    /// <param name="context">Optional synchronization context used when invoking callbacks.</param>
+    public ServiceAttributeExpressionBinder(
+        IMessageRoutingService routingService,
+        Action<string> onResolved,
+        Action<string?>? onError = null,
+        string? referencingServiceName = null,
+        SynchronizationContext? context = null)
+    {
+        _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
+        _onResolved = onResolved ?? throw new ArgumentNullException(nameof(onResolved));
+        _onError = onError;
+        _referencingServiceName = referencingServiceName;
+        _context = context ?? SynchronizationContext.Current;
+
+        WeakEventManager<IMessageRoutingService, ServiceAttributeChangedEventArgs>.AddHandler(
+            _routingService,
+            nameof(IMessageRoutingService.AttributeChanged),
+            OnAttributeChanged);
+    }
+
+    /// <summary>
+    /// Gets or sets the attribute expression to resolve.
+    /// </summary>
+    public string Expression
+    {
+        get => _expression;
+        set
+        {
+            var normalized = value ?? string.Empty;
+            if (string.Equals(_expression, normalized, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _expression = normalized;
+            lock (_sync)
+            {
+                _references = ParseReferences(_expression);
+            }
+
+            Resolve();
+        }
+    }
+
+    /// <summary>
+    /// Forces the binder to re-evaluate the current expression.
+    /// </summary>
+    public void Refresh() => Resolve();
+
+    /// <summary>
+    /// Gets or sets the service name that owns the expression.
+    /// </summary>
+    public string? ReferencingServiceName
+    {
+        get => _referencingServiceName;
+        set
+        {
+            var normalized = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+            if (string.Equals(_referencingServiceName, normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _referencingServiceName = normalized;
+            Resolve();
+        }
+    }
+
+    private void Resolve()
+    {
+        string resolved;
+        string? error = null;
+
+        try
+        {
+            resolved = string.IsNullOrEmpty(_expression)
+                ? string.Empty
+                : _routingService.ResolveTokens(_expression, _referencingServiceName);
+
+            var missing = GetMissingReferences();
+            if (missing.Count > 0)
+            {
+                error = $"Missing attributes: {string.Join(", ", missing)}";
+            }
+        }
+        catch (Exception ex)
+        {
+            resolved = string.Empty;
+            error = ex.Message;
+        }
+
+        PostCallbacks(resolved, error);
+    }
+
+    private void PostCallbacks(string resolved, string? error)
+    {
+        void Execute()
+        {
+            _onResolved(resolved);
+            _onError?.Invoke(error);
+        }
+
+        if (_context is not null)
+        {
+            _context.Post(_ => Execute(), null);
+        }
+        else
+        {
+            Execute();
+        }
+    }
+
+    private List<string> GetMissingReferences()
+    {
+        List<AttributeReference> references;
+        lock (_sync)
+        {
+            references = _references;
+        }
+
+        if (references.Count == 0)
+        {
+            return new List<string>();
+        }
+
+        var missing = new List<string>();
+        foreach (var reference in references)
+        {
+            bool exists = reference.Direction.HasValue
+                ? _routingService.TryGetMessage(reference.Service, reference.Direction.Value, out _)
+                : _routingService.TryGetAttribute(reference.Service, reference.Attribute, out _);
+
+            if (!exists)
+            {
+                missing.Add($"{reference.Service}.{reference.Attribute}");
+            }
+        }
+
+        return missing;
+    }
+
+    private static List<AttributeReference> ParseReferences(string expression)
+    {
+        if (string.IsNullOrEmpty(expression))
+        {
+            return new List<AttributeReference>();
+        }
+
+        var matches = TokenRegex.Matches(expression);
+        if (matches.Count == 0)
+        {
+            return new List<AttributeReference>();
+        }
+
+        var references = new List<AttributeReference>(matches.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in matches)
+        {
+            if (!match.Success || match.Groups.Count < 3)
+            {
+                continue;
+            }
+
+            var service = match.Groups[1].Value.Trim();
+            var attribute = match.Groups[2].Value.Trim();
+            if (service.Length == 0 || attribute.Length == 0)
+            {
+                continue;
+            }
+
+            var normalizedAttribute = NormalizeAttribute(attribute, out var direction);
+            var key = string.Concat(service, '|', normalizedAttribute);
+            if (seen.Add(key))
+            {
+                references.Add(new AttributeReference(service, normalizedAttribute, direction));
+            }
+        }
+
+        return references;
+    }
+
+    private static string NormalizeAttribute(string attribute, out MessageRoutingDirection? direction)
+    {
+        if (attribute.Equals("InputMessage", StringComparison.OrdinalIgnoreCase) ||
+            attribute.Equals("LastInputMessage", StringComparison.OrdinalIgnoreCase))
+        {
+            direction = MessageRoutingDirection.Input;
+            return "InputMessage";
+        }
+
+        if (attribute.Equals("OutputMessage", StringComparison.OrdinalIgnoreCase) ||
+            attribute.Equals("LastOutputMessage", StringComparison.OrdinalIgnoreCase))
+        {
+            direction = MessageRoutingDirection.Output;
+            return "OutputMessage";
+        }
+
+        direction = null;
+        return attribute;
+    }
+
+    private void OnAttributeChanged(object? sender, ServiceAttributeChangedEventArgs e)
+    {
+        List<AttributeReference> references;
+        lock (_sync)
+        {
+            if (_references.Count == 0)
+            {
+                return;
+            }
+
+            references = _references;
+        }
+
+        foreach (var reference in references)
+        {
+            if (string.Equals(reference.Service, e.ServiceName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(reference.Attribute, e.AttributeName, StringComparison.OrdinalIgnoreCase))
+            {
+                Resolve();
+                break;
+            }
+        }
+    }
+
+    private readonly record struct AttributeReference(string Service, string Attribute, MessageRoutingDirection? Direction);
+}

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -156,6 +156,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 if (_serviceName == value) return;
                 _serviceName = value ?? string.Empty;
                 OnPropertyChanged();
+                _testMessageBinder.ReferencingServiceName = _serviceName;
+                _scriptBinder.ReferencingServiceName = _serviceName;
                 if (!_suppressRuntimeInitialization)
                 {
                     InitializeTestMessage();
@@ -163,32 +165,91 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
         }
 
-        private string _testMessage = string.Empty;
+        private readonly ServiceAttributeExpressionBinder _testMessageBinder;
+        private readonly ServiceAttributeExpressionBinder _scriptBinder;
 
-        private string _script = string.Empty;
+        private string _testMessageExpression = string.Empty;
+        private string _resolvedTestMessage = string.Empty;
+        private string? _testMessageError;
+
+        private string _scriptExpression = string.Empty;
+        private string _resolvedScript = string.Empty;
+        private string? _scriptError;
 
         private string _scriptOutputMessage = string.Empty;
 
         /// <summary>Message used for testing communication.</summary>
-        public string TestMessage
+        public string TestMessage => _resolvedTestMessage;
+
+        /// <summary>Expression used to generate the test message.</summary>
+        public string TestMessageExpression
         {
-            get => _testMessage;
+            get => _testMessageExpression;
             set
             {
-                if (_testMessage == value) return;
-                _testMessage = value ?? string.Empty;
+                var normalized = value ?? string.Empty;
+                if (string.Equals(_testMessageExpression, normalized, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _testMessageExpression = normalized;
+                _options.InputMessageExpression = normalized;
+                OnPropertyChanged();
+                _testMessageBinder.Expression = normalized;
+            }
+        }
+
+        /// <summary>Validation message for the test message expression.</summary>
+        public string? TestMessageError
+        {
+            get => _testMessageError;
+            private set
+            {
+                if (Equals(_testMessageError, value))
+                {
+                    return;
+                }
+
+                _testMessageError = value;
                 OnPropertyChanged();
             }
         }
 
         /// <summary>Script applied to incoming messages before routing.</summary>
-        public string Script
+        public string Script => _resolvedScript;
+
+        /// <summary>Expression that generates the script.</summary>
+        public string ScriptExpression
         {
-            get => _script;
+            get => _scriptExpression;
             set
             {
-                if (_script == value) return;
-                _script = value ?? string.Empty;
+                var normalized = value ?? string.Empty;
+                if (string.Equals(_scriptExpression, normalized, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                _scriptExpression = normalized;
+                _options.ScriptExpression = normalized;
+                OnPropertyChanged();
+                _scriptBinder.Expression = normalized;
+            }
+        }
+
+        /// <summary>Validation message for the script expression.</summary>
+        public string? ScriptError
+        {
+            get => _scriptError;
+            private set
+            {
+                if (Equals(_scriptError, value))
+                {
+                    return;
+                }
+
+                _scriptError = value;
                 OnPropertyChanged();
             }
         }
@@ -236,6 +297,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 OnPropertyChanged(nameof(OutgoingResults));
             };
 
+            var context = SynchronizationContext.Current;
+            _testMessageBinder = new ServiceAttributeExpressionBinder(
+                _routing,
+                resolved => UpdateResolvedTestMessage(resolved),
+                error => TestMessageError = error,
+                context: context);
+            _scriptBinder = new ServiceAttributeExpressionBinder(
+                _routing,
+                resolved => UpdateResolvedScript(resolved),
+                error => ScriptError = error,
+                context: context);
+
             ClearLogCommand = new RelayCommand(ClearLogs);
             ExportLogCommand = new RelayCommand(ExportLogs);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
@@ -243,6 +316,39 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             OpenScriptEditorCommand = new AsyncRelayCommand(OpenScriptEditorAsync);
 
             EnsureApplicationExitHooked();
+        }
+
+        private void UpdateResolvedTestMessage(string resolved)
+        {
+            var normalized = resolved ?? string.Empty;
+            if (string.Equals(_resolvedTestMessage, normalized, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _resolvedTestMessage = normalized;
+            _options.InputMessage = normalized;
+            _options.LastTestMessage = normalized;
+            OnPropertyChanged(nameof(TestMessage));
+            _service?.UpdateInputMessage(normalized);
+
+            if (!string.IsNullOrWhiteSpace(ServiceName))
+            {
+                _routing.UpdateMessage(ServiceType, ServiceName, normalized, MessageRoutingDirection.Input);
+            }
+        }
+
+        private void UpdateResolvedScript(string resolved)
+        {
+            var normalized = resolved ?? string.Empty;
+            if (string.Equals(_resolvedScript, normalized, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            _resolvedScript = normalized;
+            _options.Script = normalized;
+            OnPropertyChanged(nameof(Script));
         }
 
         /// <summary>Associates the view model with a service and its TCP options.</summary>
@@ -280,9 +386,18 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             {
                 _suppressRuntimeInitialization = false;
             }
-            Script = string.IsNullOrWhiteSpace(_options.Script)
+            var scriptExpression = string.IsNullOrWhiteSpace(_options.ScriptExpression)
+                ? (string.IsNullOrWhiteSpace(_options.Script)
+                    ? ScriptEditorViewModel.DefaultScript
+                    : _options.Script)
+                : _options.ScriptExpression;
+            ScriptExpression = string.IsNullOrWhiteSpace(scriptExpression)
                 ? ScriptEditorViewModel.DefaultScript
-                : _options.Script;
+                : scriptExpression;
+            var testExpression = string.IsNullOrWhiteSpace(_options.InputMessageExpression)
+                ? (_options.LastTestMessage ?? _options.InputMessage ?? string.Empty)
+                : _options.InputMessageExpression;
+            TestMessageExpression = testExpression ?? string.Empty;
             ScriptOutputMessage = _options.OutputMessage;
             _runtimeContext = new TcpRuntimeContext(ServiceType, ServiceName, _options, ScriptEditorViewModel.DefaultScript);
             _pendingNavigationInitialization = true;
@@ -392,11 +507,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             try
             {
                 var state = await _tcpRuntime.InitializeAsync(_runtimeContext).ConfigureAwait(false);
-                Script = state.Script;
-                TestMessage = state.TestMessage;
+                ScriptExpression = state.Script ?? string.Empty;
+                TestMessageExpression = state.TestMessage ?? string.Empty;
                 ScriptOutputMessage = state.OutputMessage;
                 _options.OutputMessage = state.OutputMessage;
-                _routing.UpdateMessage(ServiceType, ServiceName, state.TestMessage, MessageRoutingDirection.Input);
+                _routing.UpdateMessage(ServiceType, ServiceName, TestMessage, MessageRoutingDirection.Input);
                 _routing.UpdateMessage(ServiceType, ServiceName, state.OutputMessage, MessageRoutingDirection.Output);
                 if (isNavigationInitialization)
                 {
@@ -1189,9 +1304,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
                 await RunOnUiThreadAsync(() =>
                 {
-                    TestMessage = state.TestMessage;
+                    TestMessageExpression = state.TestMessage ?? string.Empty;
                     ScriptOutputMessage = state.OutputMessage;
-                    _service?.UpdateInputMessage(state.TestMessage);
+                    _service?.UpdateInputMessage(TestMessage);
                     _service?.UpdateOutputMessage(state.OutputMessage);
                 }).ConfigureAwait(false);
             }
@@ -1382,7 +1497,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             }
 
             var options = _service.GetOrCreateOptions(() => new TcpServiceOptions());
+            options.ScriptExpression = ScriptExpression ?? string.Empty;
             options.Script = Script ?? string.Empty;
+            options.InputMessageExpression = TestMessageExpression ?? string.Empty;
             options.LastTestMessage = TestMessage ?? string.Empty;
             options.InputMessage = TestMessage ?? string.Empty;
             options.OutputMessage = ScriptOutputMessage ?? string.Empty;
@@ -1403,11 +1520,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             try
             {
                 var result = await _tcpRuntime.ExecuteAsync(new TcpRuntimeExecutionRequest(_runtimeContext, Script, TestMessage)).ConfigureAwait(false);
-                Script = result.Script;
-                TestMessage = result.TestMessage;
+                ScriptExpression = result.Script ?? string.Empty;
+                TestMessageExpression = result.TestMessage ?? string.Empty;
                 ScriptOutputMessage = result.OutputMessage;
                 _options.OutputMessage = result.OutputMessage;
-                _routing.UpdateMessage(ServiceType, ServiceName, result.TestMessage, MessageRoutingDirection.Input);
+                _routing.UpdateMessage(ServiceType, ServiceName, TestMessage, MessageRoutingDirection.Input);
                 _routing.UpdateMessage(ServiceType, ServiceName, result.OutputMessage, MessageRoutingDirection.Output);
                 Logger?.Log($"Script executed successfully: {ScriptOutputMessage}", LogLevel.Information);
             }
@@ -1446,16 +1563,15 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             void OnOutputGenerated(string output)
             {
                 ScriptOutputMessage = _options.OutputMessage = output;
-                TestMessage = svm.TestMessage;
-                _options.LastTestMessage = svm.TestMessage;
-                _routing.UpdateMessage(ServiceType, ServiceName, svm.TestMessage, MessageRoutingDirection.Input);
+                TestMessageExpression = svm.TestMessage ?? string.Empty;
+                _routing.UpdateMessage(ServiceType, ServiceName, TestMessage, MessageRoutingDirection.Input);
                 _routing.UpdateMessage(ServiceType, ServiceName, output, MessageRoutingDirection.Output);
             }
 
             void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
             {
                 if (e.PropertyName == nameof(ScriptEditorViewModel.TestMessage))
-                    TestMessage = svm.TestMessage;
+                    TestMessageExpression = svm.TestMessage ?? string.Empty;
             }
 
             svm.OutputGenerated += OnOutputGenerated;
@@ -1468,8 +1584,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
 
             if (result)
             {
-                Script = editor.ScriptText;
-                TestMessage = editor.LastTestMessage;
+                ScriptExpression = editor.ScriptText ?? string.Empty;
+                TestMessageExpression = editor.LastTestMessage ?? string.Empty;
                 await SaveAsync().ConfigureAwait(false);
             }
         }

--- a/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Tcp/TcpServiceMessagesView.xaml
@@ -4,7 +4,11 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:shared="clr-namespace:DesktopApplicationTemplate.UI.Views.Shared"
+      xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"
       mc:Ignorable="d">
+    <Page.Resources>
+        <helpers:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter" />
+    </Page.Resources>
     <Grid Margin="10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -51,7 +55,16 @@
                 </Grid.RowDefinitions>
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,5">
                     <TextBlock Text="Test Message:" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                    <TextBox Text="{Binding TestMessage, UpdateSourceTrigger=PropertyChanged}" Width="300"/>
+                    <TextBox Text="{Binding TestMessageExpression, UpdateSourceTrigger=PropertyChanged}" Width="300">
+                        <TextBox.ToolTip>
+                            <StackPanel>
+                                <TextBlock Text="Resolved:" FontWeight="Bold"/>
+                                <TextBlock Text="{Binding TestMessage}" TextWrapping="Wrap" MaxWidth="300"/>
+                                <TextBlock Text="{Binding TestMessageError}" Foreground="Red" TextWrapping="Wrap"
+                                           Visibility="{Binding TestMessageError, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
+                            </StackPanel>
+                        </TextBox.ToolTip>
+                    </TextBox>
                     <Button Content="Edit Script" Margin="10,0,0,0" Command="{Binding OpenScriptEditorCommand}" Height="24"/>
                     <TextBox Text="{Binding ScriptOutputMessage, Mode=OneWay}" Width="300"
                              IsReadOnly="True" Margin="10,0,0,0" Background="#EDEDED"/>


### PR DESCRIPTION
## Summary
- add a ServiceAttributeExpressionBinder helper that resolves routed attribute expressions and refreshes when attributes change
- track both expression and resolved values for TCP test messages and scripts, pushing resolved content into service options and routing updates
- show resolved test message details in the TCP messages view and persist new expression metadata on TCP options

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68e93755986483269c5e9661845e9bcb