### PR TITLE
Use JoinableTaskFactory for UI thread marshaling

### DIFF
--- a/DesktopApplicationTemplate.UI/Helpers/ServiceAttributeExpressionBinder.cs
+++ b/DesktopApplicationTemplate.UI/Helpers/ServiceAttributeExpressionBinder.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using DesktopApplicationTemplate.Core.Services;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.Helpers;
 
@@ -18,7 +20,7 @@ public sealed class ServiceAttributeExpressionBinder
     private readonly Action<string> _onResolved;
     private readonly Action<string?>? _onError;
     private string? _referencingServiceName;
-    private readonly SynchronizationContext? _context;
+    private readonly JoinableTaskFactory? _joinableTaskFactory;
 
     private readonly object _sync = new();
     private List<AttributeReference> _references = new();
@@ -32,19 +34,19 @@ public sealed class ServiceAttributeExpressionBinder
     /// <param name="onResolved">Callback invoked with the resolved value.</param>
     /// <param name="onError">Optional callback invoked with an error message when referenced attributes are missing.</param>
     /// <param name="referencingServiceName">Optional service name that owns the expression.</param>
-    /// <param name="context">Optional synchronization context used when invoking callbacks.</param>
+    /// <param name="joinableTaskFactory">Optional task factory used to marshal callbacks to the UI thread.</param>
     public ServiceAttributeExpressionBinder(
         IMessageRoutingService routingService,
         Action<string> onResolved,
         Action<string?>? onError = null,
         string? referencingServiceName = null,
-        SynchronizationContext? context = null)
+        JoinableTaskFactory? joinableTaskFactory = null)
     {
         _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
         _onResolved = onResolved ?? throw new ArgumentNullException(nameof(onResolved));
         _onError = onError;
         _referencingServiceName = referencingServiceName;
-        _context = context ?? SynchronizationContext.Current;
+        _joinableTaskFactory = joinableTaskFactory ?? App.UiThreadTaskFactory;
 
         WeakEventManager<IMessageRoutingService, ServiceAttributeChangedEventArgs>.AddHandler(
             _routingService,
@@ -130,13 +132,26 @@ public sealed class ServiceAttributeExpressionBinder
     {
         void Execute()
         {
-            _onResolved(resolved);
-            _onError?.Invoke(error);
+            try
+            {
+                _onResolved(resolved);
+                _onError?.Invoke(error);
+            }
+            catch (Exception ex)
+            {
+                _onError?.Invoke(ex.Message);
+            }
         }
 
-        if (_context is not null)
+        if (_joinableTaskFactory is { } factory)
         {
-            _context.Post(_ => Execute(), null);
+            var task = factory.RunAsync(async () =>
+            {
+                await factory.SwitchToMainThreadAsync();
+                Execute();
+            }).Task;
+
+            ObserveTask(task);
         }
         else
         {
@@ -171,6 +186,20 @@ public sealed class ServiceAttributeExpressionBinder
         }
 
         return missing;
+    }
+
+    private static void ObserveTask(Task task)
+    {
+        if (task is null)
+        {
+            return;
+        }
+
+        _ = task.ContinueWith(
+            t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private static List<AttributeReference> ParseReferences(string expression)

--- a/DesktopApplicationTemplate.UI/Services/LoggingService.cs
+++ b/DesktopApplicationTemplate.UI/Services/LoggingService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.Core.Services;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.Services
 {
@@ -16,7 +17,7 @@ namespace DesktopApplicationTemplate.UI.Services
         private readonly List<LogEntry> _logEntries = new();
         private readonly object _entriesLock = new();
         private readonly SemaphoreSlim _fileWriteLock = new(1, 1);
-        private readonly SynchronizationContext? _uiContext;
+        private readonly JoinableTaskFactory? _joinableTaskFactory;
 
         private LogLevel _minimumLevel = LogLevel.Debug;
         public LogLevel MinimumLevel
@@ -32,10 +33,10 @@ namespace DesktopApplicationTemplate.UI.Services
 
         public event Action<LogEntry>? LogAdded;
 
-        public LoggingService(IRichTextLogger richTextLogger, string? logFilePath = null)
+        public LoggingService(IRichTextLogger richTextLogger, string? logFilePath = null, JoinableTaskFactory? joinableTaskFactory = null)
         {
             _richTextLogger = richTextLogger;
-            _uiContext = SynchronizationContext.Current;
+            _joinableTaskFactory = joinableTaskFactory ?? App.UiThreadTaskFactory;
 
             var resolvedLogFilePath = logFilePath ?? GetDefaultLogFilePath();
             EnsureDirectoryExists(resolvedLogFilePath);
@@ -268,27 +269,18 @@ namespace DesktopApplicationTemplate.UI.Services
 
         private Task InvokeOnUiThreadAsync(Action action)
         {
-            if (_uiContext is null || SynchronizationContext.Current == _uiContext)
+            var factory = _joinableTaskFactory;
+            if (factory is null || factory.Context.IsOnMainThread)
             {
                 action();
                 return Task.CompletedTask;
             }
 
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _uiContext.Post(_ =>
+            return factory.RunAsync(async () =>
             {
-                try
-                {
-                    action();
-                    tcs.SetResult(null);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }, null);
-
-            return tcs.Task;
+                await factory.SwitchToMainThreadAsync();
+                action();
+            }).Task;
         }
 
         private static void ObserveTask(Task? task)

--- a/DesktopApplicationTemplate.UI/ViewModels/Csv/CsvServiceViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Csv/CsvServiceViewModel.cs
@@ -9,12 +9,11 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Input;
-using System.Windows.Threading;
 using DesktopApplicationTemplate.Core.Services;
 using DesktopApplicationTemplate.Core.Services.Protocols.Csv;
 using DesktopApplicationTemplate.UI.Services;
+using Microsoft.VisualStudio.Threading;
 
 namespace DesktopApplicationTemplate.UI.ViewModels.Csv
 {
@@ -33,6 +32,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
 #if DEBUG
         private readonly RelayCommand _debugSaveCommand;
 #endif
+        private readonly JoinableTaskFactory? _joinableTaskFactory;
         private ObservableCollection<CsvColumnDefinition>? _observableColumns;
         private CsvColumnDefinition? _selectedColumn;
         private bool _isBusy;
@@ -84,11 +84,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
 
         public event Action? RequestClose;
 
-        public CsvServiceViewModel(IFileDialogService fileDialog, IMessageRoutingService routingService, string? configPath = null)
+        public CsvServiceViewModel(
+            IFileDialogService fileDialog,
+            IMessageRoutingService routingService,
+            string? configPath = null,
+            JoinableTaskFactory? joinableTaskFactory = null)
         {
             _fileDialog = fileDialog ?? throw new ArgumentNullException(nameof(fileDialog));
             _routingService = routingService ?? throw new ArgumentNullException(nameof(routingService));
             _configPath = configPath ?? "csv_config.json";
+            _joinableTaskFactory = joinableTaskFactory ?? App.UiThreadTaskFactory;
             AttributeSuggestions = new ReadOnlyObservableCollection<string>(_attributeSuggestions);
             ValidationMessages = new ReadOnlyObservableCollection<string>(_validationMessages);
             _routingService.AttributeChanged += OnRoutingAttributeChanged;
@@ -451,38 +456,54 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Csv
 #endif
         }
 
-        private static void RunOnUiThread(Action action)
+        private void RunOnUiThread(Action action)
         {
             if (action is null)
             {
                 return;
             }
 
-            var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
-            if (dispatcher.CheckAccess())
+            if (_joinableTaskFactory is { } factory)
             {
-                action();
+                if (factory.Context.IsOnMainThread)
+                {
+                    action();
+                    return;
+                }
+
+                factory.Run(async () =>
+                {
+                    await factory.SwitchToMainThreadAsync();
+                    action();
+                });
+                return;
             }
-            else
-            {
-                dispatcher.Invoke(action);
-            }
+
+            action();
         }
 
-        private static T RunOnUiThread<T>(Func<T> function)
+        private T RunOnUiThread<T>(Func<T> function)
         {
             if (function is null)
             {
                 return default!;
             }
 
-            var dispatcher = Application.Current?.Dispatcher ?? Dispatcher.CurrentDispatcher;
-            if (dispatcher.CheckAccess())
+            if (_joinableTaskFactory is { } factory)
             {
-                return function();
+                if (factory.Context.IsOnMainThread)
+                {
+                    return function();
+                }
+
+                return factory.Run(async () =>
+                {
+                    await factory.SwitchToMainThreadAsync();
+                    return function();
+                });
             }
 
-            return dispatcher.Invoke(function);
+            return function();
         }
     }
 }

--- a/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/Tcp/TcpServiceMessagesViewModel.cs
@@ -300,17 +300,16 @@ namespace DesktopApplicationTemplate.UI.ViewModels.Tcp
                 OnPropertyChanged(nameof(OutgoingResults));
             };
 
-            var context = SynchronizationContext.Current;
             _testMessageBinder = new ServiceAttributeExpressionBinder(
                 _routing,
                 resolved => UpdateResolvedTestMessage(resolved),
                 error => TestMessageError = error,
-                context: context);
+                joinableTaskFactory: App.UiThreadTaskFactory);
             _scriptBinder = new ServiceAttributeExpressionBinder(
                 _routing,
                 resolved => UpdateResolvedScript(resolved),
                 error => ScriptError = error,
-                context: context);
+                joinableTaskFactory: App.UiThreadTaskFactory);
 
             ClearLogCommand = new RelayCommand(ClearLogs);
             _exportLogCommand = new AsyncRelayCommand(ExportLogsAsync, () => !_isExportingLogs);


### PR DESCRIPTION
## Summary
- inject the shared JoinableTaskFactory into the service attribute binder, logging service, and CSV view model so callbacks are marshaled on the UI thread
- replace raw SynchronizationContext/Dispatcher usage with JoinableTaskFactory.SwitchToMainThreadAsync and Run/RunAsync, observing tasks to surface failures safely
- update the TCP messages view model to provide App.UiThreadTaskFactory when constructing binders

## Testing
- not run (WPF projects require Windows tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e964b3fd308326807adf0a8b9320a2