### PR TITLE
Await logging reload after loading services

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -488,7 +488,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             ApplyFilters();
             if (_logger is LoggingService concreteLogger)
             {
-                concreteLogger.Reload();
+                await concreteLogger.ReloadAsync().ConfigureAwait(true);
             }
         }
 

--- a/Error Log/Build Errors.csv
+++ b/Error Log/Build Errors.csv
@@ -45,3 +45,4 @@ System.ArgumentException,DesktopApplicationTemplate.UI/CsvServiceCollectionExten
 System.Windows.Markup.XamlParseException,DesktopApplicationTemplate.UI/MainWindow.xaml,1
 System.Windows.Markup.XamlParseException,DesktopApplicationTemplate.UI/TcpServiceMessagesView.xaml,1
 CMD-NOT-FOUND,DesktopApplicationTemplate/dotnet,6
+CS1061,DesktopApplicationTemplate.UI/MainViewModel.cs,1

--- a/Error Log/Code Errors.csv
+++ b/Error Log/Code Errors.csv
@@ -5,3 +5,4 @@ System.NullReferenceException,1,2025-10-09T18:15:23
 System.ArgumentException,1,2025-10-09T18:26:39
 System.Windows.Markup.XamlParseException,2,2025-10-09T18:41:01
 CMD-NOT-FOUND,6,2025-10-10T19:38:57
+CS1061,1,2025-10-10T19:56:40

--- a/Error Log/Detailed Errors.csv
+++ b/Error Log/Detailed Errors.csv
@@ -55,3 +55,4 @@ System.ArgumentException,DesktopApplicationTemplate.UI/CsvServiceCollectionExten
 System.Windows.Markup.XamlParseException,DesktopApplicationTemplate.UI/MainWindow.xaml,Add value to collection of type 'System.Windows.Controls.UIElementCollection' threw an exception. Line number '195' and line position '22'.,1,2025-10-09T18:34:29
 System.Windows.Markup.XamlParseException,DesktopApplicationTemplate.UI/TcpServiceMessagesView.xaml,Add value to collection of type 'System.Windows.Controls.UIElementCollection' threw an exception. Line number '60' and line position '18'.,1,2025-10-09T18:41:01
 CMD-NOT-FOUND,DesktopApplicationTemplate/dotnet,Command 'dotnet' not found on PATH.,6,2025-10-10T19:38:57
+CS1061,DesktopApplicationTemplate.UI/MainViewModel.cs,'LoggingService' does not contain a definition for 'Reload'.,1,2025-10-10T19:56:40


### PR DESCRIPTION
## Summary
- await the logging service reload when services finish loading to keep aggregated logs in sync
- record the CS1061 build failure from the missing Reload method in the error tracking CSVs

## Testing
- not run (Windows WPF application)

------
https://chatgpt.com/codex/tasks/task_e_68e964ac7cb88326992a92b65652a5a1