### PR TITLE
Prevent duplicate service loading on startup

### DIFF
--- a/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
+++ b/DesktopApplicationTemplate.UI/ViewModels/MainViewModel.cs
@@ -216,7 +216,6 @@ namespace DesktopApplicationTemplate.UI.ViewModels
             ResetMessageCountsCommand = new AsyncRelayCommand(ResetMessageCountsAsync);
             FilteredServices = CollectionViewSource.GetDefaultView(Services);
             Filters.PropertyChanged += (_, __) => ApplyFilters();
-            ObserveTask(LoadServicesAsync());
             foreach (var service in Services)
             {
                 TrackService(service);


### PR DESCRIPTION
## Summary
- avoid loading persisted services twice by letting App startup orchestrate the load

## Testing
- not run (WPF build requires Windows tooling; rely on CI)


------
https://chatgpt.com/codex/tasks/task_e_68ef9e8f699083269343635427b42eef