### PR TITLE
Limit aggregated log buffer and configure retention

### DIFF
--- a/DesktopApplicationTemplate.UI/Configuration/appsettings.Beta.json
+++ b/DesktopApplicationTemplate.UI/Configuration/appsettings.Beta.json
@@ -4,5 +4,8 @@
   "ServerPort": 9010,
   "LogLevel": "Warning",
   "AutoStart": false,
-  "DefaultCSharpScriptPath": "Scripts/beta_script.cs"
+  "DefaultCSharpScriptPath": "Scripts/beta_script.cs",
+  "AppSettings": {
+    "AggregatedLogRetention": 1000
+  }
 }

--- a/DesktopApplicationTemplate.UI/Configuration/appsettings.Development.json
+++ b/DesktopApplicationTemplate.UI/Configuration/appsettings.Development.json
@@ -4,5 +4,8 @@
   "ServerPort": 9000,
   "LogLevel": "Debug",
   "AutoStart": false,
-  "DefaultCSharpScriptPath": "Scripts/dev_script.cs"
+  "DefaultCSharpScriptPath": "Scripts/dev_script.cs",
+  "AppSettings": {
+    "AggregatedLogRetention": 1000
+  }
 }

--- a/DesktopApplicationTemplate.UI/Configuration/appsettings.Production.json
+++ b/DesktopApplicationTemplate.UI/Configuration/appsettings.Production.json
@@ -4,5 +4,8 @@
   "ServerPort": 9020,
   "LogLevel": "Error",
   "AutoStart": false,
-  "DefaultCSharpScriptPath": "Scripts/prod_script.cs"
+  "DefaultCSharpScriptPath": "Scripts/prod_script.cs",
+  "AppSettings": {
+    "AggregatedLogRetention": 1000
+  }
 }

--- a/DesktopApplicationTemplate.UI/Configuration/appsettings.json
+++ b/DesktopApplicationTemplate.UI/Configuration/appsettings.json
@@ -3,5 +3,8 @@
     "Port": 21,
     "RootPath": "/tmp",
     "AllowAnonymous": true
+  },
+  "AppSettings": {
+    "AggregatedLogRetention": 1000
   }
 }

--- a/DesktopApplicationTemplate.UI/Helpers/LimitedObservableCollection.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/LimitedObservableCollection.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace DesktopApplicationTemplate.UI.Helpers
+{
+    public class LimitedObservableCollection<T> : ObservableCollection<T>
+    {
+        public LimitedObservableCollection(int capacity)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            Capacity = capacity;
+        }
+
+        public int Capacity { get; }
+
+        protected override void InsertItem(int index, T item)
+        {
+            base.InsertItem(Count, item);
+            TrimExcess();
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            if (items is null)
+            {
+                return;
+            }
+
+            foreach (var item in items)
+            {
+                base.InsertItem(Count, item);
+                TrimExcess();
+            }
+        }
+
+        private void TrimExcess()
+        {
+            while (Count > Capacity)
+            {
+                RemoveAt(0);
+            }
+        }
+    }
+}
+

--- a/DesktopApplicationTemplate.UI/Models/AppSettings.cs
+++ b/DesktopApplicationTemplate.UI/Models/AppSettings.cs
@@ -22,6 +22,9 @@ namespace DesktopApplicationTemplate.UI.Models
 
         /// <summary>Gets or sets the path for the default C# script.</summary>
         public string DefaultCSharpScriptPath { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the maximum number of aggregated logs to retain.</summary>
+        public int AggregatedLogRetention { get; set; } = 1000;
     }
 }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -19,15 +19,18 @@ using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
+using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
     public partial class MainViewModel : ViewModelBase
     {
+        private const int DefaultAggregatedLogCapacity = 1000;
+
         public ObservableCollection<ServiceListModel> Services { get; set; } = new();
         public ICollectionView FilteredServices { get; }
         public FilterViewModel Filters { get; } = new();
-        public ObservableCollection<LogEntry> AllLogs { get; } = new();
+        public LimitedObservableCollection<LogEntry> AllLogs { get; }
         private ServiceListModel? _selectedService;
         private ServiceListModel? _activeService;
         private bool _suppressActiveServiceReset;
@@ -56,7 +59,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
                 _activeService = value;
                 OnPropertyChanged();
-                LogViewModel.SetLogs(_activeService?.Logs ?? AllLogs, _activeService is null);
+                LogViewModel.SetLogs(
+                    _activeService?.Logs ?? AllLogs,
+                    _activeService is null,
+                    newestFirstInSource: _activeService is not null);
                 RefreshServiceCommandStates();
             }
         }
@@ -155,6 +161,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             IStartupPreferencesService startupPreferencesService,
             IMessageRoutingService messageRoutingService,
             ILoggingService? logger = null,
+            IOptions<AppSettings>? appOptions = null,
             string? servicesFilePath = null)
         {
             _csvService = csvService;
@@ -165,6 +172,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             NetworkConfig = networkConfig;
             _editHandlers = editHandlers;
             _startupPreferencesService = startupPreferencesService ?? throw new ArgumentNullException(nameof(startupPreferencesService));
+            var aggregatedLogCapacity = Math.Max(1, appOptions?.Value?.AggregatedLogRetention ?? DefaultAggregatedLogCapacity);
+            AllLogs = new LimitedObservableCollection<LogEntry>(aggregatedLogCapacity);
             ServiceListModel.OptionsSerializerResolver = ResolveOptionsSerializer;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
@@ -180,7 +189,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             Services.CollectionChanged += OnServicesCollectionChanged;
 
-            LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs, null, isAggregated: true);
+            LogViewModel = new ServiceLogViewModel(ServiceType.Mqtt, AllLogs, null, isAggregated: true, newestFirstInSource: false);
             LogViewModel.PropertyChanged += (s, e) =>
             {
                 if (e.PropertyName == nameof(ServiceLogViewModel.DisplayLogs))
@@ -457,7 +466,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
                 foreach (var log in service.Logs.Reverse())
                 {
-                    AllLogs.Insert(0, log);
+                    AllLogs.Add(log);
                 }
 
                 _logger?.Log($"Loaded service {service.DisplayName}", LogLevel.Debug);
@@ -731,7 +740,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             entry.ServiceType ??= svc.Type;
 
-            AllLogs.Insert(0, entry);
+            AllLogs.Add(entry);
             if (svc.Type != ServiceType.Csv && Services.Any(s => s.Type == ServiceType.Csv))
             {
                 try
@@ -874,7 +883,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             try
             {
-                var lines = AllLogs.Select(entry => entry.Message).ToList();
+                var lines = AllLogs.Reverse().Select(entry => entry.Message).ToList();
                 File.WriteAllLines(filePath, lines);
                 _logger?.Log($"Exported {lines.Count} total logs to {filePath}", LogLevel.Information);
                 errorMessage = null;

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
@@ -23,6 +23,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly ILogger<ServiceLogViewModel> _logger;
         private ObservableCollection<LogEntry> _logs;
         private NotifyCollectionChangedEventHandler? _logsChangedHandler;
+        private bool _newestFirstInSource = true;
 
         /// <summary>
         /// Gets the collection of service filters applied in aggregated mode.
@@ -60,12 +61,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         /// <param name="type">The category of service associated with these logs.</param>
         /// <param name="logs">The collection of log entries to display.</param>
-        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs, ILogger<ServiceLogViewModel>? logger = null, bool isAggregated = false)
+        public ServiceLogViewModel(ServiceType type, ObservableCollection<LogEntry> logs, ILogger<ServiceLogViewModel>? logger = null, bool isAggregated = false, bool newestFirstInSource = true)
         {
             Type = type;
             _logs = logs;
             _logger = logger ?? NullLogger<ServiceLogViewModel>.Instance;
             IsAggregated = isAggregated;
+            _newestFirstInSource = newestFirstInSource;
             AttachLogCollection(_logs);
             RefreshLogCommand = new RelayCommand(RefreshLogs);
             ExportLogCommand = new RelayCommand(() => ExportLogs(Path.Combine(Path.GetTempPath(), "exported_logs.txt")));
@@ -95,25 +97,26 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             get
             {
                 var filteredByLevel = _logs.Where(l => l.Level >= LogLevelFilter);
+                IEnumerable<LogEntry> result = filteredByLevel;
 
-                if (!IsAggregated)
+                if (IsAggregated)
                 {
-                    return filteredByLevel;
+                    var selectedServices = ServiceFilters
+                        .Where(filter => filter.IsSelected)
+                        .Select(filter => filter.ServiceName)
+                        .ToList();
+
+                    if (selectedServices.Count == 0)
+                    {
+                        return Array.Empty<LogEntry>();
+                    }
+
+                    var selectedSet = new HashSet<string>(selectedServices, StringComparer.OrdinalIgnoreCase);
+                    result = result.Where(entry =>
+                        string.IsNullOrWhiteSpace(entry.ServiceName) || selectedSet.Contains(entry.ServiceName));
                 }
 
-                var selectedServices = ServiceFilters
-                    .Where(filter => filter.IsSelected)
-                    .Select(filter => filter.ServiceName)
-                    .ToList();
-
-                if (selectedServices.Count == 0)
-                {
-                    return Array.Empty<LogEntry>();
-                }
-
-                var selectedSet = new HashSet<string>(selectedServices, StringComparer.OrdinalIgnoreCase);
-                return filteredByLevel.Where(entry =>
-                    string.IsNullOrWhiteSpace(entry.ServiceName) || selectedSet.Contains(entry.ServiceName));
+                return _newestFirstInSource ? result : result.Reverse();
             }
         }
 
@@ -137,7 +140,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// </summary>
         /// <param name="logs">The new log collection.</param>
         /// <param name="isAggregated">Indicates whether the view is displaying aggregated logs.</param>
-        public void SetLogs(ObservableCollection<LogEntry> logs, bool isAggregated = false)
+        public void SetLogs(ObservableCollection<LogEntry> logs, bool isAggregated = false, bool newestFirstInSource = true)
         {
             if (logs is null)
             {
@@ -147,6 +150,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (_logs == logs)
             {
                 IsAggregated = isAggregated;
+                _newestFirstInSource = newestFirstInSource;
                 RefreshLogs();
                 return;
             }
@@ -155,6 +159,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _logs = logs;
             AttachLogCollection(_logs);
             IsAggregated = isAggregated;
+            _newestFirstInSource = newestFirstInSource;
             OnPropertyChanged(nameof(DisplayLogs));
         }
 


### PR DESCRIPTION
## Summary
- replace the aggregate log buffer with a limited observable collection that appends new entries and prunes the oldest ones
- honor the buffer order throughout the log view model so aggregated logs still render newest-first while individual services retain their ordering
- surface an AggregatedLogRetention setting in appsettings files to control the buffer length

## Testing
- dotnet build DesktopApplicationTemplate.sln *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e93b5f87448326b99873eda1b0de97