### PR TITLE
Ensure plugin export descriptors refresh on UI thread

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/PluginExportViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/PluginExportViewModel.cs
@@ -204,10 +204,17 @@ public sealed class PluginExportViewModel : ViewModelBase, IDisposable
             return;
         }
 
-        _ = App.UiThreadTaskFactory.RunAsync(async () =>
+        var factory = App.UiThreadTaskFactory;
+        if (factory is null)
         {
             RefreshDescriptors();
-            await Task.CompletedTask;
+            return;
+        }
+
+        _ = factory.RunAsync(async () =>
+        {
+            await factory.SwitchToMainThreadAsync();
+            RefreshDescriptors();
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure `PluginExportViewModel` switches to the UI thread before refreshing descriptors
- remove the redundant `Task.CompletedTask` await while keeping the synchronous fallback path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef9c655d688326afa549b2d6438f57