### PR TITLE
Ensure file observer updates occur on UI thread

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/FileObserver/FileObserverViewModel.cs
@@ -124,7 +124,7 @@ public class FileObserverViewModel : ViewModelBase
         if (observer is null)
         {
             ResetFields();
-            await _fileObserverService.StopAsync().ConfigureAwait(false);
+            await _fileObserverService.StopAsync();
             return;
         }
 
@@ -138,7 +138,7 @@ public class FileObserverViewModel : ViewModelBase
         TcpCommand = observer.TcpString;
 
         OnPropertyChanged(null);
-        await ConfigureObserverServiceAsync(observer).ConfigureAwait(false);
+        await ConfigureObserverServiceAsync(observer);
     }
 
     private void ResetFields()
@@ -186,8 +186,7 @@ public class FileObserverViewModel : ViewModelBase
                 try
                 {
                     var files = await _fileSearchService
-                        .GetFilesAsync(directory, "*", CancellationToken.None)
-                        .ConfigureAwait(false);
+                        .GetFilesAsync(directory, "*", CancellationToken.None);
                     ImageNames = string.Join(",", files.Select(System.IO.Path.GetFileName));
                 }
                 catch
@@ -199,7 +198,7 @@ public class FileObserverViewModel : ViewModelBase
             if (SelectedObserver is not null)
             {
                 SelectedObserver.FilePath = FilePath;
-                await ConfigureObserverServiceAsync(SelectedObserver).ConfigureAwait(false);
+                await ConfigureObserverServiceAsync(SelectedObserver);
             }
         }
     }
@@ -219,9 +218,9 @@ public class FileObserverViewModel : ViewModelBase
             TcpCommand = observer.TcpString
         };
 
-        await _fileObserverService.ConfigureAsync(observer.Name, options).ConfigureAwait(false);
-        await _fileObserverService.StartAsync().ConfigureAwait(false);
-        var snapshot = await _fileObserverService.GetSnapshotAsync().ConfigureAwait(false);
+        await _fileObserverService.ConfigureAsync(observer.Name, options);
+        await _fileObserverService.StartAsync();
+        var snapshot = await _fileObserverService.GetSnapshotAsync();
 
         if (!string.IsNullOrWhiteSpace(snapshot.Contents))
         {


### PR DESCRIPTION
## Summary
- ensure FileObserverViewModel no longer suppresses the UI context when updating observable state
- allow observer reconfiguration to resume on the dispatcher thread before mutating bound properties

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ef9c572b3883269a88af2094d20557