### PR TITLE
Switch CSV logging to routing expressions

### DIFF
--- a/Codex/docs/CHANGELOG.md
+++ b/Codex/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Service persistence now stores `ServiceType` as short codes and reads legacy string names.
 - Service routing attributes (input/output text, message counters, runtime state, and protocol-specific metadata) persist with each service and are republished through `IMessageRoutingService` after load or rename operations.
 - Service creation and navigation now resolve services via `ServiceType` enum lookups instead of string-based switches.
+- CSV logging resolves configured attribute expressions through the routing service instead of auto-adding per-service columns.
 - `ServiceManager` loads default services from configuration using `ServiceType` short codes and accepts legacy names.
 - `ServiceListModel` now exposes a `Type` enum property, removing string-based service comparisons.
 - Standardized routed message naming to `{Service}.InputMessage` and `{Service}.OutputMessage` in the editor and UI, while keeping legacy `Last*` tokens working for compatibility.
@@ -81,6 +82,7 @@
 - MQTT create and edit views include tooltips on text fields to clarify expected input.
 - Create and edit service view models inject `IServiceRule` to validate required fields with XAML error tooltips.
 - Service editor views share a reusable `EditorButtonBar` control with consistent automation names.
+- CSV viewer replaces service/script columns with attribute expressions, autocomplete suggestions, and routed attribute validation.
 - Consolidated save and close dialogs into a configurable `ConfirmationWindow` with optional suppression.
 - Event handlers use C# property pattern matching instead of casting `sender` and accessing `DataContext`.
 - Replaced `as` cast and null check with pattern matching in `SettingsPage.NavigateBack`.

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvColumnDefinitionConverter.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvColumnDefinitionConverter.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
+
+internal sealed class CsvColumnDefinitionConverter : JsonConverter<CsvColumnDefinition>
+{
+    public override CsvColumnDefinition Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return new CsvColumnDefinition();
+        }
+
+        using var document = JsonDocument.ParseValue(ref reader);
+        var element = document.RootElement;
+        var column = new CsvColumnDefinition();
+
+        if (element.TryGetProperty(nameof(CsvColumnDefinition.Name), out var nameProp) &&
+            nameProp.ValueKind == JsonValueKind.String)
+        {
+            column.Name = nameProp.GetString() ?? column.Name;
+        }
+
+        if (element.TryGetProperty(nameof(CsvColumnDefinition.Expression), out var expressionProp) &&
+            expressionProp.ValueKind == JsonValueKind.String)
+        {
+            column.Expression = expressionProp.GetString() ?? string.Empty;
+        }
+
+        if (element.TryGetProperty(nameof(CsvColumnDefinition.Format), out var formatProp) &&
+            formatProp.ValueKind == JsonValueKind.String)
+        {
+            column.Format = formatProp.GetString();
+        }
+
+        if (string.IsNullOrWhiteSpace(column.Expression))
+        {
+            if (element.TryGetProperty("Script", out var legacyScriptProp) &&
+                legacyScriptProp.ValueKind == JsonValueKind.String)
+            {
+                column.Expression = legacyScriptProp.GetString() ?? string.Empty;
+            }
+            else if (element.TryGetProperty("Service", out var legacyServiceProp) &&
+                     legacyServiceProp.ValueKind == JsonValueKind.String)
+            {
+                var serviceName = legacyServiceProp.GetString();
+                column.Expression = BuildLegacyExpression(serviceName, column.Name);
+            }
+        }
+
+        return column;
+    }
+
+    public override void Write(Utf8JsonWriter writer, CsvColumnDefinition value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString(nameof(CsvColumnDefinition.Name), value.Name);
+        writer.WriteString(nameof(CsvColumnDefinition.Expression), value.Expression ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(value.Format))
+        {
+            writer.WriteString(nameof(CsvColumnDefinition.Format), value.Format);
+        }
+        writer.WriteEndObject();
+    }
+
+    private static string BuildLegacyExpression(string? serviceName, string columnName)
+    {
+        if (string.IsNullOrWhiteSpace(serviceName))
+        {
+            return string.Empty;
+        }
+
+        var trimmedService = serviceName.Trim();
+        if (columnName.EndsWith(" Sent", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{{{trimmedService}.OutputMessage}}";
+        }
+
+        return $"{{{trimmedService}.InputMessage}}";
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvConfiguration.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvConfiguration.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 
@@ -26,20 +29,50 @@ public class CsvConfiguration
 /// <summary>
 /// Describes a single CSV column.
 /// </summary>
-public class CsvColumnDefinition
+[JsonConverter(typeof(CsvColumnDefinitionConverter))]
+public class CsvColumnDefinition : INotifyPropertyChanged
 {
+    private string _name = "Column";
+    private string _expression = string.Empty;
+    private string? _format;
+
     /// <summary>
     /// Gets or sets the display name of the column.
     /// </summary>
-    public string Name { get; set; } = "Column";
+    public string Name
+    {
+        get => _name;
+        set => SetField(ref _name, value);
+    }
 
     /// <summary>
-    /// Gets or sets the service associated with the column.
+    /// Gets or sets the attribute expression resolved through the routing service.
     /// </summary>
-    public string Service { get; set; } = string.Empty;
+    public string Expression
+    {
+        get => _expression;
+        set => SetField(ref _expression, value);
+    }
 
     /// <summary>
-    /// Gets or sets the custom script used to populate the column.
+    /// Gets or sets an optional <see cref="string.Format(string, object?)"/> template applied to the resolved value.
     /// </summary>
-    public string Script { get; set; } = string.Empty;
+    public string? Format
+    {
+        get => _format;
+        set => SetField(ref _format, value);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
 }

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvExpressionEvaluator.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvExpressionEvaluator.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using DesktopApplicationTemplate.Core.Services;
+
+namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
+
+public static class CsvExpressionEvaluator
+{
+    private static readonly Regex TokenRegex = new(@"\{([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\}", RegexOptions.Compiled);
+
+    public static IReadOnlyList<(string Service, string Attribute)> GetReferences(string? expression)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return Array.Empty<(string, string)>();
+        }
+
+        var matches = TokenRegex.Matches(expression);
+        if (matches.Count == 0)
+        {
+            return Array.Empty<(string, string)>();
+        }
+
+        var results = new List<(string Service, string Attribute)>(matches.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match match in matches)
+        {
+            if (match.Groups.Count < 3)
+            {
+                continue;
+            }
+
+            var service = match.Groups[1].Value;
+            var attribute = match.Groups[2].Value;
+            var key = string.Concat(service, "\u001f", attribute);
+
+            if (seen.Add(key))
+            {
+                results.Add((service, attribute));
+            }
+        }
+
+        return results;
+    }
+
+    public static string Evaluate(string? expression, IMessageRoutingService routingService, string? referencingServiceName)
+    {
+        if (routingService is null)
+        {
+            throw new ArgumentNullException(nameof(routingService));
+        }
+
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return string.Empty;
+        }
+
+        return routingService.ResolveTokens(expression, referencingServiceName);
+    }
+
+    public static string ApplyFormat(string value, string? format)
+    {
+        if (string.IsNullOrWhiteSpace(format))
+        {
+            return value;
+        }
+
+        try
+        {
+            if (format.Contains('{'))
+            {
+                return string.Format(CultureInfo.InvariantCulture, format, value);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0:" + format + "}", value);
+        }
+        catch (FormatException)
+        {
+            return value;
+        }
+    }
+
+    public static bool ReferencesAttribute(string? expression, string serviceName, string attributeName)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return false;
+        }
+
+        var normalizedService = serviceName ?? string.Empty;
+        var normalizedAttribute = attributeName ?? string.Empty;
+        foreach (var reference in GetReferences(expression))
+        {
+            if (string.Equals(reference.Service, normalizedService, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(reference.Attribute, normalizedAttribute, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvService.cs
+++ b/DesktopApplicationTemplate.Core/Services/Protocols/Csv/CsvService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using DesktopApplicationTemplate.Core.Services;
 
 namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 
@@ -11,40 +12,19 @@ namespace DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 /// </summary>
 public class CsvService : ICsvService
 {
+    private readonly IMessageRoutingService _routingService;
+
+    public CsvService(IMessageRoutingService routingService)
+    {
+        _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
+    }
+
     /// <inheritdoc />
     public bool EnsureColumnsForService(CsvConfiguration configuration, string serviceName)
     {
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-
-        if (IsCsvService(serviceName))
-        {
-            return false;
-        }
-
-        bool modified = false;
-        if (!configuration.Columns.Any(c => string.Equals(c.Name, serviceName, StringComparison.Ordinal)))
-        {
-            configuration.Columns.Add(new CsvColumnDefinition
-            {
-                Name = serviceName,
-                Service = serviceName
-            });
-            modified = true;
-        }
-
-        string sentColumn = $"{serviceName} Sent";
-        if (!configuration.Columns.Any(c => string.Equals(c.Name, sentColumn, StringComparison.Ordinal)))
-        {
-            configuration.Columns.Add(new CsvColumnDefinition
-            {
-                Name = sentColumn,
-                Service = serviceName
-            });
-            modified = true;
-        }
-
-        return modified;
+        return false;
     }
 
     /// <inheritdoc />
@@ -53,29 +33,6 @@ public class CsvService : ICsvService
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentNullException.ThrowIfNull(state);
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-
-        if (IsCsvService(serviceName))
-        {
-            return false;
-        }
-
-        string sentColumn = $"{serviceName} Sent";
-        List<CsvColumnDefinition> removed = configuration.Columns
-            .Where(c => string.Equals(c.Name, serviceName, StringComparison.Ordinal) ||
-                        string.Equals(c.Name, sentColumn, StringComparison.Ordinal))
-            .ToList();
-
-        foreach (var column in removed)
-        {
-            configuration.Columns.Remove(column);
-        }
-
-        if (removed.Count > 0)
-        {
-            state.Reset();
-            return true;
-        }
-
         return false;
     }
 
@@ -86,28 +43,36 @@ public class CsvService : ICsvService
         ArgumentNullException.ThrowIfNull(state);
         ArgumentNullException.ThrowIfNull(output);
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
-        message ??= string.Empty;
 
-        if (IsCsvService(serviceName))
+        var columns = configuration.Columns ?? Array.Empty<CsvColumnDefinition>();
+        if (columns.Count == 0)
         {
             return;
         }
 
-        EnsureColumnsForService(configuration, serviceName);
         EnsureHeader(configuration, state, output);
 
-        string[] values = configuration.Columns.Select(_ => string.Empty).ToArray();
-        bool sent = message.Contains("Sending", StringComparison.OrdinalIgnoreCase) ||
-                    message.Contains("Sent", StringComparison.OrdinalIgnoreCase);
-        string columnName = sent ? $"{serviceName} Sent" : serviceName;
-
-        int columnIndex = configuration.Columns
-            .Select((column, index) => new { column, index })
-            .FirstOrDefault(item => string.Equals(item.column.Name, columnName, StringComparison.Ordinal))?.index ?? -1;
-
-        if (columnIndex >= 0)
+        var values = new string[columns.Count];
+        for (int i = 0; i < columns.Count; i++)
         {
-            values[columnIndex] = message.Replace(',', ' ');
+            var column = columns[i];
+            string resolved;
+            try
+            {
+                resolved = CsvExpressionEvaluator.Evaluate(column.Expression, _routingService, serviceName);
+            }
+            catch
+            {
+                resolved = string.Empty;
+            }
+
+            if (string.IsNullOrWhiteSpace(resolved) && string.IsNullOrWhiteSpace(column.Expression))
+            {
+                resolved = message ?? string.Empty;
+            }
+
+            resolved = CsvExpressionEvaluator.ApplyFormat(resolved, column.Format);
+            values[i] = (resolved ?? string.Empty).Replace(',', ' ');
         }
 
         AppendRow(configuration, state, output, values);
@@ -121,6 +86,8 @@ public class CsvService : ICsvService
         ArgumentNullException.ThrowIfNull(output);
         ArgumentNullException.ThrowIfNull(values);
 
+        EnsureHeader(configuration, state, output);
+
         string filePath = BuildFileName(configuration, state, output);
         string line = string.Join(',', values.Select(value => value ?? string.Empty));
         output.AppendLine(filePath, line + Environment.NewLine);
@@ -129,6 +96,11 @@ public class CsvService : ICsvService
     private static void EnsureHeader(CsvConfiguration configuration, CsvServiceState state, ICsvOutput output)
     {
         if (state.HeaderWritten)
+        {
+            return;
+        }
+
+        if (configuration.Columns is null || configuration.Columns.Count == 0)
         {
             return;
         }
@@ -197,6 +169,4 @@ public class CsvService : ICsvService
         return $"{fileName}_{timestamp}{extension}";
     }
 
-    private static bool IsCsvService(string serviceName)
-        => serviceName.Contains("CSV", StringComparison.OrdinalIgnoreCase);
 }

--- a/DesktopApplicationTemplate.UI/Services/CsvServiceAdapter.cs
+++ b/DesktopApplicationTemplate.UI/Services/CsvServiceAdapter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.UI.ViewModels.Csv;
@@ -19,21 +20,27 @@ public class CsvServiceAdapter
     private readonly ICsvOutput _output;
     private readonly CsvServiceState _state = new();
     private readonly ILoggingService? _logger;
+    private readonly IMessageRoutingService _routingService;
+    private readonly object _syncRoot = new();
 
-    public CsvServiceAdapter(CsvViewerViewModel viewModel, ProtocolCsvService csvService, ICsvOutput output, ILoggingService? logger = null)
+    public CsvServiceAdapter(
+        CsvViewerViewModel viewModel,
+        ProtocolCsvService csvService,
+        ICsvOutput output,
+        IMessageRoutingService routingService,
+        ILoggingService? logger = null)
     {
         _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
         _csvService = csvService ?? throw new ArgumentNullException(nameof(csvService));
         _output = output ?? throw new ArgumentNullException(nameof(output));
+        _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
         _logger = logger;
+        _routingService.AttributeChanged += OnRoutingAttributeChanged;
     }
 
     public void EnsureColumnsForService(string serviceName)
     {
-        if (_csvService.EnsureColumnsForService(Configuration, serviceName))
-        {
-            _viewModel.Save();
-        }
+        _csvService.EnsureColumnsForService(Configuration, serviceName);
     }
 
     public void RemoveColumnsForService(string serviceName)
@@ -62,7 +69,7 @@ public class CsvServiceAdapter
         var previousPath = GetCurrentFilePath();
         var fileExisted = !string.IsNullOrWhiteSpace(previousPath) && _output.FileExists(previousPath);
 
-        _csvService.RecordLog(Configuration, _state, _output, serviceName, message);
+        WriteSnapshot(serviceName, message);
 
         var currentPath = GetCurrentFilePath();
         if (string.IsNullOrWhiteSpace(currentPath))
@@ -83,7 +90,10 @@ public class CsvServiceAdapter
 
     public void AppendRow(IEnumerable<string?> values)
     {
-        _csvService.AppendRow(Configuration, _state, _output, values);
+        lock (_syncRoot)
+        {
+            _csvService.AppendRow(Configuration, _state, _output, values);
+        }
     }
 
     private CsvConfiguration Configuration => _viewModel.Configuration;
@@ -97,5 +107,39 @@ public class CsvServiceAdapter
 
         var directory = Configuration.OutputDirectory ?? string.Empty;
         return Path.Combine(directory, _state.CurrentFileName);
+    }
+
+    private void OnRoutingAttributeChanged(object? sender, ServiceAttributeChangedEventArgs e)
+    {
+        if (e is null)
+        {
+            return;
+        }
+
+        if (!IsExpressionReferencing(e.ServiceName, e.AttributeName))
+        {
+            return;
+        }
+
+        WriteSnapshot(e.ServiceName, e.Value ?? string.Empty);
+    }
+
+    private bool IsExpressionReferencing(string serviceName, string attributeName)
+    {
+        if (string.IsNullOrWhiteSpace(serviceName) || string.IsNullOrWhiteSpace(attributeName))
+        {
+            return false;
+        }
+
+        return Configuration.Columns.Any(column =>
+            CsvExpressionEvaluator.ReferencesAttribute(column.Expression, serviceName, attributeName));
+    }
+
+    private void WriteSnapshot(string serviceName, string message)
+    {
+        lock (_syncRoot)
+        {
+            _csvService.RecordLog(Configuration, _state, _output, serviceName, message);
+        }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Csv/CsvViewerViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Csv/CsvViewerViewModel.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Windows;
 using System.Windows.Input;
+using System.Windows.Threading;
+using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.UI.Services;
 
@@ -14,9 +19,35 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
     {
         private readonly string _configPath;
         private readonly IFileDialogService _fileDialog;
+        private readonly IMessageRoutingService _routingService;
+        private readonly ObservableCollection<string> _attributeSuggestions = new();
+        private readonly ObservableCollection<string> _validationMessages = new();
+        private readonly HashSet<string> _suggestionSet = new(StringComparer.OrdinalIgnoreCase);
+        private ObservableCollection<CsvColumnDefinition>? _observableColumns;
+        private CsvColumnDefinition? _selectedColumn;
 
         public CsvConfiguration Configuration { get; private set; } = CreateDefaultConfiguration();
-        public CsvColumnDefinition? SelectedColumn { get; set; }
+        public ReadOnlyObservableCollection<string> AttributeSuggestions { get; }
+        public ReadOnlyObservableCollection<string> ValidationMessages { get; }
+
+        public CsvColumnDefinition? SelectedColumn
+        {
+            get => _selectedColumn;
+            set
+            {
+                if (_selectedColumn == value)
+                {
+                    return;
+                }
+
+                _selectedColumn = value;
+                OnPropertyChanged();
+                if (RemoveColumnCommand is RelayCommand remove)
+                {
+                    remove.RaiseCanExecuteChanged();
+                }
+            }
+        }
 
         public ICommand AddColumnCommand { get; }
         public ICommand RemoveColumnCommand { get; }
@@ -29,13 +60,17 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
 
         public event Action? RequestClose;
 
-        public CsvViewerViewModel(IFileDialogService fileDialog, string? configPath = null)
+        public CsvViewerViewModel(IFileDialogService fileDialog, IMessageRoutingService routingService, string? configPath = null)
         {
-            _fileDialog = fileDialog;
+            _fileDialog = fileDialog ?? throw new ArgumentNullException(nameof(fileDialog));
+            _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
             _configPath = configPath ?? "csv_config.json";
+            AttributeSuggestions = new ReadOnlyObservableCollection<string>(_attributeSuggestions);
+            ValidationMessages = new ReadOnlyObservableCollection<string>(_validationMessages);
+            _routingService.AttributeChanged += OnRoutingAttributeChanged;
             Load();
-            AddColumnCommand = new RelayCommand(() => Configuration.Columns.Add(new CsvColumnDefinition()));
-            RemoveColumnCommand = new RelayCommand(() => { if (SelectedColumn != null) Configuration.Columns.Remove(SelectedColumn); });
+            AddColumnCommand = new RelayCommand(AddColumn);
+            RemoveColumnCommand = new RelayCommand(RemoveSelectedColumn, () => SelectedColumn != null);
             SaveCommand = new RelayCommand(Save);
             CloseCommand = new RelayCommand(() => RequestClose?.Invoke());
             BrowseCommand = new RelayCommand(BrowseDirectory);
@@ -54,11 +89,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
                     Configuration = JsonSerializer.Deserialize<CsvConfiguration>(json) ?? CreateDefaultConfiguration();
                     EnsureObservableColumns();
                     OnPropertyChanged(nameof(Configuration));
+                    RefreshValidationMessages();
                     return;
                 }
             }
 
             EnsureObservableColumns();
+            RefreshValidationMessages();
         }
 
         public void Save()
@@ -76,8 +113,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
                         .Select(c => new CsvColumnDefinition
                         {
                             Name = c.Name,
-                            Service = c.Service,
-                            Script = c.Script
+                            Expression = c.Expression,
+                            Format = c.Format
                         })
                         .ToList()
                 };
@@ -128,13 +165,185 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
 
         private void EnsureObservableColumns()
         {
-            if (Configuration.Columns is ObservableCollection<CsvColumnDefinition>)
+            ObservableCollection<CsvColumnDefinition> columns;
+            if (Configuration.Columns is ObservableCollection<CsvColumnDefinition> existing)
+            {
+                columns = existing;
+            }
+            else
+            {
+                var seed = Configuration.Columns ?? new List<CsvColumnDefinition>();
+                columns = new ObservableCollection<CsvColumnDefinition>(seed);
+                Configuration.Columns = columns;
+            }
+
+            AttachColumns(columns);
+        }
+
+        private void AttachColumns(ObservableCollection<CsvColumnDefinition> columns)
+        {
+            if (_observableColumns is not null)
+            {
+                _observableColumns.CollectionChanged -= OnColumnsChanged;
+                foreach (var column in _observableColumns)
+                {
+                    column.PropertyChanged -= OnColumnPropertyChanged;
+                }
+            }
+
+            _observableColumns = columns;
+            _observableColumns.CollectionChanged += OnColumnsChanged;
+
+            foreach (var column in _observableColumns)
+            {
+                column.PropertyChanged += OnColumnPropertyChanged;
+                RegisterColumn(column);
+            }
+        }
+
+        private void OnColumnsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e is null)
             {
                 return;
             }
 
-            var columns = Configuration.Columns ?? new List<CsvColumnDefinition>();
-            Configuration.Columns = new ObservableCollection<CsvColumnDefinition>(columns);
+            if (e.OldItems is not null)
+            {
+                foreach (CsvColumnDefinition item in e.OldItems)
+                {
+                    item.PropertyChanged -= OnColumnPropertyChanged;
+                }
+            }
+
+            if (e.NewItems is not null)
+            {
+                foreach (CsvColumnDefinition item in e.NewItems)
+                {
+                    item.PropertyChanged += OnColumnPropertyChanged;
+                    RegisterColumn(item);
+                }
+            }
+
+            RefreshValidationMessages();
+        }
+
+        private void OnColumnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is CsvColumnDefinition column)
+            {
+                RegisterColumn(column);
+            }
+
+            RefreshValidationMessages();
+        }
+
+        private void RegisterColumn(CsvColumnDefinition column)
+        {
+            foreach (var reference in CsvExpressionEvaluator.GetReferences(column.Expression))
+            {
+                AddSuggestion(reference.Service, reference.Attribute);
+            }
+        }
+
+        private void AddColumn()
+        {
+            var column = new CsvColumnDefinition();
+            Configuration.Columns.Add(column);
+            SelectedColumn = column;
+        }
+
+        private void RemoveSelectedColumn()
+        {
+            if (SelectedColumn is null)
+            {
+                return;
+            }
+
+            Configuration.Columns.Remove(SelectedColumn);
+            SelectedColumn = null;
+        }
+
+        private void RefreshValidationMessages()
+        {
+            _validationMessages.Clear();
+            if (_observableColumns is null)
+            {
+                return;
+            }
+
+            foreach (var column in _observableColumns)
+            {
+                if (string.IsNullOrWhiteSpace(column.Expression))
+                {
+                    _validationMessages.Add($"Column '{column.Name}' requires an attribute expression.");
+                    continue;
+                }
+
+                var references = CsvExpressionEvaluator.GetReferences(column.Expression);
+                if (references.Count == 0)
+                {
+                    _validationMessages.Add($"Column '{column.Name}' does not reference any attributes. Use tokens such as {{Service.InputMessage}}.");
+                    continue;
+                }
+
+                foreach (var reference in references)
+                {
+                    if (!_routingService.TryGetAttribute(reference.Service, reference.Attribute, out _))
+                    {
+                        _validationMessages.Add($"Column '{column.Name}' references {reference.Service}.{reference.Attribute}, but no value is published yet.");
+                    }
+                }
+            }
+
+            OnPropertyChanged(nameof(ValidationMessages));
+        }
+
+        private void AddSuggestion(string serviceName, string attributeName)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName) || string.IsNullOrWhiteSpace(attributeName))
+            {
+                return;
+            }
+
+            var token = $"{{{serviceName}.{attributeName}}}";
+            if (_suggestionSet.Add(token))
+            {
+                _attributeSuggestions.Add(token);
+                OnPropertyChanged(nameof(AttributeSuggestions));
+            }
+        }
+
+        private void OnRoutingAttributeChanged(object? sender, ServiceAttributeChangedEventArgs e)
+        {
+            if (e is null)
+            {
+                return;
+            }
+
+            RunOnUiThread(() =>
+            {
+                AddSuggestion(e.ServiceName, e.AttributeName);
+                RefreshValidationMessages();
+            });
+        }
+
+        private static void RunOnUiThread(Action action)
+        {
+            if (action is null)
+            {
+                return;
+            }
+
+            var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
+            if (dispatcher.CheckAccess())
+            {
+                action();
+            }
+            else
+            {
+                dispatcher.Invoke(action);
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/Csv/CsvServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Csv/CsvServiceView.xaml
@@ -12,7 +12,9 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel Margin="0 0 0 10">
@@ -33,14 +35,56 @@
                 </Grid>
             </StackPanel>
         </StackPanel>
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Configuration.Columns}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedColumn}">
+        <TextBlock Grid.Row="1" Margin="0,0,0,10" TextWrapping="Wrap">
+            <Run Text="Use column expressions to resolve routed attributes (for example " />
+            <Run FontWeight="SemiBold" Text="{}{Service.InputMessage}" />
+            <Run Text="). Format templates apply via " />
+            <Run FontWeight="SemiBold" Text="string.Format" />
+            <Run Text=" when provided." />
+        </TextBlock>
+        <DataGrid Grid.Row="2" ItemsSource="{Binding Configuration.Columns}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedColumn}" CanUserAddRows="False" Margin="0,0,0,10">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
-                <DataGridTextColumn Header="Service" Binding="{Binding Service}" Width="*"/>
-                <DataGridTextColumn Header="Script" Binding="{Binding Script}" Width="*"/>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="2*"/>
+                <DataGridTemplateColumn Header="Expression" Width="3*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Expression}" TextTrimming="CharacterEllipsis"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                        <DataTemplate>
+                            <ComboBox IsEditable="True"
+                                      ItemsSource="{Binding DataContext.AttributeSuggestions, RelativeSource={RelativeSource AncestorType=Page}}"
+                                      Text="{Binding Expression, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      StaysOpenOnEdit="True"
+                                      IsTextSearchEnabled="False"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Format" Binding="{Binding Format, UpdateSourceTrigger=PropertyChanged}" Width="2*"/>
             </DataGrid.Columns>
         </DataGrid>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <ItemsControl Grid.Row="3" ItemsSource="{Binding ValidationMessages}" Margin="0,0,0,10">
+            <ItemsControl.Style>
+                <Style TargetType="ItemsControl">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding HasItems, RelativeSource={RelativeSource Self}}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ItemsControl.Style>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Foreground="DarkRed" TextWrapping="Wrap">
+                        <Run Text="• " FontWeight="Bold"/>
+                        <Run Text="{Binding}"/>
+                    </TextBlock>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Add Column" Command="{Binding AddColumnCommand}" Width="90"/>
             <Button Content="Remove" Command="{Binding RemoveColumnCommand}" Width="70" Margin="5,0,0,0"/>
             <Button Content="Save" Command="{Binding SaveCommand}" Width="60" Margin="5,0,0,0"/>

--- a/README.md
+++ b/README.md
@@ -161,14 +161,9 @@ This launches the hosted service which periodically emits a heartbeat message us
 
 ## CSV editor example
 
-Use the menu option **CSV Viewer** to open the CSV configuration window. Columns can be added and associated with a service and an optional script. When another service produces a value, call `CsvService.RecordLog` or `CsvService.AppendRow` with the values and a CSV file will be written using the filename pattern from the editor. For example:
+Use the menu option **CSV Viewer** to open the CSV configuration window. Each column now stores an attribute expression such as `{TcpService.InputMessage}` or `{HttpService.StatusCode}`. The viewer evaluates these expressions through the routing service so the latest attribute values are captured automatically. Optional format templates (for example, `"{0:yyyy-MM-dd HH:mm:ss}"`) apply via `string.Format` before the row is written.
 
-```csharp
-// gather data from services
-csvService.AppendRow(new [] { tcpValue, httpStatus });
-```
-
-This appends a new row to `output_{index}.csv` with the TCP and HTTP values.
+When a referenced attribute changes, the CSV adapter records a new row using the configured expressions. You can still call `CsvService.AppendRow` manually for ad-hoc data, but most scenarios rely on routed attributes so column definitions stay declarative.
 
 ## Referencing other service messages
 


### PR DESCRIPTION
## Summary
- replace CSV column service/script fields with routing attribute expressions and optional formatting, including legacy config conversion
- evaluate routing expressions when writing CSV rows and refresh output when routing attributes change
- refresh the CSV viewer UI with expression editing, autocomplete suggestions, validation, and updated documentation

## Testing
- not run (Windows-only build)

------
https://chatgpt.com/codex/tasks/task_e_68e9375defc483268be27215b39b9f5b