### PR TITLE
Fix ServiceType namespace resolution in ServiceOptionsState

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/Services/ServiceOptionsState.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Services/ServiceOptionsState.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using DesktopApplicationTemplate.Core.Services;
+using DesktopApplicationTemplate.Models;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Services
 {


### PR DESCRIPTION
## Summary
- import the DesktopApplicationTemplate.Models namespace in ServiceOptionsState to resolve the ServiceType reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e960be345c8326b1f37d7a59182b3b