### PR TITLE
Handle module discovery type load failures

### DIFF
--- a/DesktopApplicationTemplate.Core/Modules/ServiceModuleDiscovery.cs
+++ b/DesktopApplicationTemplate.Core/Modules/ServiceModuleDiscovery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using DesktopApplicationTemplate.Core.Services;
@@ -17,7 +18,9 @@ public static class ServiceModuleDiscovery
     /// </summary>
     /// <param name="assemblies">The assemblies to scan.</param>
     /// <returns>The instantiated modules.</returns>
-    public static IReadOnlyList<IServiceModule> InstantiateModules(IEnumerable<Assembly> assemblies)
+    public static IReadOnlyList<IServiceModule> InstantiateModules(
+        IEnumerable<Assembly> assemblies,
+        Action<Assembly, IEnumerable<Exception>>? typeLoadFailureHandler = null)
     {
         if (assemblies is null)
         {
@@ -25,12 +28,32 @@ public static class ServiceModuleDiscovery
         }
 
         var moduleType = typeof(IServiceModule);
-        return assemblies
-            .SelectMany(static assembly => assembly?.GetTypes() ?? Array.Empty<Type>())
-            .Where(type => moduleType.IsAssignableFrom(type) && !type.IsAbstract && !type.IsInterface)
-            .Select(Activator.CreateInstance)
-            .OfType<IServiceModule>()
-            .ToList();
+        var modules = new List<IServiceModule>();
+
+        foreach (var assembly in assemblies)
+        {
+            if (assembly is null)
+            {
+                continue;
+            }
+
+            var assemblyTypes = GetLoadableTypes(assembly, typeLoadFailureHandler);
+            foreach (var type in assemblyTypes)
+            {
+                if (!moduleType.IsAssignableFrom(type) || type.IsAbstract || type.IsInterface)
+                {
+                    continue;
+                }
+
+                var instance = Activator.CreateInstance(type);
+                if (instance is IServiceModule module)
+                {
+                    modules.Add(module);
+                }
+            }
+        }
+
+        return modules;
     }
 
     /// <summary>
@@ -76,5 +99,60 @@ public static class ServiceModuleDiscovery
         }
 
         return descriptors;
+    }
+
+    private static IReadOnlyList<Type> GetLoadableTypes(
+        Assembly assembly,
+        Action<Assembly, IEnumerable<Exception>>? typeLoadFailureHandler)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            var nonNullTypes = ex.Types?.Where(static type => type is not null).Cast<Type>().ToArray()
+                ?? Array.Empty<Type>();
+
+            NotifyTypeLoadFailure(assembly, typeLoadFailureHandler, ex.LoaderExceptions, ex);
+            return nonNullTypes;
+        }
+        catch (Exception ex) when (IsTypeLoadException(ex))
+        {
+            NotifyTypeLoadFailure(assembly, typeLoadFailureHandler, null, ex);
+            return Array.Empty<Type>();
+        }
+    }
+
+    private static void NotifyTypeLoadFailure(
+        Assembly assembly,
+        Action<Assembly, IEnumerable<Exception>>? typeLoadFailureHandler,
+        IEnumerable<Exception?>? errors,
+        Exception fallback)
+    {
+        if (typeLoadFailureHandler is null)
+        {
+            return;
+        }
+
+        var errorList = errors?
+            .Where(static error => error is not null)
+            .Cast<Exception>()
+            .ToArray();
+
+        if (errorList is null || errorList.Length == 0)
+        {
+            errorList = new[] { fallback };
+        }
+
+        typeLoadFailureHandler(assembly, errorList);
+    }
+
+    private static bool IsTypeLoadException(Exception exception)
+    {
+        return exception is TypeLoadException
+            or FileLoadException
+            or FileNotFoundException
+            or BadImageFormatException;
     }
 }

--- a/DesktopApplicationTemplate.UI/Services/IPluginExportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IPluginExportService.cs
@@ -54,4 +54,7 @@ public sealed record PluginExportResult(
     bool Success,
     string Message,
     string? PackagePath,
-    IReadOnlyCollection<string> Descriptors);
+    IReadOnlyCollection<string> Descriptors)
+{
+    public IReadOnlyCollection<string> Diagnostics { get; init; } = Array.Empty<string>();
+}

--- a/DesktopApplicationTemplate.UI/Services/IPluginImportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/IPluginImportService.cs
@@ -38,4 +38,6 @@ public sealed record PluginImportResult(
 {
     public IReadOnlyCollection<ServiceUiRegistration<ServiceListModel, Page>> ImportedUiRegistrations { get; init; }
         = Array.Empty<ServiceUiRegistration<ServiceListModel, Page>>();
+
+    public IReadOnlyCollection<string> Diagnostics { get; init; } = Array.Empty<string>();
 }

--- a/DesktopApplicationTemplate.UI/Services/PluginExportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/PluginExportService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,7 +34,7 @@ public sealed class PluginExportService : IPluginExportService
 
     public IReadOnlyCollection<PluginDescriptorExportInfo> GetExportableDescriptors()
     {
-        var index = BuildModuleIndex();
+        var (index, _) = BuildModuleIndex();
         return index.Values
             .Select(context => new PluginDescriptorExportInfo(
                 context.Descriptor.Id,
@@ -91,7 +92,7 @@ public sealed class PluginExportService : IPluginExportService
             return new PluginExportResult(false, "Select at least one descriptor to export.", null, descriptorIds);
         }
 
-        var moduleIndex = BuildModuleIndex();
+        var (moduleIndex, moduleDiagnostics) = BuildModuleIndex();
         var selectedContexts = new List<ModuleExportContext>();
         foreach (var descriptorId in descriptorIds)
         {
@@ -99,7 +100,10 @@ public sealed class PluginExportService : IPluginExportService
 
             if (!moduleIndex.TryGetValue(descriptorId, out var context))
             {
-                return new PluginExportResult(false, $"Descriptor '{descriptorId}' is not available for export.", null, descriptorIds);
+                return new PluginExportResult(false, $"Descriptor '{descriptorId}' is not available for export.", null, descriptorIds)
+                {
+                    Diagnostics = moduleDiagnostics,
+                };
             }
 
             selectedContexts.Add(context);
@@ -107,7 +111,10 @@ public sealed class PluginExportService : IPluginExportService
 
         if (selectedContexts.Count == 0)
         {
-            return new PluginExportResult(false, "No descriptors matched the selection.", null, descriptorIds);
+            return new PluginExportResult(false, "No descriptors matched the selection.", null, descriptorIds)
+            {
+                Diagnostics = moduleDiagnostics,
+            };
         }
 
         var filesToCopy = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -136,14 +143,20 @@ public sealed class PluginExportService : IPluginExportService
 
         if (filesToCopy.Count == 0)
         {
-            return new PluginExportResult(false, "No assemblies were discovered for the selected descriptors.", null, descriptorIds);
+            return new PluginExportResult(false, "No assemblies were discovered for the selected descriptors.", null, descriptorIds)
+            {
+                Diagnostics = moduleDiagnostics,
+            };
         }
 
         entryAssembly ??= serviceAssemblies.First();
         var manifest = BuildManifest(request, entryAssembly, serviceAssemblies, probingPaths);
         if (!PluginPackageUtilities.TryValidateBasicManifest(manifest, "export", out var manifestErrors))
         {
-            return new PluginExportResult(false, string.Join(Environment.NewLine, manifestErrors), null, descriptorIds);
+            return new PluginExportResult(false, string.Join(Environment.NewLine, manifestErrors), null, descriptorIds)
+            {
+                Diagnostics = moduleDiagnostics,
+            };
         }
 
         var destination = ResolveDestinationPath(request);
@@ -194,8 +207,16 @@ public sealed class PluginExportService : IPluginExportService
             ? $"Exported descriptor '{selectedContexts[0].Descriptor.DisplayName}'."
             : $"Exported {selectedContexts.Count} descriptors.";
 
+        if (moduleDiagnostics.Count > 0)
+        {
+            successMessage += " Some modules were skipped due to load errors.";
+        }
+
         _logger.LogInformation("{Message} Package: {PackagePath}.", successMessage, destination);
-        return new PluginExportResult(true, successMessage, destination, descriptorIds);
+        return new PluginExportResult(true, successMessage, destination, descriptorIds)
+        {
+            Diagnostics = moduleDiagnostics,
+        };
     }
 
     private void IncludeFromManifest(
@@ -363,10 +384,41 @@ public sealed class PluginExportService : IPluginExportService
         }
     }
 
-    private IReadOnlyDictionary<string, ModuleExportContext> BuildModuleIndex()
+    private (Dictionary<string, ModuleExportContext> Index, IReadOnlyCollection<string> Diagnostics) BuildModuleIndex()
     {
         var assemblies = PluginLoader.CombineWithDefaultAssemblies(AppDomain.CurrentDomain.GetAssemblies());
-        var modules = ServiceModuleDiscovery.InstantiateModules(assemblies);
+        var diagnostics = new List<string>();
+        var modules = ServiceModuleDiscovery.InstantiateModules(
+            assemblies,
+            (assembly, errors) =>
+            {
+                var errorArray = errors?.Where(static error => error is not null).Cast<Exception>().ToArray()
+                    ?? Array.Empty<Exception>();
+                if (errorArray.Length == 0)
+                {
+                    return;
+                }
+
+                var diagnostic = FormatTypeLoadDiagnostic(assembly, errorArray);
+                diagnostics.Add(diagnostic);
+
+                var assemblyName = assembly?.GetName().Name ?? assembly?.FullName ?? "(unknown)";
+                var summary = string.Join("; ", errorArray.Select(error => error.Message));
+                _logger.LogWarning(
+                    errorArray[0],
+                    "Failed to load module types from assembly {AssemblyName}. Errors: {ErrorSummary}.",
+                    assemblyName,
+                    summary);
+
+                for (var i = 1; i < errorArray.Length; i++)
+                {
+                    _logger.LogDebug(
+                        errorArray[i],
+                        "Additional loader error for assembly {AssemblyName}.",
+                        assemblyName);
+                }
+            });
+
         var result = new Dictionary<string, ModuleExportContext>(StringComparer.Ordinal);
         var availableIds = new HashSet<string>(_serviceCatalog.Descriptors.Select(d => d.Id), StringComparer.Ordinal);
 
@@ -421,7 +473,7 @@ public sealed class PluginExportService : IPluginExportService
             }
         }
 
-        return result;
+        return (result, diagnostics.ToArray());
     }
 
     private bool IsWithinManagedRoots(string path)
@@ -478,6 +530,13 @@ public sealed class PluginExportService : IPluginExportService
     private static string NormalizeForManifest(string relativePath)
     {
         return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static string FormatTypeLoadDiagnostic(Assembly? assembly, IReadOnlyCollection<Exception> errors)
+    {
+        var assemblyName = assembly?.GetName().Name ?? assembly?.FullName ?? "(unknown)";
+        var summary = string.Join("; ", errors.Select(error => error.Message));
+        return FormattableString.Invariant($"Assembly '{assemblyName}' skipped: {summary}");
     }
 
     private sealed record ModuleExportContext(

--- a/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
+++ b/DesktopApplicationTemplate.UI/Services/PluginImportService.cs
@@ -61,6 +61,8 @@ public sealed class PluginImportService : IPluginImportService
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        var moduleDiagnostics = new List<string>();
+
         try
         {
             var fileName = Path.GetFileName(sourcePath);
@@ -76,14 +78,49 @@ public sealed class PluginImportService : IPluginImportService
             var loader = new PluginLoader(_options, loaderLogger);
             IReadOnlyCollection<Assembly> pluginAssemblies = loader.LoadPluginAssemblies();
 
-            var modules = ServiceModuleDiscovery.InstantiateModules(pluginAssemblies);
+            var modules = ServiceModuleDiscovery.InstantiateModules(
+                pluginAssemblies,
+                (assembly, errors) =>
+                {
+                    var errorArray = errors?.Where(static error => error is not null).Cast<Exception>().ToArray()
+                        ?? Array.Empty<Exception>();
+                    if (errorArray.Length == 0)
+                    {
+                        return;
+                    }
+
+                    var diagnostic = FormatTypeLoadDiagnostic(assembly, errorArray);
+                    moduleDiagnostics.Add(diagnostic);
+
+                    var assemblyName = assembly?.GetName().Name ?? assembly?.FullName ?? "(unknown)";
+                    var summary = string.Join("; ", errorArray.Select(error => error.Message));
+                    _logger.LogWarning(
+                        errorArray[0],
+                        "Failed to load module types from assembly {AssemblyName}. Errors: {ErrorSummary}.",
+                        assemblyName,
+                        summary);
+
+                    for (var i = 1; i < errorArray.Length; i++)
+                    {
+                        _logger.LogDebug(
+                            errorArray[i],
+                            "Additional loader error for assembly {AssemblyName}.",
+                            assemblyName);
+                    }
+                });
             var descriptors = ServiceModuleDiscovery.DescribeServices(modules);
 
             if (descriptors.Count == 0)
             {
-                var message = "The package did not expose any service descriptors.";
+                var diagnosticSnapshot = moduleDiagnostics.ToArray();
+                var message = moduleDiagnostics.Count > 0
+                    ? "The package did not expose any service descriptors. Some modules were skipped due to load errors."
+                    : "The package did not expose any service descriptors.";
                 _logger.LogWarning(message);
-                return Task.FromResult(new PluginImportResult(false, message, destinationPath, Array.Empty<IServiceDescriptor>()));
+                return Task.FromResult(new PluginImportResult(false, message, destinationPath, Array.Empty<IServiceDescriptor>())
+                {
+                    Diagnostics = diagnosticSnapshot,
+                });
             }
 
             var merged = new Dictionary<string, IServiceDescriptor>(StringComparer.Ordinal);
@@ -102,14 +139,20 @@ public sealed class PluginImportService : IPluginImportService
 
             _catalog.UpdateDescriptors(mergedDescriptors);
 
+            var diagnosticMessages = moduleDiagnostics.ToArray();
             var successMessage = descriptors.Count == 1
                 ? "Imported 1 service descriptor."
                 : $"Imported {descriptors.Count} service descriptors.";
+            if (diagnosticMessages.Length > 0)
+            {
+                successMessage += " Some modules were skipped due to load errors.";
+            }
             _logger.LogInformation("{Message} Package: {PackagePath}.", successMessage, destinationPath);
 
             return Task.FromResult(new PluginImportResult(true, successMessage, destinationPath, descriptors)
             {
                 ImportedUiRegistrations = uiRegistrations,
+                Diagnostics = diagnosticMessages,
             });
         }
         catch (OperationCanceledException)
@@ -120,7 +163,10 @@ public sealed class PluginImportService : IPluginImportService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to import plug-in package from {Source}.", sourcePath);
-            return Task.FromResult(new PluginImportResult(false, "Import failed. Check logs for details.", null, Array.Empty<IServiceDescriptor>()));
+            return Task.FromResult(new PluginImportResult(false, "Import failed. Check logs for details.", null, Array.Empty<IServiceDescriptor>())
+            {
+                Diagnostics = moduleDiagnostics.ToArray(),
+            });
         }
     }
 
@@ -145,5 +191,12 @@ public sealed class PluginImportService : IPluginImportService
             _logger.LogDebug(ex, "Failed to extract UI registrations from plug-in modules.");
             return Array.Empty<ServiceUiRegistration<ServiceListModel, Page>>();
         }
+    }
+
+    private static string FormatTypeLoadDiagnostic(Assembly? assembly, IReadOnlyCollection<Exception> errors)
+    {
+        var assemblyName = assembly?.GetName().Name ?? assembly?.FullName ?? "(unknown)";
+        var summary = string.Join("; ", errors.Select(error => error.Message));
+        return FormattableString.Invariant($"Assembly '{assemblyName}' skipped: {summary}");
     }
 }

--- a/Service Templates/PluginFixtures/MissingDependency/plugin.manifest.json
+++ b/Service Templates/PluginFixtures/MissingDependency/plugin.manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "MissingDependency.Sample",
+  "name": "Missing Dependency Fixture",
+  "version": "1.0.0",
+  "entryAssembly": "MissingDependency.dll",
+  "serviceAssemblies": [
+    "MissingDependency.dll"
+  ],
+  "probingPaths": []
+}


### PR DESCRIPTION
## Summary
- guard `ServiceModuleDiscovery` against type load exceptions and allow callers to log loader diagnostics
- surface module loader diagnostics during plug-in import and export, capturing them in the result payloads
- provide a manifest-based plug-in fixture referencing a missing dependency without checking in binary artifacts

## Testing
- Not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e95541f0cc8326a428618dad4ec107