### PR TITLE
Ensure network configuration updates run on UI thread

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -18,6 +18,7 @@ using DesktopApplicationTemplate.UI.Services;
 using DesktopApplicationTemplate.UI.ViewModels.Tcp;
 using DesktopApplicationTemplate.Models;
 using DesktopApplicationTemplate.UI.Helpers;
+using DesktopApplicationTemplate.UI;
 using DesktopApplicationTemplate.Core.Services.Protocols.Mqtt;
 using Microsoft.Extensions.Options;
 
@@ -261,6 +262,22 @@ namespace DesktopApplicationTemplate.UI.ViewModels
         }
 
         private void ApplyNetworkConfiguration(NetworkConfiguration config)
+        {
+            var factory = App.UiThreadTaskFactory;
+            if (factory is null)
+            {
+                ApplyNetworkConfigurationOnUiThread(config);
+                return;
+            }
+
+            factory.Run(async () =>
+            {
+                await factory.SwitchToMainThreadAsync();
+                ApplyNetworkConfigurationOnUiThread(config);
+            });
+        }
+
+        private void ApplyNetworkConfigurationOnUiThread(NetworkConfiguration config)
         {
             foreach (var svc in Services)
             {


### PR DESCRIPTION
## Summary
- dispatch ApplyNetworkConfiguration via App.UiThreadTaskFactory to run updates on the UI thread
- reuse the existing update loop from a helper to keep service editors in sync safely

## Testing
- not run (WPF build unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ef9c72a3708326bda3f40d598e4710