### PR TITLE
Ensure observed tasks use the default scheduler for faulted continuations

### DIFF
--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -298,7 +298,11 @@ namespace DesktopApplicationTemplate.UI.Services
                 return;
             }
 
-            _ = task.ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            _ = task.ContinueWith(
+                t => _ = t.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         private async Task AppendToLogFileAsync(string text)

--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -1148,7 +1148,9 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
             _ = task.ContinueWith(
                 t => _ = t.Exception,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
         // OnPropertyChanged inherited from ViewModelBase

--- a/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
+++ b/DesktopApplicationTemplate.UI/Views/MainWindow.xaml.cs
@@ -1115,7 +1115,9 @@ namespace DesktopApplicationTemplate.UI.Views
 
             _ = task.ContinueWith(
                 t => _ = t.Exception,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                System.Threading.CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
         }
 
     }


### PR DESCRIPTION
## Summary
- update each ObserveTask helper to attach faulted continuations via TaskScheduler.Default
- propagate the helper changes through LoggingService, MainViewModel, and MainWindow to keep fault observation consistent

## Testing
- not run (UI project targets Windows desktop APIs unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e964afcc0883269a7616132e064cd9