### PR TITLE
Remove duplicate event declarations in ServiceListModel

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/ServiceListModel.cs
@@ -536,10 +536,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public ObservableCollection<LogEntry> Logs => LogState.Logs;
 
-        public event Action<bool>? ActiveChanged;
-
-        public event Action<ServiceListModel, LogEntry>? LogAdded;
-
         public void AddLog(string message, WpfBrush? color = null, LogLevel level = LogLevel.Debug, bool checkReference = true)
         {
             var brush = color ?? WpfBrushes.Black;


### PR DESCRIPTION
## Summary
- remove the duplicate ActiveChanged and LogAdded event declarations from ServiceListModel so the handlers remain wired through LogState events and state changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e960813d408326bb58c345e712c75f