### PR TITLE
Refine service lookup and association cleanup

### DIFF
--- a/Codex/docs/CollaborationAndDebugTips.txt
+++ b/Codex/docs/CollaborationAndDebugTips.txt
@@ -9,6 +9,15 @@ Purpose: Running log of what worked, what broke, and why.
 - Always record environment limitations (e.g., missing dotnet runtime).
 - When Windows collaborators run builds or tests, capture the commands and summarize their results so Codex can reference them.
 
+[2025-10-10 11:00] Topic: Cross-service association cleanup
+Context: Added a lookup index in `MainViewModel` so rename/remove operations update linked services.
+Observations: Manual regression covers: 1) create two services, force an association via routed log, rename one service and confirm both sides update; 2) remove a service and ensure the surviving service clears the stale association badge before saving.
+Codex Limitations noticed: Linux container only; UI validation must occur on Windows where the desktop app runs.
+Effective Prompts / Instructions that worked: User request to eliminate O(n²) scans and keep associations in sync with collection changes.
+Decisions & Rationale: Document the manual checklist so regressions surface quickly until automated UI coverage exists.
+Action Items: Run the rename/remove checklist before shipping changes that touch cross-service routing.
+Related Commits/PRs:
+
 [2025-10-09 10:10] Topic: EV7 drive mapping automation
 Context: Added a PowerShell helper to remap EV7 installation media and SATA storage to the expected drive letters after automation failures.
 Observations: The script prioritizes SATA disks on bus type SATA, assigns the primary partition to drive D:, moves a second SATA disk to E:, and relocates the USB installer to E: or F: depending on availability. It safely frees conflicting letters before reassignment.

--- a/DesktopApplicationTemplate.UI/App.xaml.cs
+++ b/DesktopApplicationTemplate.UI/App.xaml.cs
@@ -134,6 +134,7 @@ namespace DesktopApplicationTemplate.UI
             services.AddSingleton<CloseConfirmationHelper>();
             services.AddSingleton<IMqttClientSessionManager, MqttClientSessionManager>();
             services.AddSingleton<MainViewModel>();
+            services.AddSingleton<IServiceLookup>(sp => sp.GetRequiredService<MainViewModel>());
             services.AddSingleton<SettingsViewModel>();
 
             services.AddCsvUi();

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -23,7 +23,14 @@ using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    public partial class MainViewModel : ViewModelBase
+    internal interface IServiceLookup
+    {
+        bool TryGetService(ServiceType type, string name, out ServiceListModel? service);
+
+        IEnumerable<ServiceListModel> FindByDisplayName(string name);
+    }
+
+    public partial class MainViewModel : ViewModelBase, IServiceLookup
     {
         private const int DefaultAggregatedLogCapacity = 1000;
 
@@ -141,8 +148,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private readonly IStartupPreferencesService _startupPreferencesService;
         private readonly HashSet<ServiceListModel> _activatingServices = new();
         private readonly HashSet<ServiceListModel> _trackedServices = new();
+        private readonly Dictionary<(ServiceType Type, string Name), ServiceListModel> _serviceIndex = new();
+        private readonly Dictionary<string, HashSet<ServiceListModel>> _servicesByName = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<ServiceListModel, ServiceIndexEntry> _serviceKeys = new();
         private static readonly TimeSpan ActivationConfirmationDelay = TimeSpan.FromMilliseconds(500);
         private int _serviceCreationScopeDepth;
+
+        private readonly record struct ServiceIndexEntry(ServiceType Type, string NormalizedName, string DisplayName);
 
         internal bool IsServiceCreationInProgress => Volatile.Read(ref _serviceCreationScopeDepth) > 0;
 
@@ -175,12 +187,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             var aggregatedLogCapacity = Math.Max(1, appOptions?.Value?.AggregatedLogRetention ?? DefaultAggregatedLogCapacity);
             AllLogs = new LimitedObservableCollection<LogEntry>(aggregatedLogCapacity);
             ServiceListModel.OptionsSerializerResolver = ResolveOptionsSerializer;
+            ServiceListModel.CrossServiceAssociationsClearing += OnCrossServiceAssociationsClearing;
             _ = NetworkConfig.LoadAsync();
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
-            ServiceListModel.ResolveService = (type, name) =>
-                Services.FirstOrDefault(s =>
-                    s.Type == type &&
-                    s.DisplayName.Equals(name, StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrWhiteSpace(servicesFilePath))
             {
                 ServicePersistence.FilePath = servicesFilePath!;
@@ -371,7 +380,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _csvService.RemoveColumnsForService(target.DisplayName);
             }
 
-            ServiceListModel.RemoveServiceAssociations(target);
+            RemoveServiceAssociations(target);
             _activatingServices.Remove(target);
             target.LogAdded -= OnServiceLogAdded;
             target.ActiveChanged -= OnServiceActiveChanged;
@@ -827,6 +836,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             if (_trackedServices.Add(service))
             {
+                AddServiceToIndex(service);
                 service.PropertyChanged += OnServicePropertyChanged;
             }
         }
@@ -841,17 +851,233 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             if (_trackedServices.Remove(service))
             {
                 service.PropertyChanged -= OnServicePropertyChanged;
+                RemoveServiceFromIndex(service);
+            }
+        }
+
+        private void AddServiceToIndex(ServiceListModel service)
+        {
+            var entry = CreateIndexEntry(service);
+            _serviceIndex[(entry.Type, entry.NormalizedName)] = service;
+            AddToNameIndex(service, entry.NormalizedName);
+            _serviceKeys[service] = entry;
+            service.ServiceLookup = this;
+        }
+
+        private void RemoveServiceFromIndex(ServiceListModel service)
+        {
+            if (_serviceKeys.Remove(service, out var entry))
+            {
+                _serviceIndex.Remove((entry.Type, entry.NormalizedName));
+                RemoveFromNameIndex(service, entry.NormalizedName);
+            }
+
+            service.ServiceLookup = null;
+        }
+
+        private void UpdateServiceIndex(ServiceListModel service, bool updateAssociations)
+        {
+            if (!_serviceKeys.TryGetValue(service, out var previousEntry))
+            {
+                AddServiceToIndex(service);
+                return;
+            }
+
+            var newEntry = CreateIndexEntry(service);
+            var keyChanged = previousEntry.Type != newEntry.Type || previousEntry.NormalizedName != newEntry.NormalizedName;
+            var nameChanged = !string.Equals(previousEntry.DisplayName, newEntry.DisplayName, StringComparison.Ordinal);
+
+            if (!keyChanged)
+            {
+                if (nameChanged)
+                {
+                    _serviceKeys[service] = newEntry;
+                    if (updateAssociations)
+                    {
+                        UpdateNeighborAssociations(service, previousEntry.DisplayName);
+                    }
+                }
+
+                return;
+            }
+
+            _serviceIndex.Remove((previousEntry.Type, previousEntry.NormalizedName));
+            RemoveFromNameIndex(service, previousEntry.NormalizedName);
+
+            _serviceIndex[(newEntry.Type, newEntry.NormalizedName)] = service;
+            AddToNameIndex(service, newEntry.NormalizedName);
+            _serviceKeys[service] = newEntry;
+
+            if (updateAssociations || nameChanged)
+            {
+                UpdateNeighborAssociations(service, previousEntry.DisplayName);
+            }
+        }
+
+        private void AddToNameIndex(ServiceListModel service, string normalizedName)
+        {
+            if (!_servicesByName.TryGetValue(normalizedName, out var bucket))
+            {
+                bucket = new HashSet<ServiceListModel>();
+                _servicesByName[normalizedName] = bucket;
+            }
+
+            bucket.Add(service);
+        }
+
+        private void RemoveFromNameIndex(ServiceListModel service, string normalizedName)
+        {
+            if (!_servicesByName.TryGetValue(normalizedName, out var bucket))
+            {
+                return;
+            }
+
+            bucket.Remove(service);
+            if (bucket.Count == 0)
+            {
+                _servicesByName.Remove(normalizedName);
+            }
+        }
+
+        private ServiceIndexEntry CreateIndexEntry(ServiceListModel service)
+        {
+            var displayName = service.DisplayName ?? string.Empty;
+            return new ServiceIndexEntry(service.Type, NormalizeServiceName(displayName), displayName);
+        }
+
+        private static string NormalizeServiceName(string? name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return string.Empty;
+            }
+
+            return name.Trim().ToUpperInvariant();
+        }
+
+        public bool TryGetService(ServiceType type, string name, out ServiceListModel? service)
+        {
+            return _serviceIndex.TryGetValue((type, NormalizeServiceName(name)), out service);
+        }
+
+        public IEnumerable<ServiceListModel> FindByDisplayName(string name)
+        {
+            var normalized = NormalizeServiceName(name);
+            if (_servicesByName.TryGetValue(normalized, out var bucket) && bucket.Count > 0)
+            {
+                return bucket.ToArray();
+            }
+
+            return Array.Empty<ServiceListModel>();
+        }
+
+        private IReadOnlyList<ServiceListModel> GetAssociatedServiceNeighbors(ServiceListModel service)
+        {
+            if (service.AssociatedServices.Count == 0)
+            {
+                return Array.Empty<ServiceListModel>();
+            }
+
+            var neighbors = new HashSet<ServiceListModel>();
+            var snapshot = service.AssociatedServices.ToList();
+            foreach (var neighborName in snapshot)
+            {
+                foreach (var neighbor in FindByDisplayName(neighborName))
+                {
+                    if (!ReferenceEquals(neighbor, service))
+                    {
+                        neighbors.Add(neighbor);
+                    }
+                }
+            }
+
+            return neighbors.Count == 0 ? Array.Empty<ServiceListModel>() : neighbors.ToList();
+        }
+
+        private void UpdateNeighborAssociations(ServiceListModel service, string previousDisplayName)
+        {
+            if (service is null || string.IsNullOrWhiteSpace(previousDisplayName))
+            {
+                return;
+            }
+
+            foreach (var neighbor in GetAssociatedServiceNeighbors(service))
+            {
+                if (neighbor.AssociatedServices.Remove(previousDisplayName))
+                {
+                    var newName = service.DisplayName;
+                    if (!string.IsNullOrWhiteSpace(newName) && !neighbor.AssociatedServices.Contains(newName))
+                    {
+                        neighbor.AssociatedServices.Add(newName);
+                    }
+                }
+            }
+        }
+
+        private void ClearAssociationsFor(ServiceListModel service)
+        {
+            if (service is null)
+            {
+                return;
+            }
+
+            var namesToRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(service.DisplayName))
+            {
+                namesToRemove.Add(service.DisplayName);
+            }
+
+            if (service.AssociatedServices.Count == 0 && namesToRemove.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var neighbor in GetAssociatedServiceNeighbors(service))
+            {
+                foreach (var name in namesToRemove)
+                {
+                    neighbor.AssociatedServices.Remove(name);
+                }
+            }
+
+            service.AssociatedServices.Clear();
+        }
+
+        internal void RemoveServiceAssociations(ServiceListModel service)
+        {
+            ClearAssociationsFor(service);
+        }
+
+        private void OnCrossServiceAssociationsClearing()
+        {
+            foreach (var service in Services.ToList())
+            {
+                ClearAssociationsFor(service);
             }
         }
 
         private void OnServicePropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (!string.Equals(e.PropertyName, nameof(ServiceListModel.DisplayName), StringComparison.Ordinal))
+            if (sender is not ServiceListModel service)
             {
                 return;
             }
 
-            LogViewModel.UpdateServiceFilters(Services.Select(s => s.DisplayName));
+            var propertyName = e.PropertyName;
+            var affectsDisplayName = string.IsNullOrEmpty(propertyName) ||
+                string.Equals(propertyName, nameof(ServiceListModel.DisplayName), StringComparison.Ordinal);
+            var affectsIndex = affectsDisplayName ||
+                string.Equals(propertyName, nameof(ServiceListModel.Type), StringComparison.Ordinal);
+
+            if (affectsIndex)
+            {
+                UpdateServiceIndex(service, affectsDisplayName);
+            }
+
+            if (affectsDisplayName)
+            {
+                LogViewModel.UpdateServiceFilters(Services.Select(s => s.DisplayName));
+            }
         }
 
         internal void OnServiceActiveChanged(bool _)

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -176,6 +176,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
         [JsonIgnore] public Page? ServicePage { get; set; }
 
+        [JsonIgnore]
+        internal IServiceLookup? ServiceLookup { get; set; }
+
         public ObservableCollection<string> AssociatedServices { get; } = new();
 
         private Dictionary<string, JsonElement> _serializedOptions = new(StringComparer.OrdinalIgnoreCase);
@@ -208,17 +211,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         [JsonIgnore]
         private readonly Dictionary<string, object?> _options = new(StringComparer.OrdinalIgnoreCase);
 
-        private static readonly object ServiceRegistryLock = new();
-        private static readonly HashSet<ServiceListModel> ServiceRegistry = new();
+        internal static event Action? CrossServiceAssociationsClearing;
 
         public ServiceListModel(IMessageRoutingService routingService)
         {
             _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
-
-            lock (ServiceRegistryLock)
-            {
-                ServiceRegistry.Add(this);
-            }
 
             ResetMessageCounts();
             SetRoutingAttribute(InputMessageAttributeName, _inputMessage, MessageRoutingDirection.Input, publish: false);
@@ -825,8 +822,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         #endregion
 
-        public static Func<ServiceType, string, ServiceListModel?>? ResolveService { get; set; }
-
         /// <summary>
         /// Enables forwarding of log entries between services when cross-service references are detected.
         /// Defaults to <c>false</c> so services remain independent unless explicitly linked.
@@ -845,7 +840,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 _enableCrossServiceLogForwarding = value;
                 if (!value)
                 {
-                    ClearAllCrossServiceAssociations();
+                    CrossServiceAssociationsClearing?.Invoke();
                 }
             }
         }
@@ -1148,12 +1143,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         private void HandleReference(string message, WpfBrush color, LogLevel level)
         {
-            if (ResolveService == null)
+            if (!EnableCrossServiceLogForwarding)
             {
                 return;
             }
 
-            if (!EnableCrossServiceLogForwarding)
+            var lookup = ServiceLookup;
+            if (lookup is null)
             {
                 return;
             }
@@ -1168,8 +1164,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 return;
             }
 
-            var target = ResolveService(type, serviceName);
-            if (target == null || ReferenceEquals(target, this))
+            if (!lookup.TryGetService(type, serviceName, out var target) || target == null || ReferenceEquals(target, this))
             {
                 return;
             }
@@ -1191,70 +1186,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             }
         }
 
-        private static void RemoveStaleAssociation(ServiceListModel first, ServiceListModel second)
-        {
-            if (first is null || second is null)
-            {
-                return;
-            }
-
-            first.AssociatedServices.Remove(second.DisplayName);
-            second.AssociatedServices.Remove(first.DisplayName);
-        }
-
-        private static void ClearAllCrossServiceAssociations()
-        {
-            var snapshot = GetRegisteredServicesSnapshot();
-            foreach (var service in snapshot)
-            {
-                RemoveAllServiceAssociations(service, snapshot);
-            }
-        }
-
-        private static IReadOnlyList<ServiceListModel> GetRegisteredServicesSnapshot()
-        {
-            lock (ServiceRegistryLock)
-            {
-                return ServiceRegistry.ToList();
-            }
-        }
-
-        internal static void RemoveServiceAssociations(ServiceListModel service)
-        {
-            if (service is null)
-            {
-                return;
-            }
-
-            var snapshot = GetRegisteredServicesSnapshot();
-            RemoveAllServiceAssociations(service, snapshot);
-
-            lock (ServiceRegistryLock)
-            {
-                ServiceRegistry.Remove(service);
-            }
-        }
-
-        private static void RemoveAllServiceAssociations(ServiceListModel service, IReadOnlyList<ServiceListModel>? snapshot = null)
-        {
-            if (service is null)
-            {
-                return;
-            }
-
-            var services = snapshot ?? GetRegisteredServicesSnapshot();
-            foreach (var other in services)
-            {
-                if (ReferenceEquals(other, service))
-                {
-                    continue;
-                }
-
-                RemoveStaleAssociation(service, other);
-            }
-
-            service.AssociatedServices.Clear();
-        }
 
         private static bool TryExtractCrossServiceReference(string message, out string typeName, out string serviceName, out string forwardedMessage)
         {

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceMessageTableViewModel.cs
@@ -14,10 +14,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels
     {
         public const int MaxRows = 100;
         private readonly Dictionary<string, LinkedList<ServiceMessageRow>> _messagesByService = new(StringComparer.OrdinalIgnoreCase);
+        private readonly IServiceLookup _serviceLookup;
         private string _activeServiceKey = string.Empty;
 
         /// <summary>Collection of service message rows.</summary>
         public ObservableCollection<ServiceMessageRow> Messages { get; } = new();
+
+        public ServiceMessageTableViewModel(IServiceLookup? serviceLookup = null)
+        {
+            _serviceLookup = serviceLookup ?? NullServiceLookup.Instance;
+        }
 
         /// <summary>
         /// Sets the active service whose messages should be surfaced to the UI.
@@ -70,7 +76,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                 rows.RemoveLast();
             }
 
-            if (ServiceListModel.ResolveService?.Invoke(serviceType, resolvedServiceName) is { } service)
+            if (_serviceLookup.TryGetService(serviceType, resolvedServiceName, out var service) && service is not null)
             {
                 service.RecordMessageHistory(incoming, outgoing, destination, timestamp);
             }
@@ -136,6 +142,26 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private static string BuildKey(ServiceType serviceType, string serviceName)
         {
             return $"{serviceType}:{serviceName}";
+        }
+
+        private sealed class NullServiceLookup : IServiceLookup
+        {
+            internal static readonly NullServiceLookup Instance = new();
+
+            private NullServiceLookup()
+            {
+            }
+
+            public bool TryGetService(ServiceType type, string name, out ServiceListModel? service)
+            {
+                service = null;
+                return false;
+            }
+
+            public IEnumerable<ServiceListModel> FindByDisplayName(string name)
+            {
+                return Array.Empty<ServiceListModel>();
+            }
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -795,7 +795,7 @@ namespace DesktopApplicationTemplate.UI.Views
 
                 var index = _viewModel.Services.IndexOf(svc);
                 svc.LogAdded -= _viewModel.OnServiceLogAdded;
-                ServiceListModel.RemoveServiceAssociations(svc);
+                _viewModel.RemoveServiceAssociations(svc);
                 _viewModel.Services.Remove(svc);
                 if (_viewModel.Services.Count > 0)
                 {


### PR DESCRIPTION
## Summary
- add a keyed service index in `MainViewModel` to keep lookups and associations in sync with collection changes
- remove the static resolver from `ServiceListModel`, route lookups through `IServiceLookup`, and update the message table view model accordingly
- document the manual rename/remove regression checklist for cross-service associations

## Testing
- dotnet --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e93dfa2318832694d34221b7e6758a