### PR TITLE
Rename SCP service view to ScpServiceView

### DIFF
--- a/DesktopApplicationTemplate.UI/DependencyInjection/ScpServiceCollectionExtensions.cs
+++ b/DesktopApplicationTemplate.UI/DependencyInjection/ScpServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.AddTransient<SCPServiceView>();
+            services.AddTransient<ScpServiceView>();
             services.AddTransient<ScpServiceViewModel>();
             services.AddTransient<ScpCreateServiceView>();
             services.AddTransient<ScpCreateServiceViewModel>();
@@ -72,7 +72,7 @@ namespace DesktopApplicationTemplate.UI.DependencyInjection
                     mainView.GetOrCreateServicePage(svc);
                     return svc;
                 },
-                provider => provider.GetRequiredService<SCPServiceView>(),
+                provider => provider.GetRequiredService<ScpServiceView>(),
                 (provider, defaultName) =>
                 {
                     var vm = provider.GetRequiredService<ScpCreateServiceViewModel>();

--- a/DesktopApplicationTemplate.UI/Views/Scp/ScpServiceView.xaml
+++ b/DesktopApplicationTemplate.UI/Views/Scp/ScpServiceView.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="DesktopApplicationTemplate.UI.Views.Scp.SCPServiceView"
+<Page x:Class="DesktopApplicationTemplate.UI.Views.Scp.ScpServiceView"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:helpers="clr-namespace:DesktopApplicationTemplate.UI.Helpers"

--- a/DesktopApplicationTemplate.UI/Views/Scp/ScpServiceView.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/Scp/ScpServiceView.xaml.cs
@@ -6,11 +6,11 @@ using DesktopApplicationTemplate.Core.Services;
 
 namespace DesktopApplicationTemplate.UI.Views.Scp
 {
-    public partial class SCPServiceView : Page
+    public partial class ScpServiceView : Page
     {
         private readonly ScpServiceViewModel _viewModel;
         private readonly ILoggingService _logger;
-        public SCPServiceView(ScpServiceViewModel vm, ILoggingService logger)
+        public ScpServiceView(ScpServiceViewModel vm, ILoggingService logger)
         {
             InitializeComponent();
             _viewModel = vm;


### PR DESCRIPTION
## Summary
- rename the SCP service view XAML/code-behind to ScpServiceView so the class name matches the file name
- update dependency injection registrations to request the renamed view type

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e95cfb182c8326ae9f89e8c6244323