### PR TITLE
Make IServiceLookup interface public

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Options;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
-    internal interface IServiceLookup
+    public interface IServiceLookup
     {
         bool TryGetService(ServiceType type, string name, out ServiceListModel? service);
 


### PR DESCRIPTION
## Summary
- change the IServiceLookup interface in MainViewModel to be public so it can be consumed outside the class scope

## Testing
- `dotnet build DesktopApplicationTemplate.sln` *(fails: `dotnet` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9606c531483269105dc1e24db402d