### PR TITLE
Use async certificate loading in MQTT view models

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Create/MqttCreateServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Create/MqttCreateServiceViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
@@ -39,7 +40,7 @@ public class MqttCreateServiceViewModel : ServiceCreateViewModelBase<MqttService
         : base(rule, logger: logger)
     {
         _fileDialogService = fileDialogService ?? throw new ArgumentNullException(nameof(fileDialogService));
-        BrowseClientCertificateCommand = new RelayCommand(BrowseForClientCertificate);
+        BrowseClientCertificateCommand = new AsyncRelayCommand(BrowseForClientCertificateAsync);
         ClearClientCertificateCommand = new RelayCommand(ClearClientCertificate);
     }
 
@@ -305,7 +306,7 @@ public class MqttCreateServiceViewModel : ServiceCreateViewModelBase<MqttService
         // Advanced configuration has been folded into the primary editor for MQTT services.
     }
 
-    private void BrowseForClientCertificate()
+    private async Task BrowseForClientCertificateAsync()
     {
         var path = _fileDialogService.OpenFile();
         if (string.IsNullOrWhiteSpace(path))
@@ -315,7 +316,7 @@ public class MqttCreateServiceViewModel : ServiceCreateViewModelBase<MqttService
 
         try
         {
-            _clientCertificate = File.ReadAllBytes(path);
+            _clientCertificate = await LoadCertificateAsync(path);
             ClientCertificatePath = path;
             UseClientCertificate = true;
             ClearErrors(nameof(ClientCertificatePath));
@@ -331,6 +332,11 @@ public class MqttCreateServiceViewModel : ServiceCreateViewModelBase<MqttService
         OnPropertyChanged(nameof(HasClientCertificate));
         OnPropertyChanged(nameof(ClientCertificateDisplay));
         ValidateClientCertificate();
+    }
+
+    private static async Task<byte[]> LoadCertificateAsync(string path)
+    {
+        return await File.ReadAllBytesAsync(path).ConfigureAwait(false);
     }
 
     private void ClearClientCertificate()

--- a/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Mqtt/Edit/MqttEditConnectionViewModel.cs
@@ -58,7 +58,7 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         _fileDialogService = fileDialogService ?? throw new ArgumentNullException(nameof(fileDialogService));
         Logger = logger;
 
-        BrowseClientCertificateCommand = new RelayCommand(BrowseForClientCertificate);
+        BrowseClientCertificateCommand = new AsyncRelayCommand(BrowseForClientCertificateAsync);
         ClearClientCertificateCommand = new RelayCommand(ClearClientCertificate);
 
         UpdateCommand = new AsyncRelayCommand(UpdateAsync);
@@ -449,7 +449,7 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
             {
                 try
                 {
-                    _clientCertificate = File.ReadAllBytes(ClientCertificatePath);
+                    _clientCertificate = await LoadCertificateAsync(ClientCertificatePath);
                 }
                 catch (Exception)
                 {
@@ -529,7 +529,7 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         }
     }
 
-    private void BrowseForClientCertificate()
+    private async Task BrowseForClientCertificateAsync()
     {
         var path = _fileDialogService.OpenFile();
         if (string.IsNullOrWhiteSpace(path))
@@ -539,7 +539,7 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
 
         try
         {
-            _clientCertificate = File.ReadAllBytes(path);
+            _clientCertificate = await LoadCertificateAsync(path);
             ClientCertificatePath = path;
             UseClientCertificate = true;
             ClearErrors(nameof(ClientCertificatePath));
@@ -555,6 +555,11 @@ public class MqttEditConnectionViewModel : ValidatableViewModelBase, ILoggingVie
         OnPropertyChanged(nameof(HasClientCertificate));
         OnPropertyChanged(nameof(ClientCertificateDisplay));
         ValidateClientCertificate();
+    }
+
+    private static async Task<byte[]> LoadCertificateAsync(string path)
+    {
+        return await File.ReadAllBytesAsync(path).ConfigureAwait(false);
     }
 
     private void ClearClientCertificate()


### PR DESCRIPTION
## Summary
- load client certificates asynchronously in the MQTT create and edit view models to keep file IO off the UI thread
- update certificate browse commands to AsyncRelayCommand so progress states are reflected while preserving existing validation and logging

## Testing
- not run (requires Windows WPF build environment)


------
https://chatgpt.com/codex/tasks/task_e_68e94f8c5c18832695e2b50c7afa23b2