### PR TITLE
Fix notification tuple naming conflict in MessageRoutingService

### DIFF
--- a/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
+++ b/DesktopApplicationTemplate.Core/Services/MessageRoutingService.cs
@@ -241,11 +241,11 @@ public class MessageRoutingService : IMessageRoutingService
         }
 
         var hasTyped = notifications.Any(n => n.ServiceType.HasValue);
-        foreach (var (type, previous) in notifications)
+        foreach (var (type, previousValue) in notifications)
         {
             if (!hasTyped || type.HasValue)
             {
-                OnAttributeChanged(type, normalizedName, normalizedAttribute, null, previous, isRemoval: true);
+                OnAttributeChanged(type, normalizedName, normalizedAttribute, null, previousValue, isRemoval: true);
             }
         }
     }


### PR DESCRIPTION
## Summary
- rename the tuple element used in ClearAttribute notifications to avoid clashing with a previous local
- continue forwarding the prior attribute value to notification handlers without change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e96044612083268c597172c24599c2