### PR TITLE
Ensure RemoveServiceAsync resumes on UI thread

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -377,7 +377,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             target.AddLog("Service removed", WpfBrushes.Red);
             if (target.Type != ServiceType.Csv)
             {
-                await _csvService.RemoveColumnsForServiceAsync(target.DisplayName).ConfigureAwait(false);
+                await _csvService.RemoveColumnsForServiceAsync(target.DisplayName);
             }
 
             RemoveServiceAssociations(target);


### PR DESCRIPTION
## Summary
- ensure the main view model awaits CSV cleanup without ConfigureAwait so UI updates stay on the dispatcher thread

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ef9c54c0ac832699ee604df1ccaaf2