### PR TITLE
Use async export workflows for log commands

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/Http/HttpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Http/HttpServiceViewModel.cs
@@ -138,6 +138,8 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
 
         private readonly SaveConfirmationHelper _saveHelper;
         private readonly IHttpClientService _httpClientService;
+        private bool _isExportingLogs;
+        private readonly AsyncRelayCommand _exportLogCommand;
 
         public HttpServiceViewModel(SaveConfirmationHelper saveHelper, IHttpClientService httpClientService)
         {
@@ -152,7 +154,8 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             });
             SaveCommand = new AsyncRelayCommand(SaveAsync);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
-            ExportLogCommand = new RelayCommand(ExportLogs);
+            _exportLogCommand = new AsyncRelayCommand(ExportLogsAsync, () => !_isExportingLogs);
+            ExportLogCommand = _exportLogCommand;
             ClearLogCommand = new RelayCommand(ClearLogs);
         }
 
@@ -227,11 +230,33 @@ public class HttpServiceViewModel : ValidatableViewModelBase, ILoggingViewModel
             Logger?.Log("HTTP logs cleared", LogLevel.Debug);
         }
 
-        private void ExportLogs()
+        private async Task ExportLogsAsync()
         {
+            if (_isExportingLogs)
+            {
+                return;
+            }
+
+            _isExportingLogs = true;
+            _exportLogCommand.RaiseCanExecuteChanged();
+
             var path = Path.Combine(Path.GetTempPath(), "http_logs.txt");
-            File.WriteAllLines(path, DisplayLogs.Select(l => l.Message));
-            Logger?.Log($"HTTP logs exported to {path}", LogLevel.Debug);
+
+            try
+            {
+                var lines = DisplayLogs.Select(l => l.Message).ToList();
+                await File.WriteAllLinesAsync(path, lines);
+                Logger?.Log($"HTTP logs exported to {path}", LogLevel.Debug);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                Logger?.Log($"Failed to export HTTP logs to {path}: {ex.Message}", LogLevel.Error);
+            }
+            finally
+            {
+                _isExportingLogs = false;
+                _exportLogCommand.RaiseCanExecuteChanged();
+            }
         }
 
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -1100,40 +1100,36 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _logger?.Log("Logs cleared", LogLevel.Debug);
         }
 
-        public void ExportDisplayedLogs(string filePath)
+        public async Task ExportDisplayedLogsAsync(string filePath)
         {
-            LogViewModel.ExportLogs(filePath);
+            await LogViewModel.ExportLogsAsync(filePath);
             _logger?.Log($"Exported {LogViewModel.DisplayLogs.Count()} logs to {filePath}", LogLevel.Debug);
         }
 
-        public bool TryExportAllLogs(string filePath, out string? errorMessage)
+        public async Task<(bool Success, string? ErrorMessage)> TryExportAllLogsAsync(string filePath)
         {
             if (string.IsNullOrWhiteSpace(filePath))
             {
-                errorMessage = "A valid file path was not provided.";
                 _logger?.Log("Export aborted because the destination file path was empty.", LogLevel.Warning);
-                return false;
+                return (false, "A valid file path was not provided.");
             }
 
             try
             {
                 var lines = AllLogs.Reverse().Select(entry => entry.Message).ToList();
-                File.WriteAllLines(filePath, lines);
+                await File.WriteAllLinesAsync(filePath, lines);
                 _logger?.Log($"Exported {lines.Count} total logs to {filePath}", LogLevel.Information);
-                errorMessage = null;
-                return true;
+                return (true, null);
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
-                errorMessage = ex.Message;
                 _logger?.Log($"Failed to export logs to {filePath}: {ex.Message}", LogLevel.Error);
-                return false;
+                return (false, ex.Message);
             }
             catch (Exception ex)
             {
-                errorMessage = ex.Message;
                 _logger?.Log($"Failed to export logs to {filePath}: {ex.Message}", LogLevel.Error);
-                return false;
+                return (false, ex.Message);
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Scp/ScpServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Scp/ScpServiceViewModel.cs
@@ -55,6 +55,8 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
         public ICommand BrowseCommand { get; }
         public ICommand TransferCommand { get; }
         public ICommand SaveCommand { get; }
+        private bool _isExportingLogs;
+        private readonly AsyncRelayCommand _exportLogCommand;
 
         private ILoggingService? _logger;
         public ILoggingService? Logger
@@ -103,7 +105,8 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
             TransferCommand = new AsyncRelayCommand(TransferAsync);
             SaveCommand = new AsyncRelayCommand(SaveAsync);
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
-            ExportLogCommand = new RelayCommand(ExportLogs);
+            _exportLogCommand = new AsyncRelayCommand(ExportLogsAsync, () => !_isExportingLogs);
+            ExportLogCommand = _exportLogCommand;
             ClearLogCommand = new RelayCommand(ClearLogs);
         }
 
@@ -138,11 +141,33 @@ public class ScpServiceViewModel : ViewModelBase, ILoggingViewModel, INetworkAwa
             Logger?.Log("SCP logs cleared", LogLevel.Debug);
         }
 
-        private void ExportLogs()
+        private async Task ExportLogsAsync()
         {
+            if (_isExportingLogs)
+            {
+                return;
+            }
+
+            _isExportingLogs = true;
+            _exportLogCommand.RaiseCanExecuteChanged();
+
             var path = Path.Combine(Path.GetTempPath(), "scp_logs.txt");
-            File.WriteAllLines(path, DisplayLogs.Select(l => l.Message));
-            Logger?.Log($"SCP logs exported to {path}", LogLevel.Debug);
+
+            try
+            {
+                var lines = DisplayLogs.Select(l => l.Message).ToList();
+                await File.WriteAllLinesAsync(path, lines);
+                Logger?.Log($"SCP logs exported to {path}", LogLevel.Debug);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                Logger?.Log($"Failed to export SCP logs to {path}: {ex.Message}", LogLevel.Error);
+            }
+            finally
+            {
+                _isExportingLogs = false;
+                _exportLogCommand.RaiseCanExecuteChanged();
+            }
         }
 
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);

--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceLogViewModel.cs
@@ -5,10 +5,12 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Models;
+using DesktopApplicationTemplate.UI.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using CoreLogLevel = DesktopApplicationTemplate.Core.Services.LogLevel;
@@ -24,6 +26,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         private ObservableCollection<LogEntry> _logs;
         private NotifyCollectionChangedEventHandler? _logsChangedHandler;
         private bool _newestFirstInSource = true;
+        private bool _isExportingLogs;
+        private readonly AsyncRelayCommand _exportLogCommand;
 
         /// <summary>
         /// Gets the collection of service filters applied in aggregated mode.
@@ -70,7 +74,10 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             _newestFirstInSource = newestFirstInSource;
             AttachLogCollection(_logs);
             RefreshLogCommand = new RelayCommand(RefreshLogs);
-            ExportLogCommand = new RelayCommand(() => ExportLogs(Path.Combine(Path.GetTempPath(), "exported_logs.txt")));
+            _exportLogCommand = new AsyncRelayCommand(
+                () => ExportLogsAsync(Path.Combine(Path.GetTempPath(), "exported_logs.txt")),
+                () => !_isExportingLogs);
+            ExportLogCommand = _exportLogCommand;
             ClearLogCommand = new RelayCommand(ClearLogs);
         }
 
@@ -217,12 +224,20 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         /// Exports the displayed logs to the specified file path.
         /// </summary>
         /// <param name="filePath">The destination file path.</param>
-        public void ExportLogs(string filePath)
+        public async Task ExportLogsAsync(string filePath)
         {
+            if (_isExportingLogs)
+            {
+                return;
+            }
+
+            _isExportingLogs = true;
+            _exportLogCommand.RaiseCanExecuteChanged();
+
             try
             {
                 var lines = DisplayLogs.Select(l => l.Message).ToList();
-                File.WriteAllLines(filePath, lines);
+                await File.WriteAllLinesAsync(filePath, lines);
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
             {
@@ -232,6 +247,11 @@ namespace DesktopApplicationTemplate.UI.ViewModels
                     "Export Failed",
                     MessageBoxButton.OK,
                     MessageBoxImage.Error);
+            }
+            finally
+            {
+                _isExportingLogs = false;
+                _exportLogCommand.RaiseCanExecuteChanged();
             }
         }
 

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -141,6 +141,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
         private bool _suppressRuntimeInitialization;
         private bool _pendingNavigationInitialization;
         private bool _navigationInitializationLogged;
+        private bool _isExportingLogs;
+        private readonly AsyncRelayCommand _exportLogCommand;
 
         /// <summary>Type of the service associated with these messages.</summary>
         public ServiceType ServiceType { get; private set; } = ServiceType.Tcp;
@@ -310,7 +312,8 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 context: context);
 
             ClearLogCommand = new RelayCommand(ClearLogs);
-            ExportLogCommand = new RelayCommand(ExportLogs);
+            _exportLogCommand = new AsyncRelayCommand(ExportLogsAsync, () => !_isExportingLogs);
+            ExportLogCommand = _exportLogCommand;
             RefreshLogCommand = new RelayCommand(() => OnPropertyChanged(nameof(DisplayLogs)));
             OpenAdvancedSettingsCommand = new RelayCommand(() => AdvancedSettingsRequested?.Invoke(this, EventArgs.Empty));
             OpenScriptEditorCommand = new AsyncRelayCommand(OpenScriptEditorAsync);
@@ -1477,11 +1480,33 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
             Logger?.Log("TCP logs cleared", LogLevel.Debug);
         }
 
-        private void ExportLogs()
+        private async Task ExportLogsAsync()
         {
+            if (_isExportingLogs)
+            {
+                return;
+            }
+
+            _isExportingLogs = true;
+            _exportLogCommand.RaiseCanExecuteChanged();
+
             var path = Path.Combine(Path.GetTempPath(), "tcp_logs.txt");
-            File.WriteAllLines(path, DisplayLogs.Select(l => l.Message));
-            Logger?.Log($"TCP logs exported to {path}", LogLevel.Debug);
+
+            try
+            {
+                var lines = DisplayLogs.Select(l => l.Message).ToList();
+                await File.WriteAllLinesAsync(path, lines);
+                Logger?.Log($"TCP logs exported to {path}", LogLevel.Debug);
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+                Logger?.Log($"Failed to export TCP logs to {path}: {ex.Message}", LogLevel.Error);
+            }
+            finally
+            {
+                _isExportingLogs = false;
+                _exportLogCommand.RaiseCanExecuteChanged();
+            }
         }
 
         private void OnLogAdded(LogEntry entry) => Logs.Insert(0, entry);

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -1018,9 +1018,15 @@ namespace DesktopApplicationTemplate.UI.Views
             _viewModel.ClearLogs();
         }
 
-        private void ExportLog_Click(object sender, RoutedEventArgs e)
+        private async void ExportLog_Click(object sender, RoutedEventArgs e)
         {
             _logger?.LogInformation("Home view export logs button clicked");
+
+            var button = sender as Button;
+            if (button is not null)
+            {
+                button.IsEnabled = false;
+            }
 
             var timestamp = DateTime.Now.ToString(LogExportTimestampFormat);
             var suggestedName = $"{LogExportDefaultPrefix}_{timestamp}.log";
@@ -1029,31 +1035,46 @@ namespace DesktopApplicationTemplate.UI.Views
             if (string.IsNullOrWhiteSpace(selectedPath))
             {
                 _logger?.LogInformation("Log export canceled by the user.");
+                if (button is not null)
+                {
+                    button.IsEnabled = true;
+                }
                 return;
             }
 
-            if (_viewModel.TryExportAllLogs(selectedPath, out var errorMessage))
+            try
             {
-                _logger?.LogInformation("All logs exported to {FilePath}", selectedPath);
-                MessageBox.Show(
-                    this,
-                    $"Logs exported to:\n{selectedPath}",
-                    "Export Complete",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Information);
+                var (success, errorMessage) = await _viewModel.TryExportAllLogsAsync(selectedPath);
+                if (success)
+                {
+                    _logger?.LogInformation("All logs exported to {FilePath}", selectedPath);
+                    MessageBox.Show(
+                        this,
+                        $"Logs exported to:\n{selectedPath}",
+                        "Export Complete",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                }
+                else
+                {
+                    var failureMessage = string.IsNullOrWhiteSpace(errorMessage)
+                        ? "An unknown error occurred."
+                        : errorMessage;
+                    _logger?.LogError("Failed to export logs to {FilePath}: {ErrorMessage}", selectedPath, failureMessage);
+                    MessageBox.Show(
+                        this,
+                        $"Failed to export logs to '{selectedPath}': {failureMessage}",
+                        "Export Failed",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                }
             }
-            else
+            finally
             {
-                var failureMessage = string.IsNullOrWhiteSpace(errorMessage)
-                    ? "An unknown error occurred."
-                    : errorMessage;
-                _logger?.LogError("Failed to export logs to {FilePath}: {ErrorMessage}", selectedPath, failureMessage);
-                MessageBox.Show(
-                    this,
-                    $"Failed to export logs to '{selectedPath}': {failureMessage}",
-                    "Export Failed",
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Error);
+                if (button is not null)
+                {
+                    button.IsEnabled = true;
+                }
             }
         }
 

--- a/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Shared/ServiceLogView.xaml.cs
@@ -55,7 +55,7 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
             }
         }
 
-        private void ExportLog_Click(object sender, RoutedEventArgs e)
+        private async void ExportLog_Click(object sender, RoutedEventArgs e)
         {
             if (DataContext is not ServiceLogViewModel viewModel)
             {
@@ -72,7 +72,22 @@ namespace DesktopApplicationTemplate.UI.Views.Shared
                 return;
             }
 
-            viewModel.ExportLogs(selectedPath);
+            if (sender is Button button)
+            {
+                button.IsEnabled = false;
+                try
+                {
+                    await viewModel.ExportLogsAsync(selectedPath);
+                }
+                finally
+                {
+                    button.IsEnabled = true;
+                }
+            }
+            else
+            {
+                await viewModel.ExportLogsAsync(selectedPath);
+            }
         }
 
         private static string SanitizeFileName(string name)


### PR DESCRIPTION
## Summary
- replace synchronous log export calls with async implementations in the main, shared log, HTTP, TCP, and SCP view models
- update export commands and UI handlers to await the async workflow and disable buttons while exports run
- preserve existing logging and dialog feedback when async exports fail

## Testing
- Not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68e94f8be9c883269b757ee4c8c0e4f5