### PR TITLE
Annotate ServiceUiRegistration TryGetRegistration outputs

### DIFF
--- a/DesktopApplicationTemplate.Services/ServiceUiRegistration.cs
+++ b/DesktopApplicationTemplate.Services/ServiceUiRegistration.cs
@@ -41,9 +41,9 @@ public interface IServiceUiRegistry<TService, TPage> : IDisposable
 
     bool TryCreateNavigationPage(string descriptorId, IServiceProvider provider, string defaultName, out TPage? page);
 
-    bool TryGetRegistration(ServiceType serviceType, out ServiceUiRegistration<TService, TPage>? registration);
+    bool TryGetRegistration(ServiceType serviceType, [NotNullWhen(true)] out ServiceUiRegistration<TService, TPage>? registration);
 
-    bool TryGetRegistration(string descriptorId, out ServiceUiRegistration<TService, TPage>? registration);
+    bool TryGetRegistration(string descriptorId, [NotNullWhen(true)] out ServiceUiRegistration<TService, TPage>? registration);
 }
 
 /// <summary>
@@ -184,7 +184,7 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
         return true;
     }
 
-    public bool TryGetRegistration(ServiceType serviceType, out ServiceUiRegistration<TService, TPage>? registration)
+    public bool TryGetRegistration(ServiceType serviceType, [NotNullWhen(true)] out ServiceUiRegistration<TService, TPage>? registration)
     {
         if (TrySelectDescriptorId(serviceType, out var descriptorId) &&
             descriptorId is not null &&
@@ -198,7 +198,7 @@ public sealed class ServiceUiRegistry<TService, TPage> : IServiceUiRegistry<TSer
         return false;
     }
 
-    public bool TryGetRegistration(string descriptorId, out ServiceUiRegistration<TService, TPage>? registration)
+    public bool TryGetRegistration(string descriptorId, [NotNullWhen(true)] out ServiceUiRegistration<TService, TPage>? registration)
     {
         if (_registrations.TryGetValue(descriptorId, out var resolved))
         {


### PR DESCRIPTION
## Summary
- add nullability annotations to ServiceUiRegistration.TryGetRegistration overloads so successful calls return non-null registrations

## Testing
- dotnet build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e964adf4fc83268a55f636c93466d2