### PR TITLE
Ensure network configuration loading marshals to UI thread

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -188,7 +188,7 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             AllLogs = new LimitedObservableCollection<LogEntry>(aggregatedLogCapacity);
             ServiceListModel.OptionsSerializerResolver = ResolveOptionsSerializer;
             ServiceListModel.CrossServiceAssociationsClearing += OnCrossServiceAssociationsClearing;
-            _ = NetworkConfig.LoadAsync();
+            ObserveTask(NetworkConfig.LoadAsync());
             _networkService.ConfigurationChanged += (_, cfg) => ApplyNetworkConfiguration(cfg);
             if (!string.IsNullOrWhiteSpace(servicesFilePath))
             {

--- a/DesktopApplicationTemplate.UI/ViewModels/NetworkConfigurationViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/NetworkConfigurationViewModel.cs
@@ -4,6 +4,7 @@ using DesktopApplicationTemplate.Core.Models;
 using DesktopApplicationTemplate.UI.Helpers;
 using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.Core.Services;
+using UI = DesktopApplicationTemplate.UI;
 
 namespace DesktopApplicationTemplate.UI.ViewModels
 {
@@ -42,7 +43,13 @@ namespace DesktopApplicationTemplate.UI.ViewModels
 
         public async Task LoadAsync()
         {
-            CurrentConfiguration = await _service.GetConfigurationAsync().ConfigureAwait(false);
+            var configuration = await _service.GetConfigurationAsync().ConfigureAwait(false);
+            if (UI.App.UiThreadTaskFactory is { } factory)
+            {
+                await factory.SwitchToMainThreadAsync();
+            }
+
+            CurrentConfiguration = configuration;
             IpAddress = CurrentConfiguration.IpAddress;
             SubnetMask = CurrentConfiguration.SubnetMask;
             Gateway = CurrentConfiguration.Gateway;


### PR DESCRIPTION
## Summary
- marshal network configuration refresh onto the UI thread before updating observable properties
- observe the asynchronous network configuration load from the main view model so failures surface

## Testing
- not run (UI project)

------
https://chatgpt.com/codex/tasks/task_e_68ef9c634df48326b778fff44284c44d